### PR TITLE
Trigger the desired code path

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -670,6 +670,7 @@ class PaginationTest extends OrmFunctionalTestCase
 
         $dql   = 'SELECT p FROM Doctrine\Tests\Models\CustomType\CustomIdObjectTypeParent p';
         $query = $this->_em->createQuery($dql);
+        $query->setMaxResults(1);
 
         $paginator = new Paginator($query, true);
         $paginator->setUseOutputWalkers(false);


### PR DESCRIPTION
Since v2.7.0 the ORM avoids using extra queries via the paginator component when the maximum results parameter isn't set on the original query. With that change, this test was not executing the code path that it was expected to run.

This makes sure we trigger the forcing of custom DBAL types when hydrating the identifiers, making sure we don't introduce bugs.

More info:
- Forcing DBAL type conversion: https://github.com/doctrine/orm/pull/7905
- Issue on optimisation: https://github.com/doctrine/orm/issues/7829
- PR on optimisation: https://github.com/doctrine/orm/pull/7863
- Minor BC-break docs: https://github.com/doctrine/orm/blob/2.12.x/UPGRADE.md#minor-bc-break-paginator-output-walkers-arent-be-called-anymore-on-sub-queries-for-queries-without-max-results