### PR TITLE
Introduce `assertQueryCount()`

### DIFF
--- a/tests/Doctrine/Tests/DbalExtensions/QueryLog.php
+++ b/tests/Doctrine/Tests/DbalExtensions/QueryLog.php
@@ -6,11 +6,11 @@ namespace Doctrine\Tests\DbalExtensions;
 
 final class QueryLog
 {
-    /** @var bool */
-    public $enabled = false;
-
     /** @var list<array{sql: string, params: array|null, types: array|null}> */
     public $queries = [];
+
+    /** @var bool */
+    private $enabled = false;
 
     public function logQuery(string $sql, ?array $params = null, ?array $types = null): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -665,11 +665,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         self::assertCount(1, $user2->articles);
         self::assertInstanceOf(CmsAddress::class, $user2->address);
 
-        $countBeforeFlush = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $this->_em->flush();
-        $countAfterFlush = $this->getCurrentQueryCount();
 
-        self::assertSame($countBeforeFlush, $countAfterFlush);
+        $this->assertQueryCount(0);
     }
 
     public function testRemoveEntityByReference(): void
@@ -1012,7 +1011,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $qc      = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $dql     = 'SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a WHERE a.id = ?1';
         $article = $this->_em->createQuery($dql)
                              ->setParameter(1, $article->id)
@@ -1020,7 +1019,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
                              ->getSingleResult();
         self::assertInstanceOf(Proxy::class, $article->user, 'It IS a proxy, ...');
         self::assertTrue($article->user->__isInitialized__, '...but its initialized!');
-        self::assertEquals($qc + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/HydrationCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/HydrationCacheTest.php
@@ -44,24 +44,24 @@ class HydrationCacheTest extends OrmFunctionalTestCase
                   ->setHydrationCacheProfile(new QueryCacheProfile(0, null, $cache))
                   ->getResult();
 
-        $c = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $this->_em->createQuery($dql)
                   ->setHydrationCacheProfile(new QueryCacheProfile(0, null, $cache))
                   ->getResult();
 
-        self::assertEquals($c, $this->getCurrentQueryCount(), 'Should not execute query. Its cached!');
+        $this->assertQueryCount(0, 'Should not execute query. Its cached!');
 
         $this->_em->createQuery($dql)
                   ->setHydrationCacheProfile(new QueryCacheProfile(0, null, $cache))
                   ->getArrayResult();
 
-        self::assertEquals($c + 1, $this->getCurrentQueryCount(), 'Hydration is part of cache key.');
+        $this->assertQueryCount(1, 'Hydration is part of cache key.');
 
         $this->_em->createQuery($dql)
                   ->setHydrationCacheProfile(new QueryCacheProfile(0, null, $cache))
                   ->getArrayResult();
 
-        self::assertEquals($c + 1, $this->getCurrentQueryCount(), 'Hydration now cached');
+        $this->assertQueryCount(1, 'Hydration now cached');
 
         $this->_em->createQuery($dql)
                   ->setHydrationCacheProfile(new QueryCacheProfile(0, 'cachekey', $cache))
@@ -72,7 +72,7 @@ class HydrationCacheTest extends OrmFunctionalTestCase
         $this->_em->createQuery($dql)
                       ->setHydrationCacheProfile(new QueryCacheProfile(0, 'cachekey', $cache))
                       ->getArrayResult();
-        self::assertEquals($c + 2, $this->getCurrentQueryCount(), 'Hydration now cached');
+        $this->assertQueryCount(2, 'Hydration now cached');
     }
 
     public function testHydrationParametersSerialization(): void
@@ -89,10 +89,10 @@ class HydrationCacheTest extends OrmFunctionalTestCase
 
         $query->getResult();
 
-        $c = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $query->getResult();
 
-        self::assertEquals($c, $this->getCurrentQueryCount(), 'Should not execute query. Its cached!');
+        $this->assertQueryCount(0, 'Should not execute query. Its cached!');
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -60,13 +60,13 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $sqlCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $train = $this->_em->find(get_class($train), $train->id);
         self::assertNotInstanceOf(Proxy::class, $train->driver);
         self::assertEquals('Benjamin', $train->driver->name);
 
-        self::assertSame($sqlCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     /**
@@ -80,13 +80,13 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $sqlCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $train = $this->_em->find(get_class($train), $train->id);
         self::assertNotInstanceOf(Proxy::class, $train->driver);
         self::assertNull($train->driver);
 
-        self::assertSame($sqlCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     /**
@@ -101,13 +101,13 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $sqlCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $driver = $this->_em->find(get_class($owner), $owner->id);
         self::assertNotInstanceOf(Proxy::class, $owner->train);
         self::assertNotNull($owner->train);
 
-        self::assertSame($sqlCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     /**
@@ -123,13 +123,13 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
 
         self::assertNull($driver->train);
 
-        $sqlCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $driver = $this->_em->find(get_class($driver), $driver->id);
         self::assertNotInstanceOf(Proxy::class, $driver->train);
         self::assertNull($driver->train);
 
-        self::assertSame($sqlCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     public function testEagerLoadManyToOne(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -120,9 +120,9 @@ class ResultCacheTest extends OrmFunctionalTestCase
      */
     public function testUseResultCacheParams(): void
     {
-        $cache    = new ArrayAdapter();
-        $sqlCount = $this->getCurrentQueryCount();
-        $query    = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux WHERE ux.id = ?1');
+        $cache = new ArrayAdapter();
+        $this->getQueryLog()->reset()->enable();
+        $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux WHERE ux.id = ?1');
 
         $this->setResultCache($query, $cache);
         $query->enableResultCache();
@@ -133,11 +133,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->setParameter(1, 2);
         $query->getResult();
 
-        self::assertSame(
-            $sqlCount + 2,
-            $this->getCurrentQueryCount(),
-            'Two non-cached queries.'
-        );
+        $this->assertQueryCount(2, 'Two non-cached queries.');
 
         // these two queries should actually be cached, as they repeat previous ones:
         $query->setParameter(1, 1);
@@ -145,11 +141,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->setParameter(1, 2);
         $query->getResult();
 
-        self::assertSame(
-            $sqlCount + 2,
-            $this->getCurrentQueryCount(),
-            'The next two sql queries should have been cached, but were not.'
-        );
+        $this->assertQueryCount(2, 'The next two sql queries should have been cached, but were not.');
     }
 
     public function testEnableResultCache(): void
@@ -169,8 +161,8 @@ class ResultCacheTest extends OrmFunctionalTestCase
 
     public function testEnableResultCacheWithIterable(): void
     {
-        $cache            = new ArrayAdapter();
-        $expectedSQLCount = $this->getCurrentQueryCount() + 1;
+        $cache = new ArrayAdapter();
+        $this->getQueryLog()->reset()->enable();
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
         $query->enableResultCache();
@@ -180,10 +172,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        self::assertSame(
-            $expectedSQLCount,
-            $this->getCurrentQueryCount()
-        );
+        $this->assertQueryCount(1);
         self::assertCacheHasItem('testing_iterable_result_cache_id', $cache);
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
@@ -192,11 +181,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->setResultCacheId('testing_iterable_result_cache_id');
         iterator_to_array($query->toIterable());
 
-        self::assertSame(
-            $expectedSQLCount,
-            $this->getCurrentQueryCount(),
-            'Expected query to be cached'
-        );
+        $this->assertQueryCount(1, 'Expected query to be cached');
 
         $this->resetCache();
     }
@@ -206,9 +191,9 @@ class ResultCacheTest extends OrmFunctionalTestCase
      */
     public function testEnableResultCacheParams(): void
     {
-        $cache    = new ArrayAdapter();
-        $sqlCount = $this->getCurrentQueryCount();
-        $query    = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux WHERE ux.id = ?1');
+        $cache = new ArrayAdapter();
+        $this->getQueryLog()->reset()->enable();
+        $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux WHERE ux.id = ?1');
 
         $this->setResultCache($query, $cache);
         $query->enableResultCache();
@@ -219,11 +204,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->setParameter(1, 2);
         $query->getResult();
 
-        self::assertSame(
-            $sqlCount + 2,
-            $this->getCurrentQueryCount(),
-            'Two non-cached queries.'
-        );
+        $this->assertQueryCount(2, 'Two non-cached queries.');
 
         // these two queries should actually be cached, as they repeat previous ones:
         $query->setParameter(1, 1);
@@ -231,11 +212,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->setParameter(1, 2);
         $query->getResult();
 
-        self::assertSame(
-            $sqlCount + 2,
-            $this->getCurrentQueryCount(),
-            'The next two sql queries should have been cached, but were not.'
-        );
+        $this->assertQueryCount(2, 'The next two sql queries should have been cached, but were not.');
     }
 
     public function testDisableResultCache(): void

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
@@ -45,7 +45,7 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[0]->getId()));
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[1]->getId()));
 
-        $queryCount  = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $flight      = $this->_em->find(Flight::class, $id);
         $leavingFrom = $flight->getLeavingFrom();
         $goingTo     = $flight->getGoingTo();
@@ -56,7 +56,7 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
 
         self::assertEquals($goingTo->getId(), $goingToId);
         self::assertEquals($leavingFrom->getId(), $leavingFromId);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     public function testRemoveCompositPrimaryKeyEntities(): void
@@ -135,7 +135,7 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[0]->getId()));
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[1]->getId()));
 
-        $queryCount  = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $flight      = $this->_em->find(Flight::class, $id);
         $leavingFrom = $flight->getLeavingFrom();
         $goingTo     = $flight->getGoingTo();
@@ -148,7 +148,7 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         self::assertEquals($flight->getDeparture(), $now);
         self::assertEquals($leavingFrom->getId(), $leavingFromId);
         self::assertEquals($leavingFrom->getId(), $leavingFromId);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         $flight->setDeparture($tomorrow);
 
@@ -160,7 +160,7 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[0]->getId()));
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[1]->getId()));
 
-        $queryCount  = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $flight      = $this->_em->find(Flight::class, $id);
         $leavingFrom = $flight->getLeavingFrom();
         $goingTo     = $flight->getGoingTo();
@@ -173,6 +173,6 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         self::assertEquals($flight->getDeparture(), $tomorrow);
         self::assertEquals($leavingFrom->getId(), $leavingFromId);
         self::assertEquals($leavingFrom->getId(), $leavingFromId);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php
@@ -52,23 +52,23 @@ class SecondLevelCacheCompositePrimaryKeyWithAssociationsTest extends OrmFunctio
     {
         $admin1Repo = $this->_em->getRepository(Admin1::class);
 
-        $queries = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $admin1Rome = $admin1Repo->findOneBy(['country' => 'IT', 'id' => 1]);
 
         self::assertEquals('Italy', $admin1Rome->country->name);
         self::assertCount(2, $admin1Rome->names);
-        self::assertEquals($queries + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
 
         $this->_em->clear();
 
-        $queries = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $admin1Rome = $admin1Repo->findOneBy(['country' => 'IT', 'id' => 1]);
 
         self::assertEquals('Italy', $admin1Rome->country->name);
         self::assertCount(2, $admin1Rome->names);
-        self::assertEquals($queries, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     private function evictRegions(): void

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -71,11 +71,11 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
 
         self::assertFalse($this->cache->containsEntity(Country::class, $countryId));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $country    = $this->_em->find(Country::class, $countryId);
+        $this->getQueryLog()->reset()->enable();
+        $country = $this->_em->find(Country::class, $countryId);
 
         self::assertInstanceOf(Country::class, $country);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertFalse($this->cache->containsEntity(Country::class, $countryId));
     }
 
@@ -110,8 +110,8 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
 
         self::assertFalse($this->cache->containsCollection(State::class, 'cities', $stateId));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $state      = $this->_em->find(State::class, $stateId);
+        $this->getQueryLog()->reset()->enable();
+        $state = $this->_em->find(State::class, $stateId);
 
         self::assertEquals(0, $this->secondLevelCacheLogger->getMissCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getHitCount());
@@ -126,7 +126,7 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
         self::assertEquals(1, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getRegionMissCount($this->getCollectionRegion(State::class, 'cities')));
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertFalse($this->cache->containsCollection(State::class, 'cities', $stateId));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
@@ -25,16 +25,16 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
 
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
-        $name       = $this->countries[0]->getName();
-        $result1    = $repository->matching(new Criteria(
+        $this->getQueryLog()->reset()->enable();
+        $name    = $this->countries[0]->getName();
+        $result1 = $repository->matching(new Criteria(
             Criteria::expr()->eq('name', $name)
         ));
 
         // Because matching returns lazy collection, we force initialization
         $result1->toArray();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
 
@@ -46,7 +46,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
             Criteria::expr()->eq('name', $name)
         ));
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(1, $result2);
 
         self::assertInstanceOf(Country::class, $result2[0]);
@@ -65,8 +65,8 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
 
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
-        $result1    = $repository->matching(new Criteria(
+        $this->getQueryLog()->reset()->enable();
+        $result1 = $repository->matching(new Criteria(
             Criteria::expr()->eq('name', $this->countries[0]->getName())
         ));
 
@@ -74,7 +74,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         $result1->toArray();
 
         self::assertCount(1, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
 
@@ -87,7 +87,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         // Because matching returns lazy collection, we force initialization
         $result2->toArray();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(1, $result2);
 
         self::assertInstanceOf(Country::class, $result2[0]);
@@ -102,7 +102,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         // Because matching returns lazy collection, we force initialization
         $result3->toArray();
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertCount(1, $result3);
 
         self::assertInstanceOf(Country::class, $result3[0]);
@@ -114,7 +114,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
             Criteria::expr()->eq('name', $this->countries[1]->getName())
         ));
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertCount(1, $result4);
 
         self::assertInstanceOf(Country::class, $result4[0]);
@@ -131,28 +131,28 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
         $this->secondLevelCacheLogger->clearStats();
 
-        $entity     = $this->_em->find(State::class, $this->states[0]->getId());
-        $itemName   = $this->states[0]->getCities()->get(0)->getName();
-        $queryCount = $this->getCurrentQueryCount();
+        $entity   = $this->_em->find(State::class, $this->states[0]->getId());
+        $itemName = $this->states[0]->getCities()->get(0)->getName();
+        $this->getQueryLog()->reset()->enable();
         $collection = $entity->getCities();
         $matching   = $collection->matching(new Criteria(
             Criteria::expr()->eq('name', $itemName)
         ));
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(Collection::class, $matching);
         self::assertCount(1, $matching);
 
         $this->_em->clear();
 
-        $entity     = $this->_em->find(State::class, $this->states[0]->getId());
-        $queryCount = $this->getCurrentQueryCount();
+        $entity = $this->_em->find(State::class, $this->states[0]->getId());
+        $this->getQueryLog()->reset()->enable();
         $collection = $entity->getCities();
         $matching   = $collection->matching(new Criteria(
             Criteria::expr()->eq('name', $itemName)
         ));
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(Collection::class, $matching);
         self::assertCount(1, $matching);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
@@ -59,12 +59,12 @@ class SecondLevelCacheExtraLazyCollectionTest extends SecondLevelCacheAbstractTe
         $this->_em->persist($newItem);
         $this->_em->persist($owner);
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertFalse($owner->getVisitedCities()->isInitialized());
         self::assertEquals(4, $owner->getVisitedCities()->count());
         self::assertFalse($owner->getVisitedCities()->isInitialized());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         $this->_em->flush();
 
@@ -73,11 +73,11 @@ class SecondLevelCacheExtraLazyCollectionTest extends SecondLevelCacheAbstractTe
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $owner      = $this->_em->find(Travel::class, $ownerId);
+        $this->getQueryLog()->reset()->enable();
+        $owner = $this->_em->find(Travel::class, $ownerId);
 
         self::assertEquals(4, $owner->getVisitedCities()->count());
         self::assertFalse($owner->getVisitedCities()->isInitialized());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
@@ -80,12 +80,12 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         self::assertFalse($this->cache->containsEntity(AttractionContactInfo::class, $entityId1));
         self::assertFalse($this->cache->containsEntity(AttractionContactInfo::class, $entityId2));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $entity1    = $this->_em->find(AttractionInfo::class, $entityId1);
-        $entity2    = $this->_em->find(AttractionInfo::class, $entityId2);
+        $this->getQueryLog()->reset()->enable();
+        $entity1 = $this->_em->find(AttractionInfo::class, $entityId1);
+        $entity2 = $this->_em->find(AttractionInfo::class, $entityId2);
 
         //load entity and relation whit sub classes
-        self::assertEquals($queryCount + 4, $this->getCurrentQueryCount());
+        $this->assertQueryCount(4);
 
         self::assertTrue($this->cache->containsEntity(AttractionInfo::class, $entityId1));
         self::assertTrue($this->cache->containsEntity(AttractionInfo::class, $entityId2));
@@ -105,11 +105,11 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $entity3    = $this->_em->find(AttractionInfo::class, $entityId1);
-        $entity4    = $this->_em->find(AttractionInfo::class, $entityId2);
+        $this->getQueryLog()->reset()->enable();
+        $entity3 = $this->_em->find(AttractionInfo::class, $entityId1);
+        $entity4 = $this->_em->find(AttractionInfo::class, $entityId2);
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(AttractionInfo::class, $entity3);
         self::assertInstanceOf(AttractionInfo::class, $entity4);
@@ -135,14 +135,14 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         $this->evictRegions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT i, a FROM Doctrine\Tests\Models\Cache\AttractionInfo i JOIN i.attraction a';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT i, a FROM Doctrine\Tests\Models\Cache\AttractionInfo i JOIN i.attraction a';
+        $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractionsInfo), $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->clear();
 
@@ -151,7 +151,7 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
             ->getResult();
 
         self::assertCount(count($this->attractionsInfo), $result2);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         foreach ($result2 as $entity) {
             self::assertInstanceOf(AttractionInfo::class, $entity);
@@ -174,8 +174,7 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         self::assertInstanceOf(PersistentCollection::class, $entity->getInfos());
         self::assertCount(1, $entity->getInfos());
 
-        $ownerId    = $this->attractions[0]->getId();
-        $queryCount = $this->getCurrentQueryCount();
+        $ownerId = $this->attractions[0]->getId();
 
         self::assertTrue($this->cache->containsEntity(Attraction::class, $ownerId));
         self::assertTrue($this->cache->containsCollection(Attraction::class, 'infos', $ownerId));
@@ -205,15 +204,15 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         $this->evictRegions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT attractionInfo FROM Doctrine\Tests\Models\Cache\AttractionInfo attractionInfo';
+        $this->getQueryLog()->reset()->enable();
+        $dql = 'SELECT attractionInfo FROM Doctrine\Tests\Models\Cache\AttractionInfo attractionInfo';
 
         $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractionsInfo), $result1);
-        self::assertEquals($queryCount + 5, $this->getCurrentQueryCount());
+        $this->assertQueryCount(5);
 
         $contact = new AttractionContactInfo(
             '1234-1234',
@@ -224,14 +223,14 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $result2 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractionsInfo) + 1, $result2);
-        self::assertEquals($queryCount + 6, $this->getCurrentQueryCount());
+        $this->assertQueryCount(6);
 
         foreach ($result2 as $entity) {
             self::assertInstanceOf(AttractionInfo::class, $entity);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -104,7 +104,7 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
         $this->secondLevelCacheLogger->clearStats();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $t3 = $this->_em->find(Travel::class, $this->travels[0]->getId());
         $t4 = $this->_em->find(Travel::class, $this->travels[1]->getId());
@@ -145,7 +145,7 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         self::assertEquals($t2->getVisitedCities()->get(1)->getName(), $t4->getVisitedCities()->get(1)->getName());
 
         self::assertEquals(4, $this->secondLevelCacheLogger->getHitCount());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     public function testStoreManyToManyAssociationWhitCascade(): void
@@ -181,12 +181,12 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(City::class, $this->cities[3]->getId()));
         self::assertTrue($this->cache->containsCollection(Travel::class, 'visitedCities', $travel->getId()));
 
-        $queryCount1 = $this->getCurrentQueryCount();
-        $t1          = $this->_em->find(Travel::class, $travel->getId());
+        $this->getQueryLog()->reset()->enable();
+        $t1 = $this->_em->find(Travel::class, $travel->getId());
 
         self::assertInstanceOf(Travel::class, $t1);
         self::assertCount(3, $t1->getVisitedCities());
-        self::assertEquals($queryCount1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     public function testReadOnlyCollection(): void
@@ -228,20 +228,20 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
 
         $this->evictRegions();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $entitiId = $this->travels[2]->getId(); //empty travel
         $entity   = $this->_em->find(Travel::class, $entitiId);
 
         self::assertEquals(0, $entity->getVisitedCities()->count());
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
 
         $this->_em->clear();
 
         $entity = $this->_em->find(Travel::class, $entitiId);
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         self::assertEquals(0, $entity->getVisitedCities()->count());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
@@ -110,7 +110,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         // load from cache
         $t3 = $this->_em->find(Traveler::class, $entity1->getId());
         $t4 = $this->_em->find(Traveler::class, $entity2->getId());
@@ -126,7 +126,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         self::assertEquals($entity1->getProfile()->getName(), $t3->getProfile()->getName());
         self::assertEquals($entity2->getProfile()->getName(), $t4->getProfile()->getName());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     public function testPutAndLoadOneToOneBidirectionalRelation(): void
@@ -171,7 +171,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $p3 = $this->_em->find(TravelerProfile::class, $entity1->getId());
         $p4 = $this->_em->find(TravelerProfile::class, $entity2->getId());
@@ -191,7 +191,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         self::assertEquals($entity2->getInfo()->getId(), $p4->getInfo()->getId());
         self::assertEquals($entity2->getInfo()->getDescription(), $p4->getInfo()->getDescription());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 
     public function testInverseSidePutAndLoadOneToOneBidirectionalRelation(): void
@@ -232,7 +232,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $p3 = $this->_em->find(Person::class, $entity1->id);
         $p4 = $this->_em->find(Person::class, $entity2->id);
@@ -252,7 +252,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         self::assertEquals($entity2->address->id, $p4->address->id);
         self::assertEquals($entity2->address->location, $p4->address->location);
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 
     public function testPutAndLoadNonCacheableOneToOne(): void
@@ -268,7 +268,7 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertTrue($this->cache->containsEntity(Token::class, $token->token));
         self::assertFalse($this->cache->containsEntity(Client::class, $client->id));
@@ -278,9 +278,9 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(Token::class, $entity);
         self::assertInstanceOf(Client::class, $entity->getClient());
         self::assertEquals('token-hash', $entity->token);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertEquals('FabioBatSilva', $entity->getClient()->name);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -35,12 +35,12 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result1    = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result1 = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[1]->getId(), $result1[1]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
@@ -57,7 +57,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(2, $result2);
 
         self::assertEquals(1, $this->secondLevelCacheLogger->getPutCount());
@@ -98,32 +98,32 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $queryGet   = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql      = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $queryGet = $this->_em->createQuery($dql)
             ->setCacheMode(Cache::MODE_GET)
             ->setCacheable(true);
 
         // MODE_GET should never add items to the cache.
         self::assertCount(2, $queryGet->getResult());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertCount(2, $queryGet->getResult());
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
 
         $result = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(2, $result);
-        self::assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
 
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         // MODE_GET should read items if exists.
         self::assertCount(2, $queryGet->getResult());
-        self::assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
     }
 
     public function testQueryCacheModePut(): void
@@ -138,9 +138,9 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result     = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql    = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
@@ -148,7 +148,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         self::assertCount(2, $result);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $queryPut = $this->_em->createQuery($dql)
             ->setCacheMode(Cache::MODE_PUT)
@@ -156,12 +156,12 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         // MODE_PUT should never read itens from cache.
         self::assertCount(2, $queryPut->getResult());
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         self::assertCount(2, $queryPut->getResult());
-        self::assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
     }
@@ -178,10 +178,10 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $region     = $this->cache->getEntityCacheRegion(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result     = $this->_em->createQuery($dql)
+        $region = $this->cache->getEntityCacheRegion(Country::class);
+        $this->getQueryLog()->reset()->enable();
+        $dql    = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
@@ -189,7 +189,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         self::assertCount(2, $result);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $countryId1   = $this->countries[0]->getId();
         $countryId2   = $this->countries[1]->getId();
@@ -214,7 +214,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertCount(2, $result1);
         self::assertEquals($countryName1, $result1[0]->getName());
         self::assertEquals($countryName2, $result1[1]->getName());
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
 
         $this->_em->clear();
 
@@ -222,7 +222,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertCount(2, $result2);
         self::assertEquals($countryName1, $result2[0]->getName());
         self::assertEquals($countryName2, $result2[1]->getName());
-        self::assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
     }
 
     public function testBasicQueryCachePutEntityCache(): void
@@ -234,12 +234,12 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->secondLevelCacheLogger->clearStats();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result1    = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result1 = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[1]->getId(), $result1[1]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
@@ -260,7 +260,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(2, $result2);
 
         self::assertEquals(3, $this->secondLevelCacheLogger->getPutCount());
@@ -308,14 +308,14 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT s, c, a FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c JOIN c.attractions a';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT s, c, a FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c JOIN c.attractions a';
+        $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertTrue($this->cache->containsEntity(State::class, $this->states[0]->getId()));
         self::assertTrue($this->cache->containsEntity(State::class, $this->states[1]->getId()));
@@ -353,7 +353,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertCount(2, $result2);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertInstanceOf(State::class, $result2[0]);
         self::assertInstanceOf(State::class, $result2[1]);
@@ -382,15 +382,15 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $name       = $this->countries[0]->getName();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c WHERE c.name = :name';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $name    = $this->countries[0]->getName();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c WHERE c.name = :name';
+        $result1 = $this->_em->createQuery($dql)
                 ->setCacheable(true)
                 ->setParameter('name', $name)
                 ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
 
@@ -400,7 +400,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
                 ->setParameter('name', $name)
                 ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(1, $result2);
 
         self::assertInstanceOf(Country::class, $result2[0]);
@@ -419,12 +419,12 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result1    = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result1 = $this->_em->createQuery($dql)->setCacheable(true)->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[1]->getId(), $result1[1]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
@@ -444,7 +444,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertCount(2, $result2);
 
         self::assertEquals(5, $this->secondLevelCacheLogger->getPutCount());
@@ -461,7 +461,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals($result1[0]->getName(), $result2[0]->getName());
         self::assertEquals($result1[1]->getName(), $result2[1]->getName());
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 
     public function testBasicQueryFetchJoinsOneToMany(): void
@@ -473,13 +473,13 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c';
+        $result1 = $this->_em->createQuery($dql)
                 ->setCacheable(true)
                 ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $result1[0]);
         self::assertInstanceOf(State::class, $result1[1]);
         self::assertCount(2, $result1[0]->getCities());
@@ -526,7 +526,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertNotNull($result2[1]->getCities()->get(0)->getName());
         self::assertNotNull($result2[1]->getCities()->get(1)->getName());
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     public function testBasicQueryFetchJoinsManyToOne(): void
@@ -539,9 +539,9 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->secondLevelCacheLogger->clearStats();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s';
+        $result1 = $this->_em->createQuery($dql)
                 ->setCacheable(true)
                 ->getResult();
 
@@ -563,7 +563,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionPutCount($this->getEntityRegion(State::class)));
         self::assertEquals(4, $this->secondLevelCacheLogger->getRegionPutCount($this->getEntityRegion(City::class)));
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->clear();
         $this->secondLevelCacheLogger->clearStats();
@@ -593,7 +593,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals($result1[0]->getState()->getName(), $result2[0]->getState()->getName());
         self::assertEquals($result1[1]->getState()->getName(), $result2[1]->getState()->getName());
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     public function testReloadQueryIfToOneIsNotFound(): void
@@ -606,9 +606,9 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->secondLevelCacheLogger->clearStats();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s';
+        $result1 = $this->_em->createQuery($dql)
                 ->setCacheable(true)
                 ->getResult();
 
@@ -622,7 +622,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(City::class, $result1[1]->getId()));
         self::assertTrue($this->cache->containsEntity(State::class, $result1[0]->getState()->getId()));
         self::assertTrue($this->cache->containsEntity(State::class, $result1[1]->getState()->getId()));
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->clear();
 
@@ -638,7 +638,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(State::class, $result2[0]->getState());
         self::assertInstanceOf(State::class, $result2[1]->getState());
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 
     public function testReloadQueryIfToManyAssociationItemIsNotFound(): void
@@ -650,13 +650,13 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c';
+        $result1 = $this->_em->createQuery($dql)
                 ->setCacheable(true)
                 ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $result1[0]);
         self::assertInstanceOf(State::class, $result1[1]);
         self::assertCount(2, $result1[0]->getCities());
@@ -685,7 +685,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(City::class, $result2[1]->getCities()->get(0));
         self::assertInstanceOf(City::class, $result2[1]->getCities()->get(1));
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 
     public function testBasicNativeQueryCache(): void
@@ -704,12 +704,12 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $rsm->addFieldResult('c', 'name', 'name');
         $rsm->addFieldResult('c', 'id', 'id');
 
-        $queryCount = $this->getCurrentQueryCount();
-        $sql        = 'SELECT id, name FROM cache_country';
-        $result1    = $this->_em->createNativeQuery($sql, $rsm)->setCacheable(true)->getResult();
+        $this->getQueryLog()->reset()->enable();
+        $sql     = 'SELECT id, name FROM cache_country';
+        $result1 = $this->_em->createNativeQuery($sql, $rsm)->setCacheable(true)->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[1]->getId(), $result1[1]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
@@ -726,7 +726,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertCount(2, $result2);
 
         self::assertEquals(1, $this->secondLevelCacheLogger->getPutCount());
@@ -763,15 +763,15 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->secondLevelCacheLogger->clearStats();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->setFirstResult(1)
             ->setMaxResults(1)
             ->getResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals(1, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getMissCount());
 
@@ -783,7 +783,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setMaxResults(1)
             ->getResult();
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertEquals(2, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
 
@@ -793,7 +793,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
         self::assertEquals(3, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(3, $this->secondLevelCacheLogger->getMissCount());
     }
@@ -813,15 +813,15 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             return $method->invoke($query);
         };
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $query      = $this->_em->createQuery($dql);
-        $result1    = $query->setCacheable(true)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $query   = $this->_em->createQuery($dql);
+        $result1 = $query->setCacheable(true)
             ->setLifetime(3600)
             ->getResult();
 
         self::assertNotEmpty($result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals(1, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getMissCount());
 
@@ -845,7 +845,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertNotEmpty($result2);
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertEquals(2, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
     }
@@ -858,9 +858,9 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->secondLevelCacheLogger->clearStats();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
-        $query      = $this->_em->createQuery($dql);
+        $this->getQueryLog()->reset()->enable();
+        $dql   = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $query = $this->_em->createQuery($dql);
 
         $query1  = clone $query;
         $result1 = $query1->setCacheable(true)
@@ -868,7 +868,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertNotEmpty($result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertEquals(0, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(1, $this->secondLevelCacheLogger->getMissCount());
@@ -881,7 +881,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertNotEmpty($result2);
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertEquals(0, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
@@ -894,7 +894,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertNotEmpty($result3);
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertEquals(3, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
@@ -908,7 +908,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
 
         self::assertNotEmpty($result3);
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
         self::assertEquals(6, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getPutCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
@@ -929,7 +929,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $countryName = $this->states[0]->getCountry()->getName();
         $dql         = 'SELECT s FROM Doctrine\Tests\Models\Cache\State s WHERE s.id = :id';
         $query       = $this->_em->createQuery($dql);
-        $queryCount  = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $query1 = clone $query;
         $state1 = $query1
@@ -940,7 +940,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         self::assertNotNull($state1);
         self::assertNotNull($state1->getCountry());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
         self::assertInstanceOf(Proxy::class, $state1->getCountry());
         self::assertEquals($countryName, $state1->getCountry()->getName());
@@ -948,9 +948,9 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $query2     = clone $query;
-        $state2     = $query2
+        $this->getQueryLog()->reset()->enable();
+        $query2 = clone $query;
+        $state2 = $query2
             ->setParameter('id', $stateId)
             ->setCacheable(true)
             ->setMaxResults(1)
@@ -958,7 +958,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         self::assertNotNull($state2);
         self::assertNotNull($state2->getCountry());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
         self::assertInstanceOf(Proxy::class, $state2->getCountry());
         self::assertEquals($countryName, $state2->getCountry()->getName());
@@ -975,10 +975,10 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $cityId     = $this->cities[0]->getId();
-        $dql        = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s WHERE c.id = :id';
-        $query      = $this->_em->createQuery($dql);
-        $queryCount = $this->getCurrentQueryCount();
+        $cityId = $this->cities[0]->getId();
+        $dql    = 'SELECT c, s FROM Doctrine\Tests\Models\Cache\City c JOIN c.state s WHERE c.id = :id';
+        $query  = $this->_em->createQuery($dql);
+        $this->getQueryLog()->reset()->enable();
 
         $query1 = clone $query;
         $city1  = $query1
@@ -987,7 +987,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setMaxResults(1)
             ->getSingleResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(City::class, $city1);
         self::assertInstanceOf(State::class, $city1->getState());
         self::assertInstanceOf(City::class, $city1->getState()->getCities()->get(0));
@@ -995,15 +995,15 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $query2     = clone $query;
-        $city2      = $query2
+        $this->getQueryLog()->reset()->enable();
+        $query2 = clone $query;
+        $city2  = $query2
             ->setParameter('id', $cityId)
             ->setCacheable(true)
             ->setMaxResults(1)
             ->getSingleResult();
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(City::class, $city2);
         self::assertInstanceOf(State::class, $city2->getState());
         self::assertInstanceOf(City::class, $city2->getState()->getCities()->get(0));
@@ -1020,10 +1020,10 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $stateId    = $this->states[0]->getId();
-        $dql        = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c WHERE s.id = :id';
-        $query      = $this->_em->createQuery($dql);
-        $queryCount = $this->getCurrentQueryCount();
+        $stateId = $this->states[0]->getId();
+        $dql     = 'SELECT s, c FROM Doctrine\Tests\Models\Cache\State s JOIN s.cities c WHERE s.id = :id';
+        $query   = $this->_em->createQuery($dql);
+        $this->getQueryLog()->reset()->enable();
 
         $query1 = clone $query;
         $state1 = $query1
@@ -1032,7 +1032,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setMaxResults(1)
             ->getSingleResult();
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
         self::assertInstanceOf(Proxy::class, $state1->getCountry());
         self::assertInstanceOf(City::class, $state1->getCities()->get(0));
@@ -1041,15 +1041,15 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $query2     = clone $query;
-        $state2     = $query2
+        $this->getQueryLog()->reset()->enable();
+        $query2 = clone $query;
+        $state2 = $query2
             ->setParameter('id', $stateId)
             ->setCacheable(true)
             ->setMaxResults(1)
             ->getSingleResult();
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
         self::assertInstanceOf(Proxy::class, $state2->getCountry());
         self::assertInstanceOf(City::class, $state2->getCities()->get(0));
@@ -1137,28 +1137,28 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->loadFixturesCountries();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT country FROM Doctrine\Tests\Models\Cache\Country country';
+        $this->getQueryLog()->reset()->enable();
+        $dql = 'SELECT country FROM Doctrine\Tests\Models\Cache\Country country';
 
         $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->persist(new Country('France'));
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $result2 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(3, $result2);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         foreach ($result2 as $entity) {
             self::assertInstanceOf(Country::class, $entity);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -24,12 +24,12 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[0]->getId()));
         self::assertTrue($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $repository = $this->_em->getRepository(Country::class);
         $country1   = $repository->find($this->countries[0]->getId());
         $country2   = $repository->find($this->countries[1]->getId());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(Country::class, $country1);
         self::assertInstanceOf(Country::class, $country2);
@@ -50,15 +50,15 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertCount(2, $repository->findAll());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
-        $queryCount = $this->getCurrentQueryCount();
-        $countries  = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $countries = $repository->findAll();
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(Country::class, $countries[0]);
         self::assertInstanceOf(Country::class, $countries[1]);
@@ -81,15 +81,15 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
 
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertCount(2, $repository->findAll());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
-        $queryCount = $this->getCurrentQueryCount();
-        $countries  = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $countries = $repository->findAll();
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertCount(2, $countries);
         self::assertInstanceOf(Country::class, $countries[0]);
@@ -101,10 +101,10 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertCount(3, $repository->findAll());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $country = $repository->find($country->getId());
 
@@ -112,10 +112,10 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertCount(2, $repository->findAll());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 
     public function testRepositoryCacheFindBy(): void
@@ -129,15 +129,15 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
 
         $criteria   = ['name' => $this->countries[0]->getName()];
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertCount(1, $repository->findBy($criteria));
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
-        $queryCount = $this->getCurrentQueryCount();
-        $countries  = $repository->findBy($criteria);
+        $this->getQueryLog()->reset()->enable();
+        $countries = $repository->findBy($criteria);
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertCount(1, $countries);
         self::assertInstanceOf(Country::class, $countries[0]);
@@ -159,15 +159,15 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
 
         $criteria   = ['name' => $this->countries[0]->getName()];
         $repository = $this->_em->getRepository(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertNotNull($repository->findOneBy($criteria));
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
-        $queryCount = $this->getCurrentQueryCount();
-        $country    = $repository->findOneBy($criteria);
+        $this->getQueryLog()->reset()->enable();
+        $country = $repository->findOneBy($criteria);
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(Country::class, $country);
 
@@ -189,11 +189,11 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
 
         // load from database
         $repository = $this->_em->getRepository(State::class);
-        $queryCount = $this->getCurrentQueryCount();
-        $entities   = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $entities = $repository->findAll();
 
         self::assertCount(4, $entities);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertInstanceOf(State::class, $entities[0]);
         self::assertInstanceOf(State::class, $entities[1]);
@@ -203,11 +203,11 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
 
         // load from cache
-        $queryCount = $this->getCurrentQueryCount();
-        $entities   = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $entities = $repository->findAll();
 
         self::assertCount(4, $entities);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(State::class, $entities[0]);
         self::assertInstanceOf(State::class, $entities[1]);
@@ -222,11 +222,11 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
 
         // load from database
-        $queryCount = $this->getCurrentQueryCount();
-        $entities   = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $entities = $repository->findAll();
 
         self::assertCount(5, $entities);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertInstanceOf(State::class, $entities[0]);
         self::assertInstanceOf(State::class, $entities[1]);
@@ -236,11 +236,11 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
 
         // load from cache
-        $queryCount = $this->getCurrentQueryCount();
-        $entities   = $repository->findAll();
+        $this->getQueryLog()->reset()->enable();
+        $entities = $repository->findAll();
 
         self::assertCount(5, $entities);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(State::class, $entities[0]);
         self::assertInstanceOf(State::class, $entities[1]);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
@@ -99,12 +99,12 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $entity3 = $this->_em->find(Attraction::class, $entityId1);
         $entity4 = $this->_em->find(Attraction::class, $entityId2);
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(Attraction::class, $entity3);
         self::assertInstanceOf(Attraction::class, $entity4);
@@ -129,14 +129,14 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT a FROM Doctrine\Tests\Models\Cache\Attraction a';
-        $result1    = $this->_em->createQuery($dql)
+        $this->getQueryLog()->reset()->enable();
+        $dql     = 'SELECT a FROM Doctrine\Tests\Models\Cache\Attraction a';
+        $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractions), $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->clear();
 
@@ -145,7 +145,7 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
             ->getResult();
 
         self::assertCount(count($this->attractions), $result2);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         foreach ($result2 as $entity) {
             self::assertInstanceOf(Attraction::class, $entity);
@@ -190,8 +190,8 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
         self::assertInstanceOf(PersistentCollection::class, $entity->getAttractions());
         self::assertCount(2, $entity->getAttractions());
 
-        $ownerId    = $this->cities[0]->getId();
-        $queryCount = $this->getCurrentQueryCount();
+        $ownerId = $this->cities[0]->getId();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertTrue($this->cache->containsEntity(City::class, $ownerId));
         self::assertTrue($this->cache->containsCollection(City::class, 'attractions', $ownerId));
@@ -209,7 +209,7 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
         self::assertInstanceOf(PersistentCollection::class, $entity->getAttractions());
         self::assertCount(2, $entity->getAttractions());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertInstanceOf(Bar::class, $entity->getAttractions()->get(0));
         self::assertInstanceOf(Bar::class, $entity->getAttractions()->get(1));
@@ -225,15 +225,15 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
         $this->loadFixturesAttractions();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
-        $dql        = 'SELECT attraction FROM Doctrine\Tests\Models\Cache\Attraction attraction';
+        $this->getQueryLog()->reset()->enable();
+        $dql = 'SELECT attraction FROM Doctrine\Tests\Models\Cache\Attraction attraction';
 
         $result1 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractions), $result1);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $contact = new Beach(
             'Botafogo',
@@ -244,14 +244,14 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
         $this->_em->flush();
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $result2 = $this->_em->createQuery($dql)
             ->setCacheable(true)
             ->getResult();
 
         self::assertCount(count($this->attractions) + 1, $result2);
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         foreach ($result2 as $entity) {
             self::assertInstanceOf(Attraction::class, $entity);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -62,12 +62,12 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $c3 = $this->_em->find(Country::class, $this->countries[0]->getId());
         $c4 = $this->_em->find(Country::class, $this->countries[1]->getId());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertEquals(2, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionHitCount($this->getEntityRegion(Country::class)));
 
@@ -177,7 +177,7 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionPutCount($this->getEntityRegion(Country::class)));
         self::assertEquals(4, $this->secondLevelCacheLogger->getRegionPutCount($this->getEntityRegion(State::class)));
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $c3 = $this->_em->find(State::class, $this->states[0]->getId());
         $c4 = $this->_em->find(State::class, $this->states[1]->getId());
@@ -185,7 +185,7 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals(2, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionHitCount($this->getEntityRegion(State::class)));
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertTrue($this->cache->containsEntity(State::class, $this->states[0]->getId()));
         self::assertTrue($this->cache->containsEntity(State::class, $this->states[1]->getId()));
@@ -326,12 +326,12 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
     {
         $this->loadFixturesCountries();
 
-        $persister  = $this->_em->getUnitOfWork()->getEntityPersister(Country::class);
-        $queryCount = $this->getCurrentQueryCount();
+        $persister = $this->_em->getUnitOfWork()->getEntityPersister(Country::class);
+        $this->getQueryLog()->reset()->enable();
 
         self::assertTrue($persister->exists($this->countries[0]));
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertFalse($persister->exists(new Country('Foo')));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -42,8 +42,8 @@ class DDC1301Test extends OrmFunctionalTestCase
 
     public function testCountNotInitializesLegacyCollection(): void
     {
-        $user       = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
-        $queryCount = $this->getCurrentQueryCount();
+        $user = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
+        $this->getQueryLog()->reset()->enable();
 
         self::assertFalse($user->articles->isInitialized());
         self::assertCount(2, $user->articles);
@@ -52,13 +52,13 @@ class DDC1301Test extends OrmFunctionalTestCase
         foreach ($user->articles as $article) {
         }
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), 'Expecting two queries to be fired for count, then iteration.');
+        $this->assertQueryCount(2, 'Expecting two queries to be fired for count, then iteration.');
     }
 
     public function testCountNotInitializesLegacyCollectionWithForeignIdentifier(): void
     {
-        $user       = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
-        $queryCount = $this->getCurrentQueryCount();
+        $user = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
+        $this->getQueryLog()->reset()->enable();
 
         self::assertFalse($user->references->isInitialized());
         self::assertCount(2, $user->references);
@@ -67,13 +67,13 @@ class DDC1301Test extends OrmFunctionalTestCase
         foreach ($user->references as $reference) {
         }
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), 'Expecting two queries to be fired for count, then iteration.');
+        $this->assertQueryCount(2, 'Expecting two queries to be fired for count, then iteration.');
     }
 
     public function testCountNotInitializesLegacyManyToManyCollection(): void
     {
-        $user       = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
-        $queryCount = $this->getCurrentQueryCount();
+        $user = $this->_em->find(Models\Legacy\LegacyUser::class, $this->userId);
+        $this->getQueryLog()->reset()->enable();
 
         self::assertFalse($user->cars->isInitialized());
         self::assertCount(3, $user->cars);
@@ -82,7 +82,7 @@ class DDC1301Test extends OrmFunctionalTestCase
         foreach ($user->cars as $reference) {
         }
 
-        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), 'Expecting two queries to be fired for count, then iteration.');
+        $this->assertQueryCount(2, 'Expecting two queries to be fired for count, then iteration.');
     }
 
     public function loadFixture(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
@@ -69,11 +69,11 @@ class DDC1400Test extends OrmFunctionalTestCase
                   ->setParameter('activeUser', $user1)
                   ->getResult();
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $this->_em->flush();
 
-        self::assertSame($queryCount, $this->getCurrentQueryCount(), 'No query should be executed during flush in this case');
+        $this->assertQueryCount(0, 'No query should be executed during flush in this case');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
@@ -65,7 +65,7 @@ class DDC2346Test extends OrmFunctionalTestCase
         $fetchedBazs = $this->_em->getRepository(DDC2346Baz::class)->findAll();
 
         self::assertCount(2, $fetchedBazs);
-        self::assertSame(2, $this->getCurrentQueryCount(), 'The total number of executed queries is 2, and not n+1');
+        $this->assertQueryCount(2, 'The total number of executed queries is 2, and not n+1');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php
@@ -46,14 +46,14 @@ class DDC2350Test extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $cnt  = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $user = $this->_em->find(DDC2350User::class, $user->id);
 
-        self::assertEquals($cnt + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         self::assertCount(2, $user->reportedBugs);
 
-        self::assertEquals($cnt + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -60,7 +60,7 @@ class DDC2494Test extends OrmFunctionalTestCase
         self::assertInstanceOf(DDC2494Campaign::class, $item);
         self::assertInstanceOf(DDC2494Currency::class, $item->getCurrency());
 
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         self::assertInstanceOf('\Doctrine\Common\Proxy\Proxy', $item->getCurrency());
         self::assertFalse($item->getCurrency()->__isInitialized());
@@ -72,13 +72,13 @@ class DDC2494Test extends OrmFunctionalTestCase
         self::assertCount(1, DDC2494TinyIntType::$calls['convertToPHPValue']);
         self::assertFalse($item->getCurrency()->__isInitialized());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
 
         self::assertIsInt($item->getCurrency()->getTemp());
         self::assertCount(3, DDC2494TinyIntType::$calls['convertToPHPValue']);
         self::assertTrue($item->getCurrency()->__isInitialized());
 
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
@@ -49,10 +49,10 @@ class DDC2862Test extends OrmFunctionalTestCase
         self::assertTrue($this->_em->getCache()->containsEntity(DDC2862User::class, ['id' => $user1->getId()]));
         self::assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::class, ['id' => $driver1->getId()]));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $driver2    = $this->_em->find(DDC2862Driver::class, $driver1->getId());
+        $this->getQueryLog()->reset()->enable();
+        $driver2 = $this->_em->find(DDC2862Driver::class, $driver1->getId());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(DDC2862Driver::class, $driver2);
         self::assertInstanceOf(DDC2862User::class, $driver2->getUserProfile());
 
@@ -64,10 +64,10 @@ class DDC2862Test extends OrmFunctionalTestCase
         self::assertTrue($this->_em->getCache()->containsEntity(DDC2862User::class, ['id' => $user1->getId()]));
         self::assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::class, ['id' => $driver1->getId()]));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $driver3    = $this->_em->find(DDC2862Driver::class, $driver1->getId());
+        $this->getQueryLog()->reset()->enable();
+        $driver3 = $this->_em->find(DDC2862Driver::class, $driver1->getId());
 
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertInstanceOf(DDC2862Driver::class, $driver3);
         self::assertInstanceOf(DDC2862User::class, $driver3->getUserProfile());
         self::assertEquals('Franta', $driver3->getName());
@@ -90,35 +90,35 @@ class DDC2862Test extends OrmFunctionalTestCase
         self::assertFalse($this->_em->getCache()->containsEntity(DDC2862User::class, ['id' => $user1->getId()]));
         self::assertFalse($this->_em->getCache()->containsEntity(DDC2862Driver::class, ['id' => $driver1->getId()]));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $driver2    = $this->_em->find(DDC2862Driver::class, $driver1->getId());
+        $this->getQueryLog()->reset()->enable();
+        $driver2 = $this->_em->find(DDC2862Driver::class, $driver1->getId());
 
         self::assertInstanceOf(DDC2862Driver::class, $driver2);
         self::assertInstanceOf(DDC2862User::class, $driver2->getUserProfile());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->_em->clear();
 
         self::assertFalse($this->_em->getCache()->containsEntity(DDC2862User::class, ['id' => $user1->getId()]));
         self::assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::class, ['id' => $driver1->getId()]));
 
-        $queryCount = $this->getCurrentQueryCount();
-        $driver3    = $this->_em->find(DDC2862Driver::class, $driver1->getId());
+        $this->getQueryLog()->reset()->enable();
+        $driver3 = $this->_em->find(DDC2862Driver::class, $driver1->getId());
 
         self::assertInstanceOf(DDC2862Driver::class, $driver3);
         self::assertInstanceOf(DDC2862User::class, $driver3->getUserProfile());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertEquals('Foo', $driver3->getUserProfile()->getName());
-        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
-        $queryCount = $this->getCurrentQueryCount();
-        $driver4    = $this->_em->find(DDC2862Driver::class, $driver1->getId());
+        $this->getQueryLog()->reset()->enable();
+        $driver4 = $this->_em->find(DDC2862Driver::class, $driver1->getId());
 
         self::assertInstanceOf(DDC2862Driver::class, $driver4);
         self::assertInstanceOf(DDC2862User::class, $driver4->getUserProfile());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
         self::assertEquals('Foo', $driver4->getUserProfile()->getName());
-        self::assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertQueryCount(0);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH2947Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH2947Test.php
@@ -30,23 +30,23 @@ class GH2947Test extends OrmFunctionalTestCase
     public function testIssue(): void
     {
         $this->createData();
-        $initialQueryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         $query = $this->createQuery();
         self::assertEquals('BMW', (string) $query->getSingleResult());
-        self::assertEquals($initialQueryCount + 1, $this->getCurrentQueryCount());
+        $this->assertQueryCount(1);
 
         $this->updateData();
         self::assertEquals('BMW', (string) $query->getSingleResult());
-        self::assertEquals($initialQueryCount + 2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
 
         $query->expireResultCache(true);
         self::assertEquals('Dacia', (string) $query->getSingleResult());
-        self::assertEquals($initialQueryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
 
         $query->expireResultCache(false);
         self::assertEquals('Dacia', (string) $query->getSingleResult());
-        self::assertEquals($initialQueryCount + 3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
     }
 
     private function createQuery(): Query

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -47,7 +47,7 @@ final class GH6217Test extends OrmFunctionalTestCase
         $filters    = ['eager' => $eager->id];
 
         self::assertCount(1, $repository->findBy($filters));
-        $queryCount = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
 
         /** @var GH6217FetchedEntity[] $found */
         $found = $repository->findBy($filters);
@@ -56,7 +56,7 @@ final class GH6217Test extends OrmFunctionalTestCase
         self::assertInstanceOf(GH6217FetchedEntity::class, $found[0]);
         self::assertSame($lazy->id, $found[0]->lazy->id);
         self::assertSame($eager->id, $found[0]->eager->id);
-        self::assertEquals($queryCount, $this->getCurrentQueryCount(), 'No queries were executed in `findBy`');
+        $this->assertQueryCount(0, 'No queries were executed in `findBy`');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7829Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7829Test.php
@@ -41,7 +41,7 @@ final class GH7829Test extends OrmFunctionalTestCase
         $paginator->count();
         $paginator->getIterator();
 
-        self::assertSame(3, $this->getCurrentQueryCount());
+        $this->assertQueryCount(3);
     }
 
     public function testPaginatorWithLimitSubquerySkipped(): void
@@ -56,6 +56,6 @@ final class GH7829Test extends OrmFunctionalTestCase
         $paginator->count();
         $paginator->getIterator();
 
-        self::assertSame(2, $this->getCurrentQueryCount());
+        $this->assertQueryCount(2);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8217Test.php
@@ -39,10 +39,9 @@ final class GH8217Test extends OrmFunctionalTestCase
         $this->_em->persist($collection);
         $this->_em->flush();
 
-        $queriesNumberBeforeSecondFlush = $this->getCurrentQueryCount();
+        $this->getQueryLog()->reset()->enable();
         $this->_em->flush();
-        $queriesNumberAfterSecondFlush = $this->getCurrentQueryCount();
-        self::assertEquals($queriesNumberBeforeSecondFlush, $queriesNumberAfterSecondFlush);
+        $this->assertQueryCount(0);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
@@ -36,7 +36,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(6002, $this->getCurrentQueryCount());
+        $this->assertQueryCount(6002);
     }
 
     public function testFindEntityWithCache(): void
@@ -46,7 +46,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(502, $this->getCurrentQueryCount());
+        $this->assertQueryCount(502);
     }
 
     public function testFindAllEntityWithoutCache(): void
@@ -54,7 +54,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findAllEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(153, $this->getCurrentQueryCount());
+        $this->assertQueryCount(153);
     }
 
     public function testFindAllEntityWithCache(): void
@@ -64,7 +64,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findAllEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(53, $this->getCurrentQueryCount());
+        $this->assertQueryCount(53);
     }
 
     public function testFindEntityOneToManyWithoutCache(): void
@@ -72,7 +72,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findEntityOneToMany($this->_em, __FUNCTION__);
 
-        self::assertEquals(502, $this->getCurrentQueryCount());
+        $this->assertQueryCount(502);
     }
 
     public function testFindEntityOneToManyWithCache(): void
@@ -82,7 +82,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->findEntityOneToMany($this->_em, __FUNCTION__);
 
-        self::assertEquals(472, $this->getCurrentQueryCount());
+        $this->assertQueryCount(472);
     }
 
     public function testQueryEntityWithoutCache(): void
@@ -90,7 +90,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->queryEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(602, $this->getCurrentQueryCount());
+        $this->assertQueryCount(602);
     }
 
     public function testQueryEntityWithCache(): void
@@ -100,7 +100,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
         $this->queryEntity($this->_em, __FUNCTION__);
 
-        self::assertEquals(503, $this->getCurrentQueryCount());
+        $this->assertQueryCount(503);
     }
 
     private function queryEntity(EntityManagerInterface $em, string $label): void

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -26,6 +26,7 @@ use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\EventListener\CacheMetadataListener;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Constraint\Count;
 use PHPUnit\Framework\Warning;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
@@ -37,7 +38,6 @@ use function array_pop;
 use function array_reverse;
 use function array_slice;
 use function assert;
-use function count;
 use function explode;
 use function get_debug_type;
 use function getenv;
@@ -356,7 +356,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         $platform = $conn->getDatabasePlatform();
 
         if ($this->isQueryLogAvailable()) {
-            $this->disableQueryLog();
+            $this->getQueryLog()->reset();
         }
 
         if (isset($this->_usedModelSets['cms'])) {
@@ -695,7 +695,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $this->_schemaTool->createSchema($classes);
         }
 
-        $this->enableQueryLog();
+        $this->getQueryLog()->enable();
     }
 
     /**
@@ -818,7 +818,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             throw $e;
         }
 
-        if ($this->isQueryLogAvailable() && $this->getCurrentQueryCount() > 0) {
+        if ($this->isQueryLogAvailable() && $this->getQueryLog()->queries !== []) {
             $queries       = '';
             $last25queries = array_slice(array_reverse($this->getQueryLog()->queries, true), 0, 25, true);
             foreach ($last25queries as $i => $query) {
@@ -875,16 +875,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         return $this->_em->getConnection() instanceof DbalExtensions\Connection;
     }
 
-    final protected function enableQueryLog(): void
-    {
-        $this->getQueryLog()->enabled = true;
-    }
-
-    final protected function disableQueryLog(): void
-    {
-        $this->getQueryLog()->enabled = false;
-    }
-
     final protected function getQueryLog(): QueryLog
     {
         $connection = $this->_em->getConnection();
@@ -899,12 +889,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         return $connection->queryLog;
     }
 
-    /**
-     * Using the SQL Logger Stack this method retrieves the current query count executed in this test.
-     */
-    final protected function getCurrentQueryCount(): int
+    final protected function assertQueryCount(int $expectedCount, string $message = ''): void
     {
-        return count($this->getQueryLog()->queries);
+        self::assertThat($this->getQueryLog()->queries, new Count($expectedCount), $message);
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new assertion `assertQueryCount()` to make it easier in tests to check how many queries have ben submitted to the database.