### PR TITLE
Public readonly properties are unset in Proxy's constructor

### DIFF
--- a/tests/Doctrine/Tests/Models/ReadonlyProperties/SimpleBook.php
+++ b/tests/Doctrine/Tests/Models/ReadonlyProperties/SimpleBook.php
@@ -19,7 +19,7 @@ class SimpleBook
     private readonly int $id;
 
     #[Column]
-    private readonly string $title;
+    public readonly string $title;
 
     #[ManyToOne, JoinColumn(nullable: false)]
     private readonly Author $author;

--- a/tests/Doctrine/Tests/ORM/Functional/ReadonlyPropertiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadonlyPropertiesTest.php
@@ -108,4 +108,22 @@ class ReadonlyPropertiesTest extends OrmFunctionalTestCase
         self::assertEquals($bookId, $book->getId());
         self::assertSame('Jane Austen', $book->getAuthors()[0]->getName());
     }
+
+    public function testEntityProxy(): void
+    {
+        $connection = $this->_em->getConnection();
+
+        $connection->insert('author', ['name' => 'Jane Austen']);
+        $authorId = $connection->lastInsertId();
+
+        $connection->insert('simple_book', ['title' => 'Pride and Prejudice', 'author_id' => $authorId]);
+        $bookId = $connection->lastInsertId();
+
+        $proxyBook = $this->_em->getReference(SimpleBook::class, $bookId);
+
+        self::assertSame('Pride and Prejudice', $proxyBook->title);
+        self::assertEquals($bookId, $proxyBook->getId());
+        self::assertSame('Jane Austen', $proxyBook->getAuthor()->getName());
+    }
+
 }


### PR DESCRIPTION
### Failing Test


|    Q        |   A
|------------ | ------
| BC Break    | no
| Version     | 2.11.0

- #9432
- https://github.com/doctrine/common/issues/954

#### Summary

Public readonly properties are unset in Proxy's constructor, which results in error.

#### Current behavior

<!-- What is the current (buggy) behavior? -->

`Cannot unset readonly property \Entity\SimpleBook::$title from scope Proxies\__CG__\Entity\SimpleBook`

#### How to reproduce

<!--
Provide steps to reproduce the bug.
If possible, also add a code snippet with relevant configuration, entity mappings, DQL etc.
Adding a failing Unit or Functional Test would help us a lot - you can submit one in a Pull Request separately, referencing this bug report.
-->

```php
#[Entity, Table]
class SimpleBook
{
    #[Column, Id, GeneratedValue]
    private readonly int $id;

    #[Column]
    public readonly string $title;

    #[ManyToOne, JoinColumn(nullable: false)]
    private readonly Author $author;

    public function getId(): int
    {
        return $this->id;
    }

    public function getTitle(): string
    {
        return $this->title;
    }

    public function getAuthor(): Author
    {
        return $this->author;
    }
}

class SimpleBook extends \Entity\SimpleBook implements \Doctrine\ORM\Proxy\Proxy
{
    // ...

    public function __construct(?\Closure $initializer = null, ?\Closure $cloner = null)
    {
        unset($this->title);

        $this->__initializer__ = $initializer;
        $this->__cloner__      = $cloner;
    }
}
```

#### Expected behavior

<!-- What was the expected (correct) behavior? -->

#### Code that generates Proxy's constructor

I dug into ProxyGenerator and here is generation of these unsets:

- https://github.com/doctrine/common/blob/3.2.x/lib/Doctrine/Common/Proxy/ProxyGenerator.php#L979

`public readonly ` properties are not tested as I see in tests.

- https://github.com/doctrine/common/blob/3.2.x/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php#L481