### PR TITLE
Introduce `DoctrineSetup` as a replacement for `Setup`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
-          extensions: "pdo, pdo_sqlite"
+          extensions: "apcu, pdo, pdo_sqlite"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade to 2.12
 
+## Deprecate `Doctrine\ORM\Configuration::newDefaultAnnotationDriver`
+
+This functionality has been moved to the new `DoctrineSetup` class. Call
+`Doctrine\ORM\Tools\DoctrineSetup::createDefaultAnnotationDriver()` to create
+a new annotation driver.
+
+## Deprecate `Doctrine\ORM\Tools\Setup`
+
+In our effort to migrate from Doctrine Cache to PSR-6, the `Setup` class which
+accepted a Doctrine Cache instance in each method has been deprecated.
+
+The replacement is `Doctrine\ORM\Tools\DoctrineSetup` which accepts a PSR-6
+cache instead.
+
 ## Deprecate `Doctrine\ORM\Cache\MultiGetRegion`
 
 The interface will be merged with `Doctrine\ORM\Cache\Region` in 3.0.

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -37,6 +37,7 @@ use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\ObjectRepository;
 use Psr\Cache\CacheItemPoolInterface;
@@ -154,6 +155,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Adds a new default annotation driver with a correctly configured annotation reader. If $useSimpleAnnotationReader
      * is true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
+     * @deprecated Use {@see DoctrineSetup::createDefaultAnnotationDriver()} instead.
+     *
      * @param string|string[] $paths
      * @param bool            $useSimpleAnnotationReader
      * @psalm-param string|list<string> $paths
@@ -162,6 +165,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function newDefaultAnnotationDriver($paths = [], $useSimpleAnnotationReader = true)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9443',
+            '%s is deprecated, call %s::createDefaultAnnotationDriver() instead.',
+            __METHOD__,
+            DoctrineSetup::class
+        );
+
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
         if ($useSimpleAnnotationReader) {

--- a/lib/Doctrine/ORM/Tools/DoctrineSetup.php
+++ b/lib/Doctrine/ORM/Tools/DoctrineSetup.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
+use Doctrine\Deprecations\Deprecation;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Memcached;
+use Psr\Cache\CacheItemPoolInterface;
+use Redis;
+use RuntimeException;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+use function class_exists;
+use function extension_loaded;
+use function md5;
+use function sys_get_temp_dir;
+
+final class DoctrineSetup
+{
+    /**
+     * Creates a configuration with an annotation metadata driver.
+     *
+     * @param string[] $paths
+     */
+    public static function createAnnotationMetadataConfiguration(
+        array $paths,
+        bool $isDevMode = false,
+        ?string $proxyDir = null,
+        ?CacheItemPoolInterface $cache = null
+    ): Configuration {
+        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(self::createDefaultAnnotationDriver($paths));
+
+        return $config;
+    }
+
+    /**
+     * Adds a new default annotation driver with a correctly configured annotation reader.
+     *
+     * @param string[] $paths
+     */
+    public static function createDefaultAnnotationDriver(
+        array $paths = [],
+        ?CacheItemPoolInterface $cache = null
+    ): AnnotationDriver {
+        $reader = new AnnotationReader();
+
+        if ($cache === null && class_exists(ArrayAdapter::class)) {
+            $cache = new ArrayAdapter();
+        }
+
+        if ($cache !== null) {
+            $reader = new PsrCachedReader($reader, $cache);
+        }
+
+        return new AnnotationDriver($reader, $paths);
+    }
+
+    /**
+     * Creates a configuration with an attribute metadata driver.
+     *
+     * @param string[] $paths
+     */
+    public static function createAttributeMetadataConfiguration(
+        array $paths,
+        bool $isDevMode = false,
+        ?string $proxyDir = null,
+        ?CacheItemPoolInterface $cache = null
+    ): Configuration {
+        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(new AttributeDriver($paths));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration with an XML metadata driver.
+     *
+     * @param string[] $paths
+     */
+    public static function createXMLMetadataConfiguration(
+        array $paths,
+        bool $isDevMode = false,
+        ?string $proxyDir = null,
+        ?CacheItemPoolInterface $cache = null
+    ): Configuration {
+        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(new XmlDriver($paths));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration with a YAML metadata driver.
+     *
+     * @deprecated YAML metadata mapping is deprecated and will be removed in 3.0
+     *
+     * @param string[] $paths
+     */
+    public static function createYAMLMetadataConfiguration(
+        array $paths,
+        bool $isDevMode = false,
+        ?string $proxyDir = null,
+        ?CacheItemPoolInterface $cache = null
+    ): Configuration {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/8465',
+            'YAML mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to attribute or XML driver.'
+        );
+
+        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(new YamlDriver($paths));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration without a metadata driver.
+     */
+    public static function createConfiguration(
+        bool $isDevMode = false,
+        ?string $proxyDir = null,
+        ?CacheItemPoolInterface $cache = null
+    ): Configuration {
+        $proxyDir = $proxyDir ?: sys_get_temp_dir();
+
+        $cache = self::createCacheInstance($isDevMode, $proxyDir, $cache);
+
+        $config = new Configuration();
+
+        $config->setMetadataCache($cache);
+        $config->setQueryCache($cache);
+        $config->setResultCache($cache);
+        $config->setProxyDir($proxyDir);
+        $config->setProxyNamespace('DoctrineProxies');
+        $config->setAutoGenerateProxyClasses($isDevMode);
+
+        return $config;
+    }
+
+    private static function createCacheInstance(
+        bool $isDevMode,
+        string $proxyDir,
+        ?CacheItemPoolInterface $cache
+    ): CacheItemPoolInterface {
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        if (! class_exists(ArrayAdapter::class)) {
+            throw new RuntimeException(
+                'The Doctrine setup tool cannot configure caches without symfony/cache.'
+                . ' Please add symfony/cache as explicit dependency or pass your own cache implementation.'
+            );
+        }
+
+        if ($isDevMode) {
+            return new ArrayAdapter();
+        }
+
+        $namespace = 'dc2_' . md5($proxyDir);
+
+        if (extension_loaded('apcu')) {
+            return new ApcuAdapter($namespace);
+        }
+
+        if (extension_loaded('memcached')) {
+            $memcached = new Memcached();
+            $memcached->addServer('127.0.0.1', 11211);
+
+            return new MemcachedAdapter($memcached, $namespace);
+        }
+
+        if (extension_loaded('redis')) {
+            $redis = new Redis();
+            $redis->connect('127.0.0.1');
+
+            return new RedisAdapter($redis, $namespace);
+        }
+
+        return new ArrayAdapter();
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -33,6 +33,8 @@ use function sys_get_temp_dir;
 
 /**
  * Convenience class for setting up Doctrine from different installations and configurations.
+ *
+ * @deprecated Use {@see DoctrineSetup} instead.
  */
 class Setup
 {
@@ -62,15 +64,23 @@ class Setup
     /**
      * Creates a configuration with an annotation metadata driver.
      *
-     * @param mixed[] $paths
-     * @param bool    $isDevMode
-     * @param string  $proxyDir
-     * @param bool    $useSimpleAnnotationReader
+     * @param string[]    $paths
+     * @param bool        $isDevMode
+     * @param string|null $proxyDir
+     * @param bool        $useSimpleAnnotationReader
      *
      * @return Configuration
      */
     public static function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, ?Cache $cache = null, $useSimpleAnnotationReader = true)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9443',
+            '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
+            self::class,
+            DoctrineSetup::class
+        );
+
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths, $useSimpleAnnotationReader));
 
@@ -80,9 +90,9 @@ class Setup
     /**
      * Creates a configuration with an attribute metadata driver.
      *
-     * @param mixed[] $paths
-     * @param bool    $isDevMode
-     * @param string  $proxyDir
+     * @param string[]    $paths
+     * @param bool        $isDevMode
+     * @param string|null $proxyDir
      */
     public static function createAttributeMetadataConfiguration(
         array $paths,
@@ -90,6 +100,14 @@ class Setup
         $proxyDir = null,
         ?Cache $cache = null
     ): Configuration {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9443',
+            '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
+            self::class,
+            DoctrineSetup::class
+        );
+
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new AttributeDriver($paths));
 
@@ -97,16 +115,24 @@ class Setup
     }
 
     /**
-     * Creates a configuration with a xml metadata driver.
+     * Creates a configuration with an XML metadata driver.
      *
-     * @param mixed[] $paths
-     * @param bool    $isDevMode
-     * @param string  $proxyDir
+     * @param string[]    $paths
+     * @param bool        $isDevMode
+     * @param string|null $proxyDir
      *
      * @return Configuration
      */
     public static function createXMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, ?Cache $cache = null)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9443',
+            '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
+            self::class,
+            DoctrineSetup::class
+        );
+
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new XmlDriver($paths));
 
@@ -114,13 +140,13 @@ class Setup
     }
 
     /**
-     * Creates a configuration with a yaml metadata driver.
+     * Creates a configuration with a YAML metadata driver.
      *
      * @deprecated YAML metadata mapping is deprecated and will be removed in 3.0
      *
-     * @param mixed[] $paths
-     * @param bool    $isDevMode
-     * @param string  $proxyDir
+     * @param string[]    $paths
+     * @param bool        $isDevMode
+     * @param string|null $proxyDir
      *
      * @return Configuration
      */
@@ -141,13 +167,21 @@ class Setup
     /**
      * Creates a configuration without a metadata driver.
      *
-     * @param bool   $isDevMode
-     * @param string $proxyDir
+     * @param bool        $isDevMode
+     * @param string|null $proxyDir
      *
      * @return Configuration
      */
     public static function createConfiguration($isDevMode = false, $proxyDir = null, ?Cache $cache = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9443',
+            '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
+            self::class,
+            DoctrineSetup::class
+        );
+
         $proxyDir = $proxyDir ?: sys_get_temp_dir();
 
         $cache = self::createCacheConfiguration($isDevMode, $proxyDir, $cache);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -992,10 +992,6 @@
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php">
-    <DeprecatedClass occurrences="2">
-      <code>YamlDriver</code>
-      <code>parent::__construct($locator, $fileExtension)</code>
-    </DeprecatedClass>
     <MissingParamType occurrences="2">
       <code>$fileExtension</code>
       <code>$prefixes</code>
@@ -3437,10 +3433,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Setup.php">
-    <DeprecatedClass occurrences="3">
+    <DeprecatedClass occurrences="2">
       <code>new ClassLoader('Doctrine', $directory)</code>
       <code>new ClassLoader('Symfony\Component', $directory . '/Doctrine')</code>
-      <code>new YamlDriver($paths)</code>
     </DeprecatedClass>
     <UnresolvableInclude occurrences="1">
       <code>require_once $directory . '/Doctrine/Common/ClassLoader.php'</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,6 +25,7 @@
                 <!-- The exception is thrown by a deprecated method. -->
                 <referencedClass name="Doctrine\ORM\Cache\Exception\InvalidResultCacheDriver"/>
                 <!-- Remove on 3.0.x -->
+                <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand"/>
@@ -51,6 +52,7 @@
                 <!-- Remove on 3.0.x -->
                 <referencedMethod name="Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateRow"/>
                 <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
+                <referencedMethod name="Doctrine\ORM\Configuration::newDefaultAnnotationDriver"/>
                 <referencedMethod name="Doctrine\ORM\Id\AbstractIdGenerator::generate"/>
             </errorLevel>
         </DeprecatedMethod>

--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\ProxyFactory;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Mocks\DriverResultMock;
 
@@ -28,10 +29,10 @@ final class EntityManagerFactory
         $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
+        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
             realpath(__DIR__ . '/Models/GeoNames'),
-        ], true));
+        ]));
 
         $entityManager = EntityManager::create(
             [
@@ -54,11 +55,11 @@ final class EntityManagerFactory
         $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
+        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
             realpath(__DIR__ . '/Models/Generic'),
             realpath(__DIR__ . '/Models/GeoNames'),
-        ], true));
+        ]));
 
         // A connection that doesn't really do anything
         $connection = new class ([], new Driver(), null, new EventManager()) extends Connection

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Proxy\ProxyFactory;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\UnitOfWork;
 
 /**
@@ -60,7 +61,7 @@ class EntityManagerMock extends EntityManager
             $config = new Configuration();
             $config->setProxyDir(__DIR__ . '/../Proxies');
             $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], false));
+            $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver());
         }
 
         if ($eventManager === null) {

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use GearmanWorker;
 use InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -118,7 +119,7 @@ class LockAgentWorker
         $config->setProxyNamespace('MyProject\Proxies');
         $config->setAutoGenerateProxyClasses(true);
 
-        $annotDriver = $config->newDefaultAnnotationDriver([__DIR__ . '/../../../Models/'], false);
+        $annotDriver = DoctrineSetup::createDefaultAnnotationDriver([__DIR__ . '/../../../Models/']);
         $config->setMetadataDriverImpl($annotDriver);
         $config->setMetadataCache(new ArrayAdapter());
 

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\DbalExtensions\Connection;
 use Doctrine\Tests\DbalExtensions\QueryLog;
@@ -240,9 +241,8 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         $config->setProxyDir(realpath(__DIR__ . '/../../Proxies'));
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
-            [realpath(__DIR__ . '/../../Models/Cache')],
-            false
+        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver(
+            [realpath(__DIR__ . '/../../Models/Cache')]
         ));
 
         // always runs on sqlite to prevent multi-connection race-conditions with the test suite

--- a/tests/Doctrine/Tests/ORM/Tools/DoctrineSetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/DoctrineSetupTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping as AnnotationNamespace;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\ORM\Tools\DoctrineSetup;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function sys_get_temp_dir;
+
+class DoctrineSetupTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testAnnotationConfiguration(): void
+    {
+        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
+        self::assertEquals('DoctrineProxies', $config->getProxyNamespace());
+        self::assertInstanceOf(AnnotationDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    public function testNewDefaultAnnotationDriver(): void
+    {
+        $paths           = [__DIR__];
+        $reflectionClass = new ReflectionClass(AnnotatedDummy::class);
+
+        $annotationDriver = DoctrineSetup::createDefaultAnnotationDriver($paths);
+        $reader           = $annotationDriver->getReader();
+        $annotation       = $reader->getMethodAnnotation(
+            $reflectionClass->getMethod('namespacedAnnotationMethod'),
+            AnnotationNamespace\PrePersist::class
+        );
+        self::assertInstanceOf(AnnotationNamespace\PrePersist::class, $annotation);
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testAttributeConfiguration(): void
+    {
+        $config = DoctrineSetup::createAttributeMetadataConfiguration([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
+        self::assertEquals('DoctrineProxies', $config->getProxyNamespace());
+        self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    public function testXMLConfiguration(): void
+    {
+        $config = DoctrineSetup::createXMLMetadataConfiguration([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertInstanceOf(XmlDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    public function testYAMLConfiguration(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8465');
+        $config = DoctrineSetup::createYAMLMetadataConfiguration([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertInstanceOf(YamlDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    /**
+     * @requires extension apcu
+     */
+    public function testCacheNamespaceShouldBeGeneratedForApcu(): void
+    {
+        $config = DoctrineSetup::createConfiguration(false, '/foo');
+        $cache  = $config->getMetadataCache();
+
+        $namespaceProperty = new ReflectionProperty(AbstractAdapter::class, 'namespace');
+        $namespaceProperty->setAccessible(true);
+
+        self::assertInstanceOf(ApcuAdapter::class, $cache);
+        self::assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf:', $namespaceProperty->getValue($cache));
+    }
+
+    /**
+     * @group DDC-1350
+     */
+    public function testConfigureProxyDir(): void
+    {
+        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true, '/foo');
+        self::assertEquals('/foo', $config->getProxyDir());
+    }
+
+    /**
+     * @group DDC-1350
+     */
+    public function testConfigureCache(): void
+    {
+        $cache  = new ArrayAdapter();
+        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true, null, $cache);
+
+        self::assertSame($cache, $config->getResultCache());
+        self::assertSame($cache, $config->getResultCacheImpl()->getPool());
+        self::assertSame($cache, $config->getQueryCache());
+        self::assertSame($cache, $config->getQueryCacheImpl()->getPool());
+        self::assertSame($cache, $config->getMetadataCache());
+        self::assertSame($cache, $config->getMetadataCacheImpl()->getPool());
+    }
+
+    /**
+     * @group DDC-3190
+     */
+    public function testConfigureCacheCustomInstance(): void
+    {
+        $cache  = new ArrayAdapter();
+        $config = DoctrineSetup::createConfiguration(true, null, $cache);
+
+        self::assertSame($cache, $config->getResultCache());
+        self::assertSame($cache, $config->getResultCacheImpl()->getPool());
+        self::assertSame($cache, $config->getQueryCache());
+        self::assertSame($cache, $config->getQueryCacheImpl()->getPool());
+        self::assertSame($cache, $config->getMetadataCache());
+        self::assertSame($cache, $config->getMetadataCacheImpl()->getPool());
+    }
+}
+
+class AnnotatedDummy
+{
+    /** @AnnotationNamespace\PrePersist */
+    public function namespacedAnnotationMethod(): void
+    {
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\ORM\Tools\Setup;
-use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function count;
@@ -21,7 +21,7 @@ use function spl_autoload_functions;
 use function spl_autoload_unregister;
 use function sys_get_temp_dir;
 
-class SetupTest extends OrmTestCase
+class SetupTest extends TestCase
 {
     /** @var int */
     private $originalAutoloaderCount;

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\DbalExtensions\QueryLog;
@@ -763,13 +764,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         $config->setMetadataDriverImpl(
-            $mappingDriver ?? $config->newDefaultAnnotationDriver(
-                [
-                    realpath(__DIR__ . '/Models/Cache'),
-                    realpath(__DIR__ . '/Models/GeoNames'),
-                ],
-                false
-            )
+            $mappingDriver ?? DoctrineSetup::createDefaultAnnotationDriver([
+                realpath(__DIR__ . '/Models/Cache'),
+                realpath(__DIR__ . '/Models/GeoNames'),
+            ])
         );
 
         $conn = $connection ?: static::$sharedConn;

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -87,16 +88,12 @@ abstract class OrmTestCase extends DoctrineTestCase
         $config = new Configuration();
 
         $config->setMetadataCache($metadataCache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], false));
         $config->setQueryCache(self::getSharedQueryCache());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
-            [
-                realpath(__DIR__ . '/Models/Cache'),
-            ],
-            false
-        ));
+        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
+            realpath(__DIR__ . '/Models/Cache'),
+        ]));
 
         if ($this->isSecondLevelCacheEnabled) {
             $cacheConfig = new CacheConfiguration();


### PR DESCRIPTION
The `Setup` class is a collection of static methods for bootstrapping a ORM configuration with recommended settings. At least that's my understanding of that class. In applications where the ORM is configured through some kind of framework integration (like DoctrineBundle), that class is more or less irrelevant.

The `Setup` class as of today operates on Doctrine Cache instances. Since the whole ORM is now able to operate on PSR-6 we should do something about it. Unfortunately, since the `Setup` class is not final, altering all method signatures is quite difficult, so I decided to deprecate the whole class and add a new class named `DoctrineSetup` as replacement.

Key differences between the two setup classes:

* The new class is declared `final` which should make future changes to that class easier.
* It accepts PSR-6 caches instead of Doctrine Cache instances.
* If no cache is passed and Symfony Cache is installed, a suitible cache adapter is configured, just like the old class did for Doctrine Cache.
* The `useSimpleAnnotationReader` flag is not supported anymore.

Furthermore, I decided to move the `newDefaultAnnotationDriver()` method from the `Configuration` class to the new `DoctrineSetup` class. That method does not really mutate the configuration, it is a simple factory for the annotation driver. `DoctrineSetup` feels like the better place for it.