### PR TITLE
Document deprecation of `AbstractCollectionPersister` helpers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade to 2.12
 
+## Deprecate helper methods from `AbstractCollectionPersister`
+
+The following protected methods of
+`Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister`
+are not in use anymore and will be removed.
+
+* `evictCollectionCache()`
+* `evictElementCache()`
+
 ## Deprecate `Doctrine\ORM\Query\TreeWalkerChainIterator`
 
 This class won't have a replacement.

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\CollectionHydrator;
 use Doctrine\ORM\Cache\EntityCacheKey;
@@ -230,6 +231,12 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      */
     protected function evictCollectionCache(PersistentCollection $collection)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9512',
+            'The method %s() is deprecated and will be removed without replacement.'
+        );
+
         $key = new CollectionCacheKey(
             $this->sourceEntity->rootEntityName,
             $this->association['fieldName'],
@@ -254,6 +261,12 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      */
     protected function evictElementCache($targetEntity, $element)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9512',
+            'The method %s() is deprecated and will be removed without replacement.'
+        );
+
         $targetPersister = $this->uow->getEntityPersister($targetEntity);
         assert($targetPersister instanceof CachedEntityPersister);
         $targetRegion = $targetPersister->getCacheRegion();


### PR DESCRIPTION
I've deprecated these methods in #9507 because they weren't used or tested anywhere. After @SenseException's comment (https://github.com/doctrine/orm/pull/9508#discussion_r806255071) I decided to document that deprecation properly.