### PR TITLE
Fix "Illegal mix of collations" in MultiTableDeleteExecutor - Take 2

### DIFF
--- a/tests/Doctrine/Tests/Models/ProductsRomanCollation/ProductColor.php
+++ b/tests/Doctrine/Tests/Models/ProductsRomanCollation/ProductColor.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ProductsRomanCollation;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="productroman_colors", options={"charset":"utf8", "collate":"utf8_roman_ci"})
+ */
+class ProductColor extends ProductFeature
+{
+    /**
+     * @var string
+     * @Column(type="string", length=50)
+     */
+    private $colorName;
+
+    /**
+     * @var int
+     * @Column(type="integer", nullable=false)
+     */
+    private $quantity;
+
+    public function __construct(string $sku, string $colorName, int $quantity)
+    {
+        parent::__construct($sku);
+        $this->colorName = $colorName;
+        $this->quantity  = $quantity;
+    }
+
+    public function getColorName(): string
+    {
+        return $this->colorName;
+    }
+
+    public function setColorName(string $value): void
+    {
+        $this->colorName = $value;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(int $value): void
+    {
+        $this->quantity = $value;
+    }
+}

--- a/tests/Doctrine/Tests/Models/ProductsRomanCollation/ProductFeature.php
+++ b/tests/Doctrine/Tests/Models/ProductsRomanCollation/ProductFeature.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ProductsRomanCollation;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * Description of ProudctFeature
+ *
+ * @Entity
+ * @Table(name="productroman_features", options={"charset":"utf8", "collate":"utf8_roman_ci"}))
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "color"    = "ProductColor",
+ * })
+ */
+class ProductFeature
+{
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string", length=10, nullable=false)
+     */
+    private $sku;
+
+    public function __construct(string $sku)
+    {
+        $this->sku = $sku;
+    }
+
+    public function getSku(): string
+    {
+        return $this->sku;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryWithCollationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryWithCollationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\Tests\Models\ProductsRomanCollation\ProductColor;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * Functional Query tests.
+ */
+class AdvancedDqlQueryWithCollationTest extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\Tests\OrmFunctionalTestCase::setUp()
+     */
+    protected function setUp(): void
+    {
+        $this->useModelSet('products_roman');
+        parent::setUp();
+        if (! static::$sharedConn->getDatabasePlatform() instanceof MySQLPlatform) {
+            self::markTestSkipped('The ' . self::class . ' requires the use of mysql.');
+        }
+
+        $this->generateFixture();
+    }
+
+    public function testDeleteAs(): void
+    {
+        $dql = 'DELETE Doctrine\Tests\Models\ProductsRomanCollation\ProductColor AS p';
+        $this->_em->createQuery($dql)->getResult();
+
+        $dql    = 'SELECT count(p) FROM Doctrine\Tests\Models\ProductsRomanCollation\ProductColor p';
+        $result = $this->_em->createQuery($dql)->getSingleScalarResult();
+
+        self::assertEquals(0, $result);
+    }
+
+    private function generateFixture(): void
+    {
+        $this->_em->persist(new ProductColor('P01', 'Red', 1));
+        $this->_em->persist(new ProductColor('P02', 'Green', 12));
+        $this->_em->persist(new ProductColor('P03', 'Blue', 123));
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -335,6 +335,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue5989\Issue5989Employee::class,
             Models\Issue5989\Issue5989Manager::class,
         ],
+        'products_roman' => [
+            Models\ProductsRomanCollation\ProductFeature::class,
+            Models\ProductsRomanCollation\ProductColor::class,
+        ],
     ];
 
     protected function useModelSet(string $setName): void
@@ -622,6 +626,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM issue5989_persons');
             $conn->executeStatement('DELETE FROM issue5989_employees');
             $conn->executeStatement('DELETE FROM issue5989_managers');
+        }
+
+        if (isset($this->_usedModelSets['products_roman'])) {
+            $conn->executeStatement('DELETE FROM productroman_colors');
+            $conn->executeStatement('DELETE FROM productroman_features');
         }
 
         $this->_em->clear();


### PR DESCRIPTION

When database tables use a collation that's not the default database one, MultiTableDeleteExecutor fails with this error:

```
In AbstractMySQLDriver.php line 128:
                                                                                                                                                    
  [Doctrine\DBAL\Exception\DriverException]                                                                                                         
  An exception occurred while executing 'DELETE FROM MessengerTaskProcesses WHERE (id) IN (SELECT id FROM MessengerProcesses_id_tmp)':              
                                                                                                                                                    
  SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_general_ci,IMPLICIT) for operation '='
```

This issue should be fixed by using the configured charset/collation.

Let's first add a test that detects the issue: I'll then update this PR to fix it.

PS: Supersedes #9370