### PR TITLE
Explicitly disallow workflows for tags

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - "*.x"
+    tag-ignore:
+      - "*"
   push:
     branches:
       - "*.x"
+    tag-ignore:
+      - "*"
 
 env:
   fail-fast: true


### PR DESCRIPTION
Despite what is described in the docs, it seems that there is still an
attempt to run a workflow for tags.