### PR TITLE
Corrected ORM version and added missing dependency

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -82,10 +82,10 @@ that directory with the following contents:
     {
         "require": {
             "doctrine/orm": "^2.11.0",
-            "doctrine/dbal": "^3.1.1",
+            "doctrine/dbal": "^3.2",
             "doctrine/annotations": "1.13.2",
-            "symfony/yaml": "2.*",
-            "symfony/cache": "^5.3"
+            "symfony/yaml": "^5.4",
+            "symfony/cache": "^5.4"
         },
         "autoload": {
             "psr-0": {"": "src/"}

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -81,8 +81,9 @@ that directory with the following contents:
 
     {
         "require": {
-            "doctrine/orm": "^2.10.2",
+            "doctrine/orm": "^2.11.0",
             "doctrine/dbal": "^3.1.1",
+            "doctrine/annotations": "1.13.2",
             "symfony/yaml": "2.*",
             "symfony/cache": "^5.3"
         },


### PR DESCRIPTION
Noticed that the version wasn't updated, pointing to 2.11.0 instead of 2.10.2. 
Also when following this tutotial ran into missing dependency for "doctrine/annotation" so added that too.