### PR TITLE
 Don't presume one-to-one lookup returned an entity 

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2872,6 +2872,10 @@ class UnitOfWork implements PropertyChangedListener
                                     break;
                             }
 
+                            if ($newValue === null) {
+                                break;
+                            }
+
                             // PERF: Inlined & optimized code from UnitOfWork#registerManaged()
                             $newValueOid                                                     = spl_object_hash($newValue);
                             $this->entityIdentifiers[$newValueOid]                           = $associatedId;
@@ -2892,7 +2896,7 @@ class UnitOfWork implements PropertyChangedListener
                     $this->originalEntityData[$oid][$field] = $newValue;
                     $class->reflFields[$field]->setValue($entity, $newValue);
 
-                    if ($assoc['inversedBy'] && $assoc['type'] & ClassMetadata::ONE_TO_ONE) {
+                    if ($assoc['inversedBy'] && $assoc['type'] & ClassMetadata::ONE_TO_ONE && $newValue !== null) {
                         $inverseAssoc = $targetClass->associationMappings[$assoc['inversedBy']];
                         $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($newValue, $entity);
                     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class GH9027Test extends OrmFunctionalTestCase
 {
@@ -15,15 +14,20 @@ class GH9027Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(GH9027Customer::class),
-                    $this->_em->getClassMetadata(GH9027Cart::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH9027Cart::class),
+            $this->_em->getClassMetadata(GH9027Customer::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(GH9027Cart::class),
+            $this->_em->getClassMetadata(GH9027Customer::class),
+        ]);
+
+        parent::tearDown();
     }
 
     /**
@@ -31,9 +35,14 @@ class GH9027Test extends OrmFunctionalTestCase
      */
     public function testUnitOfWorkHandlesNullRelations(): void
     {
-        $uow = new UnitOfWork($this->_em);
+        $uow   = new UnitOfWork($this->_em);
         $hints = ['fetchMode' => [GH9027Cart::class => ['customer' => ClassMetadata::FETCH_EAGER]]];
-        $cart = $uow->createEntity(GH9027Cart::class, ['id' => 1, 'customer' => 24252], $hints);
+
+        $cart = $uow->createEntity(
+            GH9027Cart::class,
+            ['id' => 1, 'customer' => 24252],
+            $hints
+        );
 
         $this->assertEquals(null, $cart->customer);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Exception;
+
+class GH9027Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            $this->_schemaTool->createSchema(
+                [
+                    $this->_em->getClassMetadata(GH9027Customer::class),
+                    $this->_em->getClassMetadata(GH9027Cart::class),
+                ]
+            );
+        } catch (Exception $e) {
+        }
+    }
+
+    /**
+     * @group GH-9027
+     */
+    public function testUnitOfWorkHandlesNullRelations(): void
+    {
+        $uow = new UnitOfWork($this->_em);
+        $hints = ['fetchMode' => [GH9027Cart::class => ['customer' => ClassMetadata::FETCH_EAGER]]];
+        $cart = $uow->createEntity(GH9027Cart::class, ['id' => 1, 'customer' => 24252], $hints);
+
+        $this->assertEquals(null, $cart->customer);
+    }
+}
+
+/** @Entity */
+class GH9027Customer
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var GH9027Cart
+     * @OneToOne(targetEntity="GH9027Cart", mappedBy="customer")
+     */
+    public $cart;
+}
+
+/** @Entity */
+class GH9027Cart
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var GH9027Customer
+     * @OneToOne(targetEntity="GH9027Customer", inversedBy="cart")
+     * @JoinColumn(name="customer", referencedColumnName="id")
+     */
+    public $customer;
+}


### PR DESCRIPTION
If `$this->em->find()` returns null, don't treat it like an object. Instead, just set the field to null and back out of the switch statement.

Includes a was-failing-but-now-passing test case.

Fixes #9027