### PR TITLE
Expose enumType to DBAL to make native DB Enum possible

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -781,12 +781,18 @@ class SchemaTool
      */
     private function gatherColumnOptions(array $mapping): array
     {
-        if (! isset($mapping['options'])) {
+        $mappingOptions = $mapping['options'] ?? [];
+
+        if (isset($mapping['enumType'])) {
+            $mappingOptions['enumType'] = $mapping['enumType'];
+        }
+
+        if (empty($mappingOptions)) {
             return [];
         }
 
-        $options                        = array_intersect_key($mapping['options'], array_flip(self::KNOWN_COLUMN_OPTIONS));
-        $options['customSchemaOptions'] = array_diff_key($mapping['options'], $options);
+        $options                        = array_intersect_key($mappingOptions, array_flip(self::KNOWN_COLUMN_OPTIONS));
+        $options['customSchemaOptions'] = array_diff_key($mappingOptions, $options);
 
         return $options;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -35,6 +35,8 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedChildClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedIdentityClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedRootClass;
+use Doctrine\Tests\Models\Enums\Card;
+use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
 use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\NullDefault\NullDefaultColumn;
@@ -187,6 +189,23 @@ class SchemaToolTest extends OrmTestCase
             ->getCustomSchemaOptions();
 
         self::assertSame([], $customSchemaOptions);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumTypeAddedToCustomSchemaOptions(): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $customSchemaOptions = $schemaTool->getSchemaFromMetadata([$em->getClassMetadata(Card::class)])
+            ->getTable('Card')
+            ->getColumn('suit')
+            ->getCustomSchemaOptions();
+
+        self::assertArrayHasKey('enumType', $customSchemaOptions);
+        self::assertSame(Suit::class, $customSchemaOptions['enumType']);
     }
 
     /**


### PR DESCRIPTION
The idea behing this is the following: by overriding DBAL built-in StringType we can use native enums directly in the database. But to make it possible we need enumType information on DBAL side, right now it's holded only in ORM mapping and isn't passed to DBAL in SchemaTool.

```yaml
# config/packages/doctrine.yaml
doctrine:
    dbal:
        types:
            string: App\DBAL\Type\EnumType
```

```php
# src/App/DBAL/Type/EnumType.php
<?php

namespace App\DBAL\Type;

use BackedEnum;
use Doctrine\DBAL\Platforms\AbstractPlatform;
use Doctrine\DBAL\Platforms\MySQLPlatform;
use Doctrine\DBAL\Types\StringType;

class EnumType extends StringType
{
    public function getSqlDeclaration(array $column, AbstractPlatform $platform): string
    {
        if ($platform instanceof MySQLPlatform && isset($column['enumType']) && enum_exists($column['enumType'])) {
            $values = array_map(static fn(BackedEnum $case) => "'{$case->value}'", $column['enumType']::cases());

            return 'ENUM(' . implode(', ', $values) . ')';
        }

        return parent::getSQLDeclaration($column, $platform);
    }
}
```

By doing this the following entity

```php
<?php

namespace App\Entity;

use Doctrine\ORM\Mapping as ORM;

enum Suit: string {
    case Hearts = 'H';
    case Diamonds = 'D';
    case Clubs = 'C';
    case Spades = 'S';
}

#[ORM\Entity]
class Card
{
    #[ORM\Id, ORM\GeneratedValue, ORM\Column]
    public int $id;

    #[ORM\Column]
    public Suit $suit;
}
```

results in the migration:

```sql
CREATE TABLE card (
    id INT AUTO_INCREMENT NOT NULL,
    suit ENUM('H', 'D', 'C', 'S') NOT NULL,
    PRIMARY KEY(id)
) ENGINE = InnoDB;
```
