### PR TITLE
Implementing `$qb->setIdentifier()` to support `literal-string`

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\ORM\Cache\TimestampCacheKey;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
+use Doctrine\ORM\Query\Identifier;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -92,6 +93,14 @@ abstract class AbstractQuery
      * @psalm-var ArrayCollection<int, Parameter>
      */
     protected $parameters;
+
+    /**
+     * The identifier map of this query.
+     *
+     * @var ArrayCollection|Identifier[]
+     * @psalm-var ArrayCollection<int, Identifier>
+     */
+    protected $identifiers;
 
     /**
      * The user-specified ResultSetMapping to use.
@@ -169,10 +178,11 @@ abstract class AbstractQuery
      */
     public function __construct(EntityManagerInterface $em)
     {
-        $this->_em        = $em;
-        $this->parameters = new ArrayCollection();
-        $this->_hints     = $em->getConfiguration()->getDefaultQueryHints();
-        $this->hasCache   = $this->_em->getConfiguration()->isSecondLevelCacheEnabled();
+        $this->_em         = $em;
+        $this->parameters  = new ArrayCollection();
+        $this->identifiers = new ArrayCollection();
+        $this->_hints      = $em->getConfiguration()->getDefaultQueryHints();
+        $this->hasCache    = $this->_em->getConfiguration()->isSecondLevelCacheEnabled();
 
         if ($this->hasCache) {
             $this->cacheLogger = $em->getConfiguration()
@@ -297,13 +307,14 @@ abstract class AbstractQuery
     /**
      * Frees the resources used by the query object.
      *
-     * Resets Parameters, Parameter Types and Query Hints.
+     * Resets Parameters, Parameter Types, Identifiers and Query Hints.
      *
      * @return void
      */
     public function free()
     {
-        $this->parameters = new ArrayCollection();
+        $this->parameters  = new ArrayCollection();
+        $this->identifiers = new ArrayCollection();
 
         $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
     }
@@ -448,6 +459,142 @@ abstract class AbstractQuery
     }
 
     /**
+     * Get all defined identifiers.
+     *
+     * @return ArrayCollection The defined query identifiers.
+     * @psalm-return ArrayCollection<int, Identifier>
+     */
+    public function getIdentifiers()
+    {
+        return $this->identifiers;
+    }
+
+    /**
+     * Gets a query identifier.
+     *
+     * @param mixed $key The key (index or name) of the bound identifier.
+     *
+     * @return Identifier|null The value of the bound identifier, or NULL if not available.
+     */
+    public function getIdentifier($key)
+    {
+        $key = Query\Identifier::normalizeName($key);
+
+        $filteredIdentifiers = $this->identifiers->filter(
+            static function (Query\Identifier $identifier) use ($key): bool {
+                $identifierName = $identifier->getName();
+
+                return $key === $identifierName;
+            }
+        );
+
+        return ! $filteredIdentifiers->isEmpty() ? $filteredIdentifiers->first() : null;
+    }
+
+    /**
+     * Sets a collection of query identifiers.
+     *
+     * @param ArrayCollection|mixed[] $identifiers
+     * @psalm-param ArrayCollection<int, Identifier>|mixed[] $identifiers
+     *
+     * @return static This query instance.
+     */
+    public function setIdentifiers($identifiers)
+    {
+        // BC compatibility with 2.3-
+        if (is_array($identifiers)) {
+            /** @psalm-var ArrayCollection<int, Identifier> $identifierCollection */
+            $identifierCollection = new ArrayCollection();
+
+            foreach ($identifiers as $key => $value) {
+                $identifierCollection->add(new Identifier($key, $value));
+            }
+
+            $identifiers = $identifierCollection;
+        }
+
+        $this->identifiers = $identifiers;
+
+        return $this;
+    }
+
+    /**
+     * Sets a query identifier.
+     *
+     * @param string|int $key   The identifier position or name.
+     * @param mixed      $value The identifier value.
+     *
+     * @return static This query instance.
+     */
+    public function setIdentifier($key, $value)
+    {
+        $existingIdentifier = $this->getIdentifier($key);
+
+        if ($existingIdentifier !== null) {
+            $existingIdentifier->setValue($value);
+
+            return $this;
+        }
+
+        $this->identifiers->add(new Identifier($key, $value));
+
+        return $this;
+    }
+
+    /**
+     * Processes an individual identifier value.
+     *
+     * @param mixed $value
+     *
+     * @return mixed[]|string|int|float|bool
+     * @psalm-return array|scalar
+     *
+     * @throws ORMInvalidArgumentException
+     */
+    public function processIdentifierValue($value)
+    {
+        if (is_scalar($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Collection) {
+            $value = iterator_to_array($value);
+        }
+
+        if (is_array($value)) {
+            $value = $this->processArrayIdentifierValue($value);
+
+            return $value;
+        }
+
+        if ($value instanceof Mapping\ClassMetadata) {
+            return $value->name;
+        }
+
+        if (! is_object($value)) {
+            return $value;
+        }
+
+        try {
+            $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
+
+            if ($value === null) {
+                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+            }
+        } catch (MappingException | ORMMappingException $e) {
+            /* Silence any mapping exceptions. These can occur if the object in
+               question is not a mapped entity, in which case we just don't do
+               any preparation on the value.
+               Depending on MappingDriver, either MappingException or
+               ORMMappingException is thrown. */
+
+            $value = $this->potentiallyProcessIterable($value);
+        }
+
+        return $value;
+    }
+
+    /**
      * If no mapping is detected, trying to resolve the value as a Traversable
      *
      * @param mixed $value
@@ -476,6 +623,23 @@ abstract class AbstractQuery
         foreach ($value as $key => $paramValue) {
             $paramValue  = $this->processParameterValue($paramValue);
             $value[$key] = is_array($paramValue) ? reset($paramValue) : $paramValue;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Process an identifier value which was previously identified as an array
+     *
+     * @param mixed[] $value
+     *
+     * @return mixed[]
+     */
+    private function processArrayIdentifierValue(array $value): array
+    {
+        foreach ($value as $key => $identifierValue) {
+            $identifierValue = $this->processIdentifierValue($identifierValue);
+            $value[$key]     = is_array($identifierValue) ? reset($identifierValue) : $identifierValue;
         }
 
         return $value;
@@ -1215,7 +1379,8 @@ abstract class AbstractQuery
      */
     public function __clone()
     {
-        $this->parameters = new ArrayCollection();
+        $this->parameters  = new ArrayCollection();
+        $this->identifiers = new ArrayCollection();
 
         $this->_hints = [];
         $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
@@ -1242,9 +1407,21 @@ abstract class AbstractQuery
             return $this->processParameterValue($value);
         }, $this->parameters->getValues());
 
+        $identifiers = array_map(function (Identifier $identifier) {
+            $value = $identifier->getValue();
+
+            // Small optimization
+            // Does not invoke processIdentifierValue for scalar value
+            if (is_scalar($value)) {
+                return $value;
+            }
+
+            return $this->processIdentifierValue($value);
+        }, $this->identifiers->getValues());
+
         ksort($hints);
 
-        return sha1($query . '-' . serialize($params) . '-' . serialize($hints));
+        return sha1($query . '-' . serialize($params) . '-' . serialize($identifiers) . '-' . serialize($hints));
     }
 
     /** @param iterable<mixed> $subject */

--- a/lib/Doctrine/ORM/Query/Identifier.php
+++ b/lib/Doctrine/ORM/Query/Identifier.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query;
+
+use function trim;
+
+/**
+ * Defines a Query Identifier.
+ *
+ * @link    www.doctrine-project.org
+ */
+class Identifier
+{
+    /**
+     * Returns the internal representation of a identifier name.
+     *
+     * @param string|int $name The identifier name or position.
+     *
+     * @return string The normalized identifier name.
+     */
+    public static function normalizeName($name)
+    {
+        return trim((string) $name, '{}');
+    }
+
+    /**
+     * The identifier name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The identifier value.
+     *
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param string $name  Identifier name
+     * @param mixed  $value Identifier value
+     */
+    public function __construct($name, $value)
+    {
+        $this->name = self::normalizeName($name);
+
+        $this->setValue($value);
+    }
+
+    /**
+     * Retrieves the Identifier name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Retrieves the Identifier value.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Defines the Identifier value.
+     *
+     * @param mixed $value Identifier value.
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -53,6 +53,9 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /** @var list<mixed> */
     private $parameters = [];
 
+    /** @var list<mixed> */
+    private $identifiers = [];
+
     /**
      * Constructor
      *
@@ -83,6 +86,27 @@ class QueryExpressionVisitor extends ExpressionVisitor
     public function clearParameters()
     {
         $this->parameters = [];
+    }
+
+    /**
+     * Gets bound identifiers.
+     * Filled after {@link dispach()}.
+     *
+     * @return ArrayCollection<int, mixed>
+     */
+    public function getIdentifiers()
+    {
+        return new ArrayCollection($this->identifiers);
+    }
+
+    /**
+     * Clears identifiers.
+     *
+     * @return void
+     */
+    public function clearIdentifiers()
+    {
+        $this->identifiers = [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -192,6 +192,7 @@ class Paginator implements Countable, IteratorAggregate
         $cloneQuery = clone $query;
 
         $cloneQuery->setParameters(clone $query->getParameters());
+        $cloneQuery->setIdentifiers(clone $query->getIdentifiers());
         $cloneQuery->setCacheable(false);
 
         foreach ($query->getHints() as $name => $value) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10,18 +10,20 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$resultCacheDriver !== null &amp;&amp; ! ($resultCacheDriver instanceof \Doctrine\Common\Cache\Cache)</code>
     </DocblockTypeContradiction>
-    <FalsableReturnStatement occurrences="1">
+    <FalsableReturnStatement occurrences="2">
       <code>! $filteredParameters-&gt;isEmpty() ? $filteredParameters-&gt;first() : null</code>
+      <code>! $filteredIdentifiers-&gt;isEmpty() ? $filteredIdentifiers-&gt;first() : null</code>
     </FalsableReturnStatement>
-    <InvalidFalsableReturnType occurrences="1">
+    <InvalidFalsableReturnType occurrences="2">
       <code>Parameter|null</code>
+      <code>Identifier|null</code>
     </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="3">
       <code>\Doctrine\Common\Cache\Cache</code>
       <code>int</code>
       <code>string</code>
     </InvalidNullableReturnType>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
       <code>$key</code>
     </InvalidScalarArgument>
     <MissingClosureParamType occurrences="3">
@@ -3459,16 +3461,18 @@
       <code>getRootAlias</code>
       <code>getRootAlias</code>
     </DeprecatedMethod>
-    <FalsableReturnStatement occurrences="1">
+    <FalsableReturnStatement occurrences="2">
       <code>! $filteredParameters-&gt;isEmpty() ? $filteredParameters-&gt;first() : null</code>
+      <code>! $filteredIdentifiers-&gt;isEmpty() ? $filteredIdentifiers-&gt;first() : null</code>
     </FalsableReturnStatement>
-    <InvalidFalsableReturnType occurrences="1">
+    <InvalidFalsableReturnType occurrences="2">
       <code>Parameter|null</code>
+      <code>Identifier|null</code>
     </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="1">
       <code>int</code>
     </InvalidNullableReturnType>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument occurrences="2">
       <code>$key</code>
     </InvalidScalarArgument>
     <NullableReturnStatement occurrences="1">

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Cache;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\Query\Identifier;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\QueryBuilder;
@@ -694,6 +695,69 @@ class QueryBuilderTest extends OrmTestCase
         $qb->setParameters($parameters);
 
         $this->assertEquals($parameters->first(), $qb->getParameter('id'));
+    }
+
+    public function testSetIdentifier(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u')
+            ->where('{identifier} = 1')
+            ->setIdentifier('identifier', 'id');
+
+        $identifier = new Identifier('identifier', 'id');
+        $inferred   = $qb->getIdentifier('identifier');
+
+        $this->assertEquals('{identifier} = 1', (string) $qb->getDQLPart('where'));
+
+        self::assertSame($identifier->getValue(), $inferred->getValue());
+    }
+
+    public function testSetIdentifiers(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('u')
+           ->from(CmsUser::class, 'u')
+           ->where($qb->expr()->orX('{identifier1} = 1', '{identifier2} = 1'));
+
+        $identifiers = new ArrayCollection();
+        $identifiers->add(new Identifier('identifier1', 'id'));
+        $identifiers->add(new Identifier('identifier2', 'parent_id'));
+
+        $qb->setIdentifiers($identifiers);
+
+        $this->assertEquals($identifiers, $qb->getQuery()->getIdentifiers());
+    }
+
+    public function testGetIdentifiers(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('u')
+           ->from(CmsUser::class, 'u')
+           ->where('{identifier} = 1');
+
+        $identifiers = new ArrayCollection();
+        $identifiers->add(new Identifier('identifier', 'id'));
+
+        $qb->setIdentifiers($identifiers);
+
+        $this->assertEquals($identifiers, $qb->getIdentifiers());
+    }
+
+    public function testGetIdentifier(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u')
+            ->where('{identifier} = 1');
+
+        $identifiers = new ArrayCollection();
+        $identifiers->add(new Identifier('identifier', 'id'));
+
+        $qb->setIdentifiers($identifiers);
+
+        $this->assertEquals($identifiers->first(), $qb->getIdentifier('identifier'));
+        // $this->assertEquals('TODO', $qb->getQuery()->getSQL('identifier'));
     }
 
     public function testMultipleWhere(): void


### PR DESCRIPTION
**Not ready yet**. Just trying to start a discussion on supporting `Identifiers` (table and field names), in a similar way to how `Parameters` work. 

This would allow several `QueryBuilder` methods to use `literal-string` values (strings written by the developer), so anyone using static-analysis will be prevented from creating Injection Vulnerabilities ([ref #8933](https://github.com/doctrine/orm/issues/8933)).

The first commit just adds the public methods to set/get Identifiers. I'm not too sure where the `Identifier` values should be added to the SQL, maybe in `Query::parse()`, using `$platform->quoteIdentifier()`?