### PR TITLE
Fix discriminatorColumn phpdoc

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -12,7 +12,6 @@ use RuntimeException;
 
 use function array_keys;
 use function array_search;
-use function assert;
 use function count;
 use function in_array;
 use function key;
@@ -80,8 +79,7 @@ class SimpleObjectHydrator extends AbstractHydrator
 
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {
-            $discrColumn = $this->class->discriminatorColumn;
-            assert($discrColumn !== null);
+            $discrColumn     = $this->class->getDiscriminatorColumn();
             $discrColumnName = $this->getSQLResultCasing($this->_platform, $discrColumn['name']);
 
             // Find mapped discriminator column from the result set.

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -12,6 +12,7 @@ use RuntimeException;
 
 use function array_keys;
 use function array_search;
+use function assert;
 use function count;
 use function in_array;
 use function key;
@@ -79,7 +80,9 @@ class SimpleObjectHydrator extends AbstractHydrator
 
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {
-            $discrColumnName = $this->getSQLResultCasing($this->_platform, $this->class->discriminatorColumn['name']);
+            $discrColumn = $this->class->discriminatorColumn;
+            assert($discrColumn !== null);
+            $discrColumnName = $this->getSQLResultCasing($this->_platform, $discrColumn['name']);
 
             // Find mapped discriminator column from the result set.
             $metaMappingDiscrColumnName = array_search($discrColumnName, $this->resultSetMapping()->metaMappings, true);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -496,7 +496,7 @@ class ClassMetadataInfo implements ClassMetadata
      * READ-ONLY: The definition of the discriminator column used in JOINED and SINGLE_TABLE
      * inheritance mappings.
      *
-     * @psalm-var array<string, mixed>
+     * @psalm-var array<string, mixed>|null
      */
     public $discriminatorColumn;
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ReflectionService;
 use InvalidArgumentException;
+use LogicException;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
@@ -3096,6 +3097,18 @@ class ClassMetadataInfo implements ClassMetadata
 
             $this->discriminatorColumn = $columnDef;
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    final public function getDiscriminatorColumn(): array
+    {
+        if ($this->discriminatorColumn === null) {
+            throw new LogicException('The discriminator column was not set.');
+        }
+
+        return $this->discriminatorColumn;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -24,11 +24,9 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
         $data = parent::prepareInsertData($entity);
 
         // Populate the discriminator column
-        $discColumn = $this->class->discriminatorColumn;
-        if ($discColumn !== null) {
-            $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
-            $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
-        }
+        $discColumn                                                          = $this->class->getDiscriminatorColumn();
+        $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
+        $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
 
         return $data;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -24,9 +24,11 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
         $data = parent::prepareInsertData($entity);
 
         // Populate the discriminator column
-        $discColumn                                                          = $this->class->discriminatorColumn;
-        $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
-        $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
+        $discColumn = $this->class->discriminatorColumn;
+        if ($discColumn !== null) {
+            $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
+            $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
+        }
 
         return $data;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
+use function assert;
 use function implode;
 use function is_array;
 
@@ -411,15 +412,18 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
+        $discrColumn = $this->class->discriminatorColumn;
+        assert($discrColumn !== null);
+
         $columnList       = [];
-        $discrColumn      = $this->class->discriminatorColumn['name'];
-        $discrColumnType  = $this->class->discriminatorColumn['type'];
+        $discrColumnName  = $discrColumn['name'];
+        $discrColumnType  = $discrColumn['type'];
         $baseTableAlias   = $this->getSQLTableAlias($this->class->name);
-        $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumn);
+        $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumnName);
 
         $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r');
         $this->currentPersisterContext->rsm->setDiscriminatorColumn('r', $resultColumnName);
-        $this->currentPersisterContext->rsm->addMetaResult('r', $resultColumnName, $discrColumn, false, $discrColumnType);
+        $this->currentPersisterContext->rsm->addMetaResult('r', $resultColumnName, $discrColumnName, false, $discrColumnType);
 
         // Add regular columns
         foreach ($this->class->fieldMappings as $fieldName => $mapping) {
@@ -457,7 +461,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             ? $baseTableAlias
             : $this->getSQLTableAlias($this->class->rootEntityName);
 
-        $columnList[] = $tableAlias . '.' . $discrColumn;
+        $columnList[] = $tableAlias . '.' . $discrColumnName;
 
         // sub tables
         foreach ($this->class->subClasses as $subClassName) {
@@ -540,7 +544,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add discriminator column if it is the topmost class.
         if ($this->class->name === $this->class->rootEntityName) {
-            $columns[] = $this->class->discriminatorColumn['name'];
+            $discrColumn = $this->class->discriminatorColumn;
+            assert($discrColumn !== null);
+
+            $columns[] = $discrColumn['name'];
         }
 
         return $columns;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
-use function assert;
 use function implode;
-use function is_array;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -412,10 +410,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $discrColumn = $this->class->discriminatorColumn;
-        assert($discrColumn !== null);
-
         $columnList       = [];
+        $discrColumn      = $this->class->getDiscriminatorColumn();
         $discrColumnName  = $discrColumn['name'];
         $discrColumnType  = $discrColumn['type'];
         $baseTableAlias   = $this->getSQLTableAlias($this->class->name);
@@ -544,10 +540,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add discriminator column if it is the topmost class.
         if ($this->class->name === $this->class->rootEntityName) {
-            $discrColumn = $this->class->discriminatorColumn;
-            assert($discrColumn !== null);
-
-            $columns[] = $discrColumn['name'];
+            $columns[] = $this->class->getDiscriminatorColumn()['name'];
         }
 
         return $columns;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_flip;
-use function assert;
 use function implode;
 
 /**
@@ -45,10 +44,8 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $rootClass  = $this->em->getClassMetadata($this->class->rootEntityName);
         $tableAlias = $this->getSQLTableAlias($rootClass->name);
 
-        $discrColumn = $this->class->discriminatorColumn;
-        assert($discrColumn !== null);
-
-         // Append discriminator column
+        // Append discriminator column
+        $discrColumn     = $this->class->getDiscriminatorColumn();
         $discrColumnName = $discrColumn['name'];
         $discrColumnType = $discrColumn['type'];
 
@@ -103,11 +100,8 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
     {
         $columns = parent::getInsertColumnList();
 
-        $discrColumn = $this->class->discriminatorColumn;
-        assert($discrColumn !== null);
-
         // Add discriminator column to the INSERT SQL
-        $columns[] = $discrColumn['name'];
+        $columns[] = $this->class->getDiscriminatorColumn()['name'];
 
         return $columns;
     }
@@ -165,9 +159,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
             $values[] = $this->conn->quote($discrValues[$subclassName]);
         }
 
-        $discrColumn = $this->class->discriminatorColumn;
-        assert($discrColumn !== null);
-        $discColumnName = $discrColumn['name'];
+        $discColumnName = $this->class->getDiscriminatorColumn()['name'];
 
         $values     = implode(', ', $values);
         $tableAlias = $this->getSQLTableAlias($this->class->name);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
 use InvalidArgumentException;
 
+use function assert;
 use function explode;
 use function in_array;
 use function sprintf;
@@ -369,7 +370,10 @@ class ResultSetMappingBuilder extends ResultSetMapping
     {
         if (isset($entityMapping['discriminatorColumn']) && $entityMapping['discriminatorColumn']) {
             $discriminatorColumn = $entityMapping['discriminatorColumn'];
-            $discriminatorType   = $classMetadata->discriminatorColumn['type'];
+
+            $classMetadataDiscrColumn = $classMetadata->discriminatorColumn;
+            assert($classMetadataDiscrColumn !== null);
+            $discriminatorType = $classMetadataDiscrColumn['type'];
 
             $this->setDiscriminatorColumn($alias, $discriminatorColumn);
             $this->addMetaResult($alias, $discriminatorColumn, $discriminatorColumn, false, $discriminatorType);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
 use InvalidArgumentException;
 
-use function assert;
 use function explode;
 use function in_array;
 use function sprintf;
@@ -370,10 +369,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
     {
         if (isset($entityMapping['discriminatorColumn']) && $entityMapping['discriminatorColumn']) {
             $discriminatorColumn = $entityMapping['discriminatorColumn'];
-
-            $classMetadataDiscrColumn = $classMetadata->discriminatorColumn;
-            assert($classMetadataDiscrColumn !== null);
-            $discriminatorType = $classMetadataDiscrColumn['type'];
+            $discriminatorType   = $classMetadata->getDiscriminatorColumn()['type'];
 
             $this->setDiscriminatorColumn($alias, $discriminatorColumn);
             $this->addMetaResult($alias, $discriminatorColumn, $discriminatorColumn, false, $discriminatorType);

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -23,7 +23,6 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
-use function assert;
 use function count;
 use function implode;
 use function in_array;
@@ -466,10 +465,7 @@ class SqlWalker implements TreeWalker
                 ? $this->getSQLTableAlias($class->getTableName(), $dqlAlias) . '.'
                 : '';
 
-            $discrColumn = $class->discriminatorColumn;
-            assert($discrColumn !== null);
-
-            $sqlParts[] = $sqlTableAlias . $discrColumn['name'] . ' IN (' . implode(', ', $values) . ')';
+            $sqlParts[] = $sqlTableAlias . $class->getDiscriminatorColumn()['name'] . ' IN (' . implode(', ', $values) . ')';
         }
 
         $sql = implode(' AND ', $sqlParts);
@@ -743,8 +739,7 @@ class SqlWalker implements TreeWalker
                 // Add discriminator columns to SQL
                 $rootClass   = $this->em->getClassMetadata($class->rootEntityName);
                 $tblAlias    = $this->getSQLTableAlias($rootClass->getTableName(), $dqlAlias);
-                $discrColumn = $rootClass->discriminatorColumn;
-                assert($discrColumn !== null);
+                $discrColumn = $rootClass->getDiscriminatorColumn();
                 $columnAlias = $this->getSQLColumnAlias($discrColumn['name']);
 
                 $sqlSelectExpressions[] = $tblAlias . '.' . $discrColumn['name'] . ' AS ' . $columnAlias;
@@ -2096,10 +2091,7 @@ class SqlWalker implements TreeWalker
             $sql .= $this->getSQLTableAlias($discrClass->getTableName(), $dqlAlias) . '.';
         }
 
-        $discrColumn = $class->discriminatorColumn;
-        assert($discrColumn !== null);
-
-        $sql .= $discrColumn['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
+        $sql .= $class->getDiscriminatorColumn()['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
         $sql .= $this->getChildDiscriminatorsFromClassMetadata($discrClass, $instanceOfExpr);
 
         return $sql;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -23,6 +23,7 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
+use function assert;
 use function count;
 use function implode;
 use function in_array;
@@ -465,7 +466,10 @@ class SqlWalker implements TreeWalker
                 ? $this->getSQLTableAlias($class->getTableName(), $dqlAlias) . '.'
                 : '';
 
-            $sqlParts[] = $sqlTableAlias . $class->discriminatorColumn['name'] . ' IN (' . implode(', ', $values) . ')';
+            $discrColumn = $class->discriminatorColumn;
+            assert($discrColumn !== null);
+
+            $sqlParts[] = $sqlTableAlias . $discrColumn['name'] . ' IN (' . implode(', ', $values) . ')';
         }
 
         $sql = implode(' AND ', $sqlParts);
@@ -740,6 +744,7 @@ class SqlWalker implements TreeWalker
                 $rootClass   = $this->em->getClassMetadata($class->rootEntityName);
                 $tblAlias    = $this->getSQLTableAlias($rootClass->getTableName(), $dqlAlias);
                 $discrColumn = $rootClass->discriminatorColumn;
+                assert($discrColumn !== null);
                 $columnAlias = $this->getSQLColumnAlias($discrColumn['name']);
 
                 $sqlSelectExpressions[] = $tblAlias . '.' . $discrColumn['name'] . ' AS ' . $columnAlias;
@@ -2091,7 +2096,10 @@ class SqlWalker implements TreeWalker
             $sql .= $this->getSQLTableAlias($discrClass->getTableName(), $dqlAlias) . '.';
         }
 
-        $sql .= $class->discriminatorColumn['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
+        $discrColumn = $class->discriminatorColumn;
+        assert($discrColumn !== null);
+
+        $sql .= $discrColumn['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
         $sql .= $this->getChildDiscriminatorsFromClassMetadata($discrClass, $instanceOfExpr);
 
         return $sql;

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1140,7 +1140,11 @@ public function __construct(<params>)
             return '';
         }
 
-        $discrColumn      = $metadata->discriminatorColumn;
+        $discrColumn = $metadata->discriminatorColumn;
+        if ($discrColumn === null) {
+            return '';
+        }
+
         $columnDefinition = 'name="' . $discrColumn['name']
             . '", type="' . $discrColumn['type']
             . '", length=' . $discrColumn['length'];


### PR DESCRIPTION
Hi @greg0ire, since the property is not initialized, the phpdoc should allow `null`.
This avoid a phpstan error if we're doing an `isset` check on the property.

The other solution is to initialize the value to `[]` but tests are failing