### PR TITLE
Remove useless catches

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
@@ -78,14 +78,8 @@ class OneToManyUnidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->_em->persist($routeA);
         $this->_em->persist($routeB);
 
-        $exceptionThrown = false;
-        try {
-            // exception depending on the underlying Database Driver
-            $this->_em->flush();
-        } catch (Exception $e) {
-            $exceptionThrown = true;
-        }
-
-        self::assertTrue($exceptionThrown, 'The underlying database driver throws an exception.');
+        // exception depending on the underlying Database Driver
+        $this->expectException(Exception::class);
+        $this->_em->flush();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -20,7 +20,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Enums\AccessLevel;
 use Doctrine\Tests\Models\Enums\UserStatus;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function array_values;
 use function class_exists;
@@ -566,11 +565,9 @@ class QueryTest extends OrmFunctionalTestCase
             $query = $this->_em->createQuery('UPDATE CMS:CmsUser u SET u.name = ?1');
             self::assertEquals('UPDATE cms_users SET name = ?', $query->getSQL());
             $query->free();
-        } catch (Exception $e) {
-            self::fail($e->getMessage());
+        } finally {
+            $this->_em->getConfiguration()->setEntityNamespaces([]);
         }
-
-        $this->_em->getConfiguration()->setEntityNamespaces([]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -237,15 +237,9 @@ class DDC117Test extends OrmFunctionalTestCase
         $this->article1->addTranslation('en', 'Bar');
         $this->article1->addTranslation('en', 'Baz');
 
-        $exceptionThrown = false;
-        try {
-            // exception depending on the underlying Database Driver
-            $this->_em->flush();
-        } catch (Exception $e) {
-            $exceptionThrown = true;
-        }
-
-        self::assertTrue($exceptionThrown, 'The underlying database driver throws an exception.');
+        // exception depending on the underlying Database Driver
+        $this->expectException(Exception::class);
+        $this->_em->flush();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
-use Exception;
 
 /**
  * Test case for custom AST walking and adding new joins.
@@ -28,16 +27,12 @@ class CustomTreeWalkersJoinTest extends OrmTestCase
 
     public function assertSqlGeneration(string $dqlToBeTested, string $sqlToBeConfirmed): void
     {
-        try {
-            $query = $this->em->createQuery($dqlToBeTested);
-            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CustomTreeWalkerJoin::class])
-                  ->useQueryCache(false);
+        $query = $this->em->createQuery($dqlToBeTested);
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CustomTreeWalkerJoin::class])
+              ->useQueryCache(false);
 
-            self::assertEquals($sqlToBeConfirmed, $query->getSql());
-            $query->free();
-        } catch (Exception $e) {
-            self::fail($e->getMessage() . ' at "' . $e->getFile() . '" on line ' . $e->getLine());
-        }
+        self::assertEquals($sqlToBeConfirmed, $query->getSql());
+        $query->free();
     }
 
     public function testAddsJoin(): void

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Query\TreeWalker;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
-use Exception;
 
 use function array_merge;
 use function count;
@@ -59,11 +58,7 @@ class CustomTreeWalkersTest extends OrmTestCase
         array $treeWalkers = [],
         ?string $outputWalker = null
     ): void {
-        try {
-            self::assertEquals($sqlToBeConfirmed, $this->generateSql($dqlToBeTested, $treeWalkers, $outputWalker));
-        } catch (Exception $e) {
-            self::fail($e->getMessage() . ' at "' . $e->getFile() . '" on line ' . $e->getLine());
-        }
+        self::assertEquals($sqlToBeConfirmed, $this->generateSql($dqlToBeTested, $treeWalkers, $outputWalker));
     }
 
     public function testSupportsQueriesWithoutWhere(): void

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Tests\OrmTestCase;
-use Exception;
 
 /**
  * Test case for testing the saving and referencing of query identifiers.
@@ -29,13 +28,9 @@ class DeleteSqlGenerationTest extends OrmTestCase
 
     public function assertSqlGeneration(string $dqlToBeTested, string $sqlToBeConfirmed): void
     {
-        try {
-            $query = $this->entityManager->createQuery($dqlToBeTested);
-            parent::assertEquals($sqlToBeConfirmed, $query->getSql());
-            $query->free();
-        } catch (Exception $e) {
-            self::fail($e->getMessage());
-        }
+        $query = $this->entityManager->createQuery($dqlToBeTested);
+        parent::assertEquals($sqlToBeConfirmed, $query->getSql());
+        $query->free();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -57,32 +57,28 @@ class SelectSqlGenerationTest extends OrmTestCase
         array $queryHints = [],
         array $queryParams = []
     ): void {
-        try {
-            $query = $this->entityManager->createQuery($dqlToBeTested);
+        $query = $this->entityManager->createQuery($dqlToBeTested);
 
-            foreach ($queryParams as $name => $value) {
-                $query->setParameter($name, $value);
-            }
-
-            $query->setHint(ORMQuery::HINT_FORCE_PARTIAL_LOAD, true)
-                  ->useQueryCache(false);
-
-            foreach ($queryHints as $name => $value) {
-                $query->setHint($name, $value);
-            }
-
-            $sqlGenerated = $query->getSQL();
-
-            parent::assertEquals(
-                $sqlToBeConfirmed,
-                $sqlGenerated,
-                sprintf('"%s" is not equal to "%s"', $sqlGenerated, $sqlToBeConfirmed)
-            );
-
-            $query->free();
-        } catch (Exception $e) {
-            self::fail($e->getMessage() . "\n" . $e->getTraceAsString());
+        foreach ($queryParams as $name => $value) {
+            $query->setParameter($name, $value);
         }
+
+        $query->setHint(ORMQuery::HINT_FORCE_PARTIAL_LOAD, true)
+              ->useQueryCache(false);
+
+        foreach ($queryHints as $name => $value) {
+            $query->setHint($name, $value);
+        }
+
+        $sqlGenerated = $query->getSQL();
+
+        parent::assertEquals(
+            $sqlToBeConfirmed,
+            $sqlGenerated,
+            sprintf('"%s" is not equal to "%s"', $sqlGenerated, $sqlToBeConfirmed)
+        );
+
+        $query->free();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
 use Doctrine\Tests\OrmTestCase;
-use Exception;
 
 /**
  * Test case for testing the saving and referencing of query identifiers.
@@ -37,13 +36,9 @@ class UpdateSqlGenerationTest extends OrmTestCase
 
     public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed): void
     {
-        try {
-            $query = $this->entityManager->createQuery($dqlToBeTested);
-            parent::assertEquals($sqlToBeConfirmed, $query->getSql());
-            $query->free();
-        } catch (Exception $e) {
-            self::fail($e->getMessage());
-        }
+        $query = $this->entityManager->createQuery($dqlToBeTested);
+        parent::assertEquals($sqlToBeConfirmed, $query->getSql());
+        $query->free();
     }
 
     public function testSupportsQueriesWithoutWhere(): void


### PR DESCRIPTION
Catching arbitrary exceptions in tests just to funnel them to `TestCase::fail()` seems pointless to me. And debugging failing tests when the exceptions stack trace has been destroyed isn't much fun either.