### PR TITLE
Add doctrine/dbal to project composer.json

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -114,10 +114,13 @@ Add the following directories:
     The YAML driver is deprecated and will be removed in version 3.0.
     It is strongly recommended to switch to one of the other mappings.
 .. note::
-    When using the entity data mapping it is best practice to explicity
-    specify the version of ``doctrine/dbal`` in your ``composer.json``.
-    This helps ensure that your entity data mappings remain supported
-    through package upgrades.
+    It is strongly recommended that you require doctrine/dbal in your
+    composer.json as well, because using the ORM means mapping objects
+    and their fields to database tables and their columns, and that
+    requires mentioning so-called types that are defined in doctrine/dbal
+    in your application. Having an explicit requirement means you control
+    when the upgrade to the next major version happens, so that you can
+    do the necessary changes in your application beforehand.
 
 Obtaining the EntityManager
 ---------------------------

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -114,7 +114,10 @@ Add the following directories:
     The YAML driver is deprecated and will be removed in version 3.0.
     It is strongly recommended to switch to one of the other mappings.
 .. note::
-    When using the entity data mapping it is best practice to explicity specify the version of doctrine/dbal in your composer.json. This helps ensure that your entity data mappings remain supported through package upgrades.
+    When using the entity data mapping it is best practice to explicity
+    specify the version of ``doctrine/dbal`` in your ``composer.json``.
+    This helps ensure that your entity data mappings remain supported
+    through package upgrades.
 
 Obtaining the EntityManager
 ---------------------------

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -117,7 +117,7 @@ Add the following directories:
     It is strongly recommended that you require doctrine/dbal in your
     composer.json as well, because using the ORM means mapping objects
     and their fields to database tables and their columns, and that
-    requires mentioning so-called types that are defined in doctrine/dbal
+    requires mentioning so-called types that are defined in ``doctrine/dbal``
     in your application. Having an explicit requirement means you control
     when the upgrade to the next major version happens, so that you can
     do the necessary changes in your application beforehand.

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -114,7 +114,7 @@ Add the following directories:
     The YAML driver is deprecated and will be removed in version 3.0.
     It is strongly recommended to switch to one of the other mappings.
 .. note::
-    It is strongly recommended that you require doctrine/dbal in your
+    It is strongly recommended that you require ``doctrine/dbal`` in your
     composer.json as well, because using the ORM means mapping objects
     and their fields to database tables and their columns, and that
     requires mentioning so-called types that are defined in ``doctrine/dbal``

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -81,7 +81,8 @@ that directory with the following contents:
 
     {
         "require": {
-            "doctrine/orm": "^2.6.2",
+            "doctrine/orm": "^2.10.2",
+            "doctrine/dbal": "^3.1.1",
             "symfony/yaml": "2.*",
             "symfony/cache": "^5.3"
         },
@@ -112,6 +113,8 @@ Add the following directories:
 .. note::
     The YAML driver is deprecated and will be removed in version 3.0.
     It is strongly recommended to switch to one of the other mappings.
+.. note::
+    When using the entity data mapping it is best practice to explicity specify the version of doctrine/dbal in your composer.json. This helps ensure that your entity data mappings remain supported through package upgrades.
 
 Obtaining the EntityManager
 ---------------------------

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -115,7 +115,7 @@ Add the following directories:
     It is strongly recommended to switch to one of the other mappings.
 .. note::
     It is strongly recommended that you require ``doctrine/dbal`` in your
-    composer.json as well, because using the ORM means mapping objects
+    ``composer.json`` as well, because using the ORM means mapping objects
     and their fields to database tables and their columns, and that
     requires mentioning so-called types that are defined in ``doctrine/dbal``
     in your application. Having an explicit requirement means you control


### PR DESCRIPTION
As discussed in https://github.com/doctrine/orm/issues/9078 when entities utilize data mappings which are provided by the dbal lib it is expected behavior that users will explicitly define their dependency on the package.