### PR TITLE
Avoid triggering workflows for tags

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,11 @@ name: "Continuous Integration"
 
 on:
   pull_request:
+    branches:
+      - "*.x"
   push:
+    branches:
+      - "*.x"
 
 env:
   fail-fast: true


### PR DESCRIPTION
To avoid recursive workflows, Github will prevent the release bot from
pushing tags because that would result in a new workflow being triggered.