### PR TITLE
Remove trailing underscore

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -13,7 +13,7 @@ as you want, or just pick a preferred one.
 
     The ``QueryBuilder`` is not an abstraction of DQL, but merely a tool to dynamically build it.
     You should still use plain DQL when you can, as it is simpler and more readable.
-    More about this in the :doc:`FAQ <faq>`_.
+    More about this in the :doc:`FAQ <faq>`.
 
 Constructing a new QueryBuilder object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It looks like there was confusion between the syntax for external links
and the syntax for internal links, which does not mention underscores.
See https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-doc
versus https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links

Interestingly, this results in a hash appearing in [the output](https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/reference/query-builder.html):

> The QueryBuilder is not an abstraction of DQL, but merely a tool to dynamically build it. You should still use plain DQL when you can, as it is simpler and more readable. More about this in the 6a65a9cd6e154865b12b14432ad25e61f9709367.



Cc @kuraobi