### PR TITLE
return 0 when there's no metadata to process

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -151,7 +151,7 @@ EOT
         if (empty($metadata)) {
             $ui->success('No Metadata Classes to process.');
 
-            return;
+            return 0;
         }
 
         foreach ($metadata as $class) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2022,11 +2022,6 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Tools\\\\Console\\\\Command\\\\ConvertMappingCommand\\:\\:execute\\(\\) should return int but empty return statement found\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$metadata of method Doctrine\\\\ORM\\\\Tools\\\\Export\\\\Driver\\\\AbstractExporter\\:\\:setMetadata\\(\\) expects array\\<int, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\>, array\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php


### PR DESCRIPTION
fixes symfony command throwing a type error in the run method.

happens @ https://github.com/symfony/console/blob/5.3/Command/Command.php#L301