### PR TITLE
Rename `DoctrineSetup` to `ORMSetup`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,8 +7,8 @@ the entity manager.
 
 ## Deprecate `Doctrine\ORM\Configuration::newDefaultAnnotationDriver`
 
-This functionality has been moved to the new `DoctrineSetup` class. Call
-`Doctrine\ORM\Tools\DoctrineSetup::createDefaultAnnotationDriver()` to create
+This functionality has been moved to the new `ORMSetup` class. Call
+`Doctrine\ORM\ORMSetup::createDefaultAnnotationDriver()` to create
 a new annotation driver.
 
 ## Deprecate `Doctrine\ORM\Tools\Setup`
@@ -16,7 +16,7 @@ a new annotation driver.
 In our effort to migrate from Doctrine Cache to PSR-6, the `Setup` class which
 accepted a Doctrine Cache instance in each method has been deprecated.
 
-The replacement is `Doctrine\ORM\Tools\DoctrineSetup` which accepts a PSR-6
+The replacement is `Doctrine\ORM\ORMSetup` which accepts a PSR-6
 cache instead.
 
 ## Deprecate `Doctrine\ORM\Cache\MultiGetRegion`

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -12,7 +12,7 @@ steps of configuration.
 
     use Doctrine\ORM\Configuration;
     use Doctrine\ORM\EntityManager;
-    use Doctrine\ORM\Tools\DoctrineSetup;
+    use Doctrine\ORM\ORMSetup;
     use Symfony\Component\Cache\Adapter\ArrayAdapter;
     use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 
@@ -28,7 +28,7 @@ steps of configuration.
 
     $config = new Configuration;
     $config->setMetadataCache($metadataCache);
-    $driverImpl = DoctrineSetup::createDefaultAnnotationDriver('/path/to/lib/MyProject/Entities');
+    $driverImpl = ORMSetup::createDefaultAnnotationDriver('/path/to/lib/MyProject/Entities');
     $config->setMetadataDriverImpl($driverImpl);
     $config->setQueryCache($queryCache);
     $config->setProxyDir('/path/to/myproject/lib/MyProject/Proxies');
@@ -130,9 +130,9 @@ the ``Doctrine\ORM\Configuration``:
 .. code-block:: php
 
     <?php
-    use Doctrine\ORM\Tools\DoctrineSetup;
+    use Doctrine\ORM\ORMSetup;
 
-    $driverImpl = DoctrineSetup::createDefaultAnnotationDriver('/path/to/lib/MyProject/Entities');
+    $driverImpl = ORMSetup::createDefaultAnnotationDriver('/path/to/lib/MyProject/Entities');
     $config->setMetadataDriverImpl($driverImpl);
 
 The path information to the entities is required for the annotation

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -41,8 +41,8 @@ access point to ORM functionality provided by Doctrine.
     // bootstrap.php
     require_once "vendor/autoload.php";
 
-    use Doctrine\ORM\Tools\DoctrineSetup;
     use Doctrine\ORM\EntityManager;
+    use Doctrine\ORM\ORMSetup;
 
     $paths = array("/path/to/entity-files");
     $isDevMode = false;
@@ -55,12 +55,12 @@ access point to ORM functionality provided by Doctrine.
         'dbname'   => 'foo',
     );
 
-    $config = DoctrineSetup::createAnnotationMetadataConfiguration($paths, $isDevMode);
+    $config = ORMSetup::createAnnotationMetadataConfiguration($paths, $isDevMode);
     $entityManager = EntityManager::create($dbParams, $config);
 
 .. note::
 
-    The ``DoctrineSetup`` class has been introduced with ORM 2.12. It's predecessor ``Setup`` is deprecated and will
+    The ``ORMSetup`` class has been introduced with ORM 2.12. It's predecessor ``Setup`` is deprecated and will
     be removed in version 3.0.
 
 Or if you prefer XML:
@@ -69,7 +69,7 @@ Or if you prefer XML:
 
     <?php
     $paths = array("/path/to/xml-mappings");
-    $config = DoctrineSetup::createXMLMetadataConfiguration($paths, $isDevMode);
+    $config = ORMSetup::createXMLMetadataConfiguration($paths, $isDevMode);
     $entityManager = EntityManager::create($dbParams, $config);
 
 Or if you prefer YAML:
@@ -78,7 +78,7 @@ Or if you prefer YAML:
 
     <?php
     $paths = array("/path/to/yml-mappings");
-    $config = DoctrineSetup::createYAMLMetadataConfiguration($paths, $isDevMode);
+    $config = ORMSetup::createYAMLMetadataConfiguration($paths, $isDevMode);
     $entityManager = EntityManager::create($dbParams, $config);
 
 .. note::
@@ -88,7 +88,7 @@ Or if you prefer YAML:
     
         "symfony/yaml": "*"
 
-Inside the ``DoctrineSetup`` methods several assumptions are made:
+Inside the ``ORMSetup`` methods several assumptions are made:
 
 -  If ``$isDevMode`` is true caching is done in memory with the ``ArrayAdapter``. Proxy objects are recreated on every request.
 -  If ``$isDevMode`` is false, check for Caches in the order APCu, Redis (127.0.0.1:6379), Memcache (127.0.0.1:11211) unless `$cache` is passed as fourth argument.
@@ -97,7 +97,7 @@ Inside the ``DoctrineSetup`` methods several assumptions are made:
 
 .. note::
 
-    In order to have ``DoctrineSetup`` configure the cache automatically, the library ``symfony/cache``
+    In order to have ``ORMSetup`` configure the cache automatically, the library ``symfony/cache``
     has to be installed as a dependency.
 
 If you want to configure Doctrine in more detail, take a look at the :doc:`Advanced Configuration <reference/advanced-configuration>` section.

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -137,8 +137,8 @@ step:
 
     <?php
     // bootstrap.php
-    use Doctrine\ORM\Tools\DoctrineSetup;
     use Doctrine\ORM\EntityManager;
+    use Doctrine\ORM\ORMSetup;
 
     require_once "vendor/autoload.php";
 
@@ -147,10 +147,10 @@ step:
     $proxyDir = null;
     $cache = null;
     $useSimpleAnnotationReader = false;
-    $config = DoctrineSetup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode, $proxyDir, $cache, $useSimpleAnnotationReader);
+    $config = ORMSetup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode, $proxyDir, $cache, $useSimpleAnnotationReader);
     // or if you prefer YAML or XML
-    // $config = DoctrineSetup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
-    // $config = DoctrineSetup::createYAMLMetadataConfiguration(array(__DIR__."/config/yaml"), $isDevMode);
+    // $config = ORMSetup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
+    // $config = ORMSetup::createYAMLMetadataConfiguration(array(__DIR__."/config/yaml"), $isDevMode);
 
     // database configuration parameters
     $conn = array(
@@ -173,7 +173,7 @@ The ``require_once`` statement sets up the class autoloading for Doctrine and
 its dependencies using Composer's autoloader.
 
 The second block consists of the instantiation of the ORM
-``Configuration`` object using the ``DoctrineSetup`` helper. It assumes a bunch
+``Configuration`` object using the ``ORMSetup`` helper. It assumes a bunch
 of defaults that you don't have to bother about for now. You can
 read up on the configuration details in the
 :doc:`reference chapter on configuration <../reference/configuration>`.

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -37,7 +37,6 @@ use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
-use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\ObjectRepository;
 use LogicException;
@@ -157,7 +156,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Adds a new default annotation driver with a correctly configured annotation reader. If $useSimpleAnnotationReader
      * is true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
-     * @deprecated Use {@see DoctrineSetup::createDefaultAnnotationDriver()} instead.
+     * @deprecated Use {@see ORMSetup::createDefaultAnnotationDriver()} instead.
      *
      * @param string|string[] $paths
      * @param bool            $useSimpleAnnotationReader
@@ -172,7 +171,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
             'https://github.com/doctrine/orm/pull/9443',
             '%s is deprecated, call %s::createDefaultAnnotationDriver() instead.',
             __METHOD__,
-            DoctrineSetup::class
+            ORMSetup::class
         );
 
         if (! class_exists(AnnotationReader::class)) {

--- a/lib/Doctrine/ORM/ORMSetup.php
+++ b/lib/Doctrine/ORM/ORMSetup.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\ORM\Tools;
+namespace Doctrine\ORM;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Deprecations\Deprecation;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
@@ -28,7 +27,7 @@ use function md5;
 use function sprintf;
 use function sys_get_temp_dir;
 
-final class DoctrineSetup
+final class ORMSetup
 {
     /**
      * Creates a configuration with an annotation metadata driver.

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\ORM\ORMSetup;
 use Memcached;
 use Redis;
 use RuntimeException;
@@ -34,7 +35,7 @@ use function sys_get_temp_dir;
 /**
  * Convenience class for setting up Doctrine from different installations and configurations.
  *
- * @deprecated Use {@see DoctrineSetup} instead.
+ * @deprecated Use {@see ORMSetup} instead.
  */
 class Setup
 {
@@ -78,7 +79,7 @@ class Setup
             'https://github.com/doctrine/orm/pull/9443',
             '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
             self::class,
-            DoctrineSetup::class
+            ORMSetup::class
         );
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
@@ -105,7 +106,7 @@ class Setup
             'https://github.com/doctrine/orm/pull/9443',
             '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
             self::class,
-            DoctrineSetup::class
+            ORMSetup::class
         );
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
@@ -130,7 +131,7 @@ class Setup
             'https://github.com/doctrine/orm/pull/9443',
             '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
             self::class,
-            DoctrineSetup::class
+            ORMSetup::class
         );
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
@@ -179,7 +180,7 @@ class Setup
             'https://github.com/doctrine/orm/pull/9443',
             '%s is deprecated and will be removed in Doctrine 3.0, please use %s instead.',
             self::class,
-            DoctrineSetup::class
+            ORMSetup::class
         );
 
         $proxyDir = $proxyDir ?: sys_get_temp_dir();

--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -12,8 +12,8 @@ use Doctrine\DBAL\Result;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Mocks\DriverResultMock;
 
@@ -29,7 +29,7 @@ final class EntityManagerFactory
         $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
-        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
+        $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
             realpath(__DIR__ . '/Models/GeoNames'),
         ]));
@@ -55,7 +55,7 @@ final class EntityManagerFactory
         $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
-        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
+        $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
             realpath(__DIR__ . '/Models/Generic'),
             realpath(__DIR__ . '/Models/GeoNames'),

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -7,8 +7,8 @@ namespace Doctrine\Tests\Mocks;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\UnitOfWork;
 
 /**
@@ -61,7 +61,7 @@ class EntityManagerMock extends EntityManager
             $config = new Configuration();
             $config->setProxyDir(__DIR__ . '/../Proxies');
             $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver());
+            $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
         }
 
         if ($eventManager === null) {

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Tools\DoctrineSetup;
+use Doctrine\ORM\ORMSetup;
 use GearmanWorker;
 use InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -119,7 +119,7 @@ class LockAgentWorker
         $config->setProxyNamespace('MyProject\Proxies');
         $config->setAutoGenerateProxyClasses(true);
 
-        $annotDriver = DoctrineSetup::createDefaultAnnotationDriver([__DIR__ . '/../../../Models/']);
+        $annotDriver = ORMSetup::createDefaultAnnotationDriver([__DIR__ . '/../../../Models/']);
         $config->setMetadataDriverImpl($annotDriver);
         $config->setMetadataCache(new ArrayAdapter());
 

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -9,8 +9,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\Proxy;
-use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\DbalExtensions\Connection;
 use Doctrine\Tests\DbalExtensions\QueryLog;
@@ -241,7 +241,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         $config->setProxyDir(realpath(__DIR__ . '/../../Proxies'));
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver(
+        $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver(
             [realpath(__DIR__ . '/../../Models/Cache')]
         ));
 

--- a/tests/Doctrine/Tests/ORM/ORMSetupTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMSetupTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\ORM\Tools;
+namespace Doctrine\Tests\ORM;
 
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Configuration;
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
-use Doctrine\ORM\Tools\DoctrineSetup;
+use Doctrine\ORM\ORMSetup;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -22,13 +22,13 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function sys_get_temp_dir;
 
-class DoctrineSetupTest extends TestCase
+class ORMSetupTest extends TestCase
 {
     use VerifyDeprecations;
 
     public function testAnnotationConfiguration(): void
     {
-        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true);
+        $config = ORMSetup::createAnnotationMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
         self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
@@ -41,7 +41,7 @@ class DoctrineSetupTest extends TestCase
         $paths           = [__DIR__];
         $reflectionClass = new ReflectionClass(AnnotatedDummy::class);
 
-        $annotationDriver = DoctrineSetup::createDefaultAnnotationDriver($paths);
+        $annotationDriver = ORMSetup::createDefaultAnnotationDriver($paths);
         $reader           = $annotationDriver->getReader();
         $annotation       = $reader->getMethodAnnotation(
             $reflectionClass->getMethod('namespacedAnnotationMethod'),
@@ -55,7 +55,7 @@ class DoctrineSetupTest extends TestCase
      */
     public function testAttributeConfiguration(): void
     {
-        $config = DoctrineSetup::createAttributeMetadataConfiguration([], true);
+        $config = ORMSetup::createAttributeMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
         self::assertEquals(sys_get_temp_dir(), $config->getProxyDir());
@@ -73,12 +73,12 @@ class DoctrineSetupTest extends TestCase
             'The attribute metadata driver cannot be enabled on PHP 7. Please upgrade to PHP 8 or choose a different metadata driver.'
         );
 
-        DoctrineSetup::createAttributeMetadataConfiguration([], true);
+        ORMSetup::createAttributeMetadataConfiguration([], true);
     }
 
     public function testXMLConfiguration(): void
     {
-        $config = DoctrineSetup::createXMLMetadataConfiguration([], true);
+        $config = ORMSetup::createXMLMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
         self::assertInstanceOf(XmlDriver::class, $config->getMetadataDriverImpl());
@@ -87,7 +87,7 @@ class DoctrineSetupTest extends TestCase
     public function testYAMLConfiguration(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8465');
-        $config = DoctrineSetup::createYAMLMetadataConfiguration([], true);
+        $config = ORMSetup::createYAMLMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
         self::assertInstanceOf(YamlDriver::class, $config->getMetadataDriverImpl());
@@ -98,7 +98,7 @@ class DoctrineSetupTest extends TestCase
      */
     public function testCacheNamespaceShouldBeGeneratedForApcu(): void
     {
-        $config = DoctrineSetup::createConfiguration(false, '/foo');
+        $config = ORMSetup::createConfiguration(false, '/foo');
         $cache  = $config->getMetadataCache();
 
         $namespaceProperty = new ReflectionProperty(AbstractAdapter::class, 'namespace');
@@ -113,7 +113,7 @@ class DoctrineSetupTest extends TestCase
      */
     public function testConfigureProxyDir(): void
     {
-        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true, '/foo');
+        $config = ORMSetup::createAnnotationMetadataConfiguration([], true, '/foo');
         self::assertEquals('/foo', $config->getProxyDir());
     }
 
@@ -123,7 +123,7 @@ class DoctrineSetupTest extends TestCase
     public function testConfigureCache(): void
     {
         $cache  = new ArrayAdapter();
-        $config = DoctrineSetup::createAnnotationMetadataConfiguration([], true, null, $cache);
+        $config = ORMSetup::createAnnotationMetadataConfiguration([], true, null, $cache);
 
         self::assertSame($cache, $config->getResultCache());
         self::assertSame($cache, $config->getResultCacheImpl()->getPool());
@@ -139,7 +139,7 @@ class DoctrineSetupTest extends TestCase
     public function testConfigureCacheCustomInstance(): void
     {
         $cache  = new ArrayAdapter();
-        $config = DoctrineSetup::createConfiguration(true, null, $cache);
+        $config = ORMSetup::createConfiguration(true, null, $cache);
 
         self::assertSame($cache, $config->getResultCache());
         self::assertSame($cache, $config->getResultCacheImpl()->getPool());

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -17,8 +17,8 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
-use Doctrine\ORM\Tools\DoctrineSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\DbalExtensions\QueryLog;
@@ -754,7 +754,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         $config->setMetadataDriverImpl(
-            $mappingDriver ?? DoctrineSetup::createDefaultAnnotationDriver([
+            $mappingDriver ?? ORMSetup::createDefaultAnnotationDriver([
                 realpath(__DIR__ . '/Models/Cache'),
                 realpath(__DIR__ . '/Models/GeoNames'),
             ])

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Tools\DoctrineSetup;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -91,7 +91,7 @@ abstract class OrmTestCase extends DoctrineTestCase
         $config->setQueryCache(self::getSharedQueryCache());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl(DoctrineSetup::createDefaultAnnotationDriver([
+        $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
         ]));
 


### PR DESCRIPTION
This PR renames the new `DoctrineSetup` class introduced with #9443 as suggested by @beberlei (https://github.com/doctrine/orm/pull/9443#pullrequestreview-867231318).