### PR TITLE
Use a specific configuration file for DBAL 2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -84,3 +84,8 @@ jobs:
 
       - name: "Run a static analysis with vimeo/psalm"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"
+        if: "${{ matrix.dbal-version == 'default' }}"
+
+      - name: "Run a static analysis with phpstan/phpstan"
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --config=psalm-dbal2.xml"
+        if: "${{ matrix.dbal-version == '2.13' }}"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2139,7 +2139,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
-    <InvalidScalarArgument occurrences="1"/>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;simpleArithmeticExpression</code>
     </PossiblyInvalidArgument>
@@ -2192,10 +2191,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$optionalSecondSimpleArithmeticExpression</code>
-      <code>$sqlWalker-&gt;walkSimpleArithmeticExpression($this-&gt;firstSimpleArithmeticExpression)</code>
-    </InvalidScalarArgument>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$firstSimpleArithmeticExpression</code>
       <code>$stringPrimary</code>

--- a/psalm-dbal2.xml
+++ b/psalm-dbal2.xml
@@ -18,4 +18,13 @@
         </ignoreFiles>
     </projectFiles>
     <xi:include href="psalm-issue-handlers.xml"/>
+    <issueHandlers>
+        <!-- Issues that will not be fixed on DBAL 2.x -->
+        <InvalidScalarArgument>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php"/>
+                <file name="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php"/>
+            </errorLevel>
+        </InvalidScalarArgument>
+    </issueHandlers>
 </psalm>

--- a/psalm-issue-handlers.xml
+++ b/psalm-issue-handlers.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<issueHandlers xmlns="https://getpsalm.org/schema/config">
+    <DeprecatedClass>
+        <errorLevel type="suppress">
+            <!-- DBAL 2 compatibility -->
+            <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ImportCommand"/>
+            <referencedClass name="Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper"/>
+            <!-- The exception is thrown by a deprecated method. -->
+            <referencedClass name="Doctrine\ORM\Cache\Exception\InvalidResultCacheDriver"/>
+        </errorLevel>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+        <errorLevel type="suppress">
+            <!-- We're calling the deprecated method for BC here. -->
+            <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
+            <!-- We need to keep the calls for DBAL 2.13 compatibility. -->
+            <referencedMethod name="Doctrine\DBAL\Cache\QueryCacheProfile::getResultCacheDriver"/>
+            <referencedMethod name="Doctrine\DBAL\Cache\QueryCacheProfile::setResultCacheDriver"/>
+            <referencedMethod name="Doctrine\DBAL\Configuration::getResultCacheImpl"/>
+            <referencedMethod name="Doctrine\DBAL\Configuration::setResultCacheImpl"/>
+            <referencedMethod name="Doctrine\DBAL\Connection::getSchemaManager"/>
+            <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
+        </errorLevel>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction>
+        <errorLevel type="suppress">
+            <!-- We're catching invalid input here. -->
+            <file name="lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php"/>
+
+            <!-- DBAL 3.2 forward compatibility -->
+            <file name="lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php"/>
+            <file name="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php"/>
+        </errorLevel>
+    </DocblockTypeContradiction>
+    <InvalidArgument>
+        <errorLevel type="suppress">
+            <!-- Argument type changes in DBAL 3.2 -->
+            <referencedFunction name="Doctrine\DBAL\Cache\QueryCacheProfile::__construct"/>
+        </errorLevel>
+    </InvalidArgument>
+    <InvalidClass>
+        <errorLevel type="suppress">
+            <!-- Class name changes in DBAL 3. -->
+            <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform" />
+        </errorLevel>
+    </InvalidClass>
+    <MissingDependency>
+        <errorLevel type="suppress">
+            <!-- DBAL 3.2 forward compatibility -->
+            <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
+            <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            <file name="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php"/>
+        </errorLevel>
+    </MissingDependency>
+    <ParadoxicalCondition>
+        <errorLevel type="suppress">
+            <!-- See https://github.com/vimeo/psalm/issues/3381 -->
+            <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
+        </errorLevel>
+    </ParadoxicalCondition>
+    <NullArgument>
+        <errorLevel type="suppress">
+            <!-- See https://github.com/vimeo/psalm/issues/5920 -->
+            <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php"/>
+        </errorLevel>
+    </NullArgument>
+    <RedundantCastGivenDocblockType>
+        <errorLevel type="suppress">
+            <!-- Can be removed once the "getMaxResults" methods of those classes have native parameter types -->
+            <file name="lib/Doctrine/ORM/Query.php"/>
+            <file name="lib/Doctrine/ORM/QueryBuilder.php"/>
+        </errorLevel>
+    </RedundantCastGivenDocblockType>
+    <TypeDoesNotContainType>
+        <errorLevel type="suppress">
+            <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
+            <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+        </errorLevel>
+    </TypeDoesNotContainType>
+    <UndefinedClass>
+        <errorLevel type="suppress">
+            <referencedClass name="Doctrine\Common\Cache\ApcCache"/>
+            <referencedClass name="Doctrine\Common\Cache\ArrayCache"/>
+            <referencedClass name="Doctrine\Common\Cache\XcacheCache"/>
+
+            <!-- DBAL 2 compatibility -->
+            <referencedClass name="Doctrine\DBAL\Driver\ResultStatement"/>
+            <referencedClass name="Doctrine\DBAL\ForwardCompatibility\Result"/>
+            <referencedClass name="Doctrine\DBAL\Platforms\SQLAnywherePlatform"/>
+
+            <!-- DBAL 3.2 forward compatibility -->
+            <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform"/>
+            <referencedClass name="Doctrine\DBAL\Platforms\SQLServerPlatform"/>
+        </errorLevel>
+    </UndefinedClass>
+    <UndefinedDocblockClass>
+        <errorLevel type="suppress">
+            <!-- DBAL 2 compatibility -->
+            <referencedClass name="Doctrine\DBAL\Driver\ResultStatement"/>
+        </errorLevel>
+    </UndefinedDocblockClass>
+    <UndefinedMethod>
+        <errorLevel type="suppress">
+            <!-- See https://github.com/doctrine/orm/issues/8884 -->
+            <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
+        </errorLevel>
+    </UndefinedMethod>
+</issueHandlers>


### PR DESCRIPTION
Just like for PHPStan, we now have 2 configuration files with common
ignore rules. This should make it easier to update the baseline.

Follow-up of https://github.com/doctrine/orm/pull/9336