### PR TITLE
Added "false" value to $columnPrefix type declaration.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -59,9 +59,9 @@ class ClassMetadataBuilder
     /**
      * Adds and embedded class
      *
-     * @param string      $fieldName
-     * @param string      $class
-     * @param string|null $columnPrefix
+     * @param string            $fieldName
+     * @param string            $class
+     * @param string|false|null $columnPrefix
      *
      * @return $this
      */


### PR DESCRIPTION
If i passing "false" value as third argument of ClassMetadataBuilder::addEmbedded method, I get an error from PHPStan:
`Parameter #3 $columnPrefix of method Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder::addEmbedded() expects string|null, false given.`

It is a valid value according [documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/tutorials/embeddables.html#column-prefixing) and work well.