### PR TITLE
Add DQL non-ASCII characters support

### DIFF
--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -14,6 +14,7 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="utf8" />
 
         <!-- necessary change for some CLI/console output test assertions -->
         <env name="COLUMNS" value="120"/>

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -14,6 +14,7 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="utf8" />
 
         <!-- necessary change for some CLI/console output test assertions -->
         <env name="COLUMNS" value="120"/>

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -127,11 +127,11 @@ class Lexer extends AbstractLexer
     protected function getCatchablePatterns()
     {
         return [
-            '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // aliased name
-            '[a-z_\\\][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
+            '[[:alpha:]_][[:alpha:]0-9_]*\:[[:alpha:]_][[:alpha:]0-9_]*(?:\\\[[:alpha:]_][[:alpha:]0-9_]*)*', // aliased name
+            '[[:alpha:]_\\\][[:alpha:]0-9_]*(?:\\\[[:alpha:]_][[:alpha:]0-9_]*)*', // identifier or qualified name
             '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?', // numbers
             "'(?:[^']|'')*'", // quoted strings
-            '\?[0-9]*|:[a-z_][a-z0-9_]*', // parameters
+            '\?[0-9]*|:[[:alpha:]_][[:alpha:]0-9_]*', // parameters
         ];
     }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -266,4 +266,18 @@
         <!-- https://github.com/doctrine/orm/issues/8537 -->
         <exclude-pattern>lib/Doctrine/ORM/QueryBuilder.php</exclude-pattern>
     </rule>
+
+    <!-- see https://github.com/squizlabs/PHP_CodeSniffer/pull/3532 -->
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <exclude-pattern>tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps">
+        <exclude-pattern>tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+        <exclude-pattern>tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -43,7 +43,8 @@
       <var name="db_user" value="root" />
       <var name="db_password" value="" />
       <var name="db_dbname" value="doctrine_tests" />
-      <var name="db_port" value="3306"/>-->
+      <var name="db_port" value="3306"/>
+      <var name="db_charset" value="utf8"/>-->
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
     <!--

--- a/tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php
+++ b/tests/Doctrine/Tests/Models/Diacritics/NuméroDeTéléphone.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Diacritics;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="numéros_de_téléphone")
+ */
+class NuméroDeTéléphone
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $numéro;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getNuméro(): string
+    {
+        return $this->numéro;
+    }
+
+    public function setNuméro(string $numéro): void
+    {
+        $this->numéro = $numéro;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/DqlWithDiacriticsQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DqlWithDiacriticsQueryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Diacritics\NuméroDeTéléphone;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class DqlWithDiacriticsQueryTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('diacritics');
+
+        parent::setUp();
+
+        $this->generateFixture();
+    }
+
+    public function testSimpleQueryWithDiacritics(): void
+    {
+        $dql = 'SELECT n.numéro ' .
+               'FROM Doctrine\Tests\Models\Diacritics\NuméroDeTéléphone n ';
+
+        $result = $this->_em->createQuery($dql)->getSingleScalarResult();
+
+        self::assertEquals('+33000000000', $result);
+    }
+
+    public function generateFixture(): void
+    {
+        $numero = new NuméroDeTéléphone();
+        $numero->setNuméro('+33000000000');
+
+        $this->_em->persist($numero);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -225,6 +225,80 @@ class LexerTest extends OrmTestCase
         self::assertFalse($lexer->moveNext());
     }
 
+    public function testScannerTokenizesASimpleQueryWithNonAsciiCharactersCorrectly(): void
+    {
+        $dql   = 'SELECT société FROM Domain\Société société WHERE société.représentant = :représentant_société';
+        $lexer = new Lexer($dql);
+
+        $tokens = [
+            [
+                'value' => 'SELECT',
+                'type'  => Lexer::T_SELECT,
+                'position' => 0,
+            ],
+            [
+                'value' => 'société',
+                'type'  => Lexer::T_IDENTIFIER,
+                'position' => 7,
+            ],
+            [
+                'value' => 'FROM',
+                'type'  => Lexer::T_FROM,
+                'position' => 17,
+            ],
+            [
+                'value' => 'Domain\Société',
+                'type'  => Lexer::T_FULLY_QUALIFIED_NAME,
+                'position' => 22,
+            ],
+            [
+                'value' => 'société',
+                'type'  => Lexer::T_IDENTIFIER,
+                'position' => 39,
+            ],
+            [
+                'value' => 'WHERE',
+                'type'  => Lexer::T_WHERE,
+                'position' => 49,
+            ],
+            [
+                'value' => 'société',
+                'type'  => Lexer::T_IDENTIFIER,
+                'position' => 55,
+            ],
+            [
+                'value' => '.',
+                'type'  => Lexer::T_DOT,
+                'position' => 64,
+            ],
+            [
+                'value' => 'représentant',
+                'type'  => Lexer::T_IDENTIFIER,
+                'position' => 65,
+            ],
+            [
+                'value' => '=',
+                'type'  => Lexer::T_EQUALS,
+                'position' => 79,
+            ],
+            [
+                'value' => ':représentant_société',
+                'type'  => Lexer::T_INPUT_PARAMETER,
+                'position' => 81,
+            ],
+        ];
+
+        foreach ($tokens as $expected) {
+            $lexer->moveNext();
+            $actual = $lexer->lookahead;
+            self::assertEquals($expected['value'], $actual['value']);
+            self::assertEquals($expected['type'], $actual['type']);
+            self::assertEquals($expected['position'], $actual['position']);
+        }
+
+        self::assertFalse($lexer->moveNext());
+    }
+
     /** @psalm-return list<array{int, string}> */
     public static function provideTokens(): array
     {

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -144,6 +144,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Company\CompanyCar::class,
             Models\Company\CompanyContract::class,
         ],
+        'diacritics' => [
+            Models\Diacritics\NuméroDeTéléphone::class,
+        ],
         'ecommerce' => [
             Models\ECommerce\ECommerceCart::class,
             Models\ECommerce\ECommerceCustomer::class,

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -218,6 +218,7 @@ class TestUtil
                 'ssl_capath',
                 'ssl_cipher',
                 'unix_socket',
+                'charset',
             ] as $parameter
         ) {
             if (! isset($configuration[$prefix . $parameter])) {


### PR DESCRIPTION
This PR adds support for non-ASCII characters usage in DQL.

My use case was to use the actual domain experts language in the code (french, so with some diacritics) instead of translating everything to english. The only obstable I faced was non-ASCII characters not being parsed correctly in DQL, though I only tried a few simple scenarios.

I don't know if not supporting non-ASCII characters was on purpose. If so, feel free to close this PR.

The provided naming strategies also need an update but I will do that in a subsequent PR if this one is accepted.