### PR TITLE
Run PHP 8.1 CI with stable dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,11 +35,6 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
-      # To be removed as soon as https://github.com/doctrine/dbal/pull/4818 is released.
-      - name: "Switch to dev dependencies"
-        if: "${{ matrix.php-version == '8.1' }}"
-        run: "composer config minimum-stability dev"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
 


### PR DESCRIPTION
Removing our workaround, now that DBAL 2.13.4 has been released.