### PR TITLE
Rework some tests that use hardcoded DBAL mocks

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -13,12 +13,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DatabasePlatformMock extends AbstractPlatform
 {
-    /** @var bool */
-    private $supportsIdentityColumns = true;
-
-    /** @var bool */
-    private $supportsSequences = false;
-
     public function prefersIdentityColumns(): bool
     {
         throw new BadMethodCallException('Call to deprecated method.');
@@ -26,7 +20,7 @@ class DatabasePlatformMock extends AbstractPlatform
 
     public function supportsIdentityColumns(): bool
     {
-        return $this->supportsIdentityColumns;
+        return true;
     }
 
     public function prefersSequences(): bool
@@ -36,7 +30,7 @@ class DatabasePlatformMock extends AbstractPlatform
 
     public function supportsSequences(): bool
     {
-        return $this->supportsSequences;
+        return false;
     }
 
     /**
@@ -97,16 +91,6 @@ class DatabasePlatformMock extends AbstractPlatform
     }
 
     /* MOCK API */
-
-    public function setSupportsIdentityColumns(bool $bool): void
-    {
-        $this->supportsIdentityColumns = $bool;
-    }
-
-    public function setSupportsSequences(bool $bool): void
-    {
-        $this->supportsSequences = $bool;
-    }
 
     public function getName(): string
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
@@ -12,8 +14,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Tests\Mocks\ConnectionMock;
-use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\OrmTestCase;
 
@@ -24,7 +24,15 @@ class GH7869Test extends OrmTestCase
 {
     public function testDQLDeferredEagerLoad(): void
     {
-        $decoratedEm = EntityManagerMock::create(new ConnectionMock([], new DriverMock()));
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('supportsIdentityColumns')
+            ->willReturn(true);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $decoratedEm = EntityManagerMock::create($connection);
 
         $em = $this->getMockBuilder(EntityManagerDecorator::class)
             ->setConstructorArgs([$decoratedEm])

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
@@ -25,9 +27,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\Tests\Mocks\ConnectionMock;
-use Doctrine\Tests\Mocks\DatabasePlatformMock;
-use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\MetadataDriverMock;
 use Doctrine\Tests\Models\CMS\CmsArticle;
@@ -53,13 +52,18 @@ class ClassMetadataFactoryTest extends OrmTestCase
 {
     public function testGetMetadataForSingleClass(): void
     {
-        $mockDriver    = new MetadataDriverMock();
-        $entityManager = $this->createEntityManager($mockDriver);
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('supportsSequences')
+            ->willReturn(true);
 
-        $conn         = $entityManager->getConnection();
-        $mockPlatform = $conn->getDatabasePlatform();
-        $mockPlatform->setSupportsSequences(true);
-        $mockPlatform->setSupportsIdentityColumns(false);
+        $driver = $this->createMock(Driver::class);
+        $driver->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $conn = new Connection([], $driver);
+
+        $mockDriver    = new MetadataDriverMock();
+        $entityManager = $this->createEntityManager($mockDriver, $conn);
 
         $cm1 = $this->createValidClassMetadata();
 
@@ -90,13 +94,14 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $cm1 = $this->createValidClassMetadata();
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
-        $entityManager = $this->createEntityManager(new MetadataDriverMock());
-        $connection    = $entityManager->getConnection();
-        assert($connection instanceof ConnectionMock);
-        $platform = $connection->getDatabasePlatform();
-        assert($platform instanceof DatabasePlatformMock);
-        $platform->setSupportsIdentityColumns(false);
-        $cmf = new ClassMetadataFactoryTestSubject();
+
+        $driver = $this->createMock(Driver::class);
+        $driver->method('getDatabasePlatform')
+            ->willReturn($this->createMock(AbstractPlatform::class));
+
+        $connection    = new Connection([], $driver);
+        $entityManager = $this->createEntityManager(new MetadataDriverMock(), $connection);
+        $cmf           = new ClassMetadataFactoryTestSubject();
         $cmf->setEntityManager($entityManager);
         $cmf->setMetadataForClass($cm1->name, $cm1);
         $this->expectException(CannotGenerateIds::class);
@@ -276,13 +281,20 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
     protected function createEntityManager(MappingDriver $metadataDriver, $conn = null): EntityManagerMock
     {
-        $driverMock = new DriverMock();
-        $config     = new Configuration();
+        $config = new Configuration();
         $config->setProxyDir(__DIR__ . '/../../Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $eventManager = new EventManager();
         if (! $conn) {
-            $conn = new ConnectionMock([], $driverMock, $config, $eventManager);
+            $platform = $this->createMock(AbstractPlatform::class);
+            $platform->method('supportsIdentityColumns')
+                ->willReturn(true);
+
+            $driver = $this->createMock(Driver::class);
+            $driver->method('getDatabasePlatform')
+                ->willReturn($platform);
+
+            $conn = new Connection([], $driver, $config, $eventManager);
         }
 
         $config->setMetadataDriverImpl($metadataDriver);
@@ -404,7 +416,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
      */
     public function testFallbackLoadingCausesEventTriggeringThatCanModifyFetchedMetadata(): void
     {
-        $test     = $this;
         $metadata = $this->createMock(ClassMetadata::class);
         assert($metadata instanceof ClassMetadata);
         $cmf          = new ClassMetadataFactory();

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
 use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Mocks\ConnectionMock;
-use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -27,7 +27,7 @@ class PaginatorTest extends OrmTestCase
     protected function setUp(): void
     {
         $this->connection = $this->getMockBuilder(ConnectionMock::class)
-            ->setConstructorArgs([[], new DriverMock()])
+            ->setConstructorArgs([[], $this->createMock(Driver::class)])
             ->setMethods(['executeQuery'])
             ->getMock();
 

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -7,6 +7,9 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Events;
@@ -25,7 +28,6 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
 use Doctrine\Tests\Mocks\ConnectionMock;
-use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\EntityPersisterMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;
@@ -43,6 +45,7 @@ use function assert;
 use function count;
 use function gc_collect_cycles;
 use function get_class;
+use function method_exists;
 use function random_int;
 use function uniqid;
 
@@ -80,9 +83,40 @@ class UnitOfWorkTest extends OrmTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_connectionMock = new ConnectionMock([], new DriverMock());
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('supportsIdentityColumns')
+            ->willReturn(true);
+
+        if (method_exists($platform, 'getSQLResultCasing')) {
+            $platform->method('getSQLResultCasing')
+                ->willReturnCallback(static function (string $column): string {
+                    return $column;
+                });
+        }
+
+        $driverStatement = $this->createMock(Driver\Statement::class);
+
+        if (method_exists($driverStatement, 'rowCount')) {
+            $driverStatement->method('rowCount')
+                ->willReturn(0);
+        }
+
+        $driverConnection = $this->createMock(Driver\Connection::class);
+        $driverConnection->method('prepare')
+            ->willReturn($driverStatement);
+
+        $driver = $this->createMock(Driver::class);
+        $driver->method('getDatabasePlatform')
+            ->willReturn($platform);
+        $driver->method('connect')
+            ->willReturn($driverConnection);
+
+        $connection = new Connection([], $driver);
+
+        $this->_connectionMock = $connection;
         $this->eventManager    = $this->getMockBuilder(EventManager::class)->getMock();
-        $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null, $this->eventManager);
+        $this->_emMock         = EntityManagerMock::create($connection, null, $this->eventManager);
         // SUT
         $this->_unitOfWork = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
@@ -809,9 +843,13 @@ class UnitOfWorkTest extends OrmTestCase
      */
     public function testCommitThrowOptimisticLockExceptionWhenConnectionCommitReturnFalse(): void
     {
+        $driver = $this->createMock(Driver::class);
+        $driver->method('connect')
+            ->willReturn($this->createMock(Driver\Connection::class));
+
         // Set another connection mock that fail on commit
         $this->_connectionMock = $this->getMockBuilder(ConnectionMock::class)
-            ->setConstructorArgs([[], new DriverMock()])
+            ->setConstructorArgs([[], $driver])
             ->setMethods(['commit'])
             ->getMock();
         $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null, $this->eventManager);


### PR DESCRIPTION
Hardcoded mocks cannot be compatible with the DBAL 3 and 4 SPIs and should be generated via PHPUnit.