### PR TITLE
Remove check for `getSQLResultCasing()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -19,7 +19,6 @@ use stdClass;
 
 use function array_keys;
 use function assert;
-use function method_exists;
 
 /**
  * Tests the lazy-loading capabilities of the PersistentCollection and the initialization of collections.
@@ -39,11 +38,6 @@ class PersistentCollectionTest extends OrmTestCase
         $platform = $this->createMock(AbstractPlatform::class);
         $platform->method('supportsIdentityColumns')
             ->willReturn(true);
-
-        if (method_exists($platform, 'getSQLResultCasing')) {
-            $platform->method('getSQLResultCasing')
-                ->willReturnArgument(0);
-        }
 
         $connection = $this->createMock(Connection::class);
         $connection->method('getDatabasePlatform')

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -88,13 +88,6 @@ class UnitOfWorkTest extends OrmTestCase
         $platform->method('supportsIdentityColumns')
             ->willReturn(true);
 
-        if (method_exists($platform, 'getSQLResultCasing')) {
-            $platform->method('getSQLResultCasing')
-                ->willReturnCallback(static function (string $column): string {
-                    return $column;
-                });
-        }
-
         $driverStatement = $this->createMock(Driver\Statement::class);
 
         if (method_exists($driverStatement, 'rowCount')) {


### PR DESCRIPTION
On 3.0.x, we don't support DBAL 2 anymore, so we can drop those checks.