### PR TITLE
Allow DiscriminatorColumn with length=0

### DIFF
--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -15,13 +15,13 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DiscriminatorColumn implements Annotation
 {
-    /** @var string */
+    /** @var string|null */
     public $name;
 
-    /** @var string */
+    /** @var string|null */
     public $type;
 
-    /** @var int */
+    /** @var int|null */
     public $length;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -281,7 +281,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                         [
                             'name'             => $discrColumnAnnot->name,
                             'type'             => $discrColumnAnnot->type ?: 'string',
-                            'length'           => $discrColumnAnnot->length ?: 255,
+                            'length'           => $discrColumnAnnot->length ?? 255,
                             'columnDefinition' => $discrColumnAnnot->columnDefinition,
                         ]
                     );


### PR DESCRIPTION
This patch allows to set `length` to a Zero-Value on a `@ORM\DiscriminatorColumn`:

```php
/**
 * @ORM\DiscriminatorColumn(
 *     name="type",
 *     type="string",
 *     length=0
 * )
 */
abstract class MyEntityClass
```

Right now a value <1 will be replaced by the default value (255) of a ternary operation in `\Doctrine\ORM\Mapping\Driver\AnnotationDriver::loadMetadataForClass` .
This seems to be an accidental results from the weak type comparison.

On a `@ORM\Column` a length of Zero will be parsed as is and not changed to 255.

```php
    /**
     * @ORM\Column (
     *     name="example", 
     *     type="string", 
     *     length=0, 
     *     nullable=true
     * )
     */
    private string $example;
```

## Background:

I'm mapping MySQL enums to strings as described here: https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/cookbook/mysql-enums.html#solution-1-mapping-to-varchars

Since the 3.2 release with the new Platform-aware schema comparison (
https://www.doctrine-project.org/2021/11/26/dbal-3.2.0.html) I get a lot of diffs in our enum fields.


```php
    /**
     * @ORM\Column (
     *   name="platform",
     *   type="string",
     *   columnDefinition="enum('iOS','Android') NULL DEFAULT",
     */
    private string $platform;
```

The schema diff will report different values for the `length`-property as the MySQl Platform yields lenght = 0 for the mysql native ENUM type.

To fix the diff the length has to be specified as 0:

```php
    /**
     * @ORM\Column (
     *   name="platform",
     *   type="string",
     *   length=0,
     *   columnDefinition="enum('iOS','Android') NULL DEFAULT",
     */
    private string $platform;
```

This works for all columns and the enum fields won't generate diffs anymore.

The same lenght=0 change is required if the DiscriminatorColumn uses a native Enum type like so:

```php
/**
 * @ORM\Table
 * @ORM\Entity
 * @ORM\InheritanceType("SINGLE_TABLE")
 * @ORM\DiscriminatorColumn(
 *     name="type",
 *     type="string",
 *     length=0,
 *     columnDefinition="enum('region','airport','station','poi') NOT NULL",
 * )
 * @ORM\DiscriminatorMap({
 *     "region" = "\Storage\MySQL\ApiV3\Entity\Poi\Region",
 *     "airport" = "\Storage\MySQL\ApiV3\Entity\Poi\Airport",
 *     "station" = "\Storage\MySQL\ApiV3\Entity\Poi\Station",
 *     "poi" = "\Storage\MySQL\ApiV3\Entity\Poi\GeneralPoi",
 * })
 */
abstract class Poi
```

Right now this is not possible as `length=0` on a `DiscriminatorColumn` will become `length=255` and thus a diff will be reported from the schema comparison.
