### PR TITLE
Deprecate `Setup::registerAutoloadDirectory()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## Deprecated: `Setup::registerAutoloadDirectory()`
+
+Use Composer's autoloader instead.
+
 ## Deprecated: `AbstractHydrator::hydrateRow()`
 
 Following the deprecation of the method `AbstractHydrator::iterate()`, the

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -40,6 +40,8 @@ class Setup
      * Use this method to register all autoloads for a downloaded Doctrine library.
      * Pick the directory the library was uncompressed into.
      *
+     * @deprecated Use Composer's autoloader instead.
+     *
      * @param string $directory
      *
      * @return void


### PR DESCRIPTION
Custom autoloaders shouldn't be a thing anymore.

Note that I deliberately did not trigger a runtime deprecation inside that method because I have to assume that **if** somebody really uses `registerAutoloadDirectory()`, they do it in an environment where the `Deprecation` class might not be autoloadable.