### PR TITLE
Add missing deprecations for YAML metadata mapping

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php
@@ -8,6 +8,8 @@ use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 
 /**
  * YamlDriver that additionally looks for mapping information in a global file.
+ *
+ * @deprecated This class is being removed from the ORM and won't have any replacement
  */
 class SimplifiedYamlDriver extends YamlDriver
 {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -42,7 +42,7 @@ class YamlDriver extends FileDriver
         Deprecation::trigger(
             'doctrine/orm',
             'https://github.com/doctrine/orm/issues/8465',
-            'YAML mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to annotation or XML driver.'
+            'YAML mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to attribute or XML driver.'
         );
 
         parent::__construct($locator, $fileExtension);

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\ClassLoader;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
@@ -113,6 +114,8 @@ class Setup
     /**
      * Creates a configuration with a yaml metadata driver.
      *
+     * @deprecated YAML metadata mapping is deprecated and will be removed in 3.0
+     *
      * @param mixed[] $paths
      * @param bool    $isDevMode
      * @param string  $proxyDir
@@ -121,6 +124,12 @@ class Setup
      */
     public static function createYAMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, ?Cache $cache = null)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/8465',
+            'YAML mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to attribute or XML driver.'
+        );
+
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new YamlDriver($paths));
 


### PR DESCRIPTION
Follows #8465

I've deprecated:
* `SimplifiedYamlDriver`
* `setup::createYAMLMetadataConfiguration()`

The class and the method don't make much sense if we remove YAML metadata mapping.