### PR TITLE
Allow symfony/cache 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan": "1.2.0",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
         "squizlabs/php_codesniffer": "3.6.2",
-        "symfony/cache": "^4.4 || ^5.2",
+        "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "vimeo/psalm": "4.15.0"
     },


### PR DESCRIPTION
Allowing symfony/cache 6 enables us to test with psr/cache 3.