### PR TITLE
Fixed array hydration

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -113,6 +113,7 @@ class ArrayHydrator extends AbstractHydrator
 
                     if (! isset($baseElement[$relationAlias])) {
                         $baseElement[$relationAlias] = [];
+                        $this->_identifierMap[$path][$id[$parent]] = [];
                     }
 
                     if (isset($nonemptyComponents[$dqlAlias])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -112,7 +112,7 @@ class ArrayHydrator extends AbstractHydrator
                     $oneToOne = false;
 
                     if (! isset($baseElement[$relationAlias])) {
-                        $baseElement[$relationAlias] = [];
+                        $baseElement[$relationAlias]               = [];
                         $this->_identifierMap[$path][$id[$parent]] = [];
                     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Internal\Hydration\ArrayHydrator;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Tests\Mocks\ArrayResultFactory;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmTestCase;
+
+class GH9185Test extends OrmTestCase
+{
+    /**
+     * Sometimes, the way DBMS is ordering rows is kinda random.
+     * This 'randomness' caused ArrayHydrator to return null values in one-to-many relationships
+     * instead of correct elements.
+     *
+     * select a.id, a.topic, u.id, u.username, p.phonenumber
+     * form CmsArticle a
+     * join a.user u
+     * join u.phonenumbers p
+     */
+    public function testMultipleFetchJoinWithInconsistentRowOrder(): void
+    {
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult(CmsArticle::class, 'a');
+        $rsm->addJoinedEntityResult(
+            CmsUser::class,
+            'u',
+            'a',
+            'user'
+        );
+        $rsm->addJoinedEntityResult(
+            CmsPhonenumber::class,
+            'p',
+            'u',
+            'phonenumbers'
+        );
+        $rsm->addFieldResult('a', 'a__id', 'id');
+        $rsm->addFieldResult('a', 'a__topic', 'topic');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__username', 'username');
+        $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
+
+        $resultSet = [
+            [
+                'a__id' => '1',
+                'a__topic' => 'Article 1',
+                'u__id' => '1',
+                'u__username' => 'LinasRam',
+                'p__phonenumber' => '1234567890',
+            ],
+            [
+                'a__id' => '1',
+                'a__topic' => 'Article 1',
+                'u__id' => '1',
+                'u__username' => 'LinasRam',
+                'p__phonenumber' => '9876543210',
+            ],
+            [
+                'a__id' => '2',
+                'a__topic' => 'Article 2',
+                'u__id' => '1',
+                'u__username' => 'LinasRam',
+                'p__phonenumber' => '9876543210', // Different order than in previous rows
+            ],
+            [
+                'a__id' => '2',
+                'a__topic' => 'Article 2',
+                'u__id' => '1',
+                'u__username' => 'LinasRam',
+                'p__phonenumber' => '1234567890', // Different order than in previous rows
+            ],
+        ];
+
+        $stmt     = ArrayResultFactory::createFromArray($resultSet);
+        $hydrator = new ArrayHydrator($this->getTestEntityManager());
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
+
+        $expected = [
+            [
+                'id' => 1,
+                'topic' => 'Article 1',
+                'user' => [
+                    'id' => 1,
+                    'username' => 'LinasRam',
+                    'phonenumbers' => [
+                        ['phonenumber' => '1234567890'],
+                        ['phonenumber' => '9876543210'],
+                    ],
+                ],
+            ],
+            [
+                'id' => 2,
+                'topic' => 'Article 2',
+                'user' => [
+                    'id' => 1,
+                    'username' => 'LinasRam',
+                    'phonenumbers' => [
+                        ['phonenumber' => '9876543210'],
+                        ['phonenumber' => '1234567890'],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $result);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
@@ -15,12 +15,12 @@ use Doctrine\Tests\OrmTestCase;
 class GH9185Test extends OrmTestCase
 {
     /**
-     * Sometimes, the way DBMS is ordering rows is kinda random.
+     * Sometimes, DBMS is ordering rows randomly.
      * This 'randomness' caused ArrayHydrator to return null values in one-to-many relationships
-     * instead of correct elements.
+     * instead of correct values.
      *
      * select a.id, a.topic, u.id, u.username, p.phonenumber
-     * form CmsArticle a
+     * from CmsArticle a
      * join a.user u
      * join u.phonenumbers p
      */
@@ -67,14 +67,14 @@ class GH9185Test extends OrmTestCase
                 'a__topic' => 'Article 2',
                 'u__id' => '1',
                 'u__username' => 'LinasRam',
-                'p__phonenumber' => '9876543210', // Different order than in previous rows
+                'p__phonenumber' => '9876543210', // Different order of phone number than in previous rows
             ],
             [
                 'a__id' => '2',
                 'a__topic' => 'Article 2',
                 'u__id' => '1',
                 'u__username' => 'LinasRam',
-                'p__phonenumber' => '1234567890', // Different order than in previous rows
+                'p__phonenumber' => '1234567890', // Different order of phone number than in previous rows
             ],
         ];
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9185Test.php
@@ -19,10 +19,10 @@ class GH9185Test extends OrmTestCase
      * This 'randomness' caused ArrayHydrator to return null values in one-to-many relationships
      * instead of correct values.
      *
-     * select a.id, a.topic, u.id, u.username, p.phonenumber
-     * from CmsArticle a
-     * join a.user u
-     * join u.phonenumbers p
+     * SELECT PARTIAL a.{id, topic}, PARTIAL u.{id, username}, PARTIAL p.{phonenumber}
+     * FROM CmsArticle a
+     * INNER JOIN a.user u
+     * INNER JOIN u.phonenumbers p
      */
     public function testMultipleFetchJoinWithInconsistentRowOrder(): void
     {


### PR DESCRIPTION
Resetting `$this->_identifierMap` of base element children each time the new to-many relation is added to base element.

Includes a was-failing-but-now-passing test case.

fixes #9185