### PR TITLE
Remove `final` from `SQLFilter::__toString()`

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -175,7 +175,7 @@ abstract class SQLFilter
      *
      * @return string String representation of the SQLFilter.
      */
-    final public function __toString()
+    public function __toString()
     {
         return serialize($this->parameters);
     }


### PR DESCRIPTION
This allows filter implementations to provide their own logic for computing cache keys.

#3955 describes a bug where caching the DQL -> SQL transformation result in the query cache does not correctly take into account that filters may generate different SQL depending on circumstances.

As long as filters only depend on their own parameters, the [results are probably correct](https://github.com/doctrine/orm/issues/3955#issuecomment-1042726216).

But, the [SoftDeleteable filter](https://github.com/doctrine-extensions/DoctrineExtensions/blob/2def628a9a8304c1e7f56847a0b21778a3a9ed61/src/SoftDeleteable/Filter/SoftDeleteableFilter.php) is an example for a filter that depends on "external" information, not primarily on filter parameters. Filters like that could benefit from being able to provide their own `__toString()` implementation.

(https://github.com/doctrine-extensions/DoctrineExtensions/pull/2112 adds a filter parameter to make sure `__toString()` changes, but I consider this to be a work-around)
