### PR TITLE
Replace `TreeWalkerChainIterator` with a generator

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.12
 
+## Deprecate `Doctrine\ORM\Query\TreeWalkerChainIterator`
+
+This class won't have a replacement.
+
 ## Deprecate `OnClearEventArgs::getEntityClass()` and `OnClearEventArgs::clearsAllEntities()`
 
 These methods will be removed in 3.0 along with the ability to partially clear

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Generator;
 
 use function array_diff;
 use function array_keys;
@@ -19,10 +21,16 @@ class TreeWalkerChain implements TreeWalker
     /**
      * The tree walkers.
      *
-     * @var TreeWalker[]
-     * @psalm-var TreeWalkerChainIterator
+     * @var string[]
+     * @psalm-var list<class-string<TreeWalker>>
      */
-    private $_walkers;
+    private $walkers = [];
+
+    /** @var AbstractQuery */
+    private $query;
+
+    /** @var ParserResult */
+    private $parserResult;
 
     /**
      * The query components of the original query (the "symbol table") that was produced by the Parser.
@@ -37,7 +45,7 @@ class TreeWalkerChain implements TreeWalker
      *                token: array
      *            }>
      */
-    private $_queryComponents;
+    private $queryComponents;
 
     /**
      * Returns the internal queryComponents array.
@@ -46,7 +54,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function getQueryComponents()
     {
-        return $this->_queryComponents;
+        return $this->queryComponents;
     }
 
     /**
@@ -62,7 +70,7 @@ class TreeWalkerChain implements TreeWalker
             throw QueryException::invalidQueryComponent($dqlAlias);
         }
 
-        $this->_queryComponents[$dqlAlias] = $queryComponent;
+        $this->queryComponents[$dqlAlias] = $queryComponent;
     }
 
     /**
@@ -70,20 +78,22 @@ class TreeWalkerChain implements TreeWalker
      */
     public function __construct($query, $parserResult, array $queryComponents)
     {
-        $this->_queryComponents = $queryComponents;
-        $this->_walkers         = new TreeWalkerChainIterator($this, $query, $parserResult);
+        $this->query           = $query;
+        $this->parserResult    = $parserResult;
+        $this->queryComponents = $queryComponents;
     }
 
     /**
      * Adds a tree walker to the chain.
      *
      * @param string $walkerClass The class of the walker to instantiate.
+     * @psalm-param class-string<TreeWalker> $walkerClass
      *
      * @return void
      */
     public function addTreeWalker($walkerClass)
     {
-        $this->_walkers[] = $walkerClass;
+        $this->walkers[] = $walkerClass;
     }
 
     /**
@@ -93,10 +103,10 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectStatement(AST\SelectStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSelectStatement($AST);
 
-            $this->_queryComponents = $walker->getQueryComponents();
+            $this->queryComponents = $walker->getQueryComponents();
         }
     }
 
@@ -107,7 +117,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectClause($selectClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSelectClause($selectClause);
         }
     }
@@ -119,7 +129,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkFromClause($fromClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkFromClause($fromClause);
         }
     }
@@ -131,7 +141,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkFunction($function)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkFunction($function);
         }
     }
@@ -143,7 +153,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkOrderByClause($orderByClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkOrderByClause($orderByClause);
         }
     }
@@ -155,7 +165,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkOrderByItem($orderByItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkOrderByItem($orderByItem);
         }
     }
@@ -167,7 +177,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkHavingClause($havingClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkHavingClause($havingClause);
         }
     }
@@ -179,7 +189,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkJoin($join)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkJoin($join);
         }
     }
@@ -191,7 +201,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectExpression($selectExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSelectExpression($selectExpression);
         }
     }
@@ -203,7 +213,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkQuantifiedExpression($qExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkQuantifiedExpression($qExpr);
         }
     }
@@ -215,7 +225,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSubselect($subselect)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSubselect($subselect);
         }
     }
@@ -227,7 +237,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSubselectFromClause($subselectFromClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSubselectFromClause($subselectFromClause);
         }
     }
@@ -239,7 +249,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleSelectClause($simpleSelectClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSimpleSelectClause($simpleSelectClause);
         }
     }
@@ -251,7 +261,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleSelectExpression($simpleSelectExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSimpleSelectExpression($simpleSelectExpression);
         }
     }
@@ -263,7 +273,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkAggregateExpression($aggExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkAggregateExpression($aggExpression);
         }
     }
@@ -275,7 +285,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkGroupByClause($groupByClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkGroupByClause($groupByClause);
         }
     }
@@ -287,7 +297,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkGroupByItem($groupByItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkGroupByItem($groupByItem);
         }
     }
@@ -299,7 +309,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateStatement(AST\UpdateStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkUpdateStatement($AST);
         }
     }
@@ -311,7 +321,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkDeleteStatement(AST\DeleteStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkDeleteStatement($AST);
         }
     }
@@ -323,7 +333,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkDeleteClause(AST\DeleteClause $deleteClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkDeleteClause($deleteClause);
         }
     }
@@ -335,7 +345,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateClause($updateClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkUpdateClause($updateClause);
         }
     }
@@ -347,7 +357,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateItem($updateItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkUpdateItem($updateItem);
         }
     }
@@ -359,7 +369,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkWhereClause($whereClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkWhereClause($whereClause);
         }
     }
@@ -371,7 +381,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalExpression($condExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkConditionalExpression($condExpr);
         }
     }
@@ -383,7 +393,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalTerm($condTerm)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkConditionalTerm($condTerm);
         }
     }
@@ -395,7 +405,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalFactor($factor)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkConditionalFactor($factor);
         }
     }
@@ -407,7 +417,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalPrimary($condPrimary)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkConditionalPrimary($condPrimary);
         }
     }
@@ -419,7 +429,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkExistsExpression($existsExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkExistsExpression($existsExpr);
         }
     }
@@ -431,7 +441,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkCollectionMemberExpression($collMemberExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkCollectionMemberExpression($collMemberExpr);
         }
     }
@@ -443,7 +453,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkEmptyCollectionComparisonExpression($emptyCollCompExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkEmptyCollectionComparisonExpression($emptyCollCompExpr);
         }
     }
@@ -455,7 +465,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkNullComparisonExpression($nullCompExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkNullComparisonExpression($nullCompExpr);
         }
     }
@@ -467,7 +477,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkInExpression($inExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkInExpression($inExpr);
         }
     }
@@ -479,7 +489,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkInstanceOfExpression($instanceOfExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkInstanceOfExpression($instanceOfExpr);
         }
     }
@@ -491,7 +501,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkLiteral($literal)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkLiteral($literal);
         }
     }
@@ -503,7 +513,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkBetweenExpression($betweenExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkBetweenExpression($betweenExpr);
         }
     }
@@ -515,7 +525,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkLikeExpression($likeExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkLikeExpression($likeExpr);
         }
     }
@@ -527,7 +537,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkStateFieldPathExpression($stateFieldPathExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkStateFieldPathExpression($stateFieldPathExpression);
         }
     }
@@ -539,7 +549,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkComparisonExpression($compExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkComparisonExpression($compExpr);
         }
     }
@@ -551,7 +561,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkInputParameter($inputParam)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkInputParameter($inputParam);
         }
     }
@@ -563,7 +573,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticExpression($arithmeticExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkArithmeticExpression($arithmeticExpr);
         }
     }
@@ -575,7 +585,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticTerm($term)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkArithmeticTerm($term);
         }
     }
@@ -587,7 +597,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkStringPrimary($stringPrimary)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkStringPrimary($stringPrimary);
         }
     }
@@ -599,7 +609,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticFactor($factor)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkArithmeticFactor($factor);
         }
     }
@@ -611,7 +621,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleArithmeticExpression($simpleArithmeticExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkSimpleArithmeticExpression($simpleArithmeticExpr);
         }
     }
@@ -623,7 +633,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkPathExpression($pathExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkPathExpression($pathExpr);
         }
     }
@@ -635,7 +645,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkResultVariable($resultVariable)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->getWalkers() as $walker) {
             $walker->walkResultVariable($resultVariable);
         }
     }
@@ -647,5 +657,15 @@ class TreeWalkerChain implements TreeWalker
      */
     public function getExecutor($AST)
     {
+    }
+
+    /**
+     * @psalm-return Generator<int, TreeWalker>
+     */
+    private function getWalkers(): Generator
+    {
+        foreach ($this->walkers as $walkerClass) {
+            yield new $walkerClass($this->query, $this->parserResult, $this->queryComponents);
+        }
     }
 }

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use ArrayAccess;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\AbstractQuery;
 use Iterator;
 use ReturnTypeWillChange;
@@ -14,6 +15,8 @@ use function next;
 use function reset;
 
 /**
+ * @deprecated This class will be removed in 3.0 without replacement.
+ *
  * @template-implements Iterator<TreeWalker>
  * @template-implements ArrayAccess<int, TreeWalker>
  */
@@ -34,6 +37,13 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
      */
     public function __construct(TreeWalkerChain $treeWalkerChain, $query, $parserResult)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9511',
+            '%s is deprecated and will be removed without replacement.',
+            self::class
+        );
+
         $this->treeWalkerChain = $treeWalkerChain;
         $this->query           = $query;
         $this->parserResult    = $parserResult;

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2700,54 +2700,6 @@
     <ParamNameMismatch occurrences="1">
       <code>$condPrimary</code>
     </ParamNameMismatch>
-    <PossiblyNullReference occurrences="46">
-      <code>walkAggregateExpression</code>
-      <code>walkArithmeticExpression</code>
-      <code>walkArithmeticFactor</code>
-      <code>walkArithmeticTerm</code>
-      <code>walkBetweenExpression</code>
-      <code>walkCollectionMemberExpression</code>
-      <code>walkComparisonExpression</code>
-      <code>walkConditionalExpression</code>
-      <code>walkConditionalFactor</code>
-      <code>walkConditionalPrimary</code>
-      <code>walkConditionalTerm</code>
-      <code>walkDeleteClause</code>
-      <code>walkDeleteStatement</code>
-      <code>walkEmptyCollectionComparisonExpression</code>
-      <code>walkExistsExpression</code>
-      <code>walkFromClause</code>
-      <code>walkFunction</code>
-      <code>walkGroupByClause</code>
-      <code>walkGroupByItem</code>
-      <code>walkHavingClause</code>
-      <code>walkInExpression</code>
-      <code>walkInputParameter</code>
-      <code>walkInstanceOfExpression</code>
-      <code>walkJoin</code>
-      <code>walkLikeExpression</code>
-      <code>walkLiteral</code>
-      <code>walkNullComparisonExpression</code>
-      <code>walkOrderByClause</code>
-      <code>walkOrderByItem</code>
-      <code>walkPathExpression</code>
-      <code>walkQuantifiedExpression</code>
-      <code>walkResultVariable</code>
-      <code>walkSelectClause</code>
-      <code>walkSelectExpression</code>
-      <code>walkSelectStatement</code>
-      <code>walkSimpleArithmeticExpression</code>
-      <code>walkSimpleSelectClause</code>
-      <code>walkSimpleSelectExpression</code>
-      <code>walkStateFieldPathExpression</code>
-      <code>walkStringPrimary</code>
-      <code>walkSubselect</code>
-      <code>walkSubselectFromClause</code>
-      <code>walkUpdateClause</code>
-      <code>walkUpdateItem</code>
-      <code>walkUpdateStatement</code>
-      <code>walkWhereClause</code>
-    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php">
     <ImplementedParamTypeMismatch occurrences="1">


### PR DESCRIPTION
While investigating the type errors on the tree walker classes, I stumbled on `TreeWalkerChainIterator`. This class seems unnecessarily complex and can easily replaced with a three-line generator function. So I did just that.