### PR TITLE
Fix XML export for `change-tracking-policy`

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -90,7 +90,7 @@ class XmlExporter extends AbstractExporter
         $trackingPolicy = $this->_getChangeTrackingPolicyString($metadata->changeTrackingPolicy);
 
         if ($trackingPolicy !== 'DEFERRED_IMPLICIT') {
-            $root->addChild('change-tracking-policy', $trackingPolicy);
+            $root->addAttribute('change-tracking-policy', $trackingPolicy);
         }
 
         if (isset($metadata->table['indexes'])) {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -103,4 +103,46 @@ XML;
 
         self::assertXmlStringEqualsXmlString($expectedFileContent, $exporter->exportClassMetadata($metadata));
     }
+
+    public function testPolicyExport(): void
+    {
+        $exporter = new XmlExporter();
+        $metadata = new ClassMetadata('entityTest');
+
+        // DEFERRED_IMPLICIT
+        $metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
+
+        $expectedFileContent = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="entityTest"/>
+</doctrine-mapping>
+XML;
+
+        self::assertXmlStringEqualsXmlString($expectedFileContent, $exporter->exportClassMetadata($metadata));
+
+        // DEFERRED_EXPLICIT
+        $metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_EXPLICIT);
+
+        $expectedFileContent = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="entityTest" change-tracking-policy="DEFERRED_EXPLICIT"/>
+</doctrine-mapping>
+XML;
+
+        self::assertXmlStringEqualsXmlString($expectedFileContent, $exporter->exportClassMetadata($metadata));
+
+        // NOTIFY
+        $metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_NOTIFY);
+
+        $expectedFileContent = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="entityTest" change-tracking-policy="NOTIFY"/>
+</doctrine-mapping>
+XML;
+
+        self::assertXmlStringEqualsXmlString($expectedFileContent, $exporter->exportClassMetadata($metadata));
+    }
 }


### PR DESCRIPTION
The `change-tracking-policy` is an attribute, not an Entity child.

Even thought the xml exporter is deprecated it still should produce valid output for 2.x series ;) 