### PR TITLE
Fix recognizing identifiers as T_FULLY_QUALIFIED_NAME and T_IDENTIFIER

### DIFF
--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -168,7 +168,7 @@ class Lexer extends AbstractLexer
                 if (defined($name)) {
                     $type = constant($name);
 
-                    if ($type > 100) {
+                    if ($type >= 200) {
                         return $type;
                     }
                 }

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -240,6 +240,8 @@ class LexerTest extends OrmTestCase
             [Lexer::T_FULLY_QUALIFIED_NAME, 'Some\Class'], // DQL class reference
             [Lexer::T_ALIASED_NAME, 'Some:Name'],
             [Lexer::T_ALIASED_NAME, 'Some:Subclassed\Name'],
+            [Lexer::T_IDENTIFIER, 'fully_qualified_name'], // identifier which matches a token class with a value > 100 and < 200
+            [Lexer::T_SELECT, 'select'], // reserved keyword
         ];
     }
 }


### PR DESCRIPTION
One of the added test datas produces invalid results without the added commit:

```php
[Lexer::T_IDENTIFIER, 'fully_qualified_name']
```

`fully_qualified_name` is an identifier if I'm not wrong. Currently `fully_qualified_name` is a `Lexer::T_FULLY_QUALIFIED_NAME` which is wrong I think.