### PR TITLE
Adapt test logic to PHP and SQLite II

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -312,8 +312,18 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         self::assertArrayHasKey('now', $result);
         self::assertArrayHasKey('add', $result);
 
+        $now       = new DateTimeImmutable($result['now']);
+        $inOneUnit = $now->modify(sprintf('+%d %s', $amount, $unit));
+        if (
+            $unit === 'month'
+            && $inOneUnit->format('m') === $now->modify('+2 month')->format('m')
+            && ! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform
+        ) {
+            $inOneUnit = new DateTimeImmutable('last day of next month');
+        }
+
         self::assertEqualsWithDelta(
-            (new DateTimeImmutable($result['now']))->modify(sprintf('+%d %s', $amount, $unit)),
+            $inOneUnit,
             new DateTimeImmutable($result['add']),
             $delta
         );


### PR DESCRIPTION
In a88242ee6ceb1dc8477b715c20b2f2f5e4fdfa28 (#8573), `testDateSub()` was modified
in order to satisfy different opinions to the question "What is now
minus one month", that has different answers for different pieces of
software on March 30th.

Today, we are January 30th, we need to do the same for `testDateAdd()`.
Hopefully this is the last time we hear about this.

The issue can be observed in https://github.com/doctrine/orm/runs/4995873474?check_suite_focus=true