### PR TITLE
Upgrade workflows to 1.1.1

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   coding-standards:
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.0.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"
     with:
       php-version: "7.4"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.0.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1"
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
That version fixes a bug with the release workflow. Releasing is not
possible unless we do that upgrade.