### PR TITLE
Added runtime deprecation to `UnitOfWork::commit()` and `clear()`

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2563,6 +2563,13 @@ class UnitOfWork implements PropertyChangedListener
             $this->eagerLoadingEntities           =
             $this->orphanRemovals                 = [];
         } else {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8460',
+                'Calling %s() with any arguments to clear specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
+                __METHOD__
+            );
+
             $this->clearIdentityMapForEntityName($entityName);
             $this->clearEntityInsertionsForEntityName($entityName);
         }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -340,6 +340,15 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function commit($entity = null)
     {
+        if ($entity !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8459',
+                'Calling %s() with any arguments to commit specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
+                __METHOD__
+            );
+        }
+
         $connection = $this->em->getConnection();
 
         if ($connection instanceof PrimaryReadReplicaConnection) {

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -399,6 +399,8 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity2);
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity2));
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8460');
+
         $this->_unitOfWork->clear(Country::class);
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity1));
         self::assertFalse($this->_unitOfWork->isInIdentityMap($entity2));

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -50,6 +51,8 @@ use function uniqid;
  */
 class UnitOfWorkTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     /**
      * SUT
      *
@@ -226,6 +229,9 @@ class UnitOfWorkTest extends OrmTestCase
 
         $this->_unitOfWork->persist($entity);
         $this->_unitOfWork->persist($entity2);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
+
         $this->_unitOfWork->commit($entity);
         $this->_unitOfWork->commit();
 
@@ -414,6 +420,8 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity1);
         $this->_unitOfWork->persist($entity2);
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
+
         $this->_unitOfWork->commit($entity1);
         self::assertEmpty($this->_unitOfWork->getEntityChangeSet($entity1));
         self::assertCount(1, $this->_unitOfWork->getEntityChangeSet($entity2));
@@ -435,6 +443,8 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity1);
         $this->_unitOfWork->persist($entity2);
         $this->_unitOfWork->persist($entity3);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
 
         $this->_unitOfWork->commit([$entity1, $entity3]);
 


### PR DESCRIPTION
Part of #8459. Passing an entity or a set of them to `UnitOfWork::commit()` is deprecated since ORM 2.7 (along with `EntityManager::flush($entity)`), but no runtime deprecation has been triggered so far when calling the UoW directly.

Same for `UnitOfWork::clear()`.

This PR attempts to correct that.