### PR TITLE
Use the readonly annotation

### DIFF
--- a/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
@@ -10,15 +10,13 @@ namespace Doctrine\ORM\Cache;
 class AssociationCacheEntry implements CacheEntry
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed> The entity identifier
      */
     public $identifier;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string The entity class name
      */
     public $class;

--- a/lib/Doctrine/ORM/Cache/CacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CacheKey.php
@@ -11,8 +11,7 @@ namespace Doctrine\ORM\Cache;
 abstract class CacheKey
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string Unique identifier
      */
     public $hash;

--- a/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
@@ -10,8 +10,7 @@ namespace Doctrine\ORM\Cache;
 class CollectionCacheEntry implements CacheEntry
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var CacheKey[] The list of entity identifiers hold by the collection
      */
     public $identifiers;

--- a/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
@@ -15,22 +15,19 @@ use function strtolower;
 class CollectionCacheKey extends CacheKey
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed> The owner entity identifier
      */
     public $ownerIdentifier;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string The owner entity class
      */
     public $entityClass;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string The association name
      */
     public $association;

--- a/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
@@ -14,15 +14,13 @@ use function array_map;
 class EntityCacheEntry implements CacheEntry
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string,mixed> The entity map data
      */
     public $data;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string The entity class name
      * @psalm-var class-string
      */

--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -15,15 +15,13 @@ use function strtolower;
 class EntityCacheKey extends CacheKey
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed> The entity identifier
      */
     public $identifier;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var string The entity class name
      */
     public $entityClass;

--- a/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
@@ -12,15 +12,13 @@ use function microtime;
 class QueryCacheEntry implements CacheEntry
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed> List of entity identifiers
      */
     public $result;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var float Time creation of this cache entry
      */
     public $time;

--- a/lib/Doctrine/ORM/Cache/QueryCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheKey.php
@@ -12,8 +12,7 @@ use Doctrine\ORM\Cache;
 class QueryCacheKey extends CacheKey
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var int Cache key lifetime
      */
     public $lifetime;
@@ -21,16 +20,14 @@ class QueryCacheKey extends CacheKey
     /**
      * Cache mode
      *
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var int
      * @psalm-var Cache::MODE_*
      */
     public $cacheMode;
 
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var TimestampCacheKey|null
      */
     public $timestampKey;

--- a/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
@@ -12,8 +12,7 @@ use function microtime;
 class TimestampCacheEntry implements CacheEntry
 {
     /**
-     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
-     *
+     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var float
      */
     public $time;

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -87,8 +87,7 @@ use function substr;
 class Parser
 {
     /**
-     * READ-ONLY: Maps BUILT-IN string function names to AST class names.
-     *
+     * @readonly Maps BUILT-IN string function names to AST class names.
      * @psalm-var array<string, class-string<Functions\FunctionNode>>
      */
     private static $stringFunctions = [
@@ -101,8 +100,7 @@ class Parser
     ];
 
     /**
-     * READ-ONLY: Maps BUILT-IN numeric function names to AST class names.
-     *
+     * @readonly Maps BUILT-IN numeric function names to AST class names.
      * @psalm-var array<string, class-string<Functions\FunctionNode>>
      */
     private static $numericFunctions = [
@@ -125,8 +123,7 @@ class Parser
     ];
 
     /**
-     * READ-ONLY: Maps BUILT-IN datetime function names to AST class names.
-     *
+     * @readonly Maps BUILT-IN datetime function names to AST class names.
      * @psalm-var array<string, class-string<Functions\FunctionNode>>
      */
     private static $datetimeFunctions = [


### PR DESCRIPTION
Several public properties are documented as `READ-ONLY: <some explanation>`. However, in the meantime, PHP has implemented real `readonly` properties and Psalm supports the docblock annotation `@readonly` to emulate its sematics.

https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-readonly-and-readonly

I propose to switch to that annotation to allow Psalm to detect unintended access to those properties.

Note: I have skipped the `ClassMetadataInfo` class because most of the properties flagged as `READ-ONLY` there are actually not used accoding to PHP 8.1's semantics.