### PR TITLE
Add XSD "orm:columntoken" type in order to support reserved words in column names

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -295,7 +295,7 @@
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
-    <xs:attribute name="column" type="xs:NMTOKEN" />
+    <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />
     <xs:attribute name="nullable" type="xs:boolean" default="false" />
@@ -402,7 +402,7 @@
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="type" type="xs:NMTOKEN" />
-    <xs:attribute name="column" type="xs:NMTOKEN" />
+    <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="association-key" type="xs:boolean" default="false" />
     <xs:attribute name="column-definition" type="xs:string" />
@@ -494,6 +494,12 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="ASC"/>
       <xs:enumeration value="DESC"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="columntoken" id="columntoken">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[-._:A-Za-z0-9`]+" id="columntoken.pattern"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -612,7 +618,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
-    <xs:attribute name="column" type="xs:NMTOKEN" />
+    <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />
     <xs:attribute name="nullable" type="xs:boolean" default="false" />

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1119,6 +1119,13 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $class = $this->createClassMetadata(SingleTableEntityIncompleteDiscriminatorColumnMapping::class);
         self::assertEquals('dtype', $class->discriminatorColumn['name']);
     }
+
+    public function testReservedWordInTableColumn(): void
+    {
+        $metadata = $this->createClassMetadata(ReservedWordInTableColumn::class);
+
+        self::assertSame('count', $metadata->getFieldMapping('count')['columnName']);
+    }
 }
 
 /**
@@ -1773,4 +1780,43 @@ class SingleTableEntityIncompleteDiscriminatorColumnMappingSub1 extends SingleTa
 }
 class SingleTableEntityIncompleteDiscriminatorColumnMappingSub2 extends SingleTableEntityIncompleteDiscriminatorColumnMapping
 {
+}
+
+/** @Entity */
+#[ORM\Entity]
+class ReservedWordInTableColumn
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     */
+    #[ORM\Id, ORM\Column(type: 'integer'), ORM\GeneratedValue(strategy: 'NONE')]
+    public $id;
+
+    /**
+     * @var string|null
+     * @Column(name="`count`", type="integer")
+     */
+    #[ORM\Column(name: '`count`', type: 'integer')]
+    public $count;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    {
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+                'type' => 'integer',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'count',
+                'type' => 'integer',
+                'columnName' => '`count`',
+            ]
+        );
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+        'type' => 'integer',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'count',
+        'type' => 'integer',
+        'columnName' => '`count`',
+    ]
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.dcm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\ORM\Mapping\ReservedWordInTableColumn">
+
+    <id name="id" type="integer" column="id">
+      <generator strategy="NONE"/>
+    </id>
+
+    <field name="count" column="`count`" type="integer"/>
+
+  </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.ReservedWordInTableColumn.dcm.yml
@@ -1,0 +1,10 @@
+Doctrine\Tests\ORM\Mapping\ReservedWordInTableColumn:
+  type: entity
+  id:
+    id: 
+      generator:
+        strategy: NONE
+  fields:
+    count:
+      type: integer
+      column: '`count`'


### PR DESCRIPTION
I don't know if this is the proper way to support backticks in the column definition from the XML perspective, but currently if they are used, the schema validation fails (see this [sample action](https://github.com/doctrine/orm/runs/3886078049?check_suite_focus=true#step:6:92)):
```
element field: Schemas validity error : Element '{http://doctrine-project.org/schemas/orm/doctrine-mapping}field', attribute 'column': '`count`' is not a valid value of the atomic type 'xs:NMTOKEN'.
```
See [**Quoting Reserved Words**](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html#quoting-reserved-words).