### PR TITLE
Comparison when using false value has an error

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -445,4 +445,13 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         
         $this->assertEquals(0, $andExpr->count());
     }
+
+    public function testComparisonBooleans()
+    {
+        $comparison = new Expr\Comparison('foo',Expr\Comparison::EQ, true);
+        $this->assertSame('foo = 1', (string)$comparison);
+
+        $comparison = new Expr\Comparison('foo',Expr\Comparison::EQ, false);
+        $this->assertSame('foo = 0', (string)$comparison);
+    }
 }


### PR DESCRIPTION
We had a project where we had the following:

```
    public function setDuplicate(int $id, bool $value): void
    {
        $this->_em
            ->createQueryBuilder()
            ->update(PotentialClient::class, 'w')
            ->set('w.duplicate', $value)
            ->where('w.id = :wId')
            ->setParameter('wId', $id)
            ->getQuery()
            ->execute();
    }
```
When called and setting $value to true, everything worked. When setting it to false, we get an exception from the DB because the statement ends up being `w.duplicate = WHERE...` I traced this to the __toString on the Comparision.php class.

This test causes that to be detected and fail. No fix offered as I wasn't sure what way that should be fixed, but I don't mind also including the fix if anyone here has suggestions on how to implement it.

I should point out that we 'fixed' this in our code by doing `(int)$value` when passing it to the `->set('w.duplicate', $value)` call.
