### PR TITLE
`Query::getResult` and `Query::toIterable` results differ when selecting multiple entities.

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\IterableTester;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsTag;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -111,6 +112,63 @@ final class QueryIterableTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery('select a from ' . CmsArticle::class . ' a INDEX BY a.topic');
+        IterableTester::assertResultsAreTheSame($query);
+    }
+
+    public function testIterableWithMultipleSelectElements(): void
+    {
+        $tag       = new CmsTag();
+        $tag->name = 'Symfony 2';
+
+        $article        = new CmsArticle();
+        $article->topic = 'Doctrine 2';
+        $article->text  = 'This is an introduction to Doctrine 2.';
+
+        $this->_em->persist($tag);
+        $this->_em->persist($article);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('SELECT a, t FROM ' . CmsArticle::class . ' a, ' . CmsTag::class . ' t');
+        IterableTester::assertResultsAreTheSame($query);
+    }
+
+    public function testIterableWithMultipleJoinedSelectElements(): void
+    {
+        $tag1       = new CmsTag();
+        $tag1->name = 'Doctrine 2';
+
+        $tag2       = new CmsTag();
+        $tag2->name = 'Laminas';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Doctrine 2';
+        $article2->text  = 'This is an advanced guide to Doctrine 2.';
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'Laminas';
+        $article3->text  = 'This is an introduction to Laminas.';
+
+        $article4        = new CmsArticle();
+        $article4->topic = 'Laminas';
+        $article4->text  = 'This is an advanced guide to Laminas.';
+
+        $this->_em->persist($tag1);
+        $this->_em->persist($tag2);
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($article4);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('SELECT a, t FROM ' . CmsArticle::class . ' a JOIN ' . CmsTag::class . ' t WITH a.topic = t.name');
         IterableTester::assertResultsAreTheSame($query);
     }
 }


### PR DESCRIPTION
While working on #9098 I've found this bug so I open this PR with a test for the exposed bug.

For the test in the PR with 4 articles (a), for 1 author (u), `Query::getResult` returns 5 results because it only returns one entity per position, while `Query::toIterable` returns 4 results because it combines the selected entities.

  - `Query::getResult` output is `[a1, u, a2, a3, a4]`
  - `Query::toIterable` output is `[[a1, u], [a2, u], [a3, u], [a4, u]]`

I prefer the `Query::toIterable` output, so my questions are:
  - must we fix `Query::toIterable` to mimic the `Query::getResult` output?
  - if we fix it, must we add another iterable funcion to `Query` with the same output currently produced by `Query::toIterable`?
  - can we assume that output from `Query::toIterable` and `Query::getResult` can differ when selecting multiple entities?
