### PR TITLE
Revert to older automatic releases

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -15,7 +15,9 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "laminas/automatic-releases@v1"
+        # revert to v1 when
+        # https://github.com/laminas/automatic-releases/issues/166 is fixed
+        uses: "laminas/automatic-releases@1.11.1"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -26,7 +28,9 @@ jobs:
           "SHELL_VERBOSITY": "3"
 
       - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@v1"
+        # revert to v1 when
+        # https://github.com/laminas/automatic-releases/issues/166 is fixed
+        uses: "laminas/automatic-releases@1.11.1"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
@@ -36,7 +40,9 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create new milestones"
-        uses: "laminas/automatic-releases@v1"
+        # revert to v1 when
+        # https://github.com/laminas/automatic-releases/issues/166 is fixed
+        uses: "laminas/automatic-releases@1.11.1"
         with:
           command-name: "laminas:automatic-releases:create-milestones"
         env:


### PR DESCRIPTION
1.12.0 and up comes with a migration to azjezz/psl that makes it
impossible to troubleshoot issues with external commands such as git push

Example of failing build: https://github.com/doctrine/orm/runs/3782157355?check_suite_focus=true#step:4:18
Migration to PSL: https://github.com/laminas/automatic-releases/commit/6ad991b65aa5b9d52febf91dc9ca3f812a80952e
Issue on automatic-releases: https://github.com/laminas/automatic-releases/issues/166

1.11.1 uses `symfony/process`, and unless output is disabled, it should display the output: https://github.com/symfony/process/blob/38f26c7d6ed535217ea393e05634cb0b244a1967/Exception/ProcessFailedException.php#L38-L43