### PR TITLE
[RFC] Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   coding-standards:
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:
-      php-version: "7.4"
+      php-version: "8.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
         dbal-version:
@@ -74,7 +73,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
         dbal-version:
           - "default"
         postgres-version:
@@ -131,7 +130,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
         dbal-version:
           - "default"
         mariadb-version:
@@ -192,7 +191,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
         dbal-version:
           - "default"
         mysql-version:

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-ctype": "*",
         "ext-pdo": "*",
         "composer/package-versions-deprecated": "^1.8",
@@ -35,8 +35,7 @@
         "doctrine/lexer": "^1.0",
         "doctrine/persistence": "^2.2",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/polyfill-php80": "^1.15"
+        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13",


### PR DESCRIPTION
I'd like to propose to raise the minimum PHP version for the 3.0.x branch to 8.0.

We have taken this step on the DBAL 4.0.x branch already. Having the full power of the PHP 8 type system will make it easier for us to create a codebase that is compatible with DBAL 4. Moreover, bumping to PHP 8 would allow us to use native attributes as a default for old and new functional tests. Last but not least, developing features for a PHP-8-only project is a really delightful experience. 🙂 

According to Packagist's statistics, [more than 50% of ORM 2.10 installations](https://packagist.org/packages/doctrine/orm/php-stats#2.10) run PHP 8 already.

I don't know exactly when the 3.0.x  branch will be ready for a release, but even if we released right now, I would expect the 2.x series of the ORM to live on for some time, so that projects may upgrade to the new major (and PHP 8) at their own pace.

