### PR TITLE
Improve compatibility with Doctrine DBAL 4

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
@@ -16,19 +16,19 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ComparisonExpression extends Node
 {
-    /** @var Node */
+    /** @var Node|string */
     public $leftExpression;
 
-    /** @var Node */
+    /** @var Node|string */
     public $rightExpression;
 
     /** @var string */
     public $operator;
 
     /**
-     * @param Node   $leftExpr
-     * @param string $operator
-     * @param Node   $rightExpr
+     * @param Node|string $leftExpr
+     * @param string      $operator
+     * @param Node|string $rightExpr
      */
     public function __construct($leftExpr, $operator, $rightExpr)
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -32,14 +32,20 @@ class LocateFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getLocateExpression(
-            $sqlWalker->walkStringPrimary($this->secondStringPrimary), // its the other way around in platform
-            $sqlWalker->walkStringPrimary($this->firstStringPrimary),
-            ($this->simpleArithmeticExpression
-                ? $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression)
-                : false
-            )
-        );
+        $platform = $sqlWalker->getConnection()->getDatabasePlatform();
+
+        $firstString  = $sqlWalker->walkStringPrimary($this->firstStringPrimary);
+        $secondString = $sqlWalker->walkStringPrimary($this->secondStringPrimary);
+
+        if ($this->simpleArithmeticExpression) {
+            return $platform->getLocateExpression(
+                $secondString,
+                $firstString,
+                $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression)
+            );
+        }
+
+        return $platform->getLocateExpression($secondString, $firstString);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -28,7 +28,7 @@ class TrimFunction extends FunctionNode
     /** @var bool */
     public $both;
 
-    /** @var bool */
+    /** @var string|false */
     public $trimChar = false;
 
     /** @var Node */
@@ -42,11 +42,16 @@ class TrimFunction extends FunctionNode
         $stringPrimary = $sqlWalker->walkStringPrimary($this->stringPrimary);
         $platform      = $sqlWalker->getConnection()->getDatabasePlatform();
         $trimMode      = $this->getTrimMode();
-        $trimChar      = $this->trimChar !== false
-            ? $sqlWalker->getConnection()->quote($this->trimChar)
-            : false;
 
-        return $platform->getTrimExpression($stringPrimary, $trimMode, $trimChar);
+        if ($this->trimChar !== false) {
+            return $platform->getTrimExpression(
+                $stringPrimary,
+                $trimMode,
+                $platform->quoteStringLiteral($this->trimChar)
+            );
+        }
+
+        return $platform->getTrimExpression($stringPrimary, $trimMode);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1498,7 +1498,7 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 5
+			count: 1
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -25,3 +25,8 @@ parameters:
             message: '/^Call to an undefined method Doctrine\\Common\\Cache\\Cache::deleteAll\(\)\.$/'
             count: 1
             path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+        # See https://github.com/doctrine/dbal/pull/5129
+        -
+            message: '/^Parameter #3 \$startPos of method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getLocateExpression\(\) expects int\|false, string given\.$/'
+            count: 1
+            path: lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,3 +38,8 @@ parameters:
             message: '/^Call to an undefined method Doctrine\\Common\\Cache\\Cache::deleteAll\(\)\.$/'
             count: 1
             path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+        # See https://github.com/doctrine/dbal/pull/5129
+        -
+            message: '/^Parameter #3 \$startPos of method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getLocateExpression\(\) expects int\|false, string given\.$/'
+            count: 1
+            path: lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php


### PR DESCRIPTION
The following issues have been identified by running Psalm with the DBAL `4.0.x-dev`:

1. See https://github.com/doctrine/dbal/pull/3494:
   ```
   ERROR: PossiblyFalseArgument - lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php:38:14 - Argument 3 of Doctrine\DBAL\Platforms\AbstractPlatform::getLocateExpression cannot be false, possibly null|string value expected (see https://psalm.dev/104)
               ($this->simpleArithmeticExpression
                   ? $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression)
                   : false
   ```
2. See https://github.com/doctrine/dbal/pull/3491:
   ```
    ERROR: InvalidArgument - lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php:46:50 - Argument 1 of Doctrine\DBAL\Connection::quote expects string, true provided (see https://psalm.dev/004)
                ? $sqlWalker->getConnection()->quote($this->trimChar)
    
    
    ERROR: PossiblyFalseArgument - lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php:49:72 - Argument 3 of Doctrine\DBAL\Platforms\AbstractPlatform::getTrimExpression cannot be false, possibly null|string value expected (see https://psalm.dev/104)
            return $platform->getTrimExpression($stringPrimary, $trimMode, $trimChar);
    ```
3. See https://github.com/doctrine/dbal/pull/3488:
   ```
   ERROR: InvalidArgument - lib/Doctrine/ORM/Query/SqlWalker.php:2197:71 - Argument 1 of Doctrine\DBAL\Connection::quote expects string, Doctrine\ORM\Query\AST\Node provided (see https://psalm.dev/004)
               : (is_numeric($leftExpr) ? $leftExpr : $this->conn->quote($leftExpr));
   
   ERROR: InvalidArgument - lib/Doctrine/ORM/Query/SqlWalker.php:2203:73 - Argument 1 of Doctrine\DBAL\Connection::quote expects string, Doctrine\ORM\Query\AST\Node provided (see https://psalm.dev/004)
               : (is_numeric($rightExpr) ? $rightExpr : $this->conn->quote($rightExpr));
   ```