### PR TITLE
Add detach as of list cascade-all operations

### DIFF
--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -689,6 +689,7 @@ specified by their respective tags:
 -  ``<cascade-merge />``
 -  ``<cascade-remove />``
 -  ``<cascade-refresh />``
+-  ``<cascade-detach />``
 
 Join Column Element
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As of XmlExporter (https://github.com/doctrine/orm/blob/b7d822972e8fb4a05faf81e8b4fad104a0d9578c/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php#L270-L293), there is missed `cascade-detach` operation from the list.