### PR TITLE
Add new Query::toIndexedIterable to honor INDEX BY construct

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -725,6 +725,14 @@ final class Query extends AbstractQuery
         return parent::toIterable($parameters, $hydrationMode);
     }
 
+    /** {@inheritDoc} */
+    public function toIndexedIterable(iterable $parameters = [], $hydrationMode = self::HYDRATE_OBJECT): iterable
+    {
+        $this->setHint(self::HINT_INTERNAL_ITERATION, true);
+
+        return parent::toIndexedIterable($parameters, $hydrationMode);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Fix the problem explained in #8927 as a feature

Alternative implementation as a bugfix in #9098 