### PR TITLE
Ignore PHPUnit result cache everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ vendor/
 /tests/Doctrine/Performance/history.db
 /.phpcs-cache
 composer.lock
-/.phpunit.result.cache
+.phpunit.result.cache
 /*.phpunit.xml


### PR DESCRIPTION
See the discussion on https://github.com/doctrine/dbal/pull/4876#discussion_r730230775

If I run PHPUnit with one of the configuration files in ci/github/phpunit, PHPUnit will place its cache there and not in the root directory. This is why I'd like to ignore this file everywhere.