### PR TITLE
Add support for PHP 8.1 enums.

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -199,6 +199,8 @@ list:
   unique key.
 - ``nullable``: (optional, default FALSE) Whether the database
   column is nullable.
+- ``enumType``: (optional, requires PHP 8.1 and ORM 2.11) The PHP enum type
+  name to convert the database value into.
 - ``precision``: (optional, default 0) The precision for a decimal
   (exact numeric) column (applies only for decimal column),
   which is the maximum number of digits that are stored for the values.
@@ -232,6 +234,9 @@ Additionally, Doctrine will map PHP types to ``type`` attribute as follows:
 - ``float``: ``float``
 - ``int``: ``integer``
 - ``string`` or any other type: ``string``
+
+As of version 2.11 Doctrine can also automatically map typed properties using a
+PHP 8.1 enum to set the right ``type`` and ``enumType``.
 
 .. _reference-mapping-types:
 

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -299,6 +299,7 @@
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />
     <xs:attribute name="nullable" type="xs:boolean" default="false" />
+    <xs:attribute name="enum-type" type="xs:string" />
     <xs:attribute name="version" type="xs:boolean" />
     <xs:attribute name="column-definition" type="xs:string" />
     <xs:attribute name="precision" type="xs:integer" use="optional" />

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -44,6 +44,9 @@ final class Column implements Annotation
     /** @var bool */
     public $nullable = false;
 
+    /** @var class-string<\BackedEnum>|null */
+    public $enumType = null;
+
     /** @var array<string,mixed> */
     public $options = [];
 
@@ -51,7 +54,8 @@ final class Column implements Annotation
     public $columnDefinition;
 
     /**
-     * @param array<string,mixed> $options
+     * @param class-string<\BackedEnum>|null $enumType
+     * @param array<string,mixed>            $options
      */
     public function __construct(
         ?string $name = null,
@@ -61,6 +65,7 @@ final class Column implements Annotation
         ?int $scale = null,
         bool $unique = false,
         bool $nullable = false,
+        ?string $enumType = null,
         array $options = [],
         ?string $columnDefinition = null
     ) {
@@ -71,6 +76,7 @@ final class Column implements Annotation
         $this->scale            = $scale;
         $this->unique           = $unique;
         $this->nullable         = $nullable;
+        $this->enumType         = $enumType;
         $this->options          = $options;
         $this->columnDefinition = $columnDefinition;
     }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -718,6 +718,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *                   unique: bool,
      *                   nullable: bool,
      *                   precision: int,
+     *                   enumType?: class-string,
      *                   options?: mixed[],
      *                   columnName?: string,
      *                   columnDefinition?: string
@@ -745,6 +746,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
         if (isset($column->columnDefinition)) {
             $mapping['columnDefinition'] = $column->columnDefinition;
+        }
+
+        if ($column->enumType !== null) {
+            $mapping['enumType'] = $column->enumType;
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -614,6 +614,7 @@ class AttributeDriver extends AnnotationDriver
      *                   unique: bool,
      *                   nullable: bool,
      *                   precision: int,
+     *                   enumType?: class-string,
      *                   options?: mixed[],
      *                   columnName?: string,
      *                   columnDefinition?: string
@@ -641,6 +642,10 @@ class AttributeDriver extends AnnotationDriver
 
         if (isset($column->columnDefinition)) {
             $mapping['columnDefinition'] = $column->columnDefinition;
+        }
+
+        if ($column->enumType) {
+            $mapping['enumType'] = $column->enumType;
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -800,6 +800,7 @@ class XmlDriver extends FileDriver
       *                   scale?: int,
       *                   unique?: bool,
       *                   nullable?: bool,
+      *                   enumType?: string,
       *                   version?: bool,
       *                   columnDefinition?: string,
       *                   options?: array
@@ -845,6 +846,10 @@ class XmlDriver extends FileDriver
 
         if (isset($fieldMapping['column-definition'])) {
             $mapping['columnDefinition'] = (string) $fieldMapping['column-definition'];
+        }
+
+        if (isset($fieldMapping['enum-type'])) {
+            $mapping['enumType'] = (string) $fieldMapping['enum-type'];
         }
 
         if (isset($fieldMapping->options)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -786,6 +786,7 @@ class YamlDriver extends FileDriver
      *                   unique?: mixed,
      *                   options?: mixed,
      *                   nullable?: mixed,
+     *                   enumType?: class-string,
      *                   version?: mixed,
      *                   columnDefinition?: mixed
      *              }|null $column
@@ -801,6 +802,7 @@ class YamlDriver extends FileDriver
      *                   unique?: bool,
      *                   options?: mixed,
      *                   nullable?: mixed,
+     *                   enumType?: class-string,
      *                   version?: mixed,
      *                   columnDefinition?: mixed
      *               }
@@ -854,6 +856,10 @@ class YamlDriver extends FileDriver
 
         if (isset($column['columnDefinition'])) {
             $mapping['columnDefinition'] = $column['columnDefinition'];
+        }
+
+        if (isset($column['enumType'])) {
+            $mapping['enumType'] = $column['enumType'];
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use BackedEnum;
 use Doctrine\ORM\Exception\ORMException;
 use ReflectionException;
+use ValueError;
 
 use function array_keys;
 use function array_map;
@@ -952,5 +954,45 @@ class MappingException extends ORMException
             $expectdType,
             get_debug_type($givenValue)
         ));
+    }
+
+    public static function enumsRequirePhp81(string $className, string $fieldName): self
+    {
+        return new self(sprintf('Enum types require PHP 8.1 in %s::$%s', $className, $fieldName));
+    }
+
+    public static function nonEnumTypeMapped(string $className, string $fieldName, string $enumType): self
+    {
+        return new self(sprintf(
+            'Attempting to map non-enum type %s as enum in entity %s::$%s',
+            $enumType,
+            $className,
+            $fieldName
+        ));
+    }
+
+    /**
+     * @param class-string             $className
+     * @param class-string<BackedEnum> $enumType
+     */
+    public static function invalidEnumValue(
+        string $className,
+        string $fieldName,
+        string $value,
+        string $enumType,
+        ValueError $previous
+    ): self {
+        return new self(sprintf(
+            <<<'EXCEPTION'
+Context: Trying to hydrate enum property "%s::$%s"
+Problem: Case "%s" is not listed in enum "%s"
+Solution: Either add the case to the enum type or migrate the database column to use another case of the enum
+EXCEPTION
+            ,
+            $className,
+            $fieldName,
+            $value,
+            $enumType
+        ), 0, $previous);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use BackedEnum;
+use ReflectionProperty;
+use ReturnTypeWillChange;
+use ValueError;
+
+use function assert;
+use function get_class;
+use function is_int;
+use function is_string;
+
+class ReflectionEnumProperty extends ReflectionProperty
+{
+    /** @var ReflectionProperty */
+    private $originalReflectionProperty;
+
+    /** @var class-string<BackedEnum> */
+    private $enumType;
+
+    /**
+     * @param class-string<BackedEnum> $enumType
+     */
+    public function __construct(ReflectionProperty $originalReflectionProperty, string $enumType)
+    {
+        $this->originalReflectionProperty = $originalReflectionProperty;
+        $this->enumType                   = $enumType;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param object|null $object
+     *
+     * @return int|string|null
+     */
+    #[ReturnTypeWillChange]
+    public function getValue($object = null)
+    {
+        if ($object === null) {
+            return null;
+        }
+
+        $enum = $this->originalReflectionProperty->getValue($object);
+
+        if ($enum === null) {
+            return null;
+        }
+
+        return $enum->value;
+    }
+
+    /**
+     * @param object $object
+     * @param mixed  $value
+     */
+    public function setValue($object, $value = null): void
+    {
+        if ($value !== null) {
+            $enumType = $this->enumType;
+            try {
+                $value = $enumType::from($value);
+            } catch (ValueError $e) {
+                assert(is_string($value) || is_int($value));
+
+                throw MappingException::invalidEnumValue(
+                    get_class($object),
+                    $this->originalReflectionProperty->getName(),
+                    (string) $value,
+                    $enumType,
+                    $e
+                );
+            }
+        }
+
+        $this->originalReflectionProperty->setValue($object, $value);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -265,4 +265,13 @@
         <!-- https://github.com/doctrine/orm/issues/8537 -->
         <exclude-pattern>lib/Doctrine/ORM/QueryBuilder.php</exclude-pattern>
     </rule>
+
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1746,7 +1746,7 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Offset 'version' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, columnDefinition\\?\\: string, precision\\?\\: int, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
+			message: "#^Offset 'version' on array\\{type\\: string, fieldName\\: string, columnName\\?\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, enumType\\?\\: class\\-string\\<BackedEnum\\>, columnDefinition\\?\\: string, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 

--- a/tests/Doctrine/Tests/Models/Enums/Card.php
+++ b/tests/Doctrine/Tests/Models/Enums/Card.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+#[Entity]
+class Card
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     * @var int
+     */
+    #[Id, GeneratedValue, Column(type: 'integer')]
+    public $id;
+
+    /**
+     * @Column(type="string", enumType=Suit::class)
+     * @var Suit
+     */
+    #[Column(type: 'string', enumType: Suit::class)]
+    public $suit;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    {
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+                'type' => 'integer',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'suit',
+                'type' => 'string',
+                'enumType' => Suit::class,
+            ]
+        );
+    }
+}

--- a/tests/Doctrine/Tests/Models/Enums/Suit.php
+++ b/tests/Doctrine/Tests/Models/Enums/Suit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}

--- a/tests/Doctrine/Tests/Models/Enums/TypedCard.php
+++ b/tests/Doctrine/Tests/Models/Enums/TypedCard.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class TypedCard
+{
+    #[Id, GeneratedValue, Column]
+    public int $id;
+
+    #[Column]
+    public Suit $suit;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\Models\Enums\Card;
+use Doctrine\Tests\Models\Enums\Suit;
+use Doctrine\Tests\Models\Enums\TypedCard;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * @requires PHP 8.1
+ */
+class EnumTest extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        $this->_em         = $this->getEntityManager(null, new AttributeDriver([dirname(__DIR__, 2) . '/Models/Enums']));
+        $this->_schemaTool = new SchemaTool($this->_em);
+
+        parent::setUp();
+
+        if ($this->isSecondLevelCacheEnabled) {
+            $this->markTestSkipped();
+        }
+    }
+
+    /**
+     * @param class-string $cardClass
+     *
+     * @dataProvider provideCardClasses
+     */
+    public function testEnumMapping(string $cardClass): void
+    {
+        $this->setUpEntitySchema([$cardClass]);
+
+        $card       = new $cardClass();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $fetchedCard = $this->_em->find(Card::class, $card->id);
+
+        $this->assertInstanceOf(Suit::class, $fetchedCard->suit);
+        $this->assertEquals(Suit::Clubs, $fetchedCard->suit);
+    }
+
+    /**
+     * @param class-string $cardClass
+     *
+     * @dataProvider provideCardClasses
+     */
+    public function testEnumWithNonMatchingDatabaseValueThrowsException(string $cardClass): void
+    {
+        $this->setUpEntitySchema([$cardClass]);
+
+        $card       = new $cardClass();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $metadata = $this->_em->getClassMetadata($cardClass);
+        $this->_em->getConnection()->update(
+            $metadata->table['name'],
+            [$metadata->fieldMappings['suit']['columnName'] => 'invalid'],
+            [$metadata->fieldMappings['id']['columnName'] => $card->id]
+        );
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(sprintf(
+            <<<'EXCEPTION'
+Context: Trying to hydrate enum property "%s::$suit"
+Problem: Case "invalid" is not listed in enum "Doctrine\Tests\Models\Enums\Suit"
+Solution: Either add the case to the enum type or migrate the database column to use another case of the enum
+EXCEPTION
+            ,
+            $cardClass
+        ));
+
+        $this->_em->find($cardClass, $card->id);
+    }
+
+    /**
+     * @return array<string, array{class-string}>
+     */
+    public function provideCardClasses(): array
+    {
+        return [
+            Card::class => [Card::class],
+            TypedCard::class => [TypedCard::class],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -64,6 +64,8 @@ use Doctrine\Tests\Models\DDC889\DDC889Class;
 use Doctrine\Tests\Models\DDC889\DDC889Entity;
 use Doctrine\Tests\Models\DDC964\DDC964Admin;
 use Doctrine\Tests\Models\DDC964\DDC964Guest;
+use Doctrine\Tests\Models\Enums\Card;
+use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\TypedProperties\Contact;
 use Doctrine\Tests\Models\TypedProperties\UserTyped;
 use Doctrine\Tests\OrmTestCase;
@@ -1141,6 +1143,16 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $metadata = $this->createClassMetadata(ReservedWordInTableColumn::class);
 
         self::assertSame('count', $metadata->getFieldMapping('count')['columnName']);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumType(): void
+    {
+        $metadata = $this->createClassMetadata(Card::class);
+
+        self::assertEquals(Suit::class, $metadata->fieldMappings['suit']['enumType']);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Enums.Card.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Enums.Card.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\Tests\Models\Enums\Suit;
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+        'type' => 'integer',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'suit',
+        'type' => 'string',
+        'enumType' => Suit::class,
+    ]
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Enums.Card.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Enums.Card.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Enums\Card">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="suit" type="string" enum-type="Doctrine\Tests\Models\Enums\Suit" />
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Enums.Card.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Enums.Card.dcm.yml
@@ -1,0 +1,11 @@
+Doctrine\Tests\Models\Enums\Card:
+  type: entity
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    suit:
+      type: string
+      enumType: Doctrine\Tests\Models\Enums\Suit


### PR DESCRIPTION
ORM based support for enums.

```php
enum Suit: string {
    case Hearts = 'H';
    case Diamonds = 'D'; 
    case Clubs = 'C';
    case Spades = 'S';
}

#[Entity]
class Card
{
    /** ... */

    #[Column(type: 'string', enumType: Suit::class)]
    public $suit;
```

It works based on a new `ReflectionEnumProperty` that wraps around other reflection property types. This avoids the problem of other approaches that hook into DBAL Type abstraction, since that would require some kind of paramterization which is not supported at the moment. In addition it would at the moment require to register each enum explicitly, which this approach does not.

This includes support for typed property detection, the previous example could be written as:

```php
#[Column]
public Suit $suit;
```

As for error handling, when the database returns an invalid enum case, then the regular `ValueError` is not caught that `BackedEnum::from` throws.