### PR TITLE
Document LockMode enums

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -403,6 +403,7 @@ use function sprintf;
      * @param int|null $lockVersion The version of the entity to find when using
      * optimistic locking.
      * @psalm-param class-string<T> $className
+     * @psalm-param LockMode::*|null $lockMode
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @psalm-return ?T
@@ -990,6 +991,8 @@ use function sprintf;
     }
 
     /**
+     * @psalm-param LockMode::* $lockMode
+     *
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use DateTimeInterface;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\Expr;
@@ -237,6 +238,7 @@ interface EntityManagerInterface extends ObjectManager
      * @param object                     $entity
      * @param int                        $lockMode
      * @param int|DateTimeInterface|null $lockVersion
+     * @psalm-param LockMode::* $lockMode
      *
      * @return void
      *

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
@@ -164,6 +165,7 @@ class EntityRepository implements ObjectRepository, Selectable
      *                              or NULL if no specific lock mode should be used
      *                              during the search.
      * @param int|null $lockVersion The lock version.
+     * @psalm-param LockMode::*|null $lockMode
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @psalm-return ?T

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1537,6 +1537,7 @@ class BasicEntityPersister implements EntityPersister
      * Gets the FROM and optionally JOIN conditions to lock the entity managed by this persister.
      *
      * @param int|null $lockMode One of the Doctrine\DBAL\LockMode::* constants.
+     * @psalm-param LockMode::*|null $lockMode
      *
      * @return string
      */

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\PersistentCollection;
@@ -54,6 +55,7 @@ interface EntityPersister
      * @param int|null         $limit
      * @param int|null         $offset
      * @param mixed[]|null     $orderBy
+     * @psalm-param LockMode::*|null $lockMode
      *
      * @return string
      */
@@ -185,6 +187,7 @@ interface EntityPersister
      * @psalm-param array<string, mixed>       $criteria
      * @psalm-param array<string, mixed>|null  $assoc
      * @psalm-param array<string, mixed>       $hints
+     * @psalm-param LockMode::*|null           $lockMode
      * @psalm-param array<string, string>|null $orderBy
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
@@ -239,6 +242,7 @@ interface EntityPersister
      * @psalm-param array<string, mixed> $id The identifier of the entity as an
      *                                       associative array from column or
      *                                       field names to values.
+     * @psalm-param LockMode::*|null $lockMode
      *
      * @return void
      */
@@ -300,6 +304,7 @@ interface EntityPersister
      *
      * @param int $lockMode One of the Doctrine\DBAL\LockMode::* constants.
      * @psalm-param array<string, mixed> $criteria
+     * @psalm-param LockMode::* $lockMode
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -751,6 +751,7 @@ final class Query extends AbstractQuery
      * @see \Doctrine\DBAL\LockMode
      *
      * @param int $lockMode
+     * @psalm-param LockMode::* $lockMode
      *
      * @throws TransactionRequiredException
      */

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2457,6 +2457,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object                     $entity
      * @param int|DateTimeInterface|null $lockVersion
+     * @psalm-param LockMode::* $lockMode
      *
      * @throws ORMInvalidArgumentException
      * @throws TransactionRequiredException


### PR DESCRIPTION
This PR narrows down the allowed value range for `$lockMode` parameters. This way, Psalm and PHPStan can inspect userland code that calls our methods and warn about invalid `$lockMode` values.