### PR TITLE
Leverage get_debug_type()

### DIFF
--- a/lib/Doctrine/ORM/Cache/Exception/MetadataCacheUsesNonPersistentCache.php
+++ b/lib/Doctrine/ORM/Cache/Exception/MetadataCacheUsesNonPersistentCache.php
@@ -6,14 +6,14 @@ namespace Doctrine\ORM\Cache\Exception;
 
 use Doctrine\Common\Cache\Cache;
 
-use function get_class;
+use function get_debug_type;
 
 final class MetadataCacheUsesNonPersistentCache extends CacheException
 {
     public static function fromDriver(Cache $cache): self
     {
         return new self(
-            'Metadata Cache uses a non-persistent cache driver, ' . get_class($cache) . '.'
+            'Metadata Cache uses a non-persistent cache driver, ' . get_debug_type($cache) . '.'
         );
     }
 }

--- a/lib/Doctrine/ORM/Cache/Exception/QueryCacheUsesNonPersistentCache.php
+++ b/lib/Doctrine/ORM/Cache/Exception/QueryCacheUsesNonPersistentCache.php
@@ -6,14 +6,14 @@ namespace Doctrine\ORM\Cache\Exception;
 
 use Doctrine\Common\Cache\Cache;
 
-use function get_class;
+use function get_debug_type;
 
 final class QueryCacheUsesNonPersistentCache extends CacheException
 {
     public static function fromDriver(Cache $cache): self
     {
         return new self(
-            'Query Cache uses a non-persistent cache driver, ' . get_class($cache) . '.'
+            'Query Cache uses a non-persistent cache driver, ' . get_debug_type($cache) . '.'
         );
     }
 }

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\ObjectManagerDecorator;
 
-use function get_class;
+use function get_debug_type;
 use function method_exists;
 use function sprintf;
 use function trigger_error;
@@ -67,7 +67,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     {
         if (! method_exists($this->wrapped, 'wrapInTransaction')) {
             trigger_error(
-                sprintf('Calling `transactional()` instead of `wrapInTransaction()` which is not implemented on %s', get_class($this->wrapped)),
+                sprintf('Calling `transactional()` instead of `wrapInTransaction()` which is not implemented on %s', get_debug_type($this->wrapped)),
                 E_USER_NOTICE
             );
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -32,7 +32,7 @@ use Throwable;
 
 use function array_keys;
 use function call_user_func;
-use function get_class;
+use function get_debug_type;
 use function gettype;
 use function is_array;
 use function is_callable;
@@ -948,7 +948,7 @@ use function sprintf;
             throw new InvalidArgumentException(
                 sprintf(
                     'Invalid $connection argument of type %s given%s.',
-                    is_object($connection) ? get_class($connection) : gettype($connection),
+                    get_debug_type($connection),
                     is_object($connection) ? '' : ': "' . $connection . '"'
                 )
             );

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -37,8 +37,6 @@ class EntityNotFoundException extends ORMException
 
     /**
      * Instance for which no identifier can be found
-     *
-     * @psalm-param class-string $className
      */
     public static function noIdentifierFound(string $className): self
     {

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use InvalidArgumentException;
 
-use function get_class;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -108,7 +108,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
             throw new InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the entity "%s" in PreUpdateEventArgs.',
                 $field,
-                get_class($this->getEntity())
+                get_debug_type($this->getEntity())
             ));
         }
     }

--- a/lib/Doctrine/ORM/Exception/EntityMissingAssignedId.php
+++ b/lib/Doctrine/ORM/Exception/EntityMissingAssignedId.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Exception;
 
-use function get_class;
+use function get_debug_type;
 
 final class EntityMissingAssignedId extends ORMException
 {
@@ -13,7 +13,7 @@ final class EntityMissingAssignedId extends ORMException
      */
     public static function forField($entity, string $field): self
     {
-        return new self('Entity of type ' . get_class($entity) . " is missing an assigned ID for field  '" . $field . "'. " .
+        return new self('Entity of type ' . get_debug_type($entity) . " is missing an assigned ID for field  '" . $field . "'. " .
             'The identifier generation strategy for this entity requires the ID field to be populated before ' .
             'EntityManager#persist() is called. If you want automatically generated identifiers instead ' .
             'you need to adjust the metadata mapping accordingly.');

--- a/lib/Doctrine/ORM/Mapping/Exception/CannotGenerateIds.php
+++ b/lib/Doctrine/ORM/Mapping/Exception/CannotGenerateIds.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Mapping\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Exception\ORMException;
 
-use function get_class;
+use function get_debug_type;
 use function sprintf;
 
 final class CannotGenerateIds extends ORMException
@@ -16,7 +16,7 @@ final class CannotGenerateIds extends ORMException
     {
         return new self(sprintf(
             'Platform %s does not support generating identifiers',
-            get_class($platform)
+            get_debug_type($platform)
         ));
     }
 }

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Cache\Cache as CacheDriver;
 use Doctrine\Persistence\ObjectRepository;
 use Exception;
 
-use function get_class;
+use function get_debug_type;
 use function implode;
 use function sprintf;
 
@@ -218,7 +218,7 @@ class ORMException extends Exception
      */
     public static function queryCacheUsesNonPersistentCache(CacheDriver $cache)
     {
-        return new self('Query Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');
+        return new self('Query Cache uses a non-persistent cache driver, ' . get_debug_type($cache) . '.');
     }
 
     /**
@@ -228,7 +228,7 @@ class ORMException extends Exception
      */
     public static function metadataCacheUsesNonPersistentCache(CacheDriver $cache)
     {
-        return new self('Metadata Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');
+        return new self('Metadata Cache uses a non-persistent cache driver, ' . get_debug_type($cache) . '.');
     }
 
     /**

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -9,10 +9,9 @@ use InvalidArgumentException;
 
 use function array_map;
 use function count;
-use function get_class;
+use function get_debug_type;
 use function gettype;
 use function implode;
-use function is_object;
 use function method_exists;
 use function reset;
 use function spl_object_id;
@@ -218,7 +217,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
             $expectedType,
             $assoc['sourceEntity'],
             $assoc['fieldName'],
-            is_object($actualValue) ? get_class($actualValue) : gettype($actualValue)
+            get_debug_type($actualValue)
         ));
     }
 
@@ -231,7 +230,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
      */
     public static function invalidEntityName($entityName)
     {
-        return new self(sprintf('Entity name must be a string, %s given', gettype($entityName)));
+        return new self(sprintf('Entity name must be a string, %s given', get_debug_type($entityName)));
     }
 
     /**
@@ -241,7 +240,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
      */
     private static function objToStr($obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_id($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ASTException.php
+++ b/lib/Doctrine/ORM/Query/AST/ASTException.php
@@ -6,7 +6,7 @@ namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;
 
-use function get_class;
+use function get_debug_type;
 
 /**
  * Base exception class for AST exceptions.
@@ -20,6 +20,6 @@ class ASTException extends QueryException
      */
     public static function noDispatchForNode($node)
     {
-        return new self('Double-dispatch for node ' . get_class($node) . ' is not supported.');
+        return new self('Double-dispatch for node ' . get_debug_type($node) . ' is not supported.');
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -6,7 +6,7 @@ namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\SqlWalker;
 
-use function get_class;
+use function get_debug_type;
 use function get_object_vars;
 use function is_array;
 use function is_object;
@@ -60,7 +60,7 @@ abstract class Node
         $str = '';
 
         if ($obj instanceof Node) {
-            $str  .= get_class($obj) . '(' . PHP_EOL;
+            $str  .= get_debug_type($obj) . '(' . PHP_EOL;
             $props = get_object_vars($obj);
 
             foreach ($props as $name => $prop) {
@@ -85,7 +85,7 @@ abstract class Node
             $ident -= 4;
             $str   .= ($some ? PHP_EOL . str_repeat(' ', $ident) : '') . ')';
         } elseif (is_object($obj)) {
-            $str .= 'instanceof(' . get_class($obj) . ')';
+            $str .= 'instanceof(' . get_debug_type($obj) . ')';
         } else {
             $str .= var_export($obj, true);
         }

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 
 use function count;
 use function get_class;
+use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_string;
@@ -69,15 +70,11 @@ abstract class Base
     {
         if ($arg !== null && (! $arg instanceof self || $arg->count() > 0)) {
             // If we decide to keep Expr\Base instances, we can use this check
-            if (! is_string($arg)) {
-                $class = get_class($arg);
-
-                if (! in_array($class, $this->allowedClasses, true)) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Expression of type '%s' not allowed in this context.",
-                        $class
-                    ));
-                }
+            if (! is_string($arg) && ! in_array(get_class($arg), $this->allowedClasses, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    "Expression of type '%s' not allowed in this context.",
+                    get_debug_type($arg)
+                ));
             }
 
             $this->parts[] = $arg;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -14,9 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_class;
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -93,7 +91,7 @@ EOT
             if (! $collectionRegion instanceof DefaultRegion) {
                 throw new InvalidArgumentException(sprintf(
                     'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    is_object($collectionRegion) ? get_class($collectionRegion) : gettype($collectionRegion)
+                    get_debug_type($collectionRegion)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -14,9 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_class;
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -91,7 +89,7 @@ EOT
             if (! $entityRegion instanceof DefaultRegion) {
                 throw new InvalidArgumentException(sprintf(
                     'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    is_object($entityRegion) ? get_class($entityRegion) : gettype($entityRegion)
+                    get_debug_type($entityRegion)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_class;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -84,7 +84,7 @@ EOT
         if (! ($cacheDriver instanceof ClearableCache)) {
             throw new LogicException(sprintf(
                 'Can only clear cache when ClearableCache interface is implemented, %s does not implement.',
-                get_class($cacheDriver)
+                get_debug_type($cacheDriver)
             ));
         }
 
@@ -97,7 +97,7 @@ EOT
             if (! ($cacheDriver instanceof FlushableCache)) {
                 throw new LogicException(sprintf(
                     'Can only clear cache when FlushableCache interface is implemented, %s does not implement.',
-                    get_class($cacheDriver)
+                    get_debug_type($cacheDriver)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -14,9 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_class;
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -90,7 +88,7 @@ EOT
             if (! $queryRegion instanceof DefaultRegion) {
                 throw new InvalidArgumentException(sprintf(
                     'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    is_object($queryRegion) ? get_class($queryRegion) : gettype($queryRegion)
+                    get_debug_type($queryRegion)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_class;
+use function get_debug_type;
 use function method_exists;
 use function sprintf;
 
@@ -86,7 +86,7 @@ EOT
         if (! $cache && ! ($cacheDriver instanceof ClearableCache)) {
             throw new LogicException(sprintf(
                 'Can only clear cache when ClearableCache interface is implemented, %s does not implement.',
-                get_class($cacheDriver)
+                get_debug_type($cacheDriver)
             ));
         }
 
@@ -99,7 +99,7 @@ EOT
             if (! ($cacheDriver instanceof FlushableCache)) {
                 throw new LogicException(sprintf(
                     'Can only clear cache when FlushableCache interface is implemented, %s does not implement.',
-                    get_class($cacheDriver)
+                    get_debug_type($cacheDriver)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -19,7 +19,7 @@ use function array_map;
 use function array_merge;
 use function count;
 use function current;
-use function get_class;
+use function get_debug_type;
 use function implode;
 use function is_array;
 use function is_bool;
@@ -214,7 +214,7 @@ EOT
         }
 
         if (is_object($value)) {
-            return sprintf('<%s>', get_class($value));
+            return sprintf('<%s>', get_debug_type($value));
         }
 
         if (is_scalar($value)) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -56,6 +56,7 @@ use function array_values;
 use function count;
 use function current;
 use function get_class;
+use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
@@ -912,7 +913,7 @@ class UnitOfWork implements PropertyChangedListener
                 throw UnexpectedAssociationValue::create(
                     $assoc['sourceEntity'],
                     $assoc['fieldName'],
-                    get_class($entry),
+                    get_debug_type($entry),
                     $assoc['targetEntity']
                 );
             }
@@ -3061,7 +3062,7 @@ class UnitOfWork implements PropertyChangedListener
     public function getEntityIdentifier($entity)
     {
         if (! isset($this->entityIdentifiers[spl_object_id($entity)])) {
-            throw EntityNotFoundException::noIdentifierFound(get_class($entity));
+            throw EntityNotFoundException::noIdentifierFound(get_debug_type($entity));
         }
 
         return $this->entityIdentifiers[spl_object_id($entity)];
@@ -3370,7 +3371,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private static function objToStr($obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_id($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -132,7 +132,7 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 2
+			count: 1
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
@@ -2040,11 +2040,6 @@ parameters:
 			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\XcacheCache not found\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
 
 		-
 			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\ApcCache not found\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -464,13 +464,11 @@
     <PropertyTypeCoercion occurrences="1">
       <code>new $metadataFactoryClassName()</code>
     </PropertyTypeCoercion>
-    <RedundantCondition occurrences="2">
-      <code>is_object($connection)</code>
+    <RedundantCondition occurrences="1">
       <code>is_object($connection)</code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType occurrences="1">
       <code>': "' . $connection . '"'</code>
-      <code>gettype($connection)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/EntityManagerInterface.php">
@@ -3190,23 +3188,14 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>gettype($queryRegion)</code>
-    </DocblockTypeContradiction>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>is_object($queryRegion)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php">
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
-    <PossiblyNullArgument occurrences="1">
-      <code>$cacheDriver</code>
-    </PossiblyNullArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -275,7 +275,7 @@ class EntityManagerTest extends OrmTestCase
     public function testCreateInvalidConnection(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid $connection argument of type integer given: "1".');
+        $this->expectExceptionMessage('Invalid $connection argument of type int given: "1".');
 
         $config = new Configuration();
         $config->setMetadataDriverImpl($this->createMock(MappingDriver::class));

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -19,6 +19,7 @@ use Doctrine\Tests\Models\Company\CompanyRaffle;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
+use function get_debug_type;
 use function sprintf;
 
 /**
@@ -280,7 +281,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $result = $q->getResult();
         self::assertCount(1, $result);
-        self::assertInstanceOf(CompanyAuction::class, $result[0], sprintf('Is of class %s', get_class($result[0])));
+        self::assertInstanceOf(CompanyAuction::class, $result[0], sprintf('Is of class %s', get_debug_type($result[0])));
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
 
-use function get_class;
+use function get_debug_type;
 
 /**
  * @group DDC-1383
@@ -59,13 +59,13 @@ class DDC1383Test extends OrmFunctionalTestCase
         // Parent is not instance of the abstract class
         self::assertTrue(
             $parent instanceof DDC1383AbstractEntity,
-            'Entity class is ' . get_class($parent) . ', "DDC1383AbstractEntity" was expected'
+            'Entity class is ' . get_debug_type($parent) . ', "DDC1383AbstractEntity" was expected'
         );
 
         // Parent is NOT instance of entity
         self::assertTrue(
             $parent instanceof DDC1383Entity,
-            'Entity class is ' . get_class($parent) . ', "DDC1383Entity" was expected'
+            'Entity class is ' . get_debug_type($parent) . ', "DDC1383Entity" was expected'
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
@@ -19,6 +19,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
 
 use function get_class;
+use function get_debug_type;
 
 /**
  * @group DDC-1655
@@ -65,7 +66,7 @@ class DDC1655Test extends OrmFunctionalTestCase
 
         $baz = $this->_em->find(get_class($baz), $baz->id);
         foreach ($baz->foos as $foo) {
-            self::assertEquals(1, $foo->loaded, 'should have loaded callback counter incremented for ' . get_class($foo));
+            self::assertEquals(1, $foo->loaded, 'should have loaded callback counter incremented for ' . get_debug_type($foo));
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -70,7 +70,7 @@ use Doctrine\Tests\OrmTestCase;
 
 use function assert;
 use function count;
-use function get_class;
+use function get_debug_type;
 use function sprintf;
 use function strpos;
 use function strtolower;
@@ -635,7 +635,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $driver = $this->loadDriver();
         $class  = $this->createClassMetadata(User::class);
 
-        self::assertCount(1, $class->getNamedQueries(), sprintf('Named queries not processed correctly by driver %s', get_class($driver)));
+        self::assertCount(1, $class->getNamedQueries(), sprintf('Named queries not processed correctly by driver %s', get_debug_type($driver)));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -35,11 +35,11 @@ class ORMInvalidArgumentExceptionTest extends TestCase
     public function invalidEntityNames(): array
     {
         return [
-            [null, 'Entity name must be a string, NULL given'],
-            [true, 'Entity name must be a string, boolean given'],
-            [123, 'Entity name must be a string, integer given'],
-            [123.45, 'Entity name must be a string, double given'],
-            [new stdClass(), 'Entity name must be a string, object given'],
+            [null, 'Entity name must be a string, null given'],
+            [true, 'Entity name must be a string, bool given'],
+            [123, 'Entity name must be a string, int given'],
+            [123.45, 'Entity name must be a string, float given'],
+            [new stdClass(), 'Entity name must be a string, stdClass given'],
         ];
     }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -36,7 +36,7 @@ use function array_reverse;
 use function array_slice;
 use function count;
 use function explode;
-use function get_class;
+use function get_debug_type;
 use function getenv;
 use function implode;
 use function is_object;
@@ -823,7 +823,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $last25queries = array_slice(array_reverse($this->_sqlLoggerStack->queries, true), 0, 25, true);
             foreach ($last25queries as $i => $query) {
                 $params   = array_map(static function ($p) {
-                    return is_object($p) ? get_class($p) : var_export($p, true);
+                    return is_object($p) ? get_debug_type($p) : var_export($p, true);
                 }, $query['params'] ?: []);
                 $queries .= $i . ". SQL: '" . $query['sql'] . "' Params: " . implode(', ', $params) . PHP_EOL;
             }
@@ -841,7 +841,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
                 }
             }
 
-            $message = '[' . get_class($e) . '] ' . $e->getMessage() . PHP_EOL . PHP_EOL . 'With queries:' . PHP_EOL . $queries . PHP_EOL . 'Trace:' . PHP_EOL . $traceMsg;
+            $message = '[' . get_debug_type($e) . '] ' . $e->getMessage() . PHP_EOL . PHP_EOL . 'With queries:' . PHP_EOL . $queries . PHP_EOL . 'Trace:' . PHP_EOL . $traceMsg;
 
             throw new Exception($message, (int) $e->getCode(), $e);
         }

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -12,7 +12,7 @@ use UnexpectedValueException;
 
 use function explode;
 use function fwrite;
-use function get_class;
+use function get_debug_type;
 use function method_exists;
 use function sprintf;
 use function strlen;
@@ -78,7 +78,7 @@ class TestUtil
 
         // Note, writes direct to STDERR to prevent phpunit detecting output - otherwise this would cause either an
         // "unexpected output" warning or a failure on the first test case to call this method.
-        fwrite(STDERR, sprintf("\nUsing DB driver %s\n", get_class($testConn->getDriver())));
+        fwrite(STDERR, sprintf("\nUsing DB driver %s\n", get_debug_type($testConn->getDriver())));
 
         // Connect as a privileged user to create and drop the test database.
         $privConn = DriverManager::getConnection($privConnParams);


### PR DESCRIPTION
Because we use Symfony's PHP 8.0 polyfill, we have access to the `get_debug_type()` function that was shipped with PHP 8.0. This function is helpful in two ways:

* It saves us from the ternary `is_object($var) ? get_class($var) : gettype($var)` if we just want to output the type of a variable.
* It produces a string that is safe for output while `get_class()` produces `\0` characters if anonymous classes are used.

This PR proposes to use that function wherever it makes sense.