### PR TITLE
PSR-6 second level cache

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,21 @@
 # Upgrade to 2.11
 
+## PSR-6-based second level cache
+
+The second level cache has been reworked to consume a PSR-6 cache. Using a
+Doctrine Cache instance is deprecated.
+
+* `DefaultCacheFactory`: The constructor expects a PSR-6 cache item pool as
+  second argument now.
+* `DefaultMultiGetRegion`: This class is deprecated in favor of `DefaultRegion`.
+* `DefaultRegion`:
+  * The constructor expects a PSR-6 cache item pool as second argument now.
+  * The protected `$cache` property is deprecated.
+  * The properties `$name` and `$lifetime` as well as the constant
+   `REGION_KEY_SEPARATOR` and the method `getCacheEntryKey()` are flagged as
+   `@internal` now. They all will become `private` in 3.0.
+  * The method `getCache()` is deprecated without replacement.
+
 ## Deprecated: `Doctrine\ORM\Mapping\Driver\PHPDriver`
 
 Use `StaticPHPDriver` instead when you want to programmatically configure

--- a/docs/en/reference/second-level-cache.rst
+++ b/docs/en/reference/second-level-cache.rst
@@ -172,7 +172,7 @@ To enable the second-level-cache, you should provide a cache factory.
 
     <?php
     /** @var \Doctrine\ORM\Cache\RegionsConfiguration $cacheConfig */
-    /** @var \Doctrine\Common\Cache\Cache $cache */
+    /** @var \Psr\Cache\CacheItemPoolInterface $cache */
     /** @var \Doctrine\ORM\Configuration $config */
 
     $factory = new \Doctrine\ORM\Cache\DefaultCacheFactory($cacheConfig, $cache);

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -4,64 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Region;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\MultiGetCache;
-use Doctrine\ORM\Cache\CacheEntry;
-use Doctrine\ORM\Cache\CollectionCacheEntry;
-
-use function assert;
-use function count;
-
 /**
  * A cache region that enables the retrieval of multiple elements with one call
+ *
+ * @deprecated Use {@link DefaultRegion} instead.
  */
 class DefaultMultiGetRegion extends DefaultRegion
 {
-    /**
-     * Note that the multiple type is due to doctrine/cache not integrating the MultiGetCache interface
-     * in its signature due to BC in 1.x
-     *
-     * @var MultiGetCache|Cache
-     */
-    protected $cache;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param MultiGetCache $cache
-     */
-    public function __construct($name, MultiGetCache $cache, $lifetime = 0)
-    {
-        assert($cache instanceof Cache);
-        parent::__construct($name, $cache, $lifetime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMultiple(CollectionCacheEntry $collection)
-    {
-        $keysToRetrieve = [];
-
-        foreach ($collection->identifiers as $index => $key) {
-            $keysToRetrieve[$index] = $this->getCacheEntryKey($key);
-        }
-
-        $items = $this->cache->fetchMultiple($keysToRetrieve);
-        if (count($items) !== count($keysToRetrieve)) {
-            return null;
-        }
-
-        $returnableItems = [];
-
-        foreach ($keysToRetrieve as $index => $key) {
-            if (! $items[$key] instanceof CacheEntry) {
-                return null;
-            }
-
-            $returnableItems[$index] = $items[$key];
-        }
-
-        return $returnableItems;
-    }
 }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -4,44 +4,94 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Region;
 
-use BadMethodCallException;
-use Doctrine\Common\Cache\Cache as CacheAdapter;
+use Closure;
+use Doctrine\Common\Cache\Cache as LegacyCache;
 use Doctrine\Common\Cache\CacheProvider;
-use Doctrine\Common\Cache\ClearableCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\CacheEntry;
 use Doctrine\ORM\Cache\CacheKey;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Traversable;
+use TypeError;
 
-use function get_class;
+use function array_map;
+use function get_debug_type;
+use function iterator_to_array;
 use function sprintf;
+use function strtr;
 
 /**
  * The simplest cache region compatible with all doctrine-cache drivers.
  */
 class DefaultRegion implements Region
 {
+    /**
+     * @internal since 2.11, this constant will be private in 3.0.
+     */
     public const REGION_KEY_SEPARATOR = '_';
-
-    /** @var CacheAdapter */
-    protected $cache;
-
-    /** @var string */
-    protected $name;
-
-    /** @var int */
-    protected $lifetime = 0;
+    private const REGION_PREFIX       = 'DC2_REGION_';
 
     /**
-     * @param string $name
-     * @param int    $lifetime
+     * @deprecated since 2.11, this property will be removed in 3.0.
+     *
+     * @var LegacyCache
      */
-    public function __construct($name, CacheAdapter $cache, $lifetime = 0)
+    protected $cache;
+
+    /**
+     * @internal since 2.11, this property will be private in 3.0.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @internal since 2.11, this property will be private in 3.0.
+     *
+     * @var int
+     */
+    protected $lifetime = 0;
+
+    /** @var CacheItemPoolInterface */
+    private $cacheItemPool;
+
+    /**
+     * @param CacheItemPoolInterface $cacheItemPool
+     */
+    public function __construct(string $name, $cacheItemPool, int $lifetime = 0)
     {
-        $this->cache    = $cache;
-        $this->name     = (string) $name;
-        $this->lifetime = (int) $lifetime;
+        if ($cacheItemPool instanceof LegacyCache) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9322',
+                'Passing an instance of %s to %s is deprecated, pass a %s instead.',
+                get_debug_type($cacheItemPool),
+                __METHOD__,
+                CacheItemPoolInterface::class
+            );
+
+            $this->cache         = $cacheItemPool;
+            $this->cacheItemPool = CacheAdapter::wrap($cacheItemPool);
+        } elseif (! $cacheItemPool instanceof CacheItemPoolInterface) {
+            throw new TypeError(sprintf(
+                '%s: Parameter #2 is expected to be an instance of %s, got %s.',
+                __METHOD__,
+                CacheItemPoolInterface::class,
+                get_debug_type($cacheItemPool)
+            ));
+        } else {
+            $this->cache         = DoctrineProvider::wrap($cacheItemPool);
+            $this->cacheItemPool = $cacheItemPool;
+        }
+
+        $this->name     = $name;
+        $this->lifetime = $lifetime;
     }
 
     /**
@@ -53,6 +103,8 @@ class DefaultRegion implements Region
     }
 
     /**
+     * @deprecated
+     *
      * @return CacheProvider
      */
     public function getCache()
@@ -65,7 +117,7 @@ class DefaultRegion implements Region
      */
     public function contains(CacheKey $key)
     {
-        return $this->cache->contains($this->getCacheEntryKey($key));
+        return $this->cacheItemPool->hasItem($this->getCacheEntryKey($key));
     }
 
     /**
@@ -73,7 +125,8 @@ class DefaultRegion implements Region
      */
     public function get(CacheKey $key)
     {
-        $entry = $this->cache->fetch($this->getCacheEntryKey($key));
+        $item  = $this->cacheItemPool->getItem($this->getCacheEntryKey($key));
+        $entry = $item->isHit() ? $item->get() : null;
 
         if (! $entry instanceof CacheEntry) {
             return null;
@@ -87,28 +140,31 @@ class DefaultRegion implements Region
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
+        $keys = array_map(
+            Closure::fromCallable([$this, 'getCacheEntryKey']),
+            $collection->identifiers
+        );
+        /** @var iterable<string, CacheItemInterface> $items */
+        $items = $this->cacheItemPool->getItems($keys);
+        if ($items instanceof Traversable) {
+            $items = iterator_to_array($items);
+        }
+
         $result = [];
-
-        foreach ($collection->identifiers as $key) {
-            $entryKey   = $this->getCacheEntryKey($key);
-            $entryValue = $this->cache->fetch($entryKey);
-
-            if (! $entryValue instanceof CacheEntry) {
+        foreach ($keys as $arrayKey => $cacheKey) {
+            if (! isset($items[$cacheKey]) || ! $items[$cacheKey]->isHit()) {
                 return null;
             }
 
-            $result[] = $entryValue;
+            $entry = $items[$cacheKey]->get();
+            if (! $entry instanceof CacheEntry) {
+                return null;
+            }
+
+            $result[$arrayKey] = $entry;
         }
 
         return $result;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getCacheEntryKey(CacheKey $key)
-    {
-        return $this->name . self::REGION_KEY_SEPARATOR . $key->hash;
     }
 
     /**
@@ -118,7 +174,15 @@ class DefaultRegion implements Region
      */
     public function put(CacheKey $key, CacheEntry $entry, ?Lock $lock = null)
     {
-        return $this->cache->save($this->getCacheEntryKey($key), $entry, $this->lifetime);
+        $item = $this->cacheItemPool
+            ->getItem($this->getCacheEntryKey($key))
+            ->set($entry);
+
+        if ($this->lifetime > 0) {
+            $item->expiresAfter($this->lifetime);
+        }
+
+        return $this->cacheItemPool->save($item);
     }
 
     /**
@@ -128,7 +192,7 @@ class DefaultRegion implements Region
      */
     public function evict(CacheKey $key)
     {
-        return $this->cache->delete($this->getCacheEntryKey($key));
+        return $this->cacheItemPool->deleteItem($this->getCacheEntryKey($key));
     }
 
     /**
@@ -138,13 +202,16 @@ class DefaultRegion implements Region
      */
     public function evictAll()
     {
-        if (! $this->cache instanceof ClearableCache) {
-            throw new BadMethodCallException(sprintf(
-                'Clearing all cache entries is not supported by the supplied cache adapter of type %s',
-                get_class($this->cache)
-            ));
-        }
+        return $this->cacheItemPool->clear(self::REGION_PREFIX . $this->name);
+    }
 
-        return $this->cache->deleteAll();
+    /**
+     * @internal since 2.11, this method will be private in 3.0.
+     *
+     * @return string
+     */
+    protected function getCacheEntryKey(CacheKey $key)
+    {
+        return self::REGION_PREFIX . $this->name . self::REGION_KEY_SEPARATOR . strtr($key->hash, '{}()/\@:', '________');
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
-use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -14,7 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_debug_type;
 use function sprintf;
 
 /**
@@ -86,16 +84,8 @@ EOT
         }
 
         if ($input->getOption('flush')) {
-            $collectionRegion = $cache->getCollectionCacheRegion($ownerClass, $assoc);
-
-            if (! $collectionRegion instanceof DefaultRegion) {
-                throw new InvalidArgumentException(sprintf(
-                    'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    get_debug_type($collectionRegion)
-                ));
-            }
-
-            $collectionRegion->getCache()->flushAll();
+            $cache->getCollectionCacheRegion($ownerClass, $assoc)
+                ->evictAll();
 
             $ui->comment(
                 sprintf(

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
-use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -14,7 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_debug_type;
 use function sprintf;
 
 /**
@@ -84,16 +82,8 @@ EOT
         }
 
         if ($input->getOption('flush')) {
-            $entityRegion = $cache->getEntityCacheRegion($entityClass);
-
-            if (! $entityRegion instanceof DefaultRegion) {
-                throw new InvalidArgumentException(sprintf(
-                    'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    get_debug_type($entityRegion)
-                ));
-            }
-
-            $entityRegion->getCache()->flushAll();
+            $cache->getEntityCacheRegion($entityClass)
+                ->evictAll();
 
             $ui->comment(sprintf('Flushing cache provider configured for entity named <info>"%s"</info>', $entityClass));
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
-use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -14,7 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function get_debug_type;
 use function sprintf;
 
 /**
@@ -82,17 +80,9 @@ EOT
         }
 
         if ($input->getOption('flush')) {
-            $queryCache  = $cache->getQueryCache($name);
-            $queryRegion = $queryCache->getRegion();
-
-            if (! $queryRegion instanceof DefaultRegion) {
-                throw new InvalidArgumentException(sprintf(
-                    'The option "--flush" expects a "Doctrine\ORM\Cache\Region\DefaultRegion", but got "%s".',
-                    get_debug_type($queryRegion)
-                ));
-            }
-
-            $queryRegion->getCache()->flushAll();
+            $cache->getQueryCache($name)
+                ->getRegion()
+                ->evictAll();
 
             $ui->comment(
                 sprintf(

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,11 +96,6 @@ parameters:
 			path: lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
 
 		-
-			message: "#^PHPDoc type Doctrine\\\\Common\\\\Cache\\\\Cache\\|Doctrine\\\\Common\\\\Cache\\\\MultiGetCache of property Doctrine\\\\ORM\\\\Cache\\\\Region\\\\DefaultMultiGetRegion\\:\\:\\$cache is not covariant with PHPDoc type Doctrine\\\\Common\\\\Cache\\\\Cache of overridden property Doctrine\\\\ORM\\\\Cache\\\\Region\\\\DefaultRegion\\:\\:\\$cache\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Cache\\\\Region\\\\DefaultRegion\\:\\:getCache\\(\\) should return Doctrine\\\\Common\\\\Cache\\\\CacheProvider but returns Doctrine\\\\Common\\\\Cache\\\\Cache\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Cache/Region/DefaultRegion.php

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -41,3 +41,6 @@ parameters:
             message: "#^Parameter \\#3 \\$length of method Doctrine\\\\DBAL\\\\Platforms\\\\AbstractPlatform\\:\\:getSubstringExpression\\(\\) expects int\\|null, string\\|null given\\.$#"
             count: 1
             path: lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+
+        # Symfony cache supports passing a key prefix to the clear method.
+        - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,3 +38,6 @@ parameters:
             message: '/^Call to an undefined method Doctrine\\Common\\Cache\\Cache::deleteAll\(\)\.$/'
             count: 1
             path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+
+        # Symfony cache supports passing a key prefix to the clear method.
+        - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -78,9 +78,6 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;fileLockRegionDirectory</code>
     </NullableReturnStatement>
-    <ParamNameMismatch occurrences="1">
-      <code>$em</code>
-    </ParamNameMismatch>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $fileLockRegionDirectory</code>
     </RedundantCastGivenDocblockType>
@@ -283,22 +280,6 @@
       <code>lock</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php">
-    <DeprecatedClass occurrences="2">
-      <code>MultiGetCache</code>
-      <code>MultiGetCache|Cache</code>
-    </DeprecatedClass>
-    <MissingParamType occurrences="2">
-      <code>$lifetime</code>
-      <code>$name</code>
-    </MissingParamType>
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$cache</code>
-    </NonInvariantDocblockPropertyType>
-    <PossiblyUndefinedMethod occurrences="1">
-      <code>fetchMultiple</code>
-    </PossiblyUndefinedMethod>
-  </file>
   <file src="lib/Doctrine/ORM/Cache/Region/DefaultRegion.php">
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;cache</code>
@@ -306,10 +287,6 @@
     <MoreSpecificReturnType occurrences="1">
       <code>CacheProvider</code>
     </MoreSpecificReturnType>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(int) $lifetime</code>
-      <code>(string) $name</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php">
     <MissingReturnType occurrences="1">
@@ -3011,11 +2988,17 @@
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>evictAll</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php">
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>evictAll</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php">
     <MissingReturnType occurrences="1">

--- a/psalm.xml
+++ b/psalm.xml
@@ -48,6 +48,11 @@
                 <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
             </errorLevel>
         </DeprecatedMethod>
+        <DeprecatedProperty>
+            <errorLevel type="suppress">
+                <referencedProperty name="Doctrine\ORM\Cache\Region\DefaultRegion::$cache"/>
+            </errorLevel>
+        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!-- We're catching invalid input here. -->
@@ -103,6 +108,12 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
             </errorLevel>
         </RedundantCondition>
+        <TooManyArguments>
+            <errorLevel type="suppress">
+                <!-- Symfony cache supports passing a key prefix to the clear method. -->
+                <referencedFunction name="Psr\Cache\CacheItemPoolInterface::clear"/>
+            </errorLevel>
+        </TooManyArguments>
         <TypeDoesNotContainType>
             <errorLevel type="suppress">
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>

--- a/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Cache;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\ORM\Cache\CacheEntry;
+use Doctrine\ORM\Cache\CacheKey;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -20,15 +21,15 @@ abstract class AbstractRegionTest extends OrmFunctionalTestCase
     /** @var Region */
     protected $region;
 
-    /** @var Cache */
-    protected $cache;
+    /** @var CacheItemPoolInterface */
+    protected $cacheItemPool;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->cache  = DoctrineProvider::wrap(new ArrayAdapter());
-        $this->region = $this->createRegion();
+        $this->cacheItemPool = new ArrayAdapter();
+        $this->region        = $this->createRegion();
     }
 
     abstract protected function createRegion(): Region;
@@ -45,7 +46,7 @@ abstract class AbstractRegionTest extends OrmFunctionalTestCase
     /**
      * @dataProvider dataProviderCacheValues
      */
-    public function testPutGetContainsEvict($key, $value): void
+    public function testPutGetContainsEvict(CacheKey $key, CacheEntry $value): void
     {
         self::assertFalse($this->region->contains($key));
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionLegacyTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionLegacyTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Cache;
+
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Cache\Region;
+use Doctrine\ORM\Cache\Region\DefaultRegion;
+
+class DefaultRegionLegacyTest extends DefaultRegionTest
+{
+    use VerifyDeprecations;
+
+    protected function createRegion(): Region
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9322');
+
+        return new DefaultRegion('default.region.test', DoctrineProvider::wrap($this->cacheItemPool));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -58,7 +58,7 @@ class FileLockRegionTest extends AbstractRegionTest
     {
         $this->directory = sys_get_temp_dir() . '/doctrine_lock_' . uniqid();
 
-        $region = new DefaultRegion('concurren_region_test', $this->cache);
+        $region = new DefaultRegion('concurren_region_test', $this->cacheItemPool);
 
         return new FileLockRegion($region, $this->directory, 60);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
@@ -14,7 +14,7 @@ class MultiGetRegionTest extends AbstractRegionTest
 {
     protected function createRegion(): Region
     {
-        return new DefaultMultiGetRegion('default.region.test', $this->cache);
+        return new DefaultMultiGetRegion('default.region.test', $this->cacheItemPool);
     }
 
     public function testGetMulti(): void
@@ -47,7 +47,11 @@ class MultiGetRegionTest extends AbstractRegionTest
     public function corruptedDataDoesNotLeakIntoApplication(): void
     {
         $key1 = new CacheKeyMock('key.1');
-        $this->cache->save($this->region->getName() . '_' . $key1->hash, 'a-very-invalid-value');
+        $this->cacheItemPool->save(
+            $this->cacheItemPool
+                ->getItem('DC2_REGION_' . $this->region->getName() . '_' . $key1->hash)
+                ->set('a-very-invalid-value')
+        );
 
         self::assertTrue($this->region->contains($key1));
         self::assertNull($this->region->getMultiple(new CollectionCacheEntry([$key1])));

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -60,7 +60,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
 
     protected function setUp(): void
     {
-        $this->getSharedSecondLevelCacheDriverImpl()->flushAll();
+        $this->getSharedSecondLevelCache()->clear();
         $this->enableSecondLevelCache();
         parent::setUp();
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -37,7 +37,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
     protected function setUp(): void
     {
-        $this->getSharedSecondLevelCacheDriverImpl()->flushAll();
+        $this->getSharedSecondLevelCache()->clear();
         $this->enableSecondLevelCache();
         parent::setUp();
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\EntityCacheKey;
@@ -15,6 +14,7 @@ use Doctrine\Tests\Mocks\ConcurrentRegionMock;
 use Doctrine\Tests\Mocks\TimestampRegionMock;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function assert;
 
@@ -34,7 +34,7 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
         $this->enableSecondLevelCache();
         parent::setUp();
 
-        $this->cacheFactory = new CacheFactorySecondLevelCacheConcurrentTest($this->getSharedSecondLevelCacheDriverImpl());
+        $this->cacheFactory = new CacheFactorySecondLevelCacheConcurrentTest($this->getSharedSecondLevelCache());
 
         $this->_em->getConfiguration()
             ->getSecondLevelCacheConfiguration()
@@ -133,7 +133,10 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
 
 class CacheFactorySecondLevelCacheConcurrentTest extends DefaultCacheFactory
 {
-    public function __construct(Cache $cache)
+    /** @var CacheItemPoolInterface */
+    private $cache;
+
+    public function __construct(CacheItemPoolInterface $cache)
     {
         $this->cache = $cache;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Cache\Region\DefaultMultiGetRegion;
 use Doctrine\Tests\Models\Cache\Attraction;
 use Doctrine\Tests\Models\Cache\Bar;
 use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
@@ -21,11 +20,7 @@ class DDC7969Test extends SecondLevelCacheAbstractTest
         $this->loadFixturesAttractions();
 
         // Entities are already cached due to fixtures - hence flush before testing
-        $region = $this->cache->getEntityCacheRegion(Attraction::class);
-
-        if ($region instanceof DefaultMultiGetRegion) {
-            $region->getCache()->flushAll();
-        }
+        $this->cache->getEntityCacheRegion(Attraction::class)->evictAll();
 
         $bar = $this->attractions[0];
         assert($bar instanceof Bar);

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -746,8 +746,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
 
         if ($this->isSecondLevelCacheEnabled || $enableSecondLevelCache) {
             $cacheConfig = new CacheConfiguration();
-            $cache       = $this->getSharedSecondLevelCacheDriverImpl();
-            $factory     = new DefaultCacheFactory($cacheConfig->getRegionsConfiguration(), $cache);
+            $factory     = new DefaultCacheFactory(
+                $cacheConfig->getRegionsConfiguration(),
+                $this->getSharedSecondLevelCache()
+            );
 
             $this->secondLevelCacheFactory = $factory;
 

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Annotations;
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -54,8 +52,8 @@ abstract class OrmTestCase extends DoctrineTestCase
     /** @var StatisticsCacheLogger */
     protected $secondLevelCacheLogger;
 
-    /** @var Cache|null */
-    protected $secondLevelCacheDriverImpl = null;
+    /** @var CacheItemPoolInterface|null */
+    protected $secondLevelCache = null;
 
     protected function createAnnotationDriver(array $paths = []): AnnotationDriver
     {
@@ -102,8 +100,10 @@ abstract class OrmTestCase extends DoctrineTestCase
 
         if ($this->isSecondLevelCacheEnabled) {
             $cacheConfig = new CacheConfiguration();
-            $cache       = $this->getSharedSecondLevelCacheDriverImpl();
-            $factory     = new DefaultCacheFactory($cacheConfig->getRegionsConfiguration(), $cache);
+            $factory     = new DefaultCacheFactory(
+                $cacheConfig->getRegionsConfiguration(),
+                $this->getSharedSecondLevelCache()
+            );
 
             $this->secondLevelCacheFactory = $factory;
 
@@ -152,12 +152,9 @@ abstract class OrmTestCase extends DoctrineTestCase
         return self::$queryCache;
     }
 
-    protected function getSharedSecondLevelCacheDriverImpl(): Cache
+    protected function getSharedSecondLevelCache(): CacheItemPoolInterface
     {
-        if ($this->secondLevelCacheDriverImpl === null) {
-            $this->secondLevelCacheDriverImpl = DoctrineProvider::wrap(new ArrayAdapter());
-        }
-
-        return $this->secondLevelCacheDriverImpl;
+        return $this->secondLevelCache
+            ?? $this->secondLevelCache = new ArrayAdapter();
     }
 }


### PR DESCRIPTION
I'd like to continue our effort to sunset Doctrine Cache. This PR enables `DefaultCacheFactory` and `DefaultRegion` to consume a PSR-6 cache item pool instead of a Doctrine Cache instance.