### PR TITLE
Fix SchemaValidator with abstract child class in discriminator map - Enforcing Abstract Entity in DiscriminatorMap is important for some operations

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -239,7 +239,7 @@ class SchemaValidator
             }
         }
 
-        if (! $class->isInheritanceTypeNone() && ! $class->isRootEntity() && ! $class->reflClass->isAbstract() && ! $class->isMappedSuperclass && array_search($class->name, $class->discriminatorMap, true) === false) {
+        if (! $class->isInheritanceTypeNone() && ! $class->isRootEntity() && ! $class->isMappedSuperclass && array_search($class->name, $class->discriminatorMap, true) === false) {
             $ce[] = "Entity class '" . $class->name . "' is part of inheritance hierarchy, but is " .
                 "not mapped in the root entity '" . $class->rootEntityName . "' discriminator map. " .
                 'All subclasses must be listed in the discriminator map.';

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -225,17 +225,6 @@ class SchemaValidatorTest extends OrmTestCase
 
         $this->assertEquals([], $ce);
     }
-
-    /**
-     * @group 9095
-     */
-    public function testAbstractChildClassNotPresentInDiscriminator(): void
-    {
-        $class1 = $this->em->getClassMetadata(Issue9095AbstractChild::class);
-        $ce     = $this->validator->validateClass($class1);
-
-        $this->assertEquals([], $ce);
-    }
 }
 
 /**
@@ -264,35 +253,6 @@ abstract class ParentEntity
  * @Entity
  */
 class ChildEntity extends MappedSuperclassEntity
-{
-}
-
-/**
- * @Entity
- * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorMap({"child" = Issue9095Child::class})
- */
-abstract class Issue9095Parent
-{
-    /**
-     * @var mixed
-     * @Id
-     * @Column
-     */
-    protected $key;
-}
-
-/**
- * @Entity
- */
-abstract class Issue9095AbstractChild extends Issue9095Parent
-{
-}
-
-/**
- * @Entity
- */
-class Issue9095Child extends Issue9095AbstractChild
 {
 }
 


### PR DESCRIPTION
Resolves https://github.com/doctrine/orm/issues/9142

> Recent fix introduced in 2.10.2 9096: Fix SchemaValidator with abstract child class in discriminator map is a regression to the SchemaValidator as having all @Entity classes, including those that are non-instantiable (abstract) is important for some operation.

This reverts commit bbb68d007213188dc6008ca04b7167b79433c1a5.

https://github.com/doctrine/orm/pull/9145 demonstrates that even abstract classes are required to be present in discriminator map.