### PR TITLE
Check requirements for metadata drivers

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -39,11 +39,13 @@ use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\ObjectRepository;
+use LogicException;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 
 use function class_exists;
 use function method_exists;
+use function sprintf;
 use function strtolower;
 use function trim;
 
@@ -162,6 +164,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function newDefaultAnnotationDriver($paths = [], $useSimpleAnnotationReader = true)
     {
+        if (! class_exists(AnnotationReader::class)) {
+            throw new LogicException(sprintf(
+                'The annotation metadata driver cannot be enabled because the "doctrine/annotations" library'
+                . ' is not installed. Please run "composer require doctrine/annotations" or choose a different'
+                . ' metadata driver.'
+            ));
+        }
+
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
         if ($useSimpleAnnotationReader) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
+use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -20,6 +21,9 @@ use function class_exists;
 use function constant;
 use function defined;
 use function get_class;
+use function sprintf;
+
+use const PHP_VERSION_ID;
 
 class AttributeDriver extends AnnotationDriver
 {
@@ -35,6 +39,13 @@ class AttributeDriver extends AnnotationDriver
      */
     public function __construct(array $paths)
     {
+        if (PHP_VERSION_ID < 80000) {
+            throw new LogicException(sprintf(
+                'The attribute metadata driver cannot be enabled on PHP 7. Please upgrade to PHP 8 or choose a different'
+                . ' metadata driver.'
+            ));
+        }
+
         parent::__construct(new AttributeReader(), $paths);
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use InvalidArgumentException;
+use LogicException;
 use SimpleXMLElement;
 
 use function assert;
@@ -18,6 +19,7 @@ use function constant;
 use function count;
 use function defined;
 use function explode;
+use function extension_loaded;
 use function file_get_contents;
 use function in_array;
 use function simplexml_load_string;
@@ -39,6 +41,13 @@ class XmlDriver extends FileDriver
      */
     public function __construct($locator, $fileExtension = self::DEFAULT_FILE_EXTENSION)
     {
+        if (! extension_loaded('simplexml')) {
+            throw new LogicException(sprintf(
+                'The XML metadata driver cannot be enabled because the SimpleXML PHP extension is missing.'
+                . ' Please configure PHP with SimpleXML or choose a different metadata driver.'
+            ));
+        }
+
         parent::__construct($locator, $fileExtension);
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -11,9 +11,11 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use InvalidArgumentException;
+use LogicException;
 use Symfony\Component\Yaml\Yaml;
 
 use function array_map;
+use function class_exists;
 use function constant;
 use function defined;
 use function explode;
@@ -44,6 +46,14 @@ class YamlDriver extends FileDriver
             'https://github.com/doctrine/orm/issues/8465',
             'YAML mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to attribute or XML driver.'
         );
+
+        if (! class_exists(Yaml::class)) {
+            throw new LogicException(sprintf(
+                'The YAML metadata driver cannot be enabled because the "symfony/yaml" library'
+                . ' is not installed. Please run "composer require symfony/yaml" or choose a different'
+                . ' metadata driver.'
+            ));
+        }
 
         parent::__construct($locator, $fileExtension);
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\Tests\OrmTestCase;
+use LogicException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function count;
@@ -79,6 +80,19 @@ class SetupTest extends OrmTestCase
         self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
         self::assertEquals('DoctrineProxies', $config->getProxyNamespace());
         self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    /**
+     * @requires PHP < 8
+     */
+    public function testAttributeConfigurationFailsOnPHP7(): void
+    {
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage(
+            'The attribute metadata driver cannot be enabled on PHP 7. Please upgrade to PHP 8 or choose a different metadata driver.'
+        );
+
+        Setup::createAttributeMetadataConfiguration([], true);
     }
 
     public function testXMLConfiguration(): void


### PR DESCRIPTION
Fixes #9449, replaces #9416.

Our metadata drivers require additional dependencies. If those are not met, the user receives a cryptic error message instead of a helpful one. Especially regarding Doctrine Annotations, I consider this to be a bug because `doctrine/annotations` used to be a mandatory dependency.

Please review thoroughly. Except for the attribute driver, our current CI setup does not allow me to test code that reacts to the missing dependencies.