### PR TITLE
Remove various deprecated methods and properties

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -155,18 +155,6 @@ class FieldBuilder
     /**
      * Sets field as primary key.
      *
-     * @deprecated Use makePrimaryKey() instead
-     *
-     * @return FieldBuilder
-     */
-    public function isPrimaryKey()
-    {
-        return $this->makePrimaryKey();
-    }
-
-    /**
-     * Sets field as primary key.
-     *
      * @return $this
      */
     public function makePrimaryKey()

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -626,16 +626,6 @@ class ClassMetadataInfo implements ClassMetadata
     public $sequenceGeneratorDefinition;
 
     /**
-     * READ-ONLY: The definition of the table generator of this class. Only used for the
-     * TABLE generation strategy.
-     *
-     * @deprecated
-     *
-     * @var array<string, mixed>
-     */
-    public $tableGeneratorDefinition;
-
-    /**
      * READ-ONLY: The policy used for change-tracking on entities of this class.
      *
      * @var int
@@ -2233,21 +2223,6 @@ class ClassMetadataInfo implements ClassMetadata
         return isset($this->fieldMappings[$fieldName])
             ? $this->fieldMappings[$fieldName]['type']
             : null;
-    }
-
-    /**
-     * Gets the type of a column.
-     *
-     * @deprecated 3.0 remove this. this method is bogus and unreliable, since it cannot resolve the type of a column
-     *             that is derived by a referenced field on a different entity.
-     *
-     * @param string $columnName
-     *
-     * @return string|null
-     */
-    public function getTypeOfColumn($columnName)
-    {
-        return $this->getTypeOfField($this->getFieldName($columnName));
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -370,23 +370,6 @@ class MappingException extends Exception implements ORMException
     }
 
     /**
-     * @deprecated 2.9 no longer in use
-     *
-     * @param string $className
-     * @param string $propertyName
-     *
-     * @return MappingException
-     */
-    public static function propertyTypeIsRequired($className, $propertyName)
-    {
-        return new self(sprintf(
-            "The attribute 'type' is required for the column description of property %s::\$%s.",
-            $className,
-            $propertyName
-        ));
-    }
-
-    /**
      * @param string $entity    The entity's name.
      * @param string $fieldName The name of the field that was already declared.
      *

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -14,16 +14,9 @@ class IndexBy extends Node
     /** @var PathExpression */
     public $singleValuedPathExpression = null;
 
-    /**
-     * @deprecated
-     *
-     * @var PathExpression
-     */
-    public $simpleStateFieldPathExpression = null;
-
     public function __construct(PathExpression $singleValuedPathExpression)
     {
-        $this->singleValuedPathExpression = $this->simpleStateFieldPathExpression = $singleValuedPathExpression;
+        $this->singleValuedPathExpression = $singleValuedPathExpression;
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -447,8 +447,7 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadata.php">
-    <PropertyNotSetInConstructor occurrences="5">
-      <code>ClassMetadata</code>
+    <PropertyNotSetInConstructor occurrences="4">
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
@@ -595,12 +594,11 @@
       <code>$mapping['originalField']</code>
       <code>$mapping['targetEntity']</code>
     </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor occurrences="5">
+    <PropertyNotSetInConstructor occurrences="4">
       <code>$idGenerator</code>
       <code>$namespace</code>
       <code>$sequenceGeneratorDefinition</code>
       <code>$table</code>
-      <code>$tableGeneratorDefinition</code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion occurrences="10">
       <code>$this-&gt;entityListeners</code>
@@ -1626,9 +1624,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/IndexBy.php">
-    <DeprecatedProperty occurrences="1">
-      <code>$this-&gt;simpleStateFieldPathExpression</code>
-    </DeprecatedProperty>
     <InvalidNullableReturnType occurrences="1">
       <code>dispatch</code>
     </InvalidNullableReturnType>
@@ -1638,8 +1633,7 @@
     <ParamNameMismatch occurrences="1">
       <code>$sqlWalker</code>
     </ParamNameMismatch>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>


### PR DESCRIPTION
None of the properties/methods seems to be in use. And I haven't found any note about their deprecation in the upgrade log. I guess it's just finde removing them?