### PR TITLE
Allow using Enum from different namespace than Entity

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1517,7 +1517,7 @@ class ClassMetadataInfo implements ClassMetadata
                 ! isset($mapping['type'])
                 && ($type instanceof ReflectionNamedType)
             ) {
-                if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName(), false)) {
+                if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
                     $mapping['enumType'] = $type->getName();
 
                     $reflection = new ReflectionEnum($type->getName());


### PR DESCRIPTION
Allows using Enums from different namespace than Entity, for example, `App\DBAL\Enum` and `App\Entity`.
Without this fix it works only when both Enum and Entity are placed in the same namespace like `App\Entity`, and nobody is responsible for autoloading these Enums.