### PR TITLE
Document PHPUnit mocks with intersection types

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
@@ -21,7 +21,7 @@ class CacheLoggerChainTest extends DoctrineTestCase
     /** @var CacheLoggerChain */
     private $logger;
 
-    /** @var MockObject|CacheLogger */
+    /** @var CacheLogger&MockObject */
     private $mock;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -31,6 +31,7 @@ use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\OrmTestCase;
 use InvalidArgumentException;
 use LogicException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 use function assert;
 
@@ -39,7 +40,7 @@ use function assert;
  */
 class DefaultCacheFactoryTest extends OrmTestCase
 {
-    /** @var CacheFactory */
+    /** @var CacheFactory&MockObject */
     private $factory;
 
     /** @var EntityManager */

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -14,13 +14,14 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group DDC-2183
  */
 abstract class AbstractCollectionPersisterTest extends OrmTestCase
 {
-    /** @var Region */
+    /** @var Region&MockObject */
     protected $region;
 
     /** @var CollectionPersister */
@@ -70,6 +71,9 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
                                            ->getMock();
     }
 
+    /**
+     * @return Region&MockObject
+     */
     protected function createRegion(): Region
     {
         return $this->getMockBuilder(Region::class)

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -17,16 +17,17 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group DDC-2183
  */
 abstract class AbstractEntityPersisterTest extends OrmTestCase
 {
-    /** @var Region */
+    /** @var Region&MockObject */
     protected $region;
 
-    /** @var EntityPersister */
+    /** @var EntityPersister&MockObject */
     protected $entityPersister;
 
     /** @var EntityManager */
@@ -45,6 +46,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $this->entityPersister = $this->createMock(EntityPersister::class);
     }
 
+    /**
+     * @return Region&MockObject
+     */
     protected function createRegion(): Region
     {
         return $this->createMock(Region::class);

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -33,7 +33,7 @@ class EntityManagerDecoratorTest extends TestCase
         'lock',
     ];
 
-    /** @var EntityManagerInterface|MockObject */
+    /** @var EntityManagerInterface&MockObject */
     private $wrapped;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -28,6 +27,7 @@ use Doctrine\Tests\Models\Company\CompanyOrganization;
 use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -221,7 +221,7 @@ class SQLFilterTest extends OrmFunctionalTestCase
         self::assertFalse($em->getFilters()->isEnabled('foo_filter'));
     }
 
-    protected function configureFilters($em): void
+    private function configureFilters(EntityManagerInterface $em): void
     {
         // Add filters to the configuration of the EM
         $config = $em->getConfiguration();
@@ -229,23 +229,30 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $config->addFilter('soft_delete', '\Doctrine\Tests\ORM\Functional\MySoftDeleteFilter');
     }
 
-    protected function getMockConnection(): Connection
+    /**
+     * @return Connection&MockObject
+     */
+    private function getMockConnection(): Connection
     {
-        // Setup connection mock
         return $this->createMock(Connection::class);
     }
 
-    protected function getMockEntityManager(): EntityManagerInterface
+    /**
+     * @return EntityManagerInterface&MockObject
+     */
+    private function getMockEntityManager(): EntityManagerInterface
     {
-        // Setup entity manager mock
-        return $this->createMock(EntityManager::class);
+        return $this->createMock(EntityManagerInterface::class);
     }
 
-    protected function addMockFilterCollection(EntityManagerInterface $em): FilterCollection
+    /**
+     * @psalm-param EntityManagerInterface&MockObject $em
+     *
+     * @return FilterCollection&MockObject
+     */
+    private function addMockFilterCollection(EntityManagerInterface $em): FilterCollection
     {
-        $filterCollection = $this->getMockBuilder(FilterCollection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $filterCollection = $this->createMock(FilterCollection::class);
 
         $em->expects(self::any())
             ->method('getFilters')

--- a/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -23,16 +23,16 @@ use function iterator_to_array;
  */
 class AbstractHydratorTest extends OrmFunctionalTestCase
 {
-    /** @var EventManager|MockObject */
+    /** @var EventManager&MockObject */
     private $mockEventManager;
 
-    /** @var Result|MockObject */
+    /** @var Result&MockObject */
     private $mockResult;
 
-    /** @var ResultSetMapping|MockObject */
+    /** @var ResultSetMapping&MockObject */
     private $mockResultMapping;
 
-    /** @var AbstractHydrator */
+    /** @var AbstractHydrator&MockObject */
     private $hydrator;
 
     protected function setUp(): void
@@ -43,7 +43,7 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
         $mockEntityManagerInterface = $this->createMock(EntityManagerInterface::class);
         $this->mockEventManager     = $this->createMock(EventManager::class);
         $this->mockResult           = $this->createMock(Result::class);
-        $this->mockResultMapping    = $this->getMockBuilder(ResultSetMapping::class);
+        $this->mockResultMapping    = $this->createMock(ResultSetMapping::class);
 
         $mockEntityManagerInterface
             ->expects(self::any())

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -24,10 +24,10 @@ use function in_array;
  */
 class HydrationCompleteHandlerTest extends TestCase
 {
-    /** @var ListenersInvoker|MockObject */
+    /** @var ListenersInvoker&MockObject */
     private $listenersInvoker;
 
-    /** @var EntityManagerInterface|MockObject */
+    /** @var EntityManagerInterface&MockObject */
     private $entityManager;
 
     /** @var HydrationCompleteHandler */

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -17,7 +17,7 @@ use stdClass;
  */
 class LazyCriteriaCollectionTest extends TestCase
 {
-    /** @var EntityPersister|MockObject */
+    /** @var EntityPersister&MockObject */
     private $persister;
 
     /** @var Criteria */

--- a/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Repository;
 
+use Closure;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -22,10 +23,10 @@ use function assert;
  */
 class DefaultRepositoryFactoryTest extends TestCase
 {
-    /** @var EntityManagerInterface|MockObject */
+    /** @var EntityManagerInterface&MockObject */
     private $entityManager;
 
-    /** @var Configuration|MockObject */
+    /** @var Configuration&MockObject */
     private $configuration;
 
     /** @var DefaultRepositoryFactory */
@@ -48,7 +49,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->entityManager
             ->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback([$this, 'buildClassMetadata']));
+            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
 
         self::assertInstanceOf(
             DDC869PaymentRepository::class,
@@ -61,7 +62,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->entityManager
             ->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback([$this, 'buildClassMetadata']));
+            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
 
         self::assertSame(
             $this->repositoryFactory->getRepository($this->entityManager, self::class),
@@ -92,11 +93,11 @@ class DefaultRepositoryFactoryTest extends TestCase
 
         $em1->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback([$this, 'buildClassMetadata']));
+            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
 
         $em2->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback([$this, 'buildClassMetadata']));
+            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
 
         $repo1 = $this->repositoryFactory->getRepository($em1, self::class);
         $repo2 = $this->repositoryFactory->getRepository($em2, self::class);
@@ -108,15 +109,11 @@ class DefaultRepositoryFactoryTest extends TestCase
     }
 
     /**
-     * @return MockObject|ClassMetadata
-     *
-     * @private
+     * @return ClassMetadata&MockObject
      */
-    public function buildClassMetadata(string $className)
+    private function buildClassMetadata(string $className): ClassMetadata
     {
         $metadata = $this->createMock(ClassMetadata::class);
-        assert($metadata instanceof ClassMetadata || $metadata instanceof MockObject);
-
         $metadata->expects(self::any())->method('getName')->will(self::returnValue($className));
 
         $metadata->customRepositoryClassName = null;
@@ -125,7 +122,7 @@ class DefaultRepositoryFactoryTest extends TestCase
     }
 
     /**
-     * @return EntityManagerInterface|MockObject
+     * @return EntityManagerInterface&MockObject
      */
     private function createEntityManager(): EntityManagerInterface
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -13,14 +13,15 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class PaginatorTest extends OrmTestCase
 {
-    /** @var Connection */
+    /** @var Connection&MockObject */
     private $connection;
-    /** @var EntityManagerInterface */
+    /** @var EntityManagerInterface&MockObject */
     private $em;
-    /** @var AbstractHydrator */
+    /** @var AbstractHydrator&MockObject */
     private $hydrator;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -61,7 +61,7 @@ class UnitOfWorkTest extends OrmTestCase
     /**
      * Provides a sequence mock to the UnitOfWork
      *
-     * @var ConnectionMock
+     * @var ConnectionMock&MockObject
      */
     private $_connectionMock;
 
@@ -72,7 +72,7 @@ class UnitOfWorkTest extends OrmTestCase
      */
     private $_emMock;
 
-    /** @var EventManager|MockObject */
+    /** @var EventManager&MockObject */
     private $eventManager;
 
     protected function setUp(): void


### PR DESCRIPTION
PHPUnit's `createMock()` will return an object that extends the mocked type and implements `MockObject` at the same time. The accurate way to document this is an intersection type, but we often document a union type instead. This declaration is too wide because virtally any mock object would pass it.

This might look nit-picking now, but it will become more important later when we try to infer native types from the docblock types in an automated manner.