### PR TITLE
Add a psalm type for field mapping

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -70,6 +70,26 @@ use const PHP_VERSION_ID;
  *
  * @template-covariant T of object
  * @template-implements ClassMetadata<T>
+ * @psalm-type FieldMapping = array{
+ *      type: string,
+ *      fieldName: string,
+ *      columnName?: string,
+ *      length?: int,
+ *      id?: bool,
+ *      nullable?: bool,
+ *      columnDefinition?: string,
+ *      precision?: int,
+ *      scale?: int,
+ *      unique?: string,
+ *      inherited?: class-string,
+ *      originalClass?: class-string,
+ *      originalField?: string,
+ *      quoted?: bool,
+ *      requireSQLConversion?: bool,
+ *      declared?: class-string,
+ *      declaredField?: string,
+ *      options?: array<string, mixed>
+ * }
  */
 class ClassMetadataInfo implements ClassMetadata
 {
@@ -427,26 +447,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Whether a unique constraint should be generated for the column.
      *
      * @var mixed[]
-     * @psalm-var array<string, array{
-     *      type: string,
-     *      fieldName: string,
-     *      columnName?: string,
-     *      length?: int,
-     *      id?: bool,
-     *      nullable?: bool,
-     *      columnDefinition?: string,
-     *      precision?: int,
-     *      scale?: int,
-     *      unique?: string,
-     *      inherited?: class-string,
-     *      originalClass?: class-string,
-     *      originalField?: string,
-     *      quoted?: bool,
-     *      requireSQLConversion?: bool,
-     *      declared?: class-string,
-     *      declaredField?: string,
-     *      options: array<mixed>
-     * }>
+     * @psalm-var array<string, FieldMapping>
      */
     public $fieldMappings = [];
 
@@ -1285,18 +1286,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $fieldName The field name.
      *
      * @return mixed[] The field mapping.
-     * @psalm-return array{
-     *      type: string,
-     *      fieldName: string,
-     *      columnName?: string,
-     *      inherited?: class-string,
-     *      nullable?: bool,
-     *      originalClass?: class-string,
-     *      originalField?: string,
-     *      scale?: int,
-     *      precision?: int,
-     *      length?: int
-     * }
+     * @psalm-return FieldMapping
      *
      * @throws MappingException
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -576,18 +576,8 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
 
 		-
-			message: "#^Offset 'unique' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, inherited\\?\\: class\\-string, nullable\\?\\: bool, originalClass\\?\\: class\\-string, originalField\\?\\: string, scale\\?\\: int, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
 			message: "#^Parameter \\#2 \\$type of static method Doctrine\\\\ORM\\\\Mapping\\\\MappingException\\:\\:invalidInheritanceType\\(\\) expects string, int given\\.$#"
 			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 2
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
 
 		-
@@ -2212,11 +2202,6 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Offset 'options' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, columnDefinition\\?\\: string, precision\\?\\: int, \\.\\.\\.\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
-
-		-
 			message: "#^Offset 'schema' on array\\{name\\: string, schema\\: string, indexes\\: array, uniqueConstraints\\: array, options\\: array\\<string, mixed\\>, quoted\\?\\: bool\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -2227,7 +2212,7 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Offset 'version' on array\\{type\\: string, fieldName\\: string, options\\: array, columnName\\?\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, columnDefinition\\?\\: string, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
+			message: "#^Offset 'version' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, columnDefinition\\?\\: string, precision\\?\\: int, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
@@ -2313,11 +2298,6 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/SchemaTool.php
-
-		-
-			message: "#^Offset 'columnDefinition' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, inherited\\?\\: class\\-string, nullable\\?\\: bool, originalClass\\?\\: class\\-string, originalField\\?\\: string, scale\\?\\: int, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/SchemaTool.php
 


### PR DESCRIPTION
Field mapping have different definitions
in property definition and method return.
As suggested in issue and to avoid further desynchronization,
a psalm type has been created.
Fixes #9193