### PR TITLE
Detect enums and use type string (PHP 8.1 only)

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1493,6 +1493,10 @@ class ClassMetadataInfo implements ClassMetadata
                     case 'string':
                         $mapping['type'] = Types::STRING;
                         break;
+                    default:
+                        if (PHP_VERSION_ID >= 80100 && enum_exists($type->getName())) {
+                            $mapping['type'] = Types::ENUM;
+                        }
                 }
             }
         }

--- a/tests/Doctrine/Tests/Models/TypedProperties/Article.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/Article.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\TypedProperties;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity, ORM\Table(name: 'cms_articles_enumed')]
+class Article
+{
+    #[ORM\Id, ORM\Column, ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Column]
+    public ArticleStateEnum $enum;
+}

--- a/tests/Doctrine/Tests/Models/TypedProperties/ArticleStateEnum.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/ArticleStateEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\TypedProperties;
+
+enum ArticleStateEnum
+{
+case DRAFT;
+case PUBLISHED;
+    }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -135,7 +135,7 @@ class ClassMetadataTest extends OrmTestCase
     public function testFieldTypeFromReflection(): void
     {
         if (PHP_VERSION_ID < 70400) {
-            self::markTestSkipped('requies PHP 7.4');
+            self::markTestSkipped('requires PHP 7.4');
         }
 
         $cm = new ClassMetadata(TypedProperties\UserTyped::class);
@@ -172,6 +172,19 @@ class ClassMetadataTest extends OrmTestCase
         // float
         $cm->mapField(['fieldName' => 'float']);
         self::assertEquals('float', $cm->getTypeOfField('float'));
+    }
+
+    public function testFieldTypeEnumFromReflection(): void
+    {
+        if (PHP_VERSION_ID < 80100) {
+            self::markTestSkipped('requires PHP 8.1');
+        }
+
+        $cm = new ClassMetadata(TypedProperties\Article::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'enum']);
+        self::assertEquals('enum', $cm->getTypeOfField('enum'));
     }
 
     /**


### PR DESCRIPTION
This is a patch for #9021 .

Edit: test added.


See https://github.com/doctrine/dbal/pull/4930