### PR TITLE
Add integer cast in setMaxResults methods of Query and QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -675,6 +675,10 @@ final class Query extends AbstractQuery
      */
     public function setMaxResults($maxResults): self
     {
+        if ($maxResults !== null) {
+            $maxResults = (int) $maxResults;
+        }
+
         $this->maxResults = $maxResults;
         $this->_state     = self::STATE_DIRTY;
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -652,6 +652,10 @@ class QueryBuilder
      */
     public function setMaxResults($maxResults)
     {
+        if ($maxResults !== null) {
+            $maxResults = (int) $maxResults;
+        }
+
         $this->_maxResults = $maxResults;
 
         return $this;

--- a/psalm.xml
+++ b/psalm.xml
@@ -76,6 +76,13 @@
                 <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php"/>
             </errorLevel>
         </NullArgument>
+        <RedundantCastGivenDocblockType>
+            <errorLevel type="suppress">
+                <!-- Can be removed once the "getMaxResults" methods of those classes have native parameter types -->
+                <file name="lib/Doctrine/ORM/Query.php"/>
+                <file name="lib/Doctrine/ORM/QueryBuilder.php"/>
+            </errorLevel>
+        </RedundantCastGivenDocblockType>
         <TypeDoesNotContainType>
             <errorLevel type="suppress">
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>


### PR DESCRIPTION
Hello there :wave: 

This is my first PR here :grin: Hope, I have done it right.

With version 2.9.6 a native return type was added to the `Doctrine\ORM\Query::getMaxResults()` method.
To prevent type errors in userland due to wrong usage, an integer cast while setting the max result property was added.

Alternatively a native type to the parameter could be set. But I don't know, if this would be breaking. 
Psalm is failing due to a redundant cast, which is obvious :see_no_evil: 

Nevertheless I wanted to hear you opinions, whether this could be merged or if I need to fix our 50+ wrong usages :grimacing: 

Best regards :slightly_smiling_face:  