### PR TITLE
validate schema command: allow to debug missing schema updates list

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -393,6 +393,11 @@ You can either use the Doctrine Command Line Tool:
 
     doctrine orm:validate-schema
 
+If the validation fails, you can change the verbosity level to
+check the detected errors:
+
+    doctrine orm:validate-schema -v
+
 Or you can trigger the validation manually:
 
 .. code-block:: php

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -90,10 +90,7 @@ EOT
         if ($dumpSql) {
             $ui->text('The following SQL statements will be executed:');
             $ui->newLine();
-
-            foreach ($sqls as $sql) {
-                $ui->text(sprintf('    %s;', $sql));
-            }
+            $ui->listing($sqls);
         }
 
         if ($force) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function count;
 use function sprintf;
 
 /**
@@ -76,6 +77,13 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
             $ui->text('<comment>[SKIPPED] The database was not checked for synchronicity.</comment>');
         } elseif (! $validator->schemaInSyncWithMetadata()) {
             $ui->error('The database schema is not in sync with the current mapping file.');
+
+            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $sqls = $validator->getUpdateSchemaList();
+                $ui->comment(sprintf('<info>%d</info> schema diff(s) detected:', count($sqls)));
+                $ui->listing($sqls);
+            }
+
             $exit += 2;
         } else {
             $ui->success('The database schema is in sync with the mapping files.');

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -262,10 +262,20 @@ class SchemaValidator
      */
     public function schemaInSyncWithMetadata()
     {
+        return count($this->getUpdateSchemaList()) === 0;
+    }
+
+    /**
+     * Returns the list of missing Database Schema updates.
+     *
+     * @return array<string>
+     */
+    public function getUpdateSchemaList(): array
+    {
         $schemaTool = new SchemaTool($this->em);
 
         $allMetadata = $this->em->getMetadataFactory()->getAllMetadata();
 
-        return count($schemaTool->getUpdateSchemaSql($allMetadata, true)) === 0;
+        return $schemaTool->getUpdateSchemaSql($allMetadata, true);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command;
+
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\Tools\Console\Command\InfoCommand;
+use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests for {@see \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand}
+ *
+ * @covers \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand
+ */
+class ValidateSchemaCommandTest extends OrmFunctionalTestCase
+{
+    /** @var InfoCommand */
+    private $command;
+
+    /** @var CommandTester */
+    private $tester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+            self::markTestSkipped('Only with sqlite');
+        }
+
+        $application = new Application();
+        $application->add(new ValidateSchemaCommand(new SingleManagerProvider($this->_em)));
+
+        $this->command = $application->find('orm:validate-schema');
+        $this->tester  = new CommandTester($this->command);
+    }
+
+    public function testNotInSync(): void
+    {
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+            ]
+        );
+
+        $display = $this->tester->getDisplay();
+
+        self::assertStringContainsString('The database schema is not in sync with the current mapping file', $display);
+        self::assertStringNotContainsString('cache_login', $display);
+    }
+
+    public function testNotInSyncVerbose(): void
+    {
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+            ],
+            [
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+            ]
+        );
+
+        $display = $this->tester->getDisplay();
+        self::assertStringContainsString('The database schema is not in sync with the current mapping file', $display);
+        self::assertStringContainsString('cache_login', $display);
+    }
+}


### PR DESCRIPTION
Hi,

This PR allows seeing why you get the message "The database schema is not in sync with the current mapping file" by displaying all the missing SQL so the database schema can be up-to-date. This debug is only activated when at least the verbose mode of the console is activated.

See you. COil :)

Questions: 
* Do I need to cache the update list, so there is only one call to `getUpdateSchemaList`? 
* Is it OK the tests the getVerbosity level? Or should it be displayed in every case (like for the mapping)?
* Need tests? There is currently no test for the `ValidateSchemaCommand` if I am right (except that is callable with `orm:validate-schema`)