### PR TITLE
Add deprecation hints to `orm:convert-mapping` command

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -31,6 +31,8 @@ use function strtolower;
 /**
  * Command to convert your mapping information between the various formats.
  *
+ * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
+ *
  * @link    www.doctrine-project.org
  */
 class ConvertMappingCommand extends AbstractEntityManagerCommand
@@ -86,6 +88,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
+        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
 
         $em = $this->getEntityManager($input);
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3438,11 +3438,8 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php">
-    <DeprecatedClass occurrences="4">
+    <DeprecatedClass occurrences="1">
       <code>Versions::getVersion('doctrine/orm')</code>
-      <code>new Command\ConvertDoctrine1SchemaCommand()</code>
-      <code>new Command\GenerateEntitiesCommand($entityManagerProvider)</code>
-      <code>new Command\GenerateRepositoriesCommand($entityManagerProvider)</code>
     </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -24,7 +24,11 @@
                 <!-- The exception is thrown by a deprecated method. -->
                 <referencedClass name="Doctrine\ORM\Cache\Exception\InvalidResultCacheDriver"/>
                 <!-- Remove on 3.0.x -->
+                <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>
+                <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand"/>
+                <referencedClass name="Doctrine\ORM\Tools\Console\Command\GenerateEntitiesCommand"/>
+                <referencedClass name="Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>


### PR DESCRIPTION
The `orm:convert-mapping` command had been deprecated ages ago, but somehow the class does not reflect that. Let's fix that.