### PR TITLE
Fix support for PHP 8.1 enums in embedded classes

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1056,9 +1056,19 @@ class ClassMetadataInfo implements ClassMetadata
 
         foreach ($this->fieldMappings as $field => $mapping) {
             if (isset($mapping['declaredField']) && isset($parentReflFields[$mapping['declaredField']])) {
+                $childProperty = $this->getAccessibleProperty($reflService, $mapping['originalClass'], $mapping['originalField']);
+                assert($childProperty !== null);
+
+                if (isset($mapping['enumType'])) {
+                    $childProperty = new ReflectionEnumProperty(
+                        $childProperty,
+                        $mapping['enumType']
+                    );
+                }
+
                 $this->reflFields[$field] = new ReflectionEmbeddedProperty(
                     $parentReflFields[$mapping['declaredField']],
-                    $this->getAccessibleProperty($reflService, $mapping['originalClass'], $mapping['originalField']),
+                    $childProperty,
                     $mapping['originalClass']
                 );
                 continue;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -269,9 +269,11 @@
     <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
         <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
         <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Unit.php</exclude-pattern>
     </rule>
     <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
         <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
         <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Unit.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -763,7 +763,7 @@
       <code>$fieldName</code>
       <code>$fieldName</code>
     </ParamNameMismatch>
-    <PossiblyNullArgument occurrences="9">
+    <PossiblyNullArgument occurrences="8">
       <code>$class</code>
       <code>$className</code>
       <code>$entityResult['entityClass']</code>
@@ -772,7 +772,6 @@
       <code>$parentReflFields[$embeddedClass['declaredField']]</code>
       <code>$parentReflFields[$mapping['declaredField']]</code>
       <code>$queryMapping['resultClass']</code>
-      <code>$this-&gt;getAccessibleProperty($reflService, $mapping['originalClass'], $mapping['originalField'])</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="2">
       <code>$embeddable-&gt;reflClass-&gt;name</code>

--- a/tests/Doctrine/Tests/Models/Enums/Product.php
+++ b/tests/Doctrine/Tests/Models/Enums/Product.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class Product
+{
+    #[Id, GeneratedValue, Column(type: 'integer')]
+    public int $id;
+
+    #[Embedded(class: Quantity::class)]
+    public Quantity $quantity;
+}

--- a/tests/Doctrine/Tests/Models/Enums/Quantity.php
+++ b/tests/Doctrine/Tests/Models/Enums/Quantity.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+
+#[Embeddable]
+class Quantity
+{
+    #[Column(type: 'integer')]
+    public int $value;
+
+    #[Column(type: 'string', enumType: Unit::class)]
+    public Unit $unit;
+}

--- a/tests/Doctrine/Tests/Models/Enums/Unit.php
+++ b/tests/Doctrine/Tests/Models/Enums/Unit.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+enum Unit: string
+{
+    case Gram = 'g';
+    case Meter = 'm';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -9,8 +9,11 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\Enums\Card;
+use Doctrine\Tests\Models\Enums\Product;
+use Doctrine\Tests\Models\Enums\Quantity;
 use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\Enums\TypedCard;
+use Doctrine\Tests\Models\Enums\Unit;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function dirname;
@@ -112,5 +115,24 @@ EXCEPTION
 
         $this->assertCount(1, $attributes);
         $this->assertEquals(Column::class, $attributes[0]->getName());
+    }
+
+    public function testEnumMappingWithEmbeddable(): void
+    {
+        $this->setUpEntitySchema([Product::class]);
+
+        $product                  = new Product();
+        $product->quantity        = new Quantity();
+        $product->quantity->value = 10;
+        $product->quantity->unit  = Unit::Gram;
+
+        $this->_em->persist($product);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $fetchedProduct = $this->_em->find(Product::class, $product->id);
+
+        $this->assertInstanceOf(Unit::class, $fetchedProduct->quantity->unit);
+        $this->assertEquals(Unit::Gram, $fetchedProduct->quantity->unit);
     }
 }


### PR DESCRIPTION
Fixes using `enumType` that was added in #9304 with embedded classes.