### PR TITLE
Make PrimaryReadReplicaConnection enforcement explicit

### DIFF
--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -55,14 +55,14 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     {
         if ($this->_maxValue === null || $this->_nextValue === $this->_maxValue) {
             // Allocate new values
-            $conn = $em->getConnection();
-            $sql  = $conn->getDatabasePlatform()->getSequenceNextValSQL($this->_sequenceName);
+            $connection = $em->getConnection();
+            $sql  = $connection->getDatabasePlatform()->getSequenceNextValSQL($this->_sequenceName);
 
-            if ($conn instanceof PrimaryReadReplicaConnection) {
-                $conn->ensureConnectedToPrimary();
+            if ($connection instanceof PrimaryReadReplicaConnection) {
+                $connection->ensureConnectedToPrimary();
             }
 
-            $this->_nextValue = (int) $conn->executeQuery($sql)->fetchOne();
+            $this->_nextValue = (int) $connection->executeQuery($sql)->fetchOne();
             $this->_maxValue  = $this->_nextValue + $this->_allocationSize;
         }
 

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -56,7 +56,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
         if ($this->_maxValue === null || $this->_nextValue === $this->_maxValue) {
             // Allocate new values
             $connection = $em->getConnection();
-            $sql  = $connection->getDatabasePlatform()->getSequenceNextValSQL($this->_sequenceName);
+            $sql        = $connection->getDatabasePlatform()->getSequenceNextValSQL($this->_sequenceName);
 
             if ($connection instanceof PrimaryReadReplicaConnection) {
                 $connection->ensureConnectedToPrimary();

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Id;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Exception\NotSupported;
@@ -41,6 +42,10 @@ class UuidGenerator extends AbstractIdGenerator
     {
         $conn = $em->getConnection();
         $sql  = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();
+
+        if ($conn instanceof PrimaryReadReplicaConnection) {
+            $conn->ensureConnectedToPrimary();
+        }
 
         return $conn->executeQuery($sql)->fetchOne();
     }

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -40,13 +40,13 @@ class UuidGenerator extends AbstractIdGenerator
      */
     public function generate(EntityManager $em, $entity)
     {
-        $conn = $em->getConnection();
-        $sql  = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();
+        $connection = $em->getConnection();
+        $sql        = 'SELECT ' . $connection->getDatabasePlatform()->getGuidExpression();
 
-        if ($conn instanceof PrimaryReadReplicaConnection) {
-            $conn->ensureConnectedToPrimary();
+        if ($connection instanceof PrimaryReadReplicaConnection) {
+            $connection->ensureConnectedToPrimary();
         }
 
-        return $conn->executeQuery($sql)->fetchOne();
+        return $connection->executeQuery($sql)->fetchOne();
     }
 }

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Exception\NotSupported;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Query\AST\DeleteStatement;
@@ -48,6 +49,10 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $conn          = $em->getConnection();
         $platform      = $conn->getDatabasePlatform();
         $quoteStrategy = $em->getConfiguration()->getQuoteStrategy();
+
+        if ($conn instanceof PrimaryReadReplicaConnection) {
+            $conn->ensureConnectedToPrimary();
+        }
 
         $primaryClass    = $em->getClassMetadata($AST->deleteClause->abstractSchemaName);
         $primaryDqlAlias = $AST->deleteClause->aliasIdentificationVariable;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Query\AST\UpdateStatement;
@@ -54,6 +55,10 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $conn          = $em->getConnection();
         $platform      = $conn->getDatabasePlatform();
         $quoteStrategy = $em->getConfiguration()->getQuoteStrategy();
+
+        if ($conn instanceof PrimaryReadReplicaConnection) {
+            $conn->ensureConnectedToPrimary();
+        }
 
         $updateClause = $AST->updateClause;
         $primaryClass = $sqlWalker->getEntityManager()->getClassMetadata($updateClause->abstractSchemaName);

--- a/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Query\SqlWalker;
 
@@ -37,6 +38,10 @@ class SingleTableDeleteUpdateExecutor extends AbstractSqlExecutor
      */
     public function execute(Connection $conn, array $params, array $types)
     {
+        if ($conn instanceof PrimaryReadReplicaConnection) {
+            $conn->ensureConnectedToPrimary();
+        }
+
         return $conn->executeStatement($this->_sqlStatements, $params, $types);
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Proxy\Proxy;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
@@ -338,6 +339,12 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function commit($entity = null)
     {
+        $connection = $this->em->getConnection();
+
+        if ($connection instanceof PrimaryReadReplicaConnection) {
+            $connection->ensureConnectedToPrimary();
+        }
+
         // Raise preFlush
         if ($this->evm->hasListeners(Events::preFlush)) {
             $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));


### PR DESCRIPTION
Due a breaking API change with assumptions of `PrimaryReadReplicaConnection` in DBAL 3 without the distinction of `query` and `executeStatement` it is required to address the use of primary replica connection more explicitly in ORM.

This isn't the most pretty solution, but it detects the use of primary replica connection at the right points: 1. id generation 2. commit 3. DQL update/delete statements.