### PR TITLE
Adding a setup helper for attribute metadata config

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -14,6 +14,7 @@ use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\ClassLoader;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Memcached;
@@ -69,6 +70,25 @@ class Setup
     {
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths, $useSimpleAnnotationReader));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration with an attribute metadata driver.
+     *
+     * @param mixed[] $paths
+     * @param bool    $isDevMode
+     * @param string  $proxyDir
+     */
+    public static function createAttributeMetadataConfiguration(
+        array $paths,
+        $isDevMode = false,
+        $proxyDir = null,
+        ?Cache $cache = null
+    ): Configuration {
+        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(new AttributeDriver($paths));
 
         return $config;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Tools;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\ORM\Tools\Setup;
@@ -65,6 +66,19 @@ class SetupTest extends OrmTestCase
         self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
         self::assertEquals('DoctrineProxies', $config->getProxyNamespace());
         self::assertInstanceOf(AnnotationDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testAttributeConfiguration(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
+        self::assertEquals('DoctrineProxies', $config->getProxyNamespace());
+        self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
     }
 
     public function testXMLConfiguration(): void


### PR DESCRIPTION
I noticed there was a `\Doctrine\ORM\Tools\Setup::createAnnotationMetadataConfiguration` method, but a method for attributes was missing. This PR adds a  similar `\Doctrine\ORM\Tools\Setup::createAttributeMetadataConfiguration` method as well.

First time PR to Doctrine so go easy :)