### PR TITLE
Remove reverted bc break

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,10 +16,6 @@ It is now deprecated to rely on:
 - `Doctrine\ORM\Mapping\ClassMetadata::$tableGeneratorDefinition`;
 - or `Doctrine\ORM\Mapping\ClassMetadata::isIdGeneratorTable()`.
 
-## BC Break: Removed possibility to extend the doctrine mapping xml schema with anything
-
-If you want to extend it now you have to provide your own validation schema.
-
 ## New method `Doctrine\ORM\EntityManagerInterface#wrapInTransaction($func)`
 
 Works the same as `Doctrine\ORM\EntityManagerInterface#transactional()` but returns any value returned from `$func` closure rather than just _non-empty value returned from the closure or true_.


### PR DESCRIPTION
The bc break was reverted here: https://github.com/doctrine/orm/commit/12babcc1c24759002605057b79e5bc6f93e3bf0a#diff-5d251e7137bb3f96c0e8924dd898e75cdabaee0aca204879b649520b2e49a630