### PR TITLE
Fix broken type declaration

### DIFF
--- a/tests/Doctrine/Performance/Mock/NonProxyLoadingUnitOfWork.php
+++ b/tests/Doctrine/Performance/Mock/NonProxyLoadingUnitOfWork.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\Performance\Mock;
 
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Tests\ORM\Performance\PersisterMock;
 
 /**
  * An unit of work mock that prevents lazy-loading of proxies
  */
 class NonProxyLoadingUnitOfWork extends UnitOfWork
 {
-    /** @var PersisterMock */
+    /** @var NonLoadingPersister */
     private $entityPersister;
 
     public function __construct()


### PR DESCRIPTION
The referenced class does not exist. Spotted while working on #9329.