### PR TITLE
Run static analysis on PHP 8.1

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
         dbal-version:
           - "default"
           - "2.13"
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
         dbal-version:
           - "default"
           - "2.13"


### PR DESCRIPTION
This will make it easier to add code that leverages features only
defined since that version of PHP.