### PR TITLE
Streamline cache creation in tests

### DIFF
--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests;
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -61,9 +60,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     /**
      * The metadata cache shared between all functional tests.
      *
-     * @var Cache|CacheItemPoolInterface|null
+     * @var CacheItemPoolInterface|null
      */
-    private static $_metadataCache = null;
+    private static $metadataCache = null;
 
     /**
      * The query cache shared between all functional tests.
@@ -711,12 +710,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         // NOTE: Functional tests use their own shared metadata cache, because
         // the actual database platform used during execution has effect on some
         // metadata mapping behaviors (like the choice of the ID generation).
-        if (self::$_metadataCache === null) {
-            if (isset($GLOBALS['DOCTRINE_CACHE_IMPL'])) {
-                self::$_metadataCache = new $GLOBALS['DOCTRINE_CACHE_IMPL']();
-            } else {
-                self::$_metadataCache = new ArrayAdapter();
-            }
+        if (self::$metadataCache === null) {
+            self::$metadataCache = new ArrayAdapter();
         }
 
         if (self::$queryCache === null) {
@@ -726,12 +721,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         //FIXME: two different configs! $conn and the created entity manager have
         // different configs.
         $config = new Configuration();
-        if (self::$_metadataCache instanceof CacheItemPoolInterface) {
-            $config->setMetadataCache(self::$_metadataCache);
-        } else {
-            $config->setMetadataCacheImpl(self::$_metadataCache);
-        }
-
+        $config->setMetadataCache(self::$metadataCache);
         $config->setQueryCache(self::$queryCache);
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -32,7 +32,7 @@ abstract class OrmTestCase extends DoctrineTestCase
      *
      * @var CacheItemPoolInterface|null
      */
-    private static $_metadataCache = null;
+    private static $metadataCache = null;
 
     /**
      * The query cache that is shared between all ORM tests (except functional tests).
@@ -54,7 +54,7 @@ abstract class OrmTestCase extends DoctrineTestCase
     protected $secondLevelCacheLogger;
 
     /** @var CacheItemPoolInterface|null */
-    protected $secondLevelCache = null;
+    private $secondLevelCache = null;
 
     protected function createAnnotationDriver(array $paths = []): AnnotationDriver
     {
@@ -125,28 +125,22 @@ abstract class OrmTestCase extends DoctrineTestCase
         return EntityManagerMock::create($conn, $config, $eventManager);
     }
 
-    protected function enableSecondLevelCache($log = true): void
+    protected function enableSecondLevelCache(bool $log = true): void
     {
         $this->isSecondLevelCacheEnabled    = true;
         $this->isSecondLevelCacheLogEnabled = $log;
     }
 
-    private static function getSharedMetadataCacheImpl(): ?CacheItemPoolInterface
+    private static function getSharedMetadataCacheImpl(): CacheItemPoolInterface
     {
-        if (self::$_metadataCache === null) {
-            self::$_metadataCache = new ArrayAdapter();
-        }
-
-        return self::$_metadataCache;
+        return self::$metadataCache
+            ?? self::$metadataCache = new ArrayAdapter();
     }
 
     private static function getSharedQueryCache(): CacheItemPoolInterface
     {
-        if (self::$queryCache === null) {
-            self::$queryCache = new ArrayAdapter();
-        }
-
-        return self::$queryCache;
+        return self::$queryCache
+            ?? self::$queryCache = new ArrayAdapter();
     }
 
     protected function getSharedSecondLevelCache(): CacheItemPoolInterface


### PR DESCRIPTION
In our functional tests, we evaluate a global variable `DOCTRINE_CACHE_IMPL` which allows us to change the Doctrine Cache implementation of the metadata cache. I am not aware that we use that feature anywhere in the CI. Also, when migrating away from Doctrine Cache, we would need to revamp that "feature".

This is why I'd like to remove that feature entirely.

Additionally, since we lazily create multiple caches in our test suite, I wanted to make sure we always do it the same way.