### PR TITLE
Remove the `composer/package-versions-deprecated` package

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -228,8 +228,7 @@ These methods have been deprecated:
 ## Deprecated `Doctrine\ORM\Version`
 
 The `Doctrine\ORM\Version` class is now deprecated and will be removed in Doctrine ORM 3.0:
-please refrain from checking the ORM version at runtime or use
-[ocramius/package-versions](https://github.com/Ocramius/PackageVersions/).
+please refrain from checking the ORM version at runtime or use Composer's [runtime API](https://getcomposer.org/doc/07-runtime.md#knowing-whether-package-x-is-installed-in-version-y).
 
 ## Deprecated `EntityManager#merge()` method
 

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1 ||^8.0",
+        "php": "^7.1 || ^8.0",
+        "composer-runtime-api": "^2",
         "ext-ctype": "*",
         "ext-pdo": "*",
-        "composer/package-versions-deprecated": "^1.8",
         "doctrine/cache": "^1.12.1 || ^2.1.1",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",

--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console;
 
+use Composer\InstalledVersions;
 use Doctrine\DBAL\Tools\Console as DBALConsole;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\ConnectionFromManagerProvider;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\HelperSetManagerProvider;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use OutOfBoundsException;
-use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 
+use function assert;
 use function class_exists;
 
 /**
@@ -59,7 +60,10 @@ final class ConsoleRunner
      */
     public static function createApplication($helperSetOrProvider, array $commands = []): Application
     {
-        $cli = new Application('Doctrine Command Line Interface', Versions::getVersion('doctrine/orm'));
+        $version = InstalledVersions::getVersion('doctrine/orm');
+        assert($version !== null);
+
+        $cli = new Application('Doctrine Command Line Interface', $version);
         $cli->setCatchExceptions(true);
 
         if ($helperSetOrProvider instanceof HelperSet) {

--- a/tests/Doctrine/Tests/ORM/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/ConsoleRunnerTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console;
 
+use Composer\InstalledVersions;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 use Doctrine\Tests\DoctrineTestCase;
-use PackageVersions\Versions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -28,7 +28,7 @@ final class ConsoleRunnerTest extends DoctrineTestCase
         $app       = ConsoleRunner::createApplication($helperSet);
 
         self::assertSame($helperSet, $app->getHelperSet());
-        self::assertSame(Versions::getVersion('doctrine/orm'), $app->getVersion());
+        self::assertSame(InstalledVersions::getVersion('doctrine/orm'), $app->getVersion());
 
         self::assertTrue($app->has('dbal:reserved-words'));
         self::assertTrue($app->has('dbal:run-sql'));


### PR DESCRIPTION
see symfony/symfony#44726, doctrine/dbal#5078

With Composer's new plugin policy in mind, we should avoid dropping Composer plugins into an application's dependencies. I suggest to drop the `composer/package-versions-deprecated` dependency and rely on Composer's runtime API instead.

The consequence would be that people who are still on Composer 1 won't be able to upgrade the ORM anymore. Then again, at this point of time, there really should not be a reason anymore to use Composer 1.