### PR TITLE
Add strict-sync option to ValidateSchemaCommand

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -29,6 +29,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
              ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('skip-mapping', null, InputOption::VALUE_NONE, 'Skip the mapping validation check')
              ->addOption('skip-sync', null, InputOption::VALUE_NONE, 'Skip checking if the mapping is in sync with the database')
+             ->addOption('strict-sync', null, InputOption::VALUE_NONE, 'Check that all tables in a database have a mapping files')
              ->setHelp('Validate that the mapping files are correct and in sync with the database.');
     }
 
@@ -74,7 +75,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
 
         if ($input->getOption('skip-sync')) {
             $ui->text('<comment>[SKIPPED] The database was not checked for synchronicity.</comment>');
-        } elseif (! $validator->schemaInSyncWithMetadata()) {
+        } elseif (! $validator->schemaInSyncWithMetadata($input->getOption('strict-sync'))) {
             $ui->error('The database schema is not in sync with the current mapping file.');
             $exit += 2;
         } else {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -258,14 +258,16 @@ class SchemaValidator
     /**
      * Checks if the Database Schema is in sync with the current metadata state.
      *
+     * @param bool    $strictSync If TRUE, check that all tables in a database have a mapping files
+     *
      * @return bool
      */
-    public function schemaInSyncWithMetadata()
+    public function schemaInSyncWithMetadata($strictSync = false)
     {
         $schemaTool = new SchemaTool($this->em);
 
         $allMetadata = $this->em->getMetadataFactory()->getAllMetadata();
 
-        return count($schemaTool->getUpdateSchemaSql($allMetadata, true)) === 0;
+        return count($schemaTool->getUpdateSchemaSql($allMetadata, $strictSync === false)) === 0;
     }
 }

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 use function array_diff;
+use function array_filter;
 use function array_key_exists;
 use function array_search;
 use function array_values;
@@ -268,6 +269,11 @@ class SchemaValidator
 
         $allMetadata = $this->em->getMetadataFactory()->getAllMetadata();
 
-        return count($schemaTool->getUpdateSchemaSql($allMetadata, $strictSync === false)) === 0;
+        return count(array_filter(
+                $schemaTool->getUpdateSchemaSql($allMetadata, $strictSync === false),
+                function ($value) {
+                    return $value != 'DROP TABLE migration_versions';
+                }
+            )) == 0;
     }
 }

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -258,7 +258,7 @@ class SchemaValidator
     /**
      * Checks if the Database Schema is in sync with the current metadata state.
      *
-     * @param bool    $strictSync If TRUE, check that all tables in a database have a mapping files
+     * @param bool $strictSync If TRUE, check that all tables in a database have a mapping files
      *
      * @return bool
      */


### PR DESCRIPTION
When removing ManyToMany relationship a command `orm:validate-schema` does not handle that need remove a table, which handling this relation, from DB.