### PR TITLE
Add PHP 8.1 to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,10 @@ jobs:
         include:
           - php-version: "8.0"
             dbal-version: "2.13"
-          - php-version: "8.0"
+          # To be merged with the previous job as soon as https://github.com/doctrine/dbal/pull/4818 is released.
+          - php-version: "8.1"
+            dbal-version: "2.13.4@dev"
+          - php-version: "8.1"
             dbal-version: "3.2@dev"
 
     steps:

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
@@ -55,7 +55,9 @@ final class GH7941Test extends OrmFunctionalTestCase
         $result = $query->getSingleResult();
 
         self::assertSame(6, $result['count']);
-        self::assertSame('325', $result['sales']);
+
+        // While other drivers will return a string, pdo_sqlite returns an integer as of PHP 8.1
+        self::assertEquals(325, $result['sales']);
 
         // Driver return type and precision is determined by the underlying php extension, most seem to return a string.
         // pdo_mysql and mysqli both currently return '54.1667' so this is the maximum precision we can assert.
@@ -73,7 +75,7 @@ final class GH7941Test extends OrmFunctionalTestCase
         foreach ($query->getResult() as $i => $item) {
             $product = self::PRODUCTS[$i];
 
-            self::assertSame(ltrim($product['price'], '-'), $item['absolute']);
+            self::assertEquals(ltrim($product['price'], '-'), $item['absolute']);
             self::assertSame(strlen($product['name']), $item['length']);
 
             // Driver return types for the `square_root` column are inconsistent depending on the underlying


### PR DESCRIPTION
Since the CI configuration for 2.10.x is very different from 2.9.x, I decided to open a follow-up PR to #9006 for 2.10.x.