### PR TITLE
Throw LogicException if region is tried to use for READ_WRITE

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -178,7 +178,15 @@ class DefaultCacheFactory implements CacheFactory
     public function getRegion(array $cache)
     {
         if (isset($this->regions[$cache['region']])) {
-            return $this->regions[$cache['region']];
+            $region = $this->regions[$cache['region']];
+            if (
+                $cache['usage'] === ClassMetadata::CACHE_USAGE_READ_WRITE &&
+                ! ($region instanceof ConcurrentRegion)
+            ) {
+                throw new LogicException('If you want to use a "READ_WRITE" cache an implementation of "Doctrine\ORM\Cache\ConcurrentRegion" is required.');
+            }
+
+            return $region;
         }
 
         $name         = $cache['region'];


### PR DESCRIPTION
Proposing patch: Throw LogicException if region is tried to use for READ_WRITE while implementation doesn't implement ConcurrentRegion.

PR is missing tests and I am waiting for feedback if those should be implemented.

This PR replaces #7984 and fixes #7981.