### PR TITLE
Constructor-Argument "options" has the same type as the associated property.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -31,10 +31,10 @@ final class Index implements Annotation
     public $options;
 
     /**
-     * @param array<string>|null $columns
-     * @param array<string>|null $fields
-     * @param array<string>|null $flags
-     * @param array<string>|null $options
+     * @param array<string>|null       $columns
+     * @param array<string>|null       $fields
+     * @param array<string>|null       $flags
+     * @param array<string,mixed>|null $options
      */
     public function __construct(
         ?array $columns = null,


### PR DESCRIPTION
The constructor argument "options" of ``Doctrine\ORM\Mapping\Index`` wasn't properly alligned with it's property according to its type. Psalm then isn't happy about constructions like following:

```php
#[\Doctrine\ORM\Mapping\Index(
    fields: ['name'],
    name: 'name_idx',
    options: [
        'lengths' => [255],
    ]
)]
final class Entity
{
    // ...
}
```

I'm pretty sure that this change can backported to older versions.