### PR TITLE
fix: prevent TypeError in QueryBuilder joins

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1016,7 +1016,7 @@ class QueryBuilder
      */
     public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
     {
-        $parentAlias = substr($join, 0, strpos($join, '.'));
+        $parentAlias = substr($join, 0, (int) strpos($join, '.'));
 
         $rootAlias = $this->findRootAlias($alias, $parentAlias);
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1269,4 +1269,15 @@ class QueryBuilderTest extends OrmTestCase
         self::assertSame(3, $builder->getParameter('0')->getValue());
         self::assertSame('Doctrine', $builder->getParameter('name')->getValue());
     }
+
+    public function testJoin(): void
+    {
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u')
+            ->leftJoin(CmsArticle::class, 'a0')
+            ->innerJoin(CmsArticle::class, 'a1');
+
+        self::assertSame('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN Doctrine\Tests\Models\CMS\CmsArticle a0 INNER JOIN Doctrine\Tests\Models\CMS\CmsArticle a1', $builder->getDQL());
+    }
 }


### PR DESCRIPTION
Closes https://github.com/doctrine/orm/issues/8878. Related to https://github.com/php/php-src/pull/7533.

This currently breaks API Platform's CI.