### PR TITLE
Avoid calling `merge()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -979,7 +979,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
     public function testMatchingCriteriaNullAssocComparison(): void
     {
         $fixtures       = $this->loadFixtureUserEmail();
-        $user           = $this->_em->merge($fixtures[0]);
+        $user           = $this->_em->find(CmsUser::class, $fixtures[0]->id);
         $repository     = $this->_em->getRepository(CmsUser::class);
         $criteriaIsNull = Criteria::create()->where(Criteria::expr()->isNull('email'));
         $criteriaEqNull = Criteria::create()->where(Criteria::expr()->eq('email', null));


### PR DESCRIPTION
Backported from #9488.

This test case uses the deprecated `merge()` method although it's not actually testing the behavior of that method. I've replaced `merge()` with a `find()` call.