### PR TITLE
Run static analysis with language level PHP 8.1

### DIFF
--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use ReturnTypeWillChange;
 
 /**
  * A lazy collection that allows a fast count when using criteria object
@@ -38,6 +39,7 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->isInitialized()) {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -10,12 +10,12 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use ReturnTypeWillChange;
 use RuntimeException;
 
 use function array_combine;
 use function array_diff_key;
 use function array_map;
-use function array_udiff_assoc;
 use function array_values;
 use function array_walk;
 use function get_class;
@@ -505,6 +505,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @return object|null
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->remove($offset);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -551,16 +551,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-
-			message: "#^Call to an undefined method ReflectionProperty\\:\\:getType\\(\\)\\.$#"
-			count: 3
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
-			message: "#^Call to an undefined method ReflectionProperty\\:\\:hasType\\(\\)\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\NamingStrategy\\:\\:joinColumnName\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 2
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1441,18 +1431,17 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message:
-				"""
-					#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
-					        AST\\\\CollectionMemberExpression\\|
-					        AST\\\\ComparisonExpression\\|
-					        AST\\\\EmptyCollectionComparisonExpression\\|
-					        AST\\\\ExistsExpression\\|
-					        AST\\\\InExpression\\|
-					        AST\\\\InstanceOfExpression\\|
-					        AST\\\\LikeExpression\\|
-					        AST\\\\NullComparisonExpression\\)\\: Unexpected token "\\\\n     \\* ", expected type at offset 344$#
-				"""
+			message: """
+				#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
+				        AST\\\\CollectionMemberExpression\\|
+				        AST\\\\ComparisonExpression\\|
+				        AST\\\\EmptyCollectionComparisonExpression\\|
+				        AST\\\\ExistsExpression\\|
+				        AST\\\\InExpression\\|
+				        AST\\\\InstanceOfExpression\\|
+				        AST\\\\LikeExpression\\|
+				        AST\\\\NullComparisonExpression\\)\\: Unexpected token "\\\\n     \\* ", expected type at offset 344$#
+			"""
 			count: 1
 			path: lib/Doctrine/ORM/Query/Parser.php
 

--- a/phpstan-params.neon
+++ b/phpstan-params.neon
@@ -8,4 +8,4 @@ parameters:
     earlyTerminatingMethodCalls:
         Doctrine\ORM\Query\Parser:
             - syntaxError
-    phpVersion: 70100
+    phpVersion: 80100

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="2"
+    phpVersion="8.1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -87,25 +88,12 @@
                 <file name="lib/Doctrine/ORM/QueryBuilder.php"/>
             </errorLevel>
         </RedundantCastGivenDocblockType>
-        <!-- Workaround for https://github.com/vimeo/psalm/issues/7026 -->
-        <ReservedWord>
-            <errorLevel type="suppress">
-                <directory name="lib"/>
-                <directory name="tests"/>
-            </errorLevel>
-        </ReservedWord>
         <TypeDoesNotContainType>
             <errorLevel type="suppress">
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
-        <UndefinedAttributeClass>
-            <errorLevel type="suppress">
-                <!-- The class was added in PHP 8.1 -->
-                <referencedClass name="ReturnTypeWillChange"/>
-            </errorLevel>
-        </UndefinedAttributeClass>
         <UndefinedClass>
             <errorLevel type="suppress">
                 <referencedClass name="Doctrine\Common\Cache\ApcCache"/>


### PR DESCRIPTION
Continuation of #9310

While PHP 7.1 is the lowest supported version, the repository contains features that require a more recent PHP version and we are currently hardly able to run static analysis on those parts.

Letting the static analysis tools operate on PHP 7.1 as language level causes unnecessary pain and barely spots real issues. Especially Psalm has a history of reporting funny errors if the dependencies are on a higher language level. I'd suggest to let the test suite cover PHP 7.1 support and let the SA tools operate on PHP 8.1 instead.