### PR TITLE
Bring `FilterCollection` to a "clean" state after hash computation

### DIFF
--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -192,7 +192,7 @@ class FilterCollection
             $filterHash .= $name . $filter;
         }
 
-        $this->filterHash = md5($filterHash);
+        $this->filterHash   = $filterHash;
         $this->filtersState = self::FILTERS_STATE_CLEAN;
 
         return $filterHash;

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -97,8 +97,7 @@ class FilterCollection
             // Keep the enabled filters sorted for the hash
             ksort($this->enabledFilters);
 
-            // Now the filter collection is dirty
-            $this->filtersState = self::FILTERS_STATE_DIRTY;
+            $this->setFiltersStateDirty();
         }
 
         return $this->enabledFilters[$name];
@@ -120,8 +119,7 @@ class FilterCollection
 
         unset($this->enabledFilters[$name]);
 
-        // Now the filter collection is dirty
-        $this->filtersState = self::FILTERS_STATE_DIRTY;
+        $this->setFiltersStateDirty();
 
         return $filter;
     }
@@ -193,6 +191,9 @@ class FilterCollection
         foreach ($this->enabledFilters as $name => $filter) {
             $filterHash .= $name . $filter;
         }
+
+        $this->filterHash = md5($filterHash);
+        $this->filtersState = self::FILTERS_STATE_CLEAN;
 
         return $filterHash;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -876,11 +876,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Expr/Select.php
 
 		-
-			message: "#^Property Doctrine\\\\ORM\\\\Query\\\\FilterCollection\\:\\:\\$filterHash is never written, only read\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/FilterCollection.php
-
-		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 3
 			path: lib/Doctrine/ORM/Query/Parser.php

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter;
+use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\OrmTestCase;
+use InvalidArgumentException;
 
 /**
  * Test case for FilterCollection
  */
 class FilterCollectionTest extends OrmTestCase
 {
-    /** @var EntityManagerInterface */
+    /** @var EntityManagerMock */
     private $em;
 
     protected function setUp(): void
@@ -64,7 +65,7 @@ class FilterCollectionTest extends OrmTestCase
 
     public function testGetFilterInvalidArgument(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $filterCollection = $this->em->getFilters();
         $filterCollection->getFilter('testFilter');
     }
@@ -75,6 +76,24 @@ class FilterCollectionTest extends OrmTestCase
         $filterCollection->enable('testFilter');
 
         self::assertInstanceOf(MyFilter::class, $filterCollection->getFilter('testFilter'));
+    }
+
+    public function testHashing(): void
+    {
+        $filterCollection = $this->em->getFilters();
+
+        self::assertTrue($filterCollection->isClean());
+
+        $oldHash = $filterCollection->getHash();
+        $filterCollection->enable('testFilter');
+
+        self::assertFalse($filterCollection->isClean());
+
+        $hash = $filterCollection->getHash();
+
+        self::assertNotSame($oldHash, $hash);
+        self::assertTrue($filterCollection->isClean());
+        self::assertSame($hash, $filterCollection->getHash());
     }
 }
 


### PR DESCRIPTION
### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

Effectively, the `FilterCollection` was never brought back into a "clean" state after filters were enabled or filter parameters were set.

As far as I can tell, the clean/dirty distinction only refers to the computed FilterCollection hash reflecting all enabled filters and their parameters.

The only place I could find where the distinction matters is here:

https://github.com/doctrine/orm/blob/152c04c03d68d39f485d367713dd69dec0f4106d/lib/Doctrine/ORM/Query.php#L241-L259

When the filter collection is dirty and the query cache is used, the call to `getQueryCacheId()` in the last line shown will reset the filter collection to a `clean` state.

When there is no query cache, however, `getQueryCacheId()` is not called and the `FilterCollection` will not revert to a clean state; this prevents re-using the query later on.

If desired, I could add a `FilterCollection::setFiltersStateClean()` method to improve this case as well.

Closes #9521 