### PR TITLE
Fix UnitOfWork->originalEntityData is missing not-modified collections after computeChangeSet 

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -692,6 +692,7 @@ class UnitOfWork implements PropertyChangedListener
             if ($class->isCollectionValuedAssociation($name) && $value !== null) {
                 if ($value instanceof PersistentCollection) {
                     if ($value->getOwner() === $entity) {
+                        $actualData[$name] = $value;
                         continue;
                     }
 

--- a/tests/Doctrine/Tests/Models/Issue9300/Issue9300Child.php
+++ b/tests/Doctrine/Tests/Models/Issue9300/Issue9300Child.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Issue9300;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+/**
+ * @Entity
+ */
+class Issue9300Child
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var Collection|Issue9300Parent
+     * @ManyToMany(targetEntity="Issue9300Parent")
+     */
+    public $parents;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $name;
+
+    public function __construct()
+    {
+        $this->parents = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/Issue9300/Issue9300Child.php
+++ b/tests/Doctrine/Tests/Models/Issue9300/Issue9300Child.php
@@ -26,7 +26,7 @@ class Issue9300Child
     public $id;
 
     /**
-     * @var Collection|Issue9300Parent
+     * @var Collection<int, Issue9300Parent>
      * @ManyToMany(targetEntity="Issue9300Parent")
      */
     public $parents;

--- a/tests/Doctrine/Tests/Models/Issue9300/Issue9300Parent.php
+++ b/tests/Doctrine/Tests/Models/Issue9300/Issue9300Parent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Issue9300;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class Issue9300Parent
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue9300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue9300Test.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Tests\Models\Issue9300\Issue9300Child;
+use Doctrine\Tests\Models\Issue9300\Issue9300Parent;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group 9300
+ */
+class Issue9300Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('issue9300');
+        parent::setUp();
+    }
+
+    /**
+     * @group #9300
+     */
+    public function testPersistedCollectionIsPresentInOriginalDataAfterFlush(): void
+    {
+        $parent = new Issue9300Parent();
+        $child  = new Issue9300Child();
+        $child->parents->add($parent);
+
+        $parent->name = 'abc';
+        $child->name  = 'abc';
+
+        $this->_em->persist($parent);
+        $this->_em->persist($child);
+        $this->_em->flush();
+
+        $parent->name = 'abcd';
+        $child->name  = 'abcd';
+
+        $this->_em->flush();
+
+        self::assertArrayHasKey('parents', $this->_em->getUnitOfWork()->getOriginalEntityData($child));
+    }
+
+    /**
+     * @group #9300
+     */
+    public function testPersistingCollectionAfterFlushWorksAsExpected(): void
+    {
+        $parentOne = new Issue9300Parent();
+        $parentTwo = new Issue9300Parent();
+        $childOne  = new Issue9300Child();
+
+        $parentOne->name   = 'abc';
+        $parentTwo->name   = 'abc';
+        $childOne->name    = 'abc';
+        $childOne->parents = new ArrayCollection([$parentOne]);
+
+        $this->_em->persist($parentOne);
+        $this->_em->persist($parentTwo);
+        $this->_em->persist($childOne);
+        $this->_em->flush();
+
+        // Recalculate change-set -> new original data
+        $childOne->name = 'abcd';
+        $this->_em->flush();
+
+        $childOne->parents = new ArrayCollection([$parentTwo]);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $childOneFresh = $this->_em->find(Issue9300Child::class, $childOne->id);
+        self::assertCount(1, $childOneFresh->parents);
+        self::assertEquals($parentTwo->id, $childOneFresh->parents[0]->id);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue9300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue9300Test.php
@@ -10,18 +10,19 @@ use Doctrine\Tests\Models\Issue9300\Issue9300Parent;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
- * @group 9300
+ * @group GH-9300
  */
 class Issue9300Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         $this->useModelSet('issue9300');
+
         parent::setUp();
     }
 
     /**
-     * @group #9300
+     * @group GH-9300
      */
     public function testPersistedCollectionIsPresentInOriginalDataAfterFlush(): void
     {
@@ -45,7 +46,7 @@ class Issue9300Test extends OrmFunctionalTestCase
     }
 
     /**
-     * @group #9300
+     * @group GH-9300
      */
     public function testPersistingCollectionAfterFlushWorksAsExpected(): void
     {

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -338,6 +338,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue5989\Issue5989Employee::class,
             Models\Issue5989\Issue5989Manager::class,
         ],
+        'issue9300' => [
+            Models\Issue9300\Issue9300Child::class,
+            Models\Issue9300\Issue9300Parent::class,
+        ],
     ];
 
     /** @param class-string ...$models */


### PR DESCRIPTION
Resolves https://github.com/doctrine/orm/issues/9300