### PR TITLE
convertToDatabaseValue in \Doctrine\ORM\UnitOfWork::getSingleIdentifierValue()

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -429,7 +429,7 @@ abstract class AbstractQuery
         }
 
         try {
-            $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
+            $value = $this->_em->getUnitOfWork()->getSingleIdentifierDbValue($value);
 
             if ($value === null) {
                 throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3106,7 +3106,12 @@ class UnitOfWork implements PropertyChangedListener
             ? $this->getEntityIdentifier($entity)
             : $class->getIdentifierValues($entity);
 
-        return $values[$class->identifier[0]] ?? null;
+        $value = $values[$class->identifier[0]] ?? null;
+
+        return $this->em->getConnection()->convertToDatabaseValue(
+            $value,
+            $class->getTypeOfField($class->identifier[0])
+        );
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3131,11 +3131,9 @@ class UnitOfWork implements PropertyChangedListener
             : $class->getIdentifierValues($entity);
 
         $value = $values[$class->identifier[0]] ?? null;
+        $type  = $class->getTypeOfField($class->identifier[0]);
 
-        return $this->em->getConnection()->convertToDatabaseValue(
-            $value,
-            $class->getTypeOfField($class->identifier[0])
-        );
+        return $type ? $this->em->getConnection()->convertToDatabaseValue($value, $type) : $value;
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3106,6 +3106,30 @@ class UnitOfWork implements PropertyChangedListener
             ? $this->getEntityIdentifier($entity)
             : $class->getIdentifierValues($entity);
 
+        return $values[$class->identifier[0]] ?? null;
+    }
+
+    /**
+     * Processes an entity instance to extract their identifier values and convert them to DatabaseValue.
+     *
+     * @param object $entity The entity instance.
+     *
+     * @return mixed A scalar value.
+     *
+     * @throws ORMInvalidArgumentException
+     */
+    public function getSingleIdentifierDbValue($entity)
+    {
+        $class = $this->em->getClassMetadata(get_class($entity));
+
+        if ($class->isIdentifierComposite) {
+            throw ORMInvalidArgumentException::invalidCompositeIdentifier();
+        }
+
+        $values = $this->isInIdentityMap($entity)
+            ? $this->getEntityIdentifier($entity)
+            : $class->getIdentifierValues($entity);
+
         $value = $values[$class->identifier[0]] ?? null;
 
         return $this->em->getConnection()->convertToDatabaseValue(

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -124,4 +124,21 @@ class OneToManyTest extends OrmFunctionalTestCase
 
         self::assertCount(1, $inversed->associatedEntities);
     }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatEntitiesAreFetchedByDQLWithEntityAsParameter(): void
+    {
+        $inversed = $this->_em->find(
+            Models\ValueConversionType\InversedOneToManyEntity::class,
+            'abc'
+        );
+
+        $owningArray = $this->_em->createQuery(
+            'SELECT e FROM Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity e WHERE e.associatedEntity = :associatedEntity'
+        )->setParameter('associatedEntity', $inversed)->execute();
+
+        self::assertCount(1, $owningArray);
+    }
 }


### PR DESCRIPTION
getSingleIdentifierValue() must return a scalar value, but it doesn't. Because of this, queries with entities in parameters do not work. This occurs on platforms where the string representation of the identifier differs from the representation in the database (for example, MySQL + symfony/uid).