### PR TITLE
Restore `query()` call for primary/replica connections

### DIFF
--- a/lib/Doctrine/ORM/Id/FetchOneFromPrimary.php
+++ b/lib/Doctrine/ORM/Id/FetchOneFromPrimary.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Id;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
+use Doctrine\DBAL\ForwardCompatibility\Result as ForwardCompatibilityResult;
+use Doctrine\DBAL\Result;
+
+/**
+ * @internal
+ */
+trait FetchOneFromPrimary
+{
+    /**
+     * @return string|int|false
+     */
+    private function fetchOneFromPrimary(Connection $connection, string $sql)
+    {
+        // Using `query` to force usage of the master server in PrimaryReadReplicaConnection
+        $result = $connection instanceof PrimaryReadReplicaConnection
+            ? $connection->query($sql)
+            : $connection->executeQuery($sql);
+        if (! $result instanceof Result) {
+            $result = ForwardCompatibilityResult::ensure($result);
+        }
+
+        return $result->fetchOne();
+    }
+}

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -15,6 +15,8 @@ use function unserialize;
  */
 class SequenceGenerator extends AbstractIdGenerator implements Serializable
 {
+    use FetchOneFromPrimary;
+
     /**
      * The allocation size of the sequence.
      *
@@ -57,9 +59,9 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
             $conn = $em->getConnection();
             $sql  = $conn->getDatabasePlatform()->getSequenceNextValSQL($this->_sequenceName);
 
-            // Using `query` to force usage of the master server in MasterSlaveConnection
-            $this->_nextValue = (int) $conn->executeQuery($sql)->fetchOne();
-            $this->_maxValue  = $this->_nextValue + $this->_allocationSize;
+            $this->_nextValue = (int) $this->fetchOneFromPrimary($conn, $sql);
+
+            $this->_maxValue = $this->_nextValue + $this->_allocationSize;
         }
 
         return $this->_nextValue++;

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -18,6 +18,8 @@ use function method_exists;
  */
 class UuidGenerator extends AbstractIdGenerator
 {
+    use FetchOneFromPrimary;
+
     public function __construct()
     {
         Deprecation::trigger(
@@ -42,6 +44,6 @@ class UuidGenerator extends AbstractIdGenerator
         $conn = $em->getConnection();
         $sql  = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();
 
-        return $conn->executeQuery($sql)->fetchOne();
+        return $this->fetchOneFromPrimary($conn, $sql);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,9 +26,7 @@ parameters:
         -
         	message: '/^Class Doctrine\\DBAL\\Driver\\ResultStatement not found\.$/'
         	path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
-        -
-        	message: '/^Call to static method ensure\(\) on an unknown class Doctrine\\DBAL\\ForwardCompatibility\\Result\.$/'
-        	path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+        - '/^Call to static method ensure\(\) on an unknown class Doctrine\\DBAL\\ForwardCompatibility\\Result\.$/'
 
         # False positive
         -

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,7 +27,8 @@
         </DeprecatedClass>
         <DeprecatedMethod>
             <errorLevel type="suppress">
-                <!-- We're calling the deprecated method for BC here. -->
+                <!-- We're calling the deprecated methods for BC here. -->
+                <file name="lib/Doctrine/ORM/Id/FetchOneFromPrimary.php"/>
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
                 <!-- We need to keep the calls for DBAL 2.13 compatibility. -->
                 <referencedMethod name="Doctrine\DBAL\Cache\QueryCacheProfile::getResultCacheDriver"/>
@@ -87,6 +88,12 @@
                 <file name="lib/Doctrine/ORM/QueryBuilder.php"/>
             </errorLevel>
         </RedundantCastGivenDocblockType>
+        <RedundantCondition>
+            <errorLevel type="suppress">
+                <!-- Fallback logic for DBAL 2 -->
+                <file name="lib/Doctrine/ORM/Id/FetchOneFromPrimary.php"/>
+            </errorLevel>
+        </RedundantCondition>
         <!-- Workaround for https://github.com/vimeo/psalm/issues/7026 -->
         <ReservedWord>
             <errorLevel type="suppress">

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -25,9 +25,6 @@ class ConnectionMock extends Connection
     /** @var mixed */
     private $_fetchOneResult;
 
-    /** @var Exception|null */
-    private $_fetchOneException;
-
     /** @var Result|null */
     private $_queryResult;
 
@@ -116,10 +113,6 @@ class ConnectionMock extends Connection
      */
     public function fetchOne(string $sql, array $params = [], array $types = [])
     {
-        if ($this->_fetchOneException !== null) {
-            throw $this->_fetchOneException;
-        }
-
         return $this->_fetchOneResult;
     }
 
@@ -161,11 +154,6 @@ class ConnectionMock extends Connection
     public function setFetchOneResult($fetchOneResult): void
     {
         $this->_fetchOneResult = $fetchOneResult;
-    }
-
-    public function setFetchOneException(?Exception $exception = null): void
-    {
-        $this->_fetchOneException = $exception;
     }
 
     public function setDatabasePlatform(AbstractPlatform $platform): void

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -4,52 +4,32 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Id;
 
-use BadMethodCallException;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\SequenceGenerator;
 use Doctrine\Tests\Mocks\ArrayResultFactory;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\OrmTestCase;
 
+use function assert;
+
 class SequenceGeneratorTest extends OrmTestCase
 {
-    /** @var EntityManager */
-    private $entityManager;
-
-    /** @var SequenceGenerator */
-    private $sequenceGenerator;
-
-    /** @var ConnectionMock */
-    private $connection;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->entityManager     = $this->getTestEntityManager();
-        $this->sequenceGenerator = new SequenceGenerator('seq', 10);
-        $this->connection        = $this->entityManager->getConnection();
-
-        self::assertInstanceOf(ConnectionMock::class, $this->connection);
-    }
-
     public function testGeneration(): void
     {
-        $this->connection->setFetchOneException(new BadMethodCallException(
-            'Fetch* method used. Query method should be used instead, '
-            . 'as NEXTVAL should be run on a master server in master-slave setup.'
-        ));
+        $entityManager     = $this->getTestEntityManager();
+        $sequenceGenerator = new SequenceGenerator('seq', 10);
+        $connection        = $entityManager->getConnection();
+        assert($connection instanceof ConnectionMock);
 
         for ($i = 0; $i < 42; ++$i) {
             if ($i % 10 === 0) {
-                $this->connection->setQueryResult(ArrayResultFactory::createFromArray([[(int) ($i / 10) * 10]]));
+                $connection->setQueryResult(ArrayResultFactory::createFromArray([[(int) ($i / 10) * 10]]));
             }
 
-            $id = $this->sequenceGenerator->generate($this->entityManager, null);
+            $id = $sequenceGenerator->generate($entityManager, null);
 
             self::assertSame($i, $id);
-            self::assertSame((int) ($i / 10) * 10 + 10, $this->sequenceGenerator->getCurrentMaxValue());
-            self::assertSame($i + 1, $this->sequenceGenerator->getNextValue());
+            self::assertSame((int) ($i / 10) * 10 + 10, $sequenceGenerator->getCurrentMaxValue());
+            self::assertSame($i + 1, $sequenceGenerator->getNextValue());
         }
     }
 }


### PR DESCRIPTION
On DBAL 2, `PrimaryReadReplicaConnection::query()` executed the query on the primary connection. I broke the usage of this "hidden feature" while removing deprecated calls. This PR restores the functionality. At the same time, it removes mock logic that was supposed to catch my mistake but did not succeed doing so.