### PR TITLE
Enable PHPCS rules for PHP 8.0

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80000"/>
 
     <file>lib</file>
     <file>tests</file>
@@ -26,6 +26,7 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">

--- a/tests/Doctrine/StaticAnalysis/get-metadata.php
+++ b/tests/Doctrine/StaticAnalysis/get-metadata.php
@@ -16,10 +16,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 abstract class GetMetadata
 {
     /**
-     * @param string|object $class
      * @psalm-param class-string|object $class
      */
-    abstract public function getEntityManager($class): EntityManagerInterface;
+    abstract public function getEntityManager(string|object $class): EntityManagerInterface;
 
     /**
      * @psalm-param class-string<TObject> $class

--- a/tests/Doctrine/Tests/DoctrineTestCase.php
+++ b/tests/Doctrine/Tests/DoctrineTestCase.php
@@ -25,10 +25,8 @@ abstract class DoctrineTestCase extends TestCase
 
     /**
      * @param array<mixed> $arguments
-     *
-     * @return mixed
      */
-    public static function __callStatic(string $method, array $arguments)
+    public static function __callStatic(string $method, array $arguments): mixed
     {
         if (isset(self::$phpunitMethodRenames[$method])) {
             $method = self::$phpunitMethodRenames[$method];
@@ -41,10 +39,8 @@ abstract class DoctrineTestCase extends TestCase
 
     /**
      * @param array<mixed> $arguments
-     *
-     * @return mixed
      */
-    public function __call(string $method, array $arguments)
+    public function __call(string $method, array $arguments): mixed
     {
         if ($method === 'createStub') {
             return $this->getMockBuilder(...$arguments)

--- a/tests/Doctrine/Tests/Mocks/CacheRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/CacheRegionMock.php
@@ -28,22 +28,16 @@ class CacheRegionMock implements Region
 
     /**
      * Queue a return value for a specific method invocation
-     *
-     * @param mixed $value
      */
-    public function addReturn(string $method, $value): void
+    public function addReturn(string $method, mixed $value): void
     {
         $this->returns[$method][] = $value;
     }
 
     /**
      * Dequeue a value for a specific method invocation
-     *
-     * @param mixed $default
-     *
-     * @return mixed
      */
-    private function getReturn(string $method, $default)
+    private function getReturn(string $method, mixed $default): mixed
     {
         if (isset($this->returns[$method]) && ! empty($this->returns[$method])) {
             return array_shift($this->returns[$method]);

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -145,12 +145,7 @@ class ConnectionMock extends Connection
         return $input;
     }
 
-    /* Mock API */
-
-    /**
-     * @param mixed $fetchOneResult
-     */
-    public function setFetchOneResult($fetchOneResult): void
+    public function setFetchOneResult(mixed $fetchOneResult): void
     {
         $this->_fetchOneResult = $fetchOneResult;
     }

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -34,10 +34,7 @@ class EntityPersisterMock extends BasicEntityPersister
     /** @var bool */
     private $existsCalled = false;
 
-    /**
-     * @return mixed
-     */
-    public function addInsert($entity)
+    public function addInsert($entity): mixed
     {
         $this->inserts[] = $entity;
         if (

--- a/tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityA.php
+++ b/tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityA.php
@@ -17,34 +17,22 @@ class DDC3711EntityA
     /** @var ArrayCollection */
     private $entityB;
 
-    /**
-     * @return mixed
-     */
-    public function getId1()
+    public function getId1(): mixed
     {
         return $this->id1;
     }
 
-    /**
-     * @param mixed $id1
-     */
-    public function setId1($id1): void
+    public function setId1(mixed $id1): void
     {
         $this->id1 = $id1;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getId2()
+    public function getId2(): mixed
     {
         return $this->id2;
     }
 
-    /**
-     * @param mixed $id2
-     */
-    public function setId2($id2): void
+    public function setId2(mixed $id2): void
     {
         $this->id2 = $id2;
     }

--- a/tests/Doctrine/Tests/Models/ECommerce/ECommerceShipping.php
+++ b/tests/Doctrine/Tests/Models/ECommerce/ECommerceShipping.php
@@ -38,18 +38,12 @@ class ECommerceShipping
         return $this->id;
     }
 
-    /**
-     * @return int|string
-     */
-    public function getDays()
+    public function getDays(): int|string
     {
         return $this->days;
     }
 
-    /**
-     * @param int|string $days
-     */
-    public function setDays($days): void
+    public function setDays(int|string $days): void
     {
         $this->days = $days;
     }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -223,12 +223,10 @@ class EntityManagerTest extends OrmTestCase
     }
 
     /**
-     * @param mixed $expectedValue
-     *
      * @dataProvider dataToBeReturnedByWrapInTransaction
      * @group DDC-1125
      */
-    public function testWrapInTransactionAcceptsReturn($expectedValue): void
+    public function testWrapInTransactionAcceptsReturn(mixed $expectedValue): void
     {
         $return = $this->entityManager->wrapInTransaction(
             /** @return mixed */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -105,18 +105,12 @@ class DDC2895 extends AbstractDDC2895
      */
     public $id;
 
-    /**
-     * @param mixed $id
-     */
-    public function setId($id): void
+    public function setId(mixed $id): void
     {
         $this->id = $id;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getId()
+    public function getId(): mixed
     {
         return $this->id;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -106,8 +106,7 @@ class DDC5684ObjectId
     /** @var mixed */
     public $value;
 
-    /** @param mixed $value */
-    public function __construct($value)
+    public function __construct(mixed $value)
     {
         $this->value = $value;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
@@ -126,10 +126,7 @@ class DDC6303ChildA extends DDC6303BaseClass
      */
     private $originalData;
 
-    /**
-     * @param mixed $originalData
-     */
-    public function __construct(string $id, $originalData)
+    public function __construct(string $id, mixed $originalData)
     {
         $this->id           = $id;
         $this->originalData = $originalData;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5762Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5762Test.php
@@ -61,10 +61,7 @@ class GH5762Test extends OrmFunctionalTestCase
         self::assertContains('Volvo', $cars);
     }
 
-    /**
-     * @return mixed
-     */
-    private function fetchData()
+    private function fetchData(): mixed
     {
         $this->createData();
 

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -52,11 +52,10 @@ class SingleScalarHydratorTest extends HydrationTestCase
 
     /**
      * @param list<array<string, mixed>> $resultSet
-     * @param mixed                      $expectedResult
      *
      * @dataProvider validResultSetProvider
      */
-    public function testHydrateSingleScalarFromFieldMappingWithValidResultSet(array $resultSet, $expectedResult): void
+    public function testHydrateSingleScalarFromFieldMappingWithValidResultSet(array $resultSet, mixed $expectedResult): void
     {
         $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsUser::class, 'u');
@@ -72,11 +71,10 @@ class SingleScalarHydratorTest extends HydrationTestCase
 
     /**
      * @param list<array<string, mixed>> $resultSet
-     * @param mixed                      $expectedResult
      *
      * @dataProvider validResultSetProvider
      */
-    public function testHydrateSingleScalarFromScalarMappingWithValidResultSet(array $resultSet, $expectedResult): void
+    public function testHydrateSingleScalarFromScalarMappingWithValidResultSet(array $resultSet, mixed $expectedResult): void
     {
         $rsm = new ResultSetMapping();
         $rsm->addScalarResult('u__id', 'id', 'string');

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -17,11 +17,9 @@ use function uniqid;
 class ORMInvalidArgumentExceptionTest extends TestCase
 {
     /**
-     * @param mixed $value
-     *
      * @dataProvider invalidEntityNames
      */
-    public function testInvalidEntityName($value, string $expectedMessage): void
+    public function testInvalidEntityName(mixed $value, string $expectedMessage): void
     {
         $exception = ORMInvalidArgumentException::invalidEntityName($value);
 

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -34,12 +34,9 @@ class ParameterTypeInfererTest extends OrmTestCase
     }
 
     /**
-     * @param mixed      $value
-     * @param int|string $expected
-     *
      * @dataProvider providerParameterTypeInferer
      */
-    public function testParameterTypeInferer($value, $expected): void
+    public function testParameterTypeInferer(mixed $value, int|string $expected): void
     {
         self::assertEquals($expected, ParameterTypeInferer::inferType($value));
     }

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -27,11 +27,9 @@ class QueryExpressionVisitorTest extends TestCase
     }
 
     /**
-     * @param QueryBuilder\Comparison|QueryBuilder\Func|string $queryExpr
-     *
      * @dataProvider comparisonData
      */
-    public function testWalkComparison(CriteriaComparison $criteriaExpr, $queryExpr, ?Parameter $parameter = null): void
+    public function testWalkComparison(CriteriaComparison $criteriaExpr, QueryBuilder\Comparison|QueryBuilder\Func|string $queryExpr, ?Parameter $parameter = null): void
     {
         self::assertEquals($queryExpr, $this->visitor->walkComparison($criteriaExpr));
         if ($parameter) {

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -266,8 +266,7 @@ class WhereInWalkerTest extends PaginationTestCase
         );
     }
 
-    /** @param mixed $parameter */
-    private function assertPaginatorWhereInParameterToBe(Query $query, $parameter): void
+    private function assertPaginatorWhereInParameterToBe(Query $query, mixed $parameter): void
     {
         $query->getSQL(); // forces walker to process the query
 

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -308,12 +308,10 @@ class UnitOfWorkTest extends OrmTestCase
     }
 
     /**
-     * @param mixed $invalidValue
-     *
      * @group DDC-3490
      * @dataProvider invalidAssociationValuesDataProvider
      */
-    public function testRejectsPersistenceOfObjectsWithInvalidAssociationValue($invalidValue): void
+    public function testRejectsPersistenceOfObjectsWithInvalidAssociationValue(mixed $invalidValue): void
     {
         $this->_unitOfWork->setEntityPersister(
             ForumUser::class,
@@ -333,12 +331,10 @@ class UnitOfWorkTest extends OrmTestCase
     }
 
     /**
-     * @param mixed $invalidValue
-     *
      * @group DDC-3490
      * @dataProvider invalidAssociationValuesDataProvider
      */
-    public function testRejectsChangeSetComputationForObjectsWithInvalidAssociationValue($invalidValue): void
+    public function testRejectsChangeSetComputationForObjectsWithInvalidAssociationValue(mixed $invalidValue): void
     {
         $metadata = $this->_emMock->getClassMetadata(ForumUser::class);
 
@@ -880,18 +876,12 @@ class NotifyChangedEntity implements NotifyPropertyChanged
         }
     }
 
-    /**
-     * @return mixed
-     */
-    public function getData()
+    public function getData(): mixed
     {
         return $this->data;
     }
 
-    /**
-     * @param mixed $data
-     */
-    public function setData($data): void
+    public function setData(mixed $data): void
     {
         if ($data !== $this->data) {
             $this->onPropertyChanged('data', $this->data, $data);
@@ -904,12 +894,7 @@ class NotifyChangedEntity implements NotifyPropertyChanged
         $this->_listeners[] = $listener;
     }
 
-    /**
-     * @param mixed $propName
-     * @param mixed $oldValue
-     * @param mixed $newValue
-     */
-    protected function onPropertyChanged($propName, $oldValue, $newValue): void
+    protected function onPropertyChanged(mixed $propName, mixed $oldValue, mixed $newValue): void
     {
         if ($this->_listeners) {
             foreach ($this->_listeners as $listener) {

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -72,13 +72,10 @@ abstract class OrmTestCase extends DoctrineTestCase
      * mocked out using a DriverMock, ConnectionMock, etc. These mocks can then
      * be configured in the tests to simulate the DBAL behavior that is desired
      * for a particular test,
-     *
-     * @param Connection|array $conn
-     * @param mixed            $conf
      */
     protected function getTestEntityManager(
-        $conn = null,
-        $conf = null,
+        Connection|array|null $conn = null,
+        mixed $conf = null,
         ?EventManager $eventManager = null,
         bool $withSharedMetadata = true
     ): EntityManagerMock {


### PR DESCRIPTION
This will add some types, especially to the test suite. ~~Let's see which tests fail and fix the issues on lower branches.~~