### PR TITLE
Fix types on CacheLogger implementations

### DIFF
--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Cache\QueryCacheKey;
 
 class CacheLoggerChain implements CacheLogger
 {
-    /** @var array<CacheLogger> */
+    /** @var array<string, CacheLogger> */
     private $loggers = [];
 
     /**
@@ -34,7 +34,7 @@ class CacheLoggerChain implements CacheLogger
     }
 
     /**
-     * @return array<CacheLogger>
+     * @return array<string, CacheLogger>
      */
     public function getLoggers()
     {

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -15,13 +15,13 @@ use function array_sum;
  */
 class StatisticsCacheLogger implements CacheLogger
 {
-    /** @var int[] */
+    /** @var array<string, int> */
     private $cacheMissCountMap = [];
 
-    /** @var int[] */
+    /** @var array<string, int> */
     private $cacheHitCountMap = [];
 
-    /** @var int[] */
+    /** @var array<string, int> */
     private $cachePutCountMap = [];
 
     /**
@@ -29,9 +29,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function collectionCacheMiss($regionName, CollectionCacheKey $key)
     {
-        $this->cacheMissCountMap[$regionName] = isset($this->cacheMissCountMap[$regionName])
-            ? $this->cacheMissCountMap[$regionName] + 1
-            : 1;
+        $this->cacheMissCountMap[$regionName]
+            = ($this->cacheMissCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -39,9 +38,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function collectionCacheHit($regionName, CollectionCacheKey $key)
     {
-        $this->cacheHitCountMap[$regionName] = isset($this->cacheHitCountMap[$regionName])
-            ? $this->cacheHitCountMap[$regionName] + 1
-            : 1;
+        $this->cacheHitCountMap[$regionName]
+            = ($this->cacheHitCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -49,9 +47,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function collectionCachePut($regionName, CollectionCacheKey $key)
     {
-        $this->cachePutCountMap[$regionName] = isset($this->cachePutCountMap[$regionName])
-            ? $this->cachePutCountMap[$regionName] + 1
-            : 1;
+        $this->cachePutCountMap[$regionName]
+            = ($this->cachePutCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -59,9 +56,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function entityCacheMiss($regionName, EntityCacheKey $key)
     {
-        $this->cacheMissCountMap[$regionName] = isset($this->cacheMissCountMap[$regionName])
-            ? $this->cacheMissCountMap[$regionName] + 1
-            : 1;
+        $this->cacheMissCountMap[$regionName]
+            = ($this->cacheMissCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -69,9 +65,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function entityCacheHit($regionName, EntityCacheKey $key)
     {
-        $this->cacheHitCountMap[$regionName] = isset($this->cacheHitCountMap[$regionName])
-            ? $this->cacheHitCountMap[$regionName] + 1
-            : 1;
+        $this->cacheHitCountMap[$regionName]
+            = ($this->cacheHitCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -79,9 +74,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function entityCachePut($regionName, EntityCacheKey $key)
     {
-        $this->cachePutCountMap[$regionName] = isset($this->cachePutCountMap[$regionName])
-            ? $this->cachePutCountMap[$regionName] + 1
-            : 1;
+        $this->cachePutCountMap[$regionName]
+            = ($this->cachePutCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -89,9 +83,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function queryCacheHit($regionName, QueryCacheKey $key)
     {
-        $this->cacheHitCountMap[$regionName] = isset($this->cacheHitCountMap[$regionName])
-            ? $this->cacheHitCountMap[$regionName] + 1
-            : 1;
+        $this->cacheHitCountMap[$regionName]
+            = ($this->cacheHitCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -99,9 +92,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function queryCacheMiss($regionName, QueryCacheKey $key)
     {
-        $this->cacheMissCountMap[$regionName] = isset($this->cacheMissCountMap[$regionName])
-            ? $this->cacheMissCountMap[$regionName] + 1
-            : 1;
+        $this->cacheMissCountMap[$regionName]
+            = ($this->cacheMissCountMap[$regionName] ?? 0) + 1;
     }
 
     /**
@@ -109,9 +101,8 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function queryCachePut($regionName, QueryCacheKey $key)
     {
-        $this->cachePutCountMap[$regionName] = isset($this->cachePutCountMap[$regionName])
-            ? $this->cachePutCountMap[$regionName] + 1
-            : 1;
+        $this->cachePutCountMap[$regionName]
+            = ($this->cachePutCountMap[$regionName] ?? 0) + 1;
     }
 
     /**


### PR DESCRIPTION
Some backports from #9400:

* More precise array types
* Simplified the ternary expressions in `StatisticsCacheLogger`