### PR TITLE
Run PHP CodeSniffer on PHP 8.1

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -12,4 +12,4 @@ jobs:
   coding-standards:
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:
-      php-version: "7.4"
+      php-version: "8.1"


### PR DESCRIPTION
Same as #9310, but for CodeSniffer. Running on PHP 7.4, CodeSniffer won't understand newer Syntax elements like `readonly` which will cause trouble (see #9316). Since we declare the PHP language level in CodeSniffer's configuration, running the tool on PHP 8.1 should be fine.