### PR TITLE
Deprecate MultiGetRegion

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 2.12
+
+## Deprecate `Doctrine\ORM\Cache\MultiGetRegion`
+
+The interface will be merged with `Doctrine\ORM\Cache\Region` in 3.0.
+
 # Upgrade to 2.11
 
 ## Rename `AbstractIdGenerator::generate()` to `generateId()`

--- a/lib/Doctrine/ORM/Cache/MultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/MultiGetRegion.php
@@ -8,6 +8,8 @@ namespace Doctrine\ORM\Cache;
  * Defines a region that supports multi-get reading.
  *
  * With one method call we can get multiple items.
+ *
+ * @deprecated Implement {@see Region} instead.
  */
 interface MultiGetRegion
 {

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,11 @@
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand"/>
             </errorLevel>
         </DeprecatedClass>
+        <DeprecatedInterface>
+            <errorLevel type="suppress">
+                <referencedClass name="Doctrine\ORM\Cache\MultiGetRegion"/>
+            </errorLevel>
+        </DeprecatedInterface>
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <!-- We're calling the deprecated method for BC here. -->


### PR DESCRIPTION
The `MultiGetRegion` interface is only implemented through its child interface `Region` and never type-hinted anywhere. In order to simplify the codebase on 3.0, I propose to deprecate the interface so we can merge it with `Region` in 3.0.