### PR TITLE
Fix WhereInWalker description to better describe the behaviour of this class

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -28,7 +28,7 @@ use function is_array;
 use function reset;
 
 /**
- * Appends to the whereClause of the AST a Condition "id IN (:foo_1, :foo_2)".
+ * Appends a condition "id IN (:foo_1, :foo_2)" to the whereClause of the AST.
  */
 class WhereInWalker extends TreeWalkerAdapter
 {

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -43,7 +43,7 @@ class WhereInWalker extends TreeWalkerAdapter
     public const PAGINATOR_ID_ALIAS = 'dpid';
 
     /**
-     * Appends to the whereClause of the AST a Condition equivalent to WHERE IN (:dpid_1, :dpid_2, ...)
+     * Appends a condition equivalent to "WHERE IN (:dpid_1, :dpid_2, ...)" to the whereClause of the AST.
      *
      * The parameter namespace (dpid) is defined by
      * the PAGINATOR_ID_ALIAS

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -28,7 +28,7 @@ use function is_array;
 use function reset;
 
 /**
- * Replaces the whereClause of the AST with a WHERE id IN (:foo_1, :foo_2) equivalent.
+ * Appends to the whereClause of the AST a Condition "id IN (:foo_1, :foo_2)".
  */
 class WhereInWalker extends TreeWalkerAdapter
 {
@@ -43,9 +43,7 @@ class WhereInWalker extends TreeWalkerAdapter
     public const PAGINATOR_ID_ALIAS = 'dpid';
 
     /**
-     * Replaces the whereClause in the AST.
-     *
-     * Generates a clause equivalent to WHERE IN (:dpid_1, :dpid_2, ...)
+     * Appends to the whereClause of the AST a Condition equivalent to WHERE IN (:dpid_1, :dpid_2, ...)
      *
      * The parameter namespace (dpid) is defined by
      * the PAGINATOR_ID_ALIAS


### PR DESCRIPTION
I changed the verb "replace" with "append" to better describe the behavior of this class. As you can see in lines from 105 to 140 the `$AST->whereClause` is not replaced with the IN condition, but the IN condition is appended.
This is not a detail since the verb "replace" generates confusion and in Issue https://github.com/doctrine/orm/issues/9042 we thought that there was a bug in the code.