### PR TITLE
Use `EntityManagerInterface` in type declarations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade to 2.11
 
+## Rename `AbstractIdGenerator::generate()` to `generateId()`
+
+Implementations of `AbstractIdGenerator` have to override the method
+`generateId()` without calling the parent implementation. Not doing so is
+deprecated. Calling `generate()` on any `AbstractIdGenerator` implementation
+is deprecated.
+
 ## PSR-6-based second level cache
 
 The second level cache has been reworked to consume a PSR-6 cache. Using a

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -39,7 +39,7 @@ class EntityRepository implements ObjectRepository, Selectable
     /** @var string */
     protected $_entityName;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $_em;
 
     /** @var ClassMetadata */
@@ -282,7 +282,7 @@ class EntityRepository implements ObjectRepository, Selectable
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     protected function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
 
 /**
@@ -28,7 +28,7 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClassMetadataEventArgs;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
  *
- * @method __construct(ClassMetadata $classMetadata, EntityManager $objectManager)
+ * @method __construct(ClassMetadata $classMetadata, EntityManagerInterface $objectManager)
  * @method ClassMetadata getClassMetadata()
  */
 class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
@@ -19,7 +19,7 @@ class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
     /**
      * Retrieve associated EntityManager.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -15,7 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class PostFlushEventArgs extends EventArgs
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)
@@ -26,7 +25,7 @@ class PostFlushEventArgs extends EventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -15,7 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class PreFlushEventArgs extends EventArgs
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)
@@ -24,7 +23,7 @@ class PreFlushEventArgs extends EventArgs
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -4,10 +4,54 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use LogicException;
+
+use function get_debug_type;
+use function sprintf;
 
 abstract class AbstractIdGenerator
 {
+    /** @var bool */
+    private $alreadyDelegatedToGenerateId = false;
+
+    /**
+     * Generates an identifier for an entity.
+     *
+     * @deprecated Call {@see generateId()} instead.
+     *
+     * @param object|null $entity
+     *
+     * @return mixed
+     */
+    public function generate(EntityManager $em, $entity)
+    {
+        if ($this->alreadyDelegatedToGenerateId) {
+            throw new LogicException(sprintf(
+                'Endless recursion detected in %s. Please implement generateId() without calling the parent implementation.',
+                get_debug_type($this)
+            ));
+        }
+
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9325',
+            '%s::generate() is deprecated, call generateId() instead.',
+            get_debug_type($this)
+        );
+
+        $this->alreadyDelegatedToGenerateId = true;
+
+        try {
+            return $this->generateId($em, $entity);
+        } finally {
+            $this->alreadyDelegatedToGenerateId = false;
+        }
+    }
+
     /**
      * Generates an identifier for an entity.
      *
@@ -15,7 +59,22 @@ abstract class AbstractIdGenerator
      *
      * @return mixed
      */
-    abstract public function generate(EntityManager $em, $entity);
+    public function generateId(EntityManagerInterface $em, $entity)
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9325',
+            'Not implementing %s in %s is deprecated.',
+            __FUNCTION__,
+            get_debug_type($this)
+        );
+
+        if (! $em instanceof EntityManager) {
+            throw new InvalidArgumentException('Unsupported entity manager implementation.');
+        }
+
+        return $this->generate($em, $entity);
+    }
 
     /**
      * Gets whether this generator is a post-insert generator which means that

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\EntityMissingAssignedId;
 
 use function get_class;
@@ -17,11 +17,11 @@ class AssignedGenerator extends AbstractIdGenerator
     /**
      * Returns the identifier assigned to the given entity.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @throws EntityMissingAssignedId
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         $class      = $em->getClassMetadata(get_class($entity));
         $idFields   = $class->getIdentifierFieldNames();

--- a/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -33,7 +33,7 @@ class BigIntegerIdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         return (string) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Id/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/IdentityGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -33,7 +33,7 @@ class IdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         return (int) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Id;
 
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Serializable;
 
 use function serialize;
@@ -51,7 +51,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         if ($this->_maxValue === null || $this->_nextValue === $this->_maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that uses a single-row database table and a hi/lo algorithm.
@@ -43,8 +43,8 @@ class TableGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(
-        EntityManager $em,
+    public function generateId(
+        EntityManagerInterface $em,
         $entity
     ) {
         if ($this->_maxValue === null || $this->_nextValue === $this->_maxValue) {

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Id;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\NotSupported;
 
 use function method_exists;
@@ -38,7 +38,7 @@ class UuidGenerator extends AbstractIdGenerator
      *
      * @throws NotSupported
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         $connection = $em->getConnection();
         $sql        = 'SELECT ' . $connection->getDatabasePlatform()->getGuidExpression();

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -276,7 +276,7 @@ class BasicEntityPersister implements EntityPersister
             $stmt->executeStatement();
 
             if ($isPostInsertId) {
-                $generatedId     = $idGenerator->generate($this->em, $entity);
+                $generatedId     = $idGenerator->generateId($this->em, $entity);
                 $id              = [$this->class->identifier[0] => $generatedId];
                 $postInsertIds[] = [
                     'generatedId' => $generatedId,

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -159,7 +159,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $rootTableStmt->executeStatement();
 
             if ($isPostInsertId) {
-                $generatedId     = $idGenerator->generate($this->em, $entity);
+                $generatedId     = $idGenerator->generateId($this->em, $entity);
                 $id              = [$this->class->identifier[0] => $generatedId];
                 $postInsertIds[] = [
                     'generatedId' => $generatedId,

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use InvalidArgumentException;
@@ -40,7 +39,7 @@ class FilterCollection
     /**
      * The EntityManager that "owns" this FilterCollection instance.
      *
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -986,7 +986,7 @@ class UnitOfWork implements PropertyChangedListener
         $idGen = $class->idGenerator;
 
         if (! $idGen->isPostInsertGenerator()) {
-            $idValue = $idGen->generate($this->em, $entity);
+            $idValue = $idGen->generateId($this->em, $entity);
 
             if (! $idGen instanceof AssignedGenerator) {
                 $idValue = [$class->getSingleIdentifierFieldName() => $this->convertSingleFieldIdentifierToPHPValue($class, $idValue)];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,34 +176,29 @@ parameters:
 			path: lib/Doctrine/ORM/EntityManagerInterface.php
 
 		-
+			message: "#^Method Doctrine\\\\ORM\\\\EntityRepository\\:\\:find\\(\\) should return T\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/EntityRepository.php
+
+		-
 			message: "#^Method Doctrine\\\\ORM\\\\EntityRepository\\:\\:findOneBy\\(\\) should return T\\|null but returns object\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityRepository.php
 
 		-
-			message: "#^Property Doctrine\\\\ORM\\\\EntityRepository\\<T\\>\\:\\:\\$_em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
+			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:find\\(\\) invoked with 4 parameters, 2 required\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityRepository.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Event\\\\LifecycleEventArgs\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManager but returns Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\Event\\\\LifecycleEventArgs\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManagerInterface but returns Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Event/LifecycleEventArgs.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Event\\\\LoadClassMetadataEventArgs\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManager but returns Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\Event\\\\LoadClassMetadataEventArgs\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManagerInterface but returns Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Event\\\\PostFlushEventArgs\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Event/PostFlushEventArgs.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Event\\\\PreFlushEventArgs\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Event/PreFlushEventArgs.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Platforms\\\\AbstractPlatform\\:\\:getTableHiLoCurrentValSql\\(\\)\\.$#"
@@ -736,11 +731,6 @@ parameters:
 			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
 
 		-
-			message: "#^Parameter \\#1 \\$em of method Doctrine\\\\ORM\\\\Id\\\\AbstractIdGenerator\\:\\:generate\\(\\) expects Doctrine\\\\ORM\\\\EntityManager, Doctrine\\\\ORM\\\\EntityManagerInterface given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
-
-		-
 			message: "#^Parameter \\#3 \\$hints of method Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\AbstractHydrator\\:\\:hydrateAll\\(\\) expects array\\<string, string\\>, array\\<string, Doctrine\\\\ORM\\\\PersistentCollection\\|true\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -759,11 +749,6 @@ parameters:
 			message: "#^Property Doctrine\\\\ORM\\\\Persisters\\\\Entity\\\\CachedPersisterContext\\:\\:\\$class \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\) does not accept Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
-
-		-
-			message: "#^Parameter \\#1 \\$em of method Doctrine\\\\ORM\\\\Id\\\\AbstractIdGenerator\\:\\:generate\\(\\) expects Doctrine\\\\ORM\\\\EntityManager, Doctrine\\\\ORM\\\\EntityManagerInterface given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
 
 		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isEmbeddedClass\\.$#"
@@ -944,11 +929,6 @@ parameters:
 			message: "#^PHPDoc type array\\<string\\> of property Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Select\\:\\:\\$allowedClasses is not covariant with PHPDoc type array\\<int, class\\-string\\> of overridden property Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Base\\:\\:\\$allowedClasses\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/Expr/Select.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Query\\\\FilterCollection\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/FilterCollection.php
 
 		-
 			message: "#^Property Doctrine\\\\ORM\\\\Query\\\\FilterCollection\\:\\:\\$filterHash is never written, only read\\.$#"
@@ -1866,11 +1846,6 @@ parameters:
 			path: lib/Doctrine/ORM/UnitOfWork.php
 
 		-
-			message: "#^Parameter \\#1 \\$em of method Doctrine\\\\ORM\\\\Id\\\\AbstractIdGenerator\\:\\:generate\\(\\) expects Doctrine\\\\ORM\\\\EntityManager, Doctrine\\\\ORM\\\\EntityManagerInterface given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/UnitOfWork.php
-
-		-
 			message: "#^Parameter \\#3 \\$changeSet of class Doctrine\\\\ORM\\\\Event\\\\PreUpdateEventArgs constructor is passed by reference, so it expects variables only$#"
 			count: 1
 			path: lib/Doctrine/ORM/UnitOfWork.php
@@ -1889,4 +1864,3 @@ parameters:
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$subClasses\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -473,16 +473,16 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>string</code>
     </LessSpecificImplementedReturnType>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$em</code>
-    </PropertyTypeCoercion>
+    <TooManyArguments occurrences="1">
+      <code>find</code>
+    </TooManyArguments>
   </file>
   <file src="lib/Doctrine/ORM/Event/LifecycleEventArgs.php">
     <LessSpecificReturnStatement occurrences="1">
       <code>$this-&gt;getObjectManager()</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType occurrences="1">
-      <code>EntityManager</code>
+      <code>EntityManagerInterface</code>
     </MoreSpecificReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php">
@@ -490,23 +490,13 @@
       <code>$this-&gt;getObjectManager()</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType occurrences="1">
-      <code>EntityManager</code>
+      <code>EntityManagerInterface</code>
     </MoreSpecificReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php">
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $className</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="lib/Doctrine/ORM/Event/PostFlushEventArgs.php">
-    <PropertyTypeCoercion occurrences="1">
-      <code>$em</code>
-    </PropertyTypeCoercion>
-  </file>
-  <file src="lib/Doctrine/ORM/Event/PreFlushEventArgs.php">
-    <PropertyTypeCoercion occurrences="1">
-      <code>$em</code>
-    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Exception/ORMException.php">
     <DeprecatedClass occurrences="1">
@@ -1514,9 +1504,6 @@
     </PossiblyNullArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;em</code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>$value === null</code>
     </DocblockTypeContradiction>
@@ -1593,9 +1580,6 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;em</code>
-    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement occurrences="1">
       <code>$postInsertIds</code>
     </LessSpecificReturnStatement>
@@ -2314,8 +2298,7 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$filterHash</code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="2">
-      <code>$em</code>
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;enabledFilters</code>
     </PropertyTypeCoercion>
   </file>
@@ -3417,13 +3400,12 @@
     </UnresolvableInclude>
   </file>
   <file src="lib/Doctrine/ORM/UnitOfWork.php">
-    <ArgumentTypeCoercion occurrences="6">
+    <ArgumentTypeCoercion occurrences="5">
       <code>$class</code>
       <code>$class</code>
       <code>$collectionToDelete</code>
       <code>$collectionToUpdate</code>
       <code>$commitOrder[$i]</code>
-      <code>$this-&gt;em</code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="4">
       <code>! is_object($object)</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -46,6 +46,7 @@
                 <!-- Remove on 3.0.x -->
                 <referencedMethod name="Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateRow"/>
                 <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
+                <referencedMethod name="Doctrine\ORM\Id\AbstractIdGenerator::generate"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 
@@ -46,7 +46,7 @@ class CacheMetadataListener
         $this->enabledItems[$metadata->getName()] = true;
     }
 
-    protected function enableCaching(ClassMetadata $metadata, EntityManager $em): void
+    protected function enableCaching(ClassMetadata $metadata, EntityManagerInterface $em): void
     {
         if ($this->isVisited($metadata)) {
             return; // Already handled in the past

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Cache\Persister\Entity\ReadOnlyCachedEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache\RegionsConfiguration;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
@@ -39,7 +39,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
     /** @var CacheFactory&MockObject */
     private $factory;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var RegionsConfiguration */

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Cache\DefaultEntityHydrator;
 use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\EntityHydrator;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
@@ -24,7 +24,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
     /** @var EntityHydrator */
     private $structure;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Cache\QueryCache;
 use Doctrine\ORM\Cache\QueryCacheEntry;
 use Doctrine\ORM\Cache\QueryCacheKey;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Tests\Mocks\CacheEntryMock;
@@ -38,7 +37,7 @@ class DefaultQueryCacheTest extends OrmTestCase
     /** @var DefaultQueryCache */
     private $queryCache;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var CacheRegionMock */

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\Tests\Models\Cache\State;
@@ -27,7 +27,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     /** @var CollectionPersister */
     protected $collectionPersister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $em;
 
     /** @var array */
@@ -56,7 +56,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         'loadCriteria',
     ];
 
-    abstract protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister;
+    abstract protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
 /**
@@ -18,7 +18,7 @@ class NonStrictReadWriteCachedCollectionPersisterTest extends AbstractCollection
     /**
      * {@inheritdoc}
      */
-    protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
+    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
     {
         return new NonStrictReadWriteCachedCollectionPersister($persister, $region, $em, $mapping);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
 /**
@@ -15,7 +15,7 @@ use Doctrine\ORM\Persisters\Collection\CollectionPersister;
  */
 class ReadOnlyCachedCollectionPersisterTest extends AbstractCollectionPersisterTest
 {
-    protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
+    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
     {
         return new ReadOnlyCachedCollectionPersister($persister, $region, $em, $mapping);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\Tests\Models\Cache\State;
 use ReflectionProperty;
@@ -33,7 +33,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         'unlock',
     ];
 
-    protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
+    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
     {
         return new ReadWriteCachedCollectionPersister($persister, $region, $em, $mapping);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
@@ -30,10 +30,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     /** @var EntityPersister&MockObject */
     protected $entityPersister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $em;
 
-    abstract protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister;
+    abstract protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\Tests\Models\Cache\Country;
@@ -20,7 +20,7 @@ use ReflectionProperty;
  */
 class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
 {
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {
         return new NonStrictReadWriteCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\ReadOnlyCachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\Tests\Models\Cache\Country;
@@ -18,7 +18,7 @@ use Doctrine\Tests\Models\Cache\Country;
  */
 class ReadOnlyCachedEntityPersisterTest extends AbstractEntityPersisterTest
 {
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {
         return new ReadOnlyCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\Tests\Models\Cache\Country;
@@ -21,7 +21,7 @@ use ReflectionProperty;
  */
 class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
 {
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {
         return new ReadWriteCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToOneOrphanRemovalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToOneOrphanRemovalTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Models\OrnementalOrphanRemoval\Person;
@@ -87,7 +87,7 @@ class ManyToOneOrphanRemovalTest extends OrmFunctionalTestCase
     protected function getEntityManager(
         ?Connection $connection = null,
         ?MappingDriver $mappingDriver = null
-    ): EntityManager {
+    ): EntityManagerInterface {
         return parent::getEntityManager($connection, new XmlDriver(
             __DIR__ . DIRECTORY_SEPARATOR . 'xml'
         ));

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
@@ -233,7 +234,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         );
     }
 
-    private function createEntityManager(SQLLogger $logger): EntityManager
+    private function createEntityManager(SQLLogger $logger): EntityManagerInterface
     {
         $config = new Configuration();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Driver\StaticPHPDriver;
@@ -108,7 +108,7 @@ class DDC2415ChildEntity extends DDC2415ParentEntity
 
 class DDC2415Generator extends AbstractIdGenerator
 {
-    public function generate(EntityManager $em, $entity): string
+    public function generateId(EntityManagerInterface $em, $entity): string
     {
         return md5($entity->getName());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\CustomIdGenerator;
@@ -54,7 +54,7 @@ final class GH5804Generator extends AbstractIdGenerator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         return 'test5804';
     }

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Hydration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
@@ -24,7 +24,7 @@ class ResultSetMappingTest extends OrmTestCase
     /** @var ResultSetMapping */
     private $_rsm;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Id/AbstractIdGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AbstractIdGeneratorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Id;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class AbstractIdGeneratorTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testDeprecationLayerForLegacyImplementation(): void
+    {
+        $generator = new class extends AbstractIdGenerator
+        {
+            /** @var mixed */
+            public $receivedEm;
+            /** @var mixed */
+            public $receivedEntity;
+
+            /**
+             * {@inheritdoc}
+             */
+            public function generate(EntityManager $em, $entity): string
+            {
+                $this->receivedEm     = $em;
+                $this->receivedEntity = $entity;
+
+                return '4711';
+            }
+        };
+
+        $em     = $this->createMock(EntityManager::class);
+        $entity = new stdClass();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9325');
+
+        self::assertSame('4711', $generator->generateId($em, $entity));
+        self::assertSame($em, $generator->receivedEm);
+        self::assertSame($entity, $generator->receivedEntity);
+    }
+
+    public function testNoEndlessRecursionOnGenerateId(): void
+    {
+        $generator = new class extends AbstractIdGenerator
+        {
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Endless recursion detected in Doctrine\ORM\Id\AbstractIdGenerator@anonymous. Please implement generateId() without calling the parent implementation.');
+
+        $generator->generateId($this->createMock(EntityManager::class), (object) []);
+    }
+
+    public function testNoEndlessRecursionOnGenerate(): void
+    {
+        $generator = new class extends AbstractIdGenerator
+        {
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Endless recursion detected in Doctrine\ORM\Id\AbstractIdGenerator@anonymous. Please implement generateId() without calling the parent implementation.');
+
+        $generator->generate($this->createMock(EntityManager::class), (object) []);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Id;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -35,7 +36,7 @@ class AssignedGeneratorTest extends OrmTestCase
     {
         $this->expectException(ORMException::class);
 
-        $this->assignedGen->generate($this->entityManager, $entity);
+        $this->assignedGen->generateId($this->entityManager, $entity);
     }
 
     public function entitiesWithoutId(): array
@@ -50,13 +51,13 @@ class AssignedGeneratorTest extends OrmTestCase
     {
         $entity       = new AssignedSingleIdEntity();
         $entity->myId = 1;
-        $id           = $this->assignedGen->generate($this->entityManager, $entity);
+        $id           = $this->assignedGen->generateId($this->entityManager, $entity);
         self::assertEquals(['myId' => 1], $id);
 
         $entity        = new AssignedCompositeIdEntity();
         $entity->myId2 = 2;
         $entity->myId1 = 4;
-        $id            = $this->assignedGen->generate($this->entityManager, $entity);
+        $id            = $this->assignedGen->generateId($this->entityManager, $entity);
         self::assertEquals(['myId1' => 4, 'myId2' => 2], $id);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Id;
 
 use BadMethodCallException;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\SequenceGenerator;
 use Doctrine\Tests\Mocks\ArrayResultFactory;
 use Doctrine\Tests\Mocks\ConnectionMock;
@@ -13,7 +13,7 @@ use Doctrine\Tests\OrmTestCase;
 
 class SequenceGeneratorTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
     /** @var SequenceGenerator */
@@ -45,7 +45,7 @@ class SequenceGeneratorTest extends OrmTestCase
                 $this->connection->setQueryResult(ArrayResultFactory::createFromArray([[(int) ($i / 10) * 10]]));
             }
 
-            $id = $this->sequenceGenerator->generate($this->entityManager, null);
+            $id = $this->sequenceGenerator->generateId($this->entityManager, null);
 
             self::assertSame($i, $id);
             self::assertSame((int) ($i / 10) * 10 + 10, $this->sequenceGenerator->getCurrentMaxValue());

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -100,10 +100,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         return $class;
     }
 
-    protected function createClassMetadataFactory(?EntityManager $em = null): ClassMetadataFactory
+    protected function createClassMetadataFactory(?EntityManagerInterface $em = null): ClassMetadataFactory
     {
         $driver  = $this->loadDriver();
-        $em      = $em ?: $this->getTestEntityManager();
+        $em      = $em ?? $this->getTestEntityManager();
         $factory = new ClassMetadataFactory();
         $em->getConfiguration()->setMetadataDriverImpl($driver);
         $factory->setEntityManager($em);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
@@ -589,7 +588,11 @@ class TestEntity1
 
 class CustomIdGenerator extends AbstractIdGenerator
 {
-    public function generate(EntityManager $em, $entity): void
+    /**
+     * {@inheritdoc}
+     */
+    public function generateId(EntityManagerInterface $em, $entity): string
     {
+        return 'foo';
     }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\Models\GeoNames\Admin1;
 use Doctrine\Tests\Models\GeoNames\Admin1AlternateName;
@@ -17,7 +17,7 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
     /** @var BasicEntityPersister */
     protected $persister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $entityManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\Common\Collections\Expr\Comparison;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Persisters\Exception\CantUseInOperatorOnCompositeKeys;
 use Doctrine\Tests\Models\GeoNames\Admin1AlternateName;
@@ -16,7 +16,7 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
     /** @var BasicEntityPersister */
     protected $persister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $entityManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM\Persisters;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\DBAL\Types\Type as DBALType;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
@@ -22,7 +22,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     /** @var BasicEntityPersister */
     protected $persister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $entityManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Persisters;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\OrmTestCase;
@@ -19,7 +19,7 @@ class JoinedSubClassPersisterTest extends OrmTestCase
     /** @var JoinedSubclassPersister */
     protected $persister;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $em;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\Tests\OrmTestCase;
@@ -14,7 +14,7 @@ use Doctrine\Tests\OrmTestCase;
  */
 class FilterCollectionTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Query\Parameter;
@@ -29,7 +29,7 @@ use function get_class;
  */
 class QueryBuilderTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Column;
@@ -19,7 +19,7 @@ use function func_get_args;
 
 class AttachEntityListenersListenerTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var AttachEntityListenersListener */

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Column;
@@ -22,7 +22,7 @@ use Doctrine\Tests\OrmTestCase;
 
 class ResolveTargetEntityListenerTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var ResolveTargetEntityListener */

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Embeddable;
@@ -29,7 +29,7 @@ use Doctrine\Tests\OrmTestCase;
 
 class SchemaValidatorTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em = null;
 
     /** @var SchemaValidator */

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -75,7 +76,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      */
     protected static $sharedConn;
 
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $_em;
 
     /** @var SchemaTool */
@@ -706,7 +707,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     protected function getEntityManager(
         ?Connection $connection = null,
         ?MappingDriver $mappingDriver = null
-    ): EntityManager {
+    ): EntityManagerInterface {
         // NOTE: Functional tests use their own shared metadata cache, because
         // the actual database platform used during execution has effect on some
         // metadata mapping behaviors (like the choice of the ID generation).


### PR DESCRIPTION
The codebase inconsitently switched between `EntityManagerInterface` and `EntityManager` in type declarations. This will get us into trouble if we want to migrate to native type declarations on 3.0.

This PR switches all type declarations to `EntityManagerInterface` where possible.