### PR TITLE
Deprecate `ensureProductionSettings()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,16 @@
 Following the deprecation of the method `AbstractHydrator::iterate()`, the
 method `hydrateRow()` has been deprecated as well.
 
+## Deprecate cache settings inspection
+
+Doctrine does not provide its own cache implementation anymore and relies on
+the PSR-6 standard instead. As a consequence, we cannot determine anymore
+whether a given cache adapter is suitable for a production environment.
+Because of that, functionality that aims to do so has been deprecated:
+
+* `Configuration::ensureProductionSettings()`
+* the `orm:ensure-production-settings` console command
+
 # Upgrade to 2.10
 
 ## BC Break: Removed `TABLE` id generator strategy

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -510,6 +510,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Ensures that this Configuration instance contains settings that are
      * suitable for a production environment.
      *
+     * @deprecated
+     *
      * @return void
      *
      * @throws ProxyClassesAlwaysRegenerating
@@ -518,6 +520,13 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function ensureProductionSettings()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9074',
+            '%s is deprecated',
+            __METHOD__
+        );
+
         $queryCacheImpl = $this->getQueryCacheImpl();
 
         if (! $queryCacheImpl) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -13,6 +13,8 @@ use Throwable;
 /**
  * Command to ensure that Doctrine is properly configured for a production environment.
  *
+ * @deprecated
+ *
  * @link    www.doctrine-project.org
  */
 class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
@@ -37,6 +39,7 @@ class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
+        $ui->warning('This console command has been deprecated and will be removed in a future version of Doctrine ORM.');
 
         $em = $this->getEntityManager($input);
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,6 +23,8 @@
                 <referencedClass name="Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper"/>
                 <!-- The exception is thrown by a deprecated method. -->
                 <referencedClass name="Doctrine\ORM\Cache\Exception\InvalidResultCacheDriver"/>
+                <!-- Remove on 3.0.x -->
+                <referencedClass name="Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>
@@ -34,6 +36,7 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
                 <!-- Remove on 3.0.x -->
                 <referencedMethod name="Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateRow"/>
+                <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>


### PR DESCRIPTION
Doctrine does not provide its own cache implementation anymore and relies on the PSR-6 standard instead. As a consequence, we cannot determine anymore whether a given cache adapter is suitable for a production environment.

The corresponding functionality has always been error-prone. For instance if cache adapters are decorated, the `orm:ensure-production-settings` command would not complain anymore. By adopting PSR-6, this gets even harder because we would need to have internal knowledge of any PSR-6 compatible library a user might potentially use.

Moreover, I really don't think that we should offer this kind of inspection and therefore propose to remove it.