### PR TITLE
JoinedSubclassPersister fix nonInsertable columns with JOINED inheritance type + test

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -516,6 +516,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     || isset($this->class->associationMappings[$name]['inherited'])
                     || ($this->class->isVersioned && $this->class->versionField === $name)
                     || isset($this->class->embeddedClasses[$name])
+                    || isset($this->class->fieldMappings[$name]['notInsertable'])
             ) {
                 continue;
             }

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceType/ChildClassWithNonWritableFields.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceType/ChildClassWithNonWritableFields.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceType;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class ChildClassWithNonWritableFields extends ChildClass
+{
+    /**
+     * @var string
+     * @Column(type="string", insertable=false, options={"default": "1234"})
+     */
+    public $nonInsertableContent;
+
+    /**
+     * @var string
+     * @Column(type="string", updatable=false)
+     */
+    public $nonUpdatableContent;
+
+    /**
+     * @var string
+     * @Column(type="integer", insertable=false, updatable=false, options={"default": 5678})
+     */
+    public $nonWritableContent;
+
+    /**
+     * @var string
+     * @Column(type="string", insertable=true, updatable=true)
+     */
+    public $writableContent;
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Persisters;
 
+use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Models\JoinedInheritanceType\AnotherChildClass;
+use Doctrine\Tests\Models\JoinedInheritanceType\ChildClassWithNonWritableFields;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\OrmTestCase;
 
@@ -14,7 +19,7 @@ use Doctrine\Tests\OrmTestCase;
  *
  * @covers \Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister
  */
-class JoinedSubClassPersisterTest extends OrmTestCase
+class JoinedSubclassPersisterTest extends OrmTestCase
 {
     /** @var JoinedSubclassPersister */
     protected $persister;
@@ -36,5 +41,22 @@ class JoinedSubClassPersisterTest extends OrmTestCase
     public function testExecuteInsertsWillReturnEmptySetWithNoQueuedInserts(): void
     {
         self::assertSame([], $this->persister->executeInserts());
+    }
+
+    public function testNonInsertablePropertyInChildClass(): void
+    {
+        $em = $this->getTestEntityManager();
+        $em->getConfiguration()->setMetadataDriverImpl($this->createAnnotationDriver([__DIR__ . '/../../Models/JoinedInheritanceType/']));
+        $conn = $em->getConnection();
+        assert($conn instanceof ConnectionMock);
+        $logger = new DebugStack();
+        $conn->getConfiguration()->setSQLLogger($logger);
+        $entity = new ChildClassWithNonWritableFields();
+        $em->persist($entity);
+        $em->flush();
+
+        $subClassInsertQuery = $logger->queries[\count($logger->queries) - 1];
+        self::assertSame($subClassInsertQuery['sql'], 'INSERT INTO ChildClassWithNonWritableFields (id, nonUpdatableContent, writableContent) VALUES (?, ?, ?)', 'Non-insertable fields must be absent from query.');
+        self::assertCount(3, $subClassInsertQuery['params'], 'Non-insertable fields must be absent from params.');
     }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
@@ -6,13 +6,14 @@ namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\Tests\Mocks\ConnectionMock;
-use Doctrine\Tests\Models\JoinedInheritanceType\AnotherChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\ChildClassWithNonWritableFields;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\OrmTestCase;
+
+use function assert;
+use function count;
 
 /**
  * Tests for {@see \Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister}
@@ -55,7 +56,7 @@ class JoinedSubclassPersisterTest extends OrmTestCase
         $em->persist($entity);
         $em->flush();
 
-        $subClassInsertQuery = $logger->queries[\count($logger->queries) - 1];
+        $subClassInsertQuery = $logger->queries[count($logger->queries) - 1];
         self::assertSame($subClassInsertQuery['sql'], 'INSERT INTO ChildClassWithNonWritableFields (id, nonUpdatableContent, writableContent) VALUES (?, ?, ?)', 'Non-insertable fields must be absent from query.');
         self::assertCount(3, $subClassInsertQuery['params'], 'Non-insertable fields must be absent from params.');
     }


### PR DESCRIPTION
Fixes #9467

There wasn't any check for fields with notInsertable mapping at JoinedSubclassPersister's getInsertColumnList. This causes more column in the resulting SQL Insert query than expected when insertable=false is set on a field of joined subclass.
A test is created for this case.