### PR TITLE
Make test types compatible with Doctrine DBAL 4.0.x-dev

### DIFF
--- a/tests/Doctrine/Tests/DbalTypes/CustomIdObject.php
+++ b/tests/Doctrine/Tests/DbalTypes/CustomIdObject.php
@@ -6,12 +6,11 @@ namespace Doctrine\Tests\DbalTypes;
 
 class CustomIdObject
 {
-    /** @var string */
-    public $id;
+    public string $id;
 
     public function __construct(string $id)
     {
-        $this->id = (string) $id;
+        $this->id = $id;
     }
 
     public function __toString(): string

--- a/tests/Doctrine/Tests/DbalTypes/CustomIdObjectType.php
+++ b/tests/Doctrine/Tests/DbalTypes/CustomIdObjectType.php
@@ -14,7 +14,7 @@ class CustomIdObjectType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return $value->id;
     }
@@ -22,7 +22,7 @@ class CustomIdObjectType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): CustomIdObject
     {
         return new CustomIdObject($value);
     }
@@ -30,15 +30,12 @@ class CustomIdObjectType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/DbalTypes/NegativeToPositiveType.php
+++ b/tests/Doctrine/Tests/DbalTypes/NegativeToPositiveType.php
@@ -11,10 +11,7 @@ class NegativeToPositiveType extends Type
 {
     public const NAME = 'negative_to_positive';
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -22,9 +19,9 @@ class NegativeToPositiveType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getIntegerTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getIntegerTypeDeclarationSQL($column);
     }
 
     /**
@@ -38,7 +35,7 @@ class NegativeToPositiveType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return 'ABS(' . $sqlExpr . ')';
     }
@@ -46,7 +43,7 @@ class NegativeToPositiveType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValueSQL($sqlExpr, $platform)
+    public function convertToPHPValueSQL($sqlExpr, $platform): string
     {
         return '-(' . $sqlExpr . ')';
     }

--- a/tests/Doctrine/Tests/DbalTypes/Rot13Type.php
+++ b/tests/Doctrine/Tests/DbalTypes/Rot13Type.php
@@ -19,10 +19,8 @@ class Rot13Type extends Type
      *
      * @param string|null      $value
      * @param AbstractPlatform $platform
-     *
-     * @return string|null
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return null;
@@ -36,10 +34,8 @@ class Rot13Type extends Type
      *
      * @param string|null      $value
      * @param AbstractPlatform $platform
-     *
-     * @return string|null
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return null;
@@ -51,14 +47,14 @@ class Rot13Type extends Type
     /**
      * {@inheritdoc}
      *
-     * @param array            $fieldDeclaration
+     * @param array            $column
      * @param AbstractPlatform $platform
      *
      * @return string
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
     /**
@@ -78,7 +74,7 @@ class Rot13Type extends Type
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'rot13';
     }

--- a/tests/Doctrine/Tests/DbalTypes/UpperCaseStringType.php
+++ b/tests/Doctrine/Tests/DbalTypes/UpperCaseStringType.php
@@ -11,10 +11,7 @@ class UpperCaseStringType extends StringType
 {
     public const NAME = 'upper_case_string';
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -30,7 +27,7 @@ class UpperCaseStringType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return 'UPPER(' . $sqlExpr . ')';
     }
@@ -38,7 +35,7 @@ class UpperCaseStringType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValueSQL($sqlExpr, $platform)
+    public function convertToPHPValueSQL($sqlExpr, $platform): string
     {
         return 'LOWER(' . $sqlExpr . ')';
     }

--- a/tests/Doctrine/Tests/ORM/Functional/GH5988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH5988Test.php
@@ -60,7 +60,7 @@ class GH5988CustomIdObjectHashType extends DBALType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return $value->id . '_test';
     }
@@ -68,7 +68,7 @@ class GH5988CustomIdObjectHashType extends DBALType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): CustomIdObject
     {
         return new CustomIdObject(str_replace('_test', '', $value));
     }
@@ -76,15 +76,12 @@ class GH5988CustomIdObjectHashType extends DBALType
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
@@ -77,7 +77,7 @@ class DDC1998Type extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return (string) $value;
     }
@@ -85,15 +85,12 @@ class DDC1998Type extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DDC1998Id
     {
         return new DDC1998Id($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -129,15 +129,15 @@ class DDC2012TsVectorType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         if (is_array($value)) {
             $value = implode(' ', $value);
@@ -153,8 +153,10 @@ class DDC2012TsVectorType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return list<string>
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): array
     {
         self::$calls[__FUNCTION__][] = [
             'value'     => $value,
@@ -167,7 +169,7 @@ class DDC2012TsVectorType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         self::$calls[__FUNCTION__][] = [
             'sqlExpr'   => $sqlExpr,
@@ -188,10 +190,7 @@ class DDC2012TsVectorType extends Type
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::MYTYPE;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2224Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2224Test.php
@@ -53,9 +53,9 @@ class DDC2224Type extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
     public function getName(): string
@@ -74,7 +74,7 @@ class DDC2224Type extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return sprintf('FUNCTION(%s)', $sqlExpr);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -177,15 +177,15 @@ class DDC2494TinyIntType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getSmallIntTypeDeclarationSQL($column);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         $return = (string) $value;
 
@@ -201,7 +201,7 @@ class DDC2494TinyIntType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): int
     {
         $return = (int) $value;
 
@@ -214,10 +214,7 @@ class DDC2494TinyIntType extends Type
         return $return;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'ddc2494_tinyint';
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
@@ -149,7 +149,7 @@ class DDC2579Type extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return (string) $value;
     }
@@ -157,15 +157,12 @@ class DDC2579Type extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DDC2579Id
     {
         return new DDC2579Id($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
@@ -155,7 +155,7 @@ class DDC2984UserIdCustomDbalType extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?DDC2984DomainUserId
     {
         return ! empty($value)
             ? new DDC2984DomainUserId($value)
@@ -165,7 +165,7 @@ class DDC2984UserIdCustomDbalType extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         if (empty($value)) {
             return null;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
@@ -146,15 +146,15 @@ class DDC3192CurrencyCode extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getSmallIntTypeDeclarationSQL($column);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): int
     {
         return self::$map[$value];
     }
@@ -162,15 +162,12 @@ class DDC3192CurrencyCode extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): mixed
     {
         return array_search((int) $value, self::$map, true);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'ddc3192_currency_code';
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -146,7 +146,7 @@ final class LastInsertIdMockConnection extends AbstractConnectionMiddleware
     /**
      * {@inheritdoc}
      */
-    public function lastInsertId($name = null)
+    public function lastInsertId($name = null): int|string
     {
         return $this->idMocker->mockedId ?? parent::lastInsertId($name);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -177,15 +177,15 @@ class DDC3785AssetIdType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getGuidTypeDeclarationSQL($column);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return (string) $value;
     }
@@ -193,15 +193,12 @@ class DDC3785AssetIdType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DDC3785AssetId
     {
         return new DDC3785AssetId($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'ddc3785_asset_id';
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -66,12 +66,12 @@ class DDC5684Test extends OrmFunctionalTestCase
     }
 }
 
-class DDC5684ObjectIdType extends DBALTypes\IntegerType
+class DDC5684ObjectIdType extends DBALTypes\BigIntType
 {
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DDC5684ObjectId
     {
         return new DDC5684ObjectId($value);
     }
@@ -79,23 +79,17 @@ class DDC5684ObjectIdType extends DBALTypes\IntegerType
     /**
      * {@inheritDoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         return $value->value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -61,10 +61,7 @@ final class GH5804Type extends Type
 {
     public const NAME = 'GH5804Type';
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -72,15 +69,15 @@ final class GH5804Type extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (empty($value)) {
             return null;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
@@ -185,7 +185,7 @@ class GH5887CustomIdObjectType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         return $value->getId();
     }
@@ -193,15 +193,12 @@ class GH5887CustomIdObjectType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): GH5887CustomIdObject
     {
         return new GH5887CustomIdObject((int) $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
@@ -85,7 +85,7 @@ class GH6141PeopleType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         if (! $value instanceof GH6141People) {
             $value = GH6141People::get($value);
@@ -97,15 +97,12 @@ class GH6141PeopleType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): GH6141People
     {
         return GH6141People::get($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -173,7 +173,7 @@ final class GH7820LineTextType extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): mixed
     {
         $text = parent::convertToPHPValue($value, $platform);
 
@@ -187,7 +187,7 @@ final class GH7820LineTextType extends StringType
     /**
      * {@inheritDoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         if (! $value instanceof GH7820LineText) {
             return parent::convertToDatabaseValue($value, $platform);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
@@ -56,9 +56,9 @@ final class GH8061Entity
 
 final class GH8061Type extends Type
 {
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getVarcharTypeDeclarationSQL($column);
     }
 
     public function getName(): string


### PR DESCRIPTION
This is a step towards making the ORM test suite compatible with DBAL 4.0.x-dev.

The test type classes may be reworked by adding return type declarations and remain compatible with DBAL 3.x. Other mock classes (e.g. `DatabasePlatformMock`) will have to be replaced with PHPUnit mocks since it's impossible to implement both the DBAL 3.x and 4.0-x SPIs statically (without code generation).