### PR TITLE
Drop support for DBAL 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/cache": "^1.12.1 || ^2.1.1",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
-        "doctrine/dbal": "^2.13.1 || ^3.1.1",
+        "doctrine/dbal": "^2.13.1 || ^3.2",
         "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4 || ^2.0",

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -540,7 +540,7 @@ abstract class AbstractQuery
             return $this;
         }
 
-        // DBAL < 3.2
+        // DBAL 2
         if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
             if (! $profile->getResultCacheDriver()) {
                 $defaultHydrationCacheImpl = $this->_em->getConfiguration()->getHydrationCache();
@@ -584,7 +584,7 @@ abstract class AbstractQuery
             return $this;
         }
 
-        // DBAL < 3.2
+        // DBAL 2
         if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
             if (! $profile->getResultCacheDriver()) {
                 $defaultResultCacheDriver = $this->_em->getConfiguration()->getResultCache();
@@ -640,7 +640,7 @@ abstract class AbstractQuery
             return $this;
         }
 
-        // DBAL < 3.2
+        // DBAL 2
         if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
             $resultCacheDriver = DoctrineProvider::wrap($resultCache);
 
@@ -746,7 +746,7 @@ abstract class AbstractQuery
             return $this;
         }
 
-        // Compatibility for DBAL < 3.2
+        // Compatibility for DBAL 2
         if (! method_exists($this->_queryCacheProfile, 'setResultCache')) {
             $this->_queryCacheProfile = $this->_queryCacheProfile->setResultCacheDriver(DoctrineProvider::wrap($cache));
 
@@ -1177,7 +1177,7 @@ abstract class AbstractQuery
     {
         assert($this->_hydrationCacheProfile !== null);
 
-        // Support for DBAL < 3.2
+        // Support for DBAL 2
         if (! method_exists($this->_hydrationCacheProfile, 'getResultCache')) {
             $cacheDriver = $this->_hydrationCacheProfile->getResultCacheDriver();
             assert($cacheDriver !== null);

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -256,7 +256,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getResultCache(): ?CacheItemPoolInterface
     {
-        // Compatibility with DBAL < 3.2
+        // Compatibility with DBAL 2
         if (! method_exists(parent::class, 'getResultCache')) {
             $cacheImpl = $this->getResultCacheImpl();
 
@@ -271,7 +271,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function setResultCache(CacheItemPoolInterface $cache): void
     {
-        // Compatibility with DBAL < 3.2
+        // Compatibility with DBAL 2
         if (! method_exists(parent::class, 'setResultCache')) {
             $this->setResultCacheImpl(DoctrineProvider::wrap($cache));
 

--- a/lib/Doctrine/ORM/Internal/SQLResultCasing.php
+++ b/lib/Doctrine/ORM/Internal/SQLResultCasing.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Internal;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
 use function method_exists;
@@ -25,7 +24,7 @@ trait SQLResultCasing
             return strtoupper($column);
         }
 
-        if ($platform instanceof PostgreSQL94Platform || $platform instanceof PostgreSQLPlatform) {
+        if ($platform instanceof PostgreSQLPlatform) {
             return strtolower($column);
         }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -647,7 +647,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         if (
             $platform instanceof Platforms\OraclePlatform
-            || $platform instanceof Platforms\PostgreSQL94Platform
             || $platform instanceof Platforms\PostgreSQLPlatform
         ) {
             return ClassMetadata::GENERATOR_TYPE_SEQUENCE;

--- a/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
+use function sprintf;
+
 /**
  * "LOWER" "(" StringPrimary ")"
  *
@@ -16,7 +18,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class LowerFunction extends FunctionNode
 {
-    /** @psalm-var Node */
+    /** @var Node */
     public $stringPrimary;
 
     /**
@@ -25,7 +27,8 @@ class LowerFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getLowerExpression(
+        return sprintf(
+            'LOWER(%s)',
             $sqlWalker->walkSimpleArithmeticExpression($this->stringPrimary)
         );
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
+use function sprintf;
+
 /**
  * "SQRT" "(" SimpleArithmeticExpression ")"
  *
@@ -25,7 +27,8 @@ class SqrtFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getSqrtExpression(
+        return sprintf(
+            'SQRT(%s)',
             $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression)
         );
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
+use function sprintf;
+
 /**
  * "UPPER" "(" StringPrimary ")"
  *
@@ -25,7 +27,8 @@ class UpperFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getUpperExpression(
+        return sprintf(
+            'UPPER(%s)',
             $sqlWalker->walkSimpleArithmeticExpression($this->stringPrimary)
         );
     }

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\SelectStatement;
@@ -72,7 +71,7 @@ class CountOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform instanceof SQLServer2012Platform || $this->platform instanceof SQLServerPlatform) {
+        if ($this->platform instanceof SQLServerPlatform) {
             $AST->orderByClause = null;
         }
 
@@ -80,8 +79,7 @@ class CountOutputWalker extends SqlWalker
 
         if ($AST->groupByClause) {
             return sprintf(
-                'SELECT %s AS dctrn_count FROM (%s) dctrn_table',
-                $this->platform->getCountExpression('*'),
+                'SELECT COUNT(*) AS dctrn_count FROM (%s) dctrn_table',
                 $sql
             );
         }
@@ -133,8 +131,7 @@ class CountOutputWalker extends SqlWalker
 
         // Build the counter query
         return sprintf(
-            'SELECT %s AS dctrn_count FROM (SELECT DISTINCT %s FROM (%s) dctrn_result) dctrn_table',
-            $this->platform->getCountExpression('*'),
+            'SELECT COUNT(*) AS dctrn_count FROM (SELECT DISTINCT %s FROM (%s) dctrn_result) dctrn_table',
             implode(', ', $sqlIdentifier),
             $sql
         );

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -7,10 +7,8 @@ namespace Doctrine\ORM\Tools\Pagination;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\QuoteStrategy;
@@ -117,9 +115,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     private function platformSupportsRowNumber(): bool
     {
-        return $this->platform instanceof PostgreSQL94Platform // DBAL 3.1 compatibility
-            || $this->platform instanceof PostgreSQLPlatform
-            || $this->platform instanceof SQLServer2012Platform // DBAL 3.1 compatibility
+        return $this->platform instanceof PostgreSQLPlatform
             || $this->platform instanceof SQLServerPlatform
             || $this->platform instanceof OraclePlatform
             || $this->platform instanceof SQLAnywherePlatform

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -191,7 +191,6 @@ class SchemaTool
         $eventManager         = $this->em->getEventManager();
         $metadataSchemaConfig = $this->schemaManager->createSchemaConfig();
 
-        $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
         $schema = new Schema([], [], $metadataSchemaConfig);
 
         $addedFks       = [];
@@ -931,7 +930,7 @@ class SchemaTool
         $fromSchema = $this->createSchemaForComparison($toSchema);
 
         $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+        $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
         if ($saveMode) {
             return $schemaDiff->toSaveSql($this->platform);

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -9,7 +9,7 @@ parameters:
         # PHPStan doesn't understand our method_exists() safeguards.
         - '/Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\./'
         # Class name will change in DBAL 3.
-        - '/Class Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform referenced with incorrect case: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform\./'
+        - '/^Class Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform not found\.$/'
 
         # Forward compatibility for DBAL 3.2
         - '/^Call to an undefined method Doctrine\\DBAL\\Cache\\QueryCacheProfile::[gs]etResultCache\(\)\.$/'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2181,9 +2181,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;stringPrimary</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
-      <code>getLowerExpression</code>
-    </DeprecatedMethod>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
@@ -2213,9 +2210,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php">
-    <DeprecatedMethod occurrences="1">
-      <code>getSqrtExpression</code>
-    </DeprecatedMethod>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$simpleArithmeticExpression</code>
     </PropertyNotSetInConstructor>
@@ -2254,9 +2248,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;stringPrimary</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
-      <code>getUpperExpression</code>
-    </DeprecatedMethod>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
@@ -3650,10 +3641,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php">
-    <DeprecatedMethod occurrences="2">
-      <code>getCountExpression</code>
-      <code>getCountExpression</code>
-    </DeprecatedMethod>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$query</code>
     </MoreSpecificImplementedParamType>
@@ -3723,10 +3710,8 @@
     <RedundantConditionGivenDocblockType occurrences="1"/>
   </file>
   <file src="lib/Doctrine/ORM/Tools/SchemaTool.php">
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod occurrences="1">
       <code>canEmulateSchemas</code>
-      <code>compare</code>
-      <code>setExplicitForeignKeyIndexes</code>
     </DeprecatedMethod>
     <DocblockTypeContradiction occurrences="2">
       <code>! $definingClass</code>

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
@@ -231,9 +229,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         // FIXME: Condition here is fugly.
         // NOTE: PostgreSQL and SQL SERVER do not support UNSIGNED integer
 
-        return ! $platform instanceof SQLServer2012Platform
-            && ! $platform instanceof SQLServerPlatform
-            && ! $platform instanceof PostgreSQL94Platform
+        return ! $platform instanceof SQLServerPlatform
             && ! $platform instanceof PostgreSQLPlatform;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -29,7 +28,7 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $platform = $this->_em->getConnection()->getDatabasePlatform();
-        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
+        if (! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('The ' . self::class . ' requires the use of postgresql.');
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -23,7 +22,7 @@ class DDC1151Test extends OrmFunctionalTestCase
     public function testQuoteForeignKey(): void
     {
         $platform = $this->_em->getConnection()->getDatabasePlatform();
-        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
+        if (! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('This test is useful for all databases, but designed only for postgresql.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -21,7 +20,7 @@ class DDC1360Test extends OrmFunctionalTestCase
     public function testSchemaDoubleQuotedCreate(): void
     {
         $platform = $this->_em->getConnection()->getDatabasePlatform();
-        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
+        if (! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('PostgreSQL only test.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -20,6 +20,7 @@ use function explode;
 use function get_class;
 use function implode;
 use function is_array;
+use function sprintf;
 use function strtolower;
 
 /**
@@ -176,7 +177,7 @@ class DDC2012TsVectorType extends Type
         // changed to upper expression to keep the test compatible with other Databases
         //sprintf('to_tsvector(%s)', $sqlExpr);
 
-        return $platform->getUpperExpression($sqlExpr);
+        return sprintf('UPPER(%s)', $sqlExpr);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Configuration;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -33,7 +32,7 @@ final class GH7875Test extends OrmFunctionalTestCase
         $connection->executeStatement('DROP TABLE IF EXISTS gh7875_my_other_entity');
 
         $platform = $connection->getDatabasePlatform();
-        if ($platform instanceof PostgreSQL94Platform || $platform instanceof PostgreSQLPlatform) {
+        if ($platform instanceof PostgreSQLPlatform) {
             $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_entity_id_seq');
             $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_other_entity_id_seq');
         }

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Mapping\Column;
@@ -39,7 +40,7 @@ class UUIDGeneratorTest extends OrmFunctionalTestCase
             self::markTestSkipped('Test valid for doctrine/dbal:2.x only.');
         }
 
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
             self::markTestSkipped('Currently restricted to MySQL platform.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -7,9 +7,8 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
@@ -37,6 +36,7 @@ use function sprintf;
 
 // DBAL 2 compatibility
 class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');
+class_exists('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
 
 class SelectSqlGenerationTest extends OrmTestCase
 {
@@ -658,7 +658,7 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT CONCAT(c0_.id, c0_.name) AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
         );
 
-        $connMock->setDatabasePlatform(new PostgreSQL94Platform());
+        $connMock->setDatabasePlatform(new PostgreSQLPlatform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE c0_.name || 's' = ?"
@@ -954,7 +954,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     public function testBooleanLiteralInWhereOnPostgres(): void
     {
         $oldPlat = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $this->assertSqlGeneration(
             'SELECT b FROM Doctrine\Tests\Models\Generic\BooleanModel b WHERE b.booleanField = true',
@@ -1096,7 +1096,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function testPessimisticReadLockQueryHintPostgreSql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $this->assertSqlGeneration(
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\CountOutputWalker;
@@ -70,7 +69,7 @@ class CountOutputWalkerTest extends PaginationTestCase
     public function testCountQueryOrderBySqlServer(): void
     {
         $platform = $this->entityManager->getConnection()->getDatabasePlatform();
-        if (! $platform instanceof SQLServer2012Platform && ! $platform instanceof SQLServerPlatform) {
+        if (! $platform instanceof SQLServerPlatform) {
             self::markTestSkipped('SQLServer only test.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker;
 
@@ -14,6 +14,7 @@ use function class_exists;
 
 // DBAL 2 compatibility
 class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');
+class_exists('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
 
 final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
 {
@@ -35,7 +36,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p JOIN p.category c JOIN p.author a ORDER BY p.title'
@@ -54,7 +55,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithScalarSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity'
@@ -73,7 +74,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithMixedSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity, u.id DESC'
@@ -92,7 +93,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithHiddenScalarSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS hidden g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity, u.id DESC'
@@ -111,7 +112,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $this->testLimitSubquery();
 
@@ -354,7 +355,7 @@ ORDER BY b.id DESC'
 
     public function testLimitSubqueryWithOrderByAndSubSelectInWhereClausePgSql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
         $query = $this->entityManager->createQuery(
             'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b
 WHERE  ((SELECT COUNT(simple.id) FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost simple) = 1)
@@ -417,7 +418,7 @@ ORDER BY b.id DESC'
      */
     public function testLimitSubqueryOrderBySubSelectOrderByExpressionPg(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQLPlatform());
 
         $query = $this->entityManager->createQuery(
             'SELECT a,

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
@@ -667,7 +666,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $platform = static::$sharedConn->getDatabasePlatform();
             if (
                 $platform instanceof MySQLPlatform
-                || $platform instanceof PostgreSQL94Platform
                 || $platform instanceof PostgreSQLPlatform
             ) {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . static::class . '*/');


### PR DESCRIPTION
Dropping support for DBAL 3.1 allows us to simplify some code, so let's do it.