### PR TITLE
[Documentation] Events Overview Table: Adding "Passed Argument" column

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -297,6 +297,7 @@ specific to a particular entity class's lifecycle.
 
         <?php
         
+        use Doctrine\DBAL\Types\Types;
         use Doctrine\Persistence\Event\LifecycleEventArgs;
 
         /**
@@ -307,7 +308,7 @@ specific to a particular entity class's lifecycle.
         {
             // ...
 
-            #[Column(type: 'string', length: 255)]
+            #[Column(type: Types::STRING, length: 255)]
             public $value;
 
             #[PrePersist]

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -1079,8 +1079,8 @@ and the EntityManager.
         }
     }
 
-.. _LifecycleEventArgs: https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php
-.. _PreUpdateEventArgs: https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/Event/PreUpdateEventArgs.php
+.. _LifecycleEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+.. _PreUpdateEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
 .. _PreFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
 .. _PostFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
 .. _OnFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnFlushEventArgs.php

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -135,38 +135,38 @@ see :ref:`Lifecycle Callbacks<lifecycle-callbacks>`
 Events Overview
 ---------------
 
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| Event                                                           | Dispatched by         | Lifecycle | Passed                 |
-|                                                                 |                       | Callback  | Argument               |
-+=================================================================+=======================+===========+========================+
-| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       | `_LifecycleEventArgs`_ |
-|                                                                 | on *initial* persist  |           |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`preUpdate<reference-events-pre-update>`                   | ``$em->flush()``      | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`loadClassMetadata<reference-events-load-class-metadata>`  | Loading of mapping    | No        |                        |
-|                                                                 | metadata              |           |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| ``onClassMetadataNotFound``                                     | ``MappingException``  | No        |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`preFlush<reference-events-pre-flush>`                     | ``$em->flush()``      | Yes       |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`onFlush<reference-events-on-flush>`                       | ``$em->flush()``      | No        |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| :ref:`postFlush<reference-events-post-flush>`                   | ``$em->flush()``      | No        |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
-| ``onClear``                                                     | ``$em->clear()``      | No        |                        |
-+-----------------------------------------------------------------+-----------------------+-----------+------------------------+
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| Event                                                           | Dispatched by         | Lifecycle | Passed                              |
+|                                                                 |                       | Callback  | Argument                            |
++=================================================================+=======================+===========+=====================================+
+| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       | `_LifecycleEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `_LifecycleEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       | `_LifecycleEventArgs`_              |
+|                                                                 | on *initial* persist  |           |                                     |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       | `_LifecycleEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`preUpdate<reference-events-pre-update>`                   | ``$em->flush()``      | Yes       | `_PreUpdateEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `_LifecycleEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       | `_LifecycleEventArgs`_              |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`loadClassMetadata<reference-events-load-class-metadata>`  | Loading of mapping    | No        | `_LoadClassMetadataEventArgs`       |
+|                                                                 | metadata              |           |                                     |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| ``onClassMetadataNotFound``                                     | ``MappingException``  | No        | `_OnClassMetadataNotFoundEventArgs` |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`preFlush<reference-events-pre-flush>`                     | ``$em->flush()``      | Yes       | `_PreFlushEventArgs`_               |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`onFlush<reference-events-on-flush>`                       | ``$em->flush()``      | No        | `_OnFlushEventArgs`                 |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| :ref:`postFlush<reference-events-post-flush>`                   | ``$em->flush()``      | No        | `_PostFlushEventArgs`               |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
+| ``onClear``                                                     | ``$em->clear()``      | No        | `_OnClearEventArgs`                 |
++-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
 
 Naming convention
 ~~~~~~~~~~~~~~~~~
@@ -1079,4 +1079,11 @@ and the EntityManager.
         }
     }
 
-.. _LifecycleEventArgs: https://github.com/doctrine/persistence/blob/2.2.x/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php
+.. _LifecycleEventArgs: https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php
+.. _PreUpdateEventArgs: https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/Event/PreUpdateEventArgs.php
+.. _PreFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+.. _PostFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+.. _OnFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+.. _OnClearEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+.. _LoadClassMetadataEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+.. _OnClassMetadataNotFoundEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -135,38 +135,38 @@ see :ref:`Lifecycle Callbacks<lifecycle-callbacks>`
 Events Overview
 ---------------
 
-+-----------------------------------------------------------------+-----------------------+-----------+
-| Event                                                           | Dispatched by         | Lifecycle |
-|                                                                 |                       | Callback  |
-+=================================================================+=======================+===========+
-| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       |
-|                                                                 | on *initial* persist  |           |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`preUpdate<reference-events-pre-update>`                   | ``$em->flush()``      | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`loadClassMetadata<reference-events-load-class-metadata>`  | Loading of mapping    | No        |
-|                                                                 | metadata              |           |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| ``onClassMetadataNotFound``                                     | ``MappingException``  | No        |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`preFlush<reference-events-pre-flush>`                     | ``$em->flush()``      | Yes       |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`onFlush<reference-events-on-flush>`                       | ``$em->flush()``      | No        |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| :ref:`postFlush<reference-events-post-flush>`                   | ``$em->flush()``      | No        |
-+-----------------------------------------------------------------+-----------------------+-----------+
-| ``onClear``                                                     | ``$em->clear()``      | No        |
-+-----------------------------------------------------------------+-----------------------+-----------+
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| Event                                                           | Dispatched by         | Lifecycle | Passed                 |
+|                                                                 |                       | Callback  | Argument               |
++=================================================================+=======================+===========+========================+
+| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       | `_LifecycleEventArgs`_ |
+|                                                                 | on *initial* persist  |           |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`preUpdate<reference-events-pre-update>`                   | ``$em->flush()``      | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`loadClassMetadata<reference-events-load-class-metadata>`  | Loading of mapping    | No        |                        |
+|                                                                 | metadata              |           |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| ``onClassMetadataNotFound``                                     | ``MappingException``  | No        |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`preFlush<reference-events-pre-flush>`                     | ``$em->flush()``      | Yes       |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`onFlush<reference-events-on-flush>`                       | ``$em->flush()``      | No        |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| :ref:`postFlush<reference-events-post-flush>`                   | ``$em->flush()``      | No        |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
+| ``onClear``                                                     | ``$em->clear()``      | No        |                        |
++-----------------------------------------------------------------+-----------------------+-----------+------------------------+
 
 Naming convention
 ~~~~~~~~~~~~~~~~~
@@ -296,6 +296,8 @@ specific to a particular entity class's lifecycle.
     .. code-block:: attribute
 
         <?php
+        
+        use Doctrine\Persistence\Event\LifecycleEventArgs;
 
         /**
          * #[Entity]
@@ -309,7 +311,7 @@ specific to a particular entity class's lifecycle.
             public $value;
 
             #[PrePersist]
-            public function doStuffOnPrePersist()
+            public function doStuffOnPrePersist(LifecycleEventArgs $eventArgs)
             {
                 $this->createdAt = date('Y-m-d H:i:s');
             }
@@ -320,15 +322,17 @@ specific to a particular entity class's lifecycle.
                 $this->value = 'changed from prePersist callback!';
             }
 
-            #[PostLoad]
-            public function doStuffOnPostLoad()
+            #[PreUpdate]
+            public function doStuffOnPreUpdate(PreUpdateEventArgs $eventArgs)
             {
-                $this->value = 'changed from postLoad callback!';
+                $this->value = 'changed from preUpdate callback!';
             }
         }
     .. code-block:: annotation
 
         <?php
+        
+        use Doctrine\Persistence\Event\LifecycleEventArgs;
 
         /**
          * @Entity
@@ -342,7 +346,7 @@ specific to a particular entity class's lifecycle.
             public $value;
 
             /** @PrePersist */
-            public function doStuffOnPrePersist()
+            public function doStuffOnPrePersist(LifecycleEventArgs $eventArgs)
             {
                 $this->createdAt = date('Y-m-d H:i:s');
             }
@@ -353,10 +357,10 @@ specific to a particular entity class's lifecycle.
                 $this->value = 'changed from prePersist callback!';
             }
 
-            /** @PostLoad */
-            public function doStuffOnPostLoad()
+            /** @PreUpdate */
+            public function doStuffOnPreUpdate(PreUpdateEventArgs $eventArgs)
             {
-                $this->value = 'changed from postLoad callback!';
+                $this->value = 'changed from preUpdate callback!';
             }
         }
     .. code-block:: xml
@@ -372,7 +376,7 @@ specific to a particular entity class's lifecycle.
                 <lifecycle-callbacks>
                     <lifecycle-callback type="prePersist" method="doStuffOnPrePersist"/>
                     <lifecycle-callback type="prePersist" method="doOtherStuffOnPrePersist"/>
-                    <lifecycle-callback type="postLoad" method="doStuffOnPostLoad"/>
+                    <lifecycle-callback type="preUpdate" method="doStuffOnPreUpdate"/>
                 </lifecycle-callbacks>
             </entity>
         </doctrine-mapping>
@@ -386,7 +390,7 @@ specific to a particular entity class's lifecycle.
               type: string(255)
           lifecycleCallbacks:
             prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersist ]
-            postLoad: [ doStuffOnPostLoad ]
+            preUpdate: [ doStuffOnPreUpdate ]
 
 Lifecycle Callbacks Event Argument
 ----------------------------------
@@ -1073,3 +1077,5 @@ and the EntityManager.
             $em = $eventArgs->getEntityManager();
         }
     }
+
+.. _LifecycleEventArgs: https://github.com/doctrine/persistence/blob/2.2.x/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -1079,11 +1079,11 @@ and the EntityManager.
         }
     }
 
-.. _LifecycleEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
-.. _PreUpdateEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
-.. _PreFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
-.. _PostFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
-.. _OnFlushEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
-.. _OnClearEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnClearEventArgs.php
-.. _LoadClassMetadataEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
-.. _OnClassMetadataNotFoundEventArgs: https://github.com/doctrine/orm/blob/2.10.x/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+.. _LifecycleEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+.. _PreUpdateEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+.. _PreFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+.. _PostFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+.. _OnFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+.. _OnClearEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+.. _LoadClassMetadataEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+.. _OnClassMetadataNotFoundEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php


### PR DESCRIPTION
As announced in https://github.com/doctrine/orm/pull/9160#issuecomment-954304588 I'm adding the passed "EventArgs" class to the overview table. Once this is complete, my further plan is to remove the entire paragraph https://www.doctrine-project.org/projects/doctrine-orm/en/2.10/reference/events.html#lifecycle-callbacks-event-argument, and probably also the second code block at https://www.doctrine-project.org/projects/doctrine-orm/en/2.10/reference/events.html#entity-listeners-class

@SenseException Is there a better way to link to the source code of `LifecycleEventArgs` than https://github.com/doctrine/persistence/blob/2.2.x/lib/Doctrine/Persistence/Event/LifecycleEventArgs.php ?
=> Waiting for feedback before I do the others :-)
EDIT: This is an example from Symfony, is this syntax working here too?
> :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`

Also, I changed `postLoad` to `preUpdate` in the code block, to have an example that does not receive `LifecycleEventArgs` ;-)