### PR TITLE
Remove Psalm job for analyzing DBAL 2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -59,9 +59,6 @@ jobs:
       matrix:
         php-version:
           - "8.1"
-        dbal-version:
-          - "default"
-          - "2.13"
 
     steps:
       - name: "Checkout code"
@@ -72,10 +69,6 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
-
-      - name: "Require specific DBAL version"
-        run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
-        if: "${{ matrix.dbal-version != 'default' }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2139,7 +2139,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
-    <InvalidScalarArgument occurrences="1"/>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;simpleArithmeticExpression</code>
     </PossiblyInvalidArgument>
@@ -2192,10 +2191,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$optionalSecondSimpleArithmeticExpression</code>
-      <code>$sqlWalker-&gt;walkSimpleArithmeticExpression($this-&gt;firstSimpleArithmeticExpression)</code>
-    </InvalidScalarArgument>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$firstSimpleArithmeticExpression</code>
       <code>$stringPrimary</code>


### PR DESCRIPTION
As of now, we cannot have specific config files for each DBAL version
and avoid repetition. We already have PHPStan performing checks with
DBAL 2, which could be considered enough.

See:
- https://github.com/vimeo/psalm/issues/7353
- https://github.com/doctrine/orm/pull/9341
- https://github.com/doctrine/orm/pull/9343