### PR TITLE
Introduce __unserialize behaviour in docs

### DIFF
--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -82,9 +82,9 @@ be any regular PHP class observing the following restrictions:
    :doc:`do so safely <../cookbook/implementing-wakeup-or-clone>`.
 -  An entity class must not implement ``__wakeup`` or
    :doc:`do so safely <../cookbook/implementing-wakeup-or-clone>`.
-   Also consider implementing
-   `Serializable <https://php.net/manual/en/class.serializable.php>`_
-   instead.
+   You can also consider implementing
+   `Serializable <https://php.net/manual/en/class.serializable.php>`_,
+   but be aware that it is deprecated since PHP 8.1. We do not recommend its usage.
 -  PHP 7.4 introduces the new magic method ``__unserialize``, which changes the execution
    priority between ``__wakeup`` and itself when used. This can cause unexpected behaviour in
    an Entity.
@@ -164,7 +164,8 @@ possible for ``__sleep`` to return names of private properties in
 parent classes. On the other hand it is not a solution for proxy
 objects to implement ``Serializable`` because Serializable does not
 work well with any potential cyclic object references (at least we
-did not find a way yet, if you did, please contact us).
+did not find a way yet, if you did, please contact us). The
+``Serializable`` interface is also deprecated beginning with PHP 8.1.
 
 The EntityManager
 ~~~~~~~~~~~~~~~~~

--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -85,6 +85,9 @@ be any regular PHP class observing the following restrictions:
    Also consider implementing
    `Serializable <https://php.net/manual/en/class.serializable.php>`_
    instead.
+-  PHP 7.4 introduces the new magic method ``__unserialize``, which changes the execution
+   priority between ``__wakeup`` and itself when used. This can cause unexpected behaviour in
+   an Entity.
 -  Any two entity classes in a class hierarchy that inherit
    directly or indirectly from one another must not have a mapped
    property with the same name. That is, if B inherits from A then B

--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -85,8 +85,9 @@ be any regular PHP class observing the following restrictions:
    You can also consider implementing
    `Serializable <https://php.net/manual/en/class.serializable.php>`_,
    but be aware that it is deprecated since PHP 8.1. We do not recommend its usage.
--  PHP 7.4 introduces the new magic method ``__unserialize``, which changes the execution
-   priority between ``__wakeup`` and itself when used. This can cause unexpected behaviour in
+-  PHP 7.4 introduces :doc:`the new magic method <https://php.net/manual/en/language.oop5.magic.php#object.unserialize>`
+   ``__unserialize``, which changes the execution priority between
+   ``__wakeup`` and itself when used. This can cause unexpected behaviour in
    an Entity.
 -  Any two entity classes in a class hierarchy that inherit
    directly or indirectly from one another must not have a mapped


### PR DESCRIPTION
I'm not sure about the detail in which this should be described in the docs, which is why the first change is another list entry.

This PR mentions the magic method `__unserialize()` in entities. `__wakeup` is already considered a problem when used in an entity and  `__unserialize()` introduces a new behaviour that should be mentioned in the docs: https://3v4l.org/EQ90P

It probably needs a link to the the new methods and maybe a more detailed description about how it should be handled.