### PR TITLE
Explicitly allow to use `Comparison` and `Composite` in JOIN conditions

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Join.php
+++ b/lib/Doctrine/ORM/Query/Expr/Join.php
@@ -47,19 +47,19 @@ class Join
     /** @var string */
     protected $conditionType;
 
-    /** @var string */
+    /** @var string|Comparison|Composite */
     protected $condition;
 
     /** @var string */
     protected $indexBy;
 
     /**
-     * @param string      $joinType      The condition type constant. Either INNER_JOIN or LEFT_JOIN.
-     * @param string      $join          The relationship to join.
-     * @param string|null $alias         The alias of the join.
-     * @param string|null $conditionType The condition type constant. Either ON or WITH.
-     * @param string|null $condition     The condition for the join.
-     * @param string|null $indexBy       The index for the join.
+     * @param string                           $joinType      The condition type constant. Either INNER_JOIN or LEFT_JOIN.
+     * @param string                           $join          The relationship to join.
+     * @param string|null                      $alias         The alias of the join.
+     * @param string|null                      $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Comparison|Composite|null $condition     The condition for the join.
+     * @param string|null                      $indexBy       The index for the join.
      */
     public function __construct($joinType, $join, $alias = null, $conditionType = null, $condition = null, $indexBy = null)
     {
@@ -104,7 +104,7 @@ class Join
     }
 
     /**
-     * @return string
+     * @return string|Comparison|Composite
      */
     public function getCondition()
     {

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -956,11 +956,11 @@ class QueryBuilder
      *         ->join('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      * </code>
      *
-     * @param string      $join          The relationship to join.
-     * @param string      $alias         The alias of the join.
-     * @param string|null $conditionType The condition type constant. Either ON or WITH.
-     * @param string|null $condition     The condition for the join.
-     * @param string|null $indexBy       The index for the join.
+     * @param string                                     $join          The relationship to join.
+     * @param string                                     $alias         The alias of the join.
+     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
+     * @param string|null                                $indexBy       The index for the join.
      *
      * @return self
      */
@@ -982,11 +982,11 @@ class QueryBuilder
      *         ->from('User', 'u')
      *         ->innerJoin('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      *
-     * @param string      $join          The relationship to join.
-     * @param string      $alias         The alias of the join.
-     * @param string|null $conditionType The condition type constant. Either ON or WITH.
-     * @param string|null $condition     The condition for the join.
-     * @param string|null $indexBy       The index for the join.
+     * @param string                                     $join          The relationship to join.
+     * @param string                                     $alias         The alias of the join.
+     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
+     * @param string|null                                $indexBy       The index for the join.
      *
      * @return static
      */
@@ -1022,11 +1022,11 @@ class QueryBuilder
      *         ->leftJoin('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      * </code>
      *
-     * @param string      $join          The relationship to join.
-     * @param string      $alias         The alias of the join.
-     * @param string|null $conditionType The condition type constant. Either ON or WITH.
-     * @param string|null $condition     The condition for the join.
-     * @param string|null $indexBy       The index for the join.
+     * @param string                                     $join          The relationship to join.
+     * @param string                                     $alias         The alias of the join.
+     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
+     * @param string|null                                $indexBy       The index for the join.
      *
      * @return static
      */

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\QueryBuilder;
@@ -146,6 +147,37 @@ class QueryBuilderTest extends OrmTestCase
         $this->assertValidQueryBuilder(
             $qb,
             'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id'
+        );
+    }
+
+    public function testComplexInnerJoinWithComparisonCondition(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->select('u', 'a')
+            ->from(CmsUser::class, 'u')
+            ->innerJoin('u.articles', 'a', Join::ON, $qb->expr()->eq('u.id', 'a.author_id'));
+
+        $this->assertValidQueryBuilder(
+            $qb,
+            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id'
+        );
+    }
+
+    public function testComplexInnerJoinWithCompositeCondition(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->select('u', 'a')
+            ->from(CmsUser::class, 'u')
+            ->innerJoin('u.articles', 'a', Join::ON, $qb->expr()->andX(
+                $qb->expr()->eq('u.id', 'a.author_id'),
+                $qb->expr()->isNotNull('u.name')
+            ));
+
+        $this->assertValidQueryBuilder(
+            $qb,
+            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id AND u.name IS NOT NULL'
         );
     }
 


### PR DESCRIPTION
These changes explicitly allow to use `Comparison` and `Composite` in JOIN conditions.
This is currently possible, but in an implicit way, since the values are silently converted to string as both classes are implementing the `__toString()` method.
After these changes, PHPStan findings like this, can be resolved:
```
Parameter #4 $condition of method Doctrine\ORM\QueryBuilder::join() expects string|null, Doctrine\ORM\Query\Expr\Andx given.
```