### PR TITLE
Whitelist composer plugins used by this repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
     "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
Since Composer 2.2, plugins need to be whitelisted. Otherwise Composer will keep asking about them.