### PR TITLE
Support enums in findBy() calls

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Persisters\Entity;
 
+use BackedEnum;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Util\ClassUtils;
@@ -1976,13 +1977,16 @@ class BasicEntityPersister implements EntityPersister
      *
      * @param mixed $value
      *
-     * @return       array<mixed>
      * @psalm-return list<mixed>
      */
-    private function getIndividualValue($value)
+    private function getIndividualValue($value): array
     {
         if (! is_object($value)) {
             return [$value];
+        }
+
+        if ($value instanceof BackedEnum) {
+            return [$value->value];
         }
 
         $valueClass = ClassUtils::getClass($value);

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -58,6 +58,30 @@ class EnumTest extends OrmFunctionalTestCase
         $this->assertEquals(Suit::Clubs, $fetchedCard->suit);
     }
 
+    public function testFindByEnum(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card1       = new Card();
+        $card1->suit = Suit::Clubs;
+        $card2       = new Card();
+        $card2->suit = Suit::Hearts;
+
+        $this->_em->persist($card1);
+        $this->_em->persist($card2);
+        $this->_em->flush();
+
+        unset($card1, $card2);
+        $this->_em->clear();
+
+        /** @var list<Card> $foundCards */
+        $foundCards = $this->_em->getRepository(Card::class)->findBy(['suit' => Suit::Clubs]);
+        $this->assertNotEmpty($foundCards);
+        foreach ($foundCards as $card) {
+            $this->assertSame(Suit::Clubs, $card->suit);
+        }
+    }
+
     /**
      * @param class-string $cardClass
      *


### PR DESCRIPTION
Fixes https://github.com/doctrine/orm/issues/9372#issuecomment-1025628689

This PR allows to use enums in `findBy()` calls:

```PHP
$cardRepository->findBy(['suit' => Suit::Clubs]);
```