### PR TITLE
Deprecate `AbstractHydrator::hydrateRow()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade to 2.11
+
+## Deprecated: `AbstractHydrator::hydrateRow()`
+
+Following the deprecation of the method `AbstractHydrator::iterate()`, the
+method `hydrateRow()` has been deprecated as well.
+
 # Upgrade to 2.10
 
 ## BC Break: Removed `TABLE` id generator strategy

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -274,10 +274,19 @@ abstract class AbstractHydrator
      * Hydrates a single row returned by the current statement instance during
      * row-by-row hydration with {@link iterate()} or {@link toIterable()}.
      *
+     * @deprecated
+     *
      * @return mixed[]|false
      */
     public function hydrateRow()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9072',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         $row = $this->statement()->fetchAssociative();
 
         if ($row === false) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,8 @@
                 <!-- We need to keep the calls for DBAL 2.13 compatibility. -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getSchemaManager"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
+                <!-- Remove on 3.0.x -->
+                <referencedMethod name="Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateRow"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>


### PR DESCRIPTION
While removing the `iterate()` methods, I noticed that the public method `AbstractHydrator::hydrateRow()` has become obsolete because we don't call it anymore. I'd like to remove it as well.