### PR TITLE
Changed EntityRepository count method $criteria parameter to optional

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.0
 
+## BC BREAK: EntityRepository::count() signature change
+
+The argument `$criteria` of `Doctrine\ORM\EntityRepository::count()` is now
+optional. Overrides in child classes should be made compatible.
+
 ## BC BREAK: changes in exception hierarchy
 
 - `Doctrine\ORM\ORMException` has been removed

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -227,7 +227,7 @@ class EntityRepository implements ObjectRepository, Selectable
      *
      * @todo Add this method to `ObjectRepository` interface in the next major release
      */
-    public function count(array $criteria)
+    public function count(array $criteria = [])
     {
         return $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName)->count($criteria);
     }


### PR DESCRIPTION
Currently to get count of all items there is need to provide empty array to count() method as $criteria parameter is required.
I believe there shouldn't be a need to provide it if I want to count all Entities without any criteria.