### PR TITLE
PDO is not a required extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^7.1 || ^8.0",
         "composer-runtime-api": "^2",
         "ext-ctype": "*",
-        "ext-pdo": "*",
         "doctrine/cache": "^1.12.1 || ^2.1.1",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",


### PR DESCRIPTION
The ORM can be operated with DBAL 3 and a non-PDO database extension like MySQLi. Furthermore, the ORM never interacts directly with PDO, only through the DBAL.

Because of that, I believe the PDO extension should not be a mandatory requirement.