### PR TITLE
Fix sql expression in `SelectSqlGenerationTest::testSupportsMoreThanTwoParametersInConcatFunction()` to match what DBAL generates

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2125,11 +2125,11 @@ class SelectSqlGenerationTest extends OrmTestCase
         $connMock->setDatabasePlatform(new SQLServer2012Platform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, u.status, 's') = ?1",
-            "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE (c0_.name + c0_.status + 's') = ?"
+            "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE CONCAT(c0_.name, c0_.status, 's') = ?"
         );
         $this->assertSqlGeneration(
             'SELECT CONCAT(u.id, u.name, u.status) FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = ?1',
-            'SELECT (c0_.id + c0_.name + c0_.status) AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
+            'SELECT CONCAT(c0_.id, c0_.name, c0_.status) AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
         );
 
         $connMock->setDatabasePlatform($orgPlatform);


### PR DESCRIPTION
Change was introduced in https://github.com/doctrine/dbal/pull/4939