### PR TITLE
Fine-tuning Licecycle Callbacks codeblock

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -292,21 +292,52 @@ specific to a particular entity class's lifecycle.
 
 .. configuration-block::
 
-    .. code-block:: php
+    .. code-block:: attribute
 
         <?php
 
         /**
-         * @Entity
-         * @HasLifecycleCallbacks // Not needed for XML and YAML mapping
+         * #[Entity]
+         * #[HasLifecycleCallbacks]
          */
         class User
         {
             // ...
 
-            /**
-             * @Column(type="string", length=255)
-             */
+            #[Column(type: 'string', length: 255)]
+            public $value;
+
+            #[PrePersist]
+            public function doStuffOnPrePersist()
+            {
+                $this->createdAt = date('Y-m-d H:i:s');
+            }
+
+            #[PrePersist]
+            public function doOtherStuffOnPrePersist()
+            {
+                $this->value = 'changed from prePersist callback!';
+            }
+
+            #[PostLoad]
+            public function doStuffOnPostLoad()
+            {
+                $this->value = 'changed from postLoad callback!';
+            }
+        }
+    .. code-block:: annotation
+
+        <?php
+
+        /**
+         * @Entity
+         * @HasLifecycleCallbacks
+         */
+        class User
+        {
+            // ...
+
+            /** @Column(type="string", length=255) */
             public $value;
 
             /** @PrePersist */
@@ -335,17 +366,14 @@ specific to a particular entity class's lifecycle.
               xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://doctrine-project.org/schemas/orm/doctrine-mapping
                                   https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-
             <entity name="User">
-
+                <!-- ... -->
                 <lifecycle-callbacks>
                     <lifecycle-callback type="prePersist" method="doStuffOnPrePersist"/>
                     <lifecycle-callback type="prePersist" method="doOtherStuffOnPrePersist"/>
                     <lifecycle-callback type="postLoad" method="doStuffOnPostLoad"/>
                 </lifecycle-callbacks>
-
             </entity>
-
         </doctrine-mapping>
     .. code-block:: yaml
 


### PR DESCRIPTION
* Deleting "Not needed for XML and YAML mapping" - this was stupid of me, since *all* annotations are obviously not needed in XML&YAML ;-)
* Shortening the `@Column` annotation, for consistency with the following event handlers
* Removing some blank lines from XML, for consistency with YAML
* Adding PHP Attributes