### PR TITLE
Fix "Illegal mix of collations" in MultiTableDeleteExecutor

### DIFF
--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -49,6 +49,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $conn          = $em->getConnection();
         $platform      = $conn->getDatabasePlatform();
         $quoteStrategy = $em->getConfiguration()->getQuoteStrategy();
+        $schemaConfig  = $conn->getSchemaManager()->createSchemaConfig();
 
         if ($conn instanceof PrimaryReadReplicaConnection) {
             $conn->ensureConnectedToPrimary();
@@ -89,11 +90,16 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
+        $schemaOptions = $schemaConfig->getDefaultTableOptions();
+        $columnsCharset = $schemaOptions['charset'] ?? null;
+        $columnsCollation = $schemaOptions['collate'] ?? null;
         $columnDefinitions = [];
         foreach ($idColumnNames as $idColumnName) {
             $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $em)),
+                'charset' => $columnsCharset,
+                'collation' => $columnsCollation,
             ];
         }
 

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -90,9 +90,9 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
-        $schemaOptions = $schemaConfig->getDefaultTableOptions();
-        $columnsCharset = $schemaOptions['charset'] ?? null;
-        $columnsCollation = $schemaOptions['collate'] ?? null;
+        $schemaOptions     = $schemaConfig->getDefaultTableOptions();
+        $columnsCharset    = $schemaOptions['charset'] ?? null;
+        $columnsCollation  = $schemaOptions['collate'] ?? null;
         $columnDefinitions = [];
         foreach ($idColumnNames as $idColumnName) {
             $columnDefinitions[$idColumnName] = [


### PR DESCRIPTION
When database tables use a collation that's not the default database one, MultiTableDeleteExecutor fails with this error:

```
In AbstractMySQLDriver.php line 128:
                                                                                                                                                    
  [Doctrine\DBAL\Exception\DriverException]                                                                                                         
  An exception occurred while executing 'DELETE FROM MessengerTaskProcesses WHERE (id) IN (SELECT id FROM MessengerProcesses_id_tmp)':              
                                                                                                                                                    
  SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_general_ci,IMPLICIT) for operation '='
```

This issue should be fixed by using the configured charset/collation.