### PR TITLE
Catch exception from Connection::commit()

### DIFF
--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Exception;
 use RuntimeException;
+use Throwable;
 
 /**
  * An OptimisticLockException is thrown when a version check on an object
@@ -22,9 +23,9 @@ class OptimisticLockException extends Exception implements ORMException
      * @param string      $msg
      * @param object|null $entity
      */
-    public function __construct($msg, $entity)
+    public function __construct($msg, $entity, ?Throwable $previous = null)
     {
-        parent::__construct($msg);
+        parent::__construct($msg, 0, $previous);
         $this->entity = $entity;
     }
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -92,6 +92,8 @@
             <errorLevel type="suppress">
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+                <!-- DBAL 3 compatibility -->
+                <file name="lib/Doctrine/ORM/UnitOfWork.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
         <UndefinedAttributeClass>


### PR DESCRIPTION
`Connection::commit()` will return `void` in DBAL 4. See https://github.com/doctrine/dbal/pull/3480.