### PR TITLE
Make creating test models more straightforward and revert to swallowing exceptions

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -32,25 +32,13 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(Phrase::class),
-            $this->_em->getClassMetadata(PhraseType::class),
-            $this->_em->getClassMetadata(Definition::class),
-            $this->_em->getClassMetadata(Lemma::class),
-            $this->_em->getClassMetadata(Type::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(Phrase::class),
-            $this->_em->getClassMetadata(PhraseType::class),
-            $this->_em->getClassMetadata(Definition::class),
-            $this->_em->getClassMetadata(Lemma::class),
-            $this->_em->getClassMetadata(Type::class),
-        ]);
+        $this->createSchemaForModels(
+            Phrase::class,
+            PhraseType::class,
+            Definition::class,
+            Lemma::class,
+            Type::class
+        );
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
@@ -24,23 +24,9 @@ class CascadeRemoveOrderTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
-                $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
-                $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
-            ]
+        $this->createSchemaForModels(
+            CascadeRemoveOrderEntityO::class,
+            CascadeRemoveOrderEntityG::class
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
@@ -30,23 +30,12 @@ class ClassTableInheritanceSecondTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(CTIParent::class),
-            $this->_em->getClassMetadata(CTIChild::class),
-            $this->_em->getClassMetadata(CTIRelated::class),
-            $this->_em->getClassMetadata(CTIRelated2::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(CTIParent::class),
-            $this->_em->getClassMetadata(CTIChild::class),
-            $this->_em->getClassMetadata(CTIRelated::class),
-            $this->_em->getClassMetadata(CTIRelated2::class),
-        ]);
+        $this->createSchemaForModels(
+            CTIParent::class,
+            CTIChild::class,
+            CTIRelated::class,
+            CTIRelated2::class
+        );
     }
 
     public function testOneToOneAssocToBaseTypeBidirectional(): void

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -23,19 +23,10 @@ class DefaultValuesTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(DefaultValueUser::class),
-            $this->_em->getClassMetadata(DefaultValueAddress::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(DefaultValueUser::class),
-            $this->_em->getClassMetadata(DefaultValueAddress::class),
-        ]);
-        parent::tearDown();
+        $this->createSchemaForModels(
+            DefaultValueUser::class,
+            DefaultValueAddress::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -41,23 +41,12 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(LifecycleCallbackEventArgEntity::class),
-            $this->_em->getClassMetadata(LifecycleCallbackTestEntity::class),
-            $this->_em->getClassMetadata(LifecycleCallbackTestUser::class),
-            $this->_em->getClassMetadata(LifecycleCallbackCascader::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(LifecycleCallbackEventArgEntity::class),
-            $this->_em->getClassMetadata(LifecycleCallbackTestEntity::class),
-            $this->_em->getClassMetadata(LifecycleCallbackTestUser::class),
-            $this->_em->getClassMetadata(LifecycleCallbackCascader::class),
-        ]);
-        parent::tearDown();
+        $this->createSchemaForModels(
+            LifecycleCallbackEventArgEntity::class,
+            LifecycleCallbackTestEntity::class,
+            LifecycleCallbackTestUser::class,
+            LifecycleCallbackCascader::class
+        );
     }
 
     public function testPreSavePostSaveCallbacksAreInvoked(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -35,22 +35,12 @@ class OptimisticTest extends OrmFunctionalTestCase
 
     private function createSchema(): void
     {
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(OptimisticJoinedParent::class),
-            $this->_em->getClassMetadata(OptimisticJoinedChild::class),
-            $this->_em->getClassMetadata(OptimisticStandard::class),
-            $this->_em->getClassMetadata(OptimisticTimestamp::class),
-        ]);
-    }
-
-    private function dropSchema(): void
-    {
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(OptimisticJoinedParent::class),
-            $this->_em->getClassMetadata(OptimisticJoinedChild::class),
-            $this->_em->getClassMetadata(OptimisticStandard::class),
-            $this->_em->getClassMetadata(OptimisticTimestamp::class),
-        ]);
+        $this->createSchemaForModels(
+            OptimisticJoinedParent::class,
+            OptimisticJoinedChild::class,
+            OptimisticStandard::class,
+            OptimisticTimestamp::class
+        );
     }
 
     public function testJoinedChildInsertSetsInitialVersionValue(): OptimisticJoinedChild
@@ -93,8 +83,6 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
-
-        $this->dropSchema();
     }
 
     public function testJoinedParentInsertSetsInitialVersionValue(): OptimisticJoinedParent
@@ -136,8 +124,6 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
-
-        $this->dropSchema();
     }
 
     public function testMultipleFlushesDoIncrementalUpdates(): void
@@ -155,8 +141,6 @@ class OptimisticTest extends OrmFunctionalTestCase
             self::assertIsInt($test->getVersion());
             self::assertEquals($i + 1, $test->getVersion());
         }
-
-        $this->dropSchema();
     }
 
     public function testStandardInsertSetsInitialVersionValue(): OptimisticStandard
@@ -200,8 +184,6 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
-
-        $this->dropSchema();
     }
 
     public function testLockWorksWithProxy(): void
@@ -219,7 +201,6 @@ class OptimisticTest extends OrmFunctionalTestCase
         $this->_em->lock($proxy, LockMode::OPTIMISTIC, 1);
 
         $this->addToAssertionCount(1);
-        $this->dropSchema();
     }
 
     public function testOptimisticTimestampSetsDefaultValue(): OptimisticTimestamp
@@ -300,8 +281,6 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         self::assertNotNull($caughtException, 'No OptimisticLockingException was thrown');
         self::assertSame($test, $caughtException->getEntity());
-
-        $this->dropSchema();
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -15,9 +15,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Proxy\Proxy;
-use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function count;
 use function get_class;
@@ -30,19 +28,13 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $schemaTool = new SchemaTool($this->_em);
-        try {
-            $schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(Train::class),
-                    $this->_em->getClassMetadata(TrainDriver::class),
-                    $this->_em->getClassMetadata(TrainOwner::class),
-                    $this->_em->getClassMetadata(Waggon::class),
-                    $this->_em->getClassMetadata(TrainOrder::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            Train::class,
+            TrainDriver::class,
+            TrainOwner::class,
+            Waggon::class,
+            TrainOrder::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
@@ -14,22 +14,16 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class PersistentCollectionTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(PersistentCollectionHolder::class),
-                    $this->_em->getClassMetadata(PersistentCollectionContent::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            PersistentCollectionHolder::class,
+            PersistentCollectionContent::class
+        );
 
         PersistentObject::setObjectManager($this->_em);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * Test that Doctrine ORM correctly works with the ObjectManagerAware and PersistentObject
@@ -25,14 +24,7 @@ class PersistentObjectTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(PersistentEntity::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(PersistentEntity::class);
 
         PersistentObject::setObjectManager($this->_em);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -13,7 +13,6 @@ use Doctrine\Tests\Models\CMS\CmsTag;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser as CmsUserProxy;
-use Exception;
 
 use function assert;
 
@@ -34,20 +33,15 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(CmsUser::class),
-                    $this->_em->getClassMetadata(CmsTag::class),
-                    $this->_em->getClassMetadata(CmsPhonenumber::class),
-                    $this->_em->getClassMetadata(CmsArticle::class),
-                    $this->_em->getClassMetadata(CmsAddress::class),
-                    $this->_em->getClassMetadata(CmsEmail::class),
-                    $this->_em->getClassMetadata(CmsGroup::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            CmsUser::class,
+            CmsTag::class,
+            CmsPhonenumber::class,
+            CmsArticle::class,
+            CmsAddress::class,
+            CmsEmail::class,
+            CmsGroup::class
+        );
 
         $this->user           = new CmsUser();
         $this->user->username = 'ocramius';

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
@@ -16,22 +16,7 @@ class QueryBuilderParenthesisTest extends OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(QueryBuilderParenthesisEntity::class),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(QueryBuilderParenthesisEntity::class),
-            ]
-        );
+        $this->createSchemaForModels(QueryBuilderParenthesisEntity::class);
     }
 
     public function testParenthesisOnSingleLine(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Query;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function get_class;
 
@@ -25,14 +24,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(ReadOnlyEntity::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(ReadOnlyEntity::class);
     }
 
     public function testReadOnlyEntityNeverChangeTracked(): void

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\SequenceGenerator;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * Description of SequenceGeneratorTest
@@ -25,14 +24,7 @@ class SequenceGeneratorTest extends OrmFunctionalTestCase
             self::markTestSkipped('Only working for Databases that support sequences.');
         }
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(SequenceEntity::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(SequenceEntity::class);
     }
 
     public function testHighAllocationSizeSequence(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * @group DDC-1113
@@ -25,17 +24,12 @@ class DDC1113Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1113Engine::class),
-                    $this->_em->getClassMetadata(DDC1113Vehicle::class),
-                    $this->_em->getClassMetadata(DDC1113Car::class),
-                    $this->_em->getClassMetadata(DDC1113Bus::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC1113Engine::class,
+            DDC1113Vehicle::class,
+            DDC1113Car::class,
+            DDC1113Bus::class
+        );
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -12,23 +12,17 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC1209Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1209One::class),
-                    $this->_em->getClassMetadata(DDC1209Two::class),
-                    $this->_em->getClassMetadata(DDC1209Three::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC1209One::class,
+            DDC1209Two::class,
+            DDC1209Three::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * @group DDC-1228
@@ -21,15 +20,7 @@ class DDC1228Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1228User::class),
-                    $this->_em->getClassMetadata(DDC1228Profile::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC1228User::class, DDC1228Profile::class);
     }
 
     public function testOneToOnePersist(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * @group DDC-1238
@@ -19,14 +18,7 @@ class DDC1238Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1238User::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC1238User::class);
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -14,7 +15,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * @group DDC-1335
@@ -24,15 +24,10 @@ class DDC1335Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        $this->createSchemaForModels(DDC1335User::class, DDC1335Phone::class);
         try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1335User::class),
-                    $this->_em->getClassMetadata(DDC1335Phone::class),
-                ]
-            );
             $this->loadFixture();
-        } catch (Exception $e) {
+        } catch (UniqueConstraintViolationException $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function get_class;
 
@@ -25,15 +24,10 @@ class DDC1461Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1461TwitterAccount::class),
-                    $this->_em->getClassMetadata(DDC1461User::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC1461TwitterAccount::class,
+            DDC1461User::class
+        );
     }
 
     public function testChangeDetectionDeferredExplicit(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\PostLoad;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function get_class;
 use function get_debug_type;
@@ -32,16 +31,11 @@ class DDC1655Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1655Foo::class),
-                    $this->_em->getClassMetadata(DDC1655Bar::class),
-                    $this->_em->getClassMetadata(DDC1655Baz::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC1655Foo::class,
+            DDC1655Bar::class,
+            DDC1655Baz::class
+        );
     }
 
     public function testPostLoadOneToManyInheritance(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
@@ -20,22 +20,7 @@ class DDC1719Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(DDC1719SimpleEntity::class),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(DDC1719SimpleEntity::class),
-            ]
-        );
+        $this->createSchemaForModels(DDC1719SimpleEntity::class);
     }
 
     public function testCreateRetrieveUpdateDelete(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
@@ -29,30 +29,14 @@ class DDC2602Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(DDC2602User::class),
-                $this->_em->getClassMetadata(DDC2602Biography::class),
-                $this->_em->getClassMetadata(DDC2602BiographyField::class),
-                $this->_em->getClassMetadata(DDC2602BiographyFieldChoice::class),
-            ]
+        $this->createSchemaForModels(
+            DDC2602User::class,
+            DDC2602Biography::class,
+            DDC2602BiographyField::class,
+            DDC2602BiographyFieldChoice::class
         );
 
         $this->loadFixture();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(DDC2602User::class),
-                $this->_em->getClassMetadata(DDC2602Biography::class),
-                $this->_em->getClassMetadata(DDC2602BiographyField::class),
-                $this->_em->getClassMetadata(DDC2602BiographyFieldChoice::class),
-            ]
-        );
     }
 
     public function testPostLoadListenerShouldBeAbleToRunQueries(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\PrePersist;
 use Doctrine\ORM\Mapping\PreUpdate;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function assert;
 use function get_class;
@@ -24,14 +23,7 @@ class DDC2895Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC2895::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC2895::class);
     }
 
     public function testPostLoadOneToManyInheritance(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
@@ -17,24 +17,7 @@ class DDC309Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(DDC309Country::class),
-                $this->_em->getClassMetadata(DDC309User::class),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(DDC309Country::class),
-                $this->_em->getClassMetadata(DDC309User::class),
-            ]
-        );
-
-        parent::tearDown();
+        $this->createSchemaForModels(DDC309Country::class, DDC309User::class);
     }
 
     public function testTwoIterateHydrations(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -18,7 +18,6 @@ use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC3785Test extends OrmFunctionalTestCase
 {
@@ -28,16 +27,11 @@ class DDC3785Test extends OrmFunctionalTestCase
 
         Type::addType('ddc3785_asset_id', DDC3785AssetIdType::class);
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC3785Asset::class),
-                    $this->_em->getClassMetadata(DDC3785AssetId::class),
-                    $this->_em->getClassMetadata(DDC3785Attribute::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC3785Asset::class,
+            DDC3785AssetId::class,
+            DDC3785Attribute::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function serialize;
 use function unserialize;
@@ -20,14 +19,7 @@ class DDC381Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC381Entity::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC381Entity::class);
     }
 
     public function testCallUnserializedProxyMethods(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function get_class;
 
@@ -26,16 +25,11 @@ class DDC522Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC522Customer::class),
-                    $this->_em->getClassMetadata(DDC522Cart::class),
-                    $this->_em->getClassMetadata(DDC522ForeignKeyTest::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC522Customer::class,
+            DDC522Cart::class,
+            DDC522ForeignKeyTest::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -32,14 +32,7 @@ class DDC5684Test extends OrmFunctionalTestCase
             DBALTypes\Type::addType(DDC5684ObjectIdType::class, DDC5684ObjectIdType::class);
         }
 
-        $this->_schemaTool->createSchema([$this->_em->getClassMetadata(DDC5684Object::class)]);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema([$this->_em->getClassMetadata(DDC5684Object::class)]);
-
-        parent::tearDown();
+        $this->createSchemaForModels(DDC5684Object::class);
     }
 
     public function testAutoIncrementIdWithCustomType(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -14,7 +15,6 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Query;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 /**
  * @group DDC-618
@@ -24,14 +24,9 @@ class DDC618Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC618Author::class),
-                    $this->_em->getClassMetadata(DDC618Book::class),
-                ]
-            );
+        $this->createSchemaForModels(DDC618Author::class, DDC618Book::class);
 
+        try {
             // Create author 10/Joe with two books 22/JoeA and 20/JoeB
             $author       = new DDC618Author();
             $author->id   = 10;
@@ -50,7 +45,7 @@ class DDC618Test extends OrmFunctionalTestCase
 
             $this->_em->flush();
             $this->_em->clear();
-        } catch (Exception $e) {
+        } catch (UniqueConstraintViolationException $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -11,22 +11,16 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC633Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC633Patient::class),
-                    $this->_em->getClassMetadata(DDC633Appointment::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC633Patient::class,
+            DDC633Appointment::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function array_keys;
 use function get_class;
@@ -19,14 +18,7 @@ class DDC656Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC656Entity::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC656Entity::class);
     }
 
     public function testRecomputeSingleEntityChangeSetPreservesFieldOrder(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function strtolower;
 
@@ -23,15 +22,7 @@ class DDC698Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC698Role::class),
-                    $this->_em->getClassMetadata(DDC698Privilege::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC698Role::class, DDC698Privilege::class);
     }
 
     public function testTicket(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
@@ -27,21 +27,11 @@ class DDC69Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(Lemma::class),
-            $this->_em->getClassMetadata(Relation::class),
-            $this->_em->getClassMetadata(RelationType::class),
-        ]);
-    }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(Lemma::class),
-            $this->_em->getClassMetadata(Relation::class),
-            $this->_em->getClassMetadata(RelationType::class),
-        ]);
+        // some of these models are created in other tests, but not all
+        $this->createSchemaForModels(RelationType::class);
+        $this->createSchemaForModels(Relation::class);
+        $this->createSchemaForModels(Lemma::class);
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function count;
 
@@ -24,16 +22,7 @@ class DDC729Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $schemaTool = new SchemaTool($this->_em);
-            $schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC729A::class),
-                    $this->_em->getClassMetadata(DDC729B::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC729A::class, DDC729B::class);
     }
 
     public function testMergeManyToMany(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
@@ -13,22 +13,13 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC735Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC735Product::class),
-                    $this->_em->getClassMetadata(DDC735Review::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC735Product::class, DDC735Review::class);
     }
 
     public function testRemoveElementAppliesOrphanRemoval(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function class_exists;
 use function mkdir;
@@ -43,15 +42,7 @@ class DDC742Test extends OrmFunctionalTestCase
         // using a Filesystemcache to ensure that the cached data is serialized
         $this->_em->getMetadataFactory()->setCacheDriver(new FilesystemCache($testDir));
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC742User::class),
-                    $this->_em->getClassMetadata(DDC742Comment::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC742User::class, DDC742Comment::class);
 
         // make sure classes will be deserialized from caches
         $this->_em->getMetadataFactory()->setMetadataFor(DDC742User::class, null);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC832Test extends OrmFunctionalTestCase
 {
@@ -27,16 +26,11 @@ class DDC832Test extends OrmFunctionalTestCase
             self::markTestSkipped('Doesnt run on Oracle.');
         }
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC832JoinedIndex::class),
-                    $this->_em->getClassMetadata(DDC832JoinedTreeIndex::class),
-                    $this->_em->getClassMetadata(DDC832Like::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC832JoinedIndex::class,
+            DDC832JoinedTreeIndex::class,
+            DDC832Like::class
+        );
     }
 
     public function tearDown(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC881Test extends OrmFunctionalTestCase
 {
@@ -25,16 +24,11 @@ class DDC881Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC881User::class),
-                    $this->_em->getClassMetadata(DDC881Phonenumber::class),
-                    $this->_em->getClassMetadata(DDC881Phonecall::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC881User::class,
+            DDC881PhoneNumber::class,
+            DDC881PhoneCall::class
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -12,22 +12,13 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 class DDC960Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC960Root::class),
-                    $this->_em->getClassMetadata(DDC960Child::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(DDC960Root::class, DDC960Child::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -18,7 +18,6 @@ use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function get_class;
 
@@ -30,16 +29,11 @@ class DDC992Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC992Role::class),
-                    $this->_em->getClassMetadata(DDC992Parent::class),
-                    $this->_em->getClassMetadata(DDC992Child::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC992Role::class,
+            DDC992Parent::class,
+            DDC992Child::class
+        );
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8443Test.php
@@ -27,13 +27,7 @@ final class GH8443Test extends OrmFunctionalTestCase
     {
         $this->useModelSet('company');
         parent::setUp();
-        $this->_schemaTool->createSchema([$this->_em->getClassMetadata(GH8443Foo::class)]);
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->_schemaTool->dropSchema([$this->_em->getClassMetadata(GH8443Foo::class)]);
+        $this->createSchemaForModels(GH8443Foo::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8499Test.php
@@ -33,16 +33,7 @@ class GH8499Test extends OrmFunctionalTestCase
 
     protected function createSchema(): void
     {
-        $this->_schemaTool->createSchema(
-            [$this->_em->getClassMetadata(GH8499VersionableEntity::class)]
-        );
-    }
-
-    protected function dropSchema(): void
-    {
-        $this->_schemaTool->dropSchema(
-            [$this->_em->getClassMetadata(GH8499VersionableEntity::class)]
-        );
+        $this->createSchemaForModels(GH8499VersionableEntity::class);
     }
 
     /**
@@ -102,7 +93,6 @@ class GH8499Test extends OrmFunctionalTestCase
             $test->getRevision()->getTimestamp(),
             'Current version timestamp is not greater than previous one.'
         );
-        $this->dropSchema();
     }
 
     /**
@@ -119,7 +109,6 @@ class GH8499Test extends OrmFunctionalTestCase
 
         $this->expectException(OptimisticLockException::class);
         $this->_em->lock($entity, LockMode::OPTIMISTIC, new DateTime('2020-07-15 18:04:00'));
-        $this->dropSchema();
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8663Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8663Test.php
@@ -18,18 +18,7 @@ class GH8663Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(GH8663VersionedEntity::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(GH8663VersionedEntity::class),
-        ]);
-
-        parent::tearDown();
+        $this->createSchemaForModels(GH8663VersionedEntity::class);
     }
 
     public function testDeletedEntity(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9027Test.php
@@ -20,20 +20,7 @@ class GH9027Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(GH9027Cart::class),
-            $this->_em->getClassMetadata(GH9027Customer::class),
-        ]);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(GH9027Cart::class),
-            $this->_em->getClassMetadata(GH9027Customer::class),
-        ]);
-
-        parent::tearDown();
+        $this->createSchemaForModels(GH9027Cart::class, GH9027Customer::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9109Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9109Test.php
@@ -23,24 +23,7 @@ class GH9109Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(GH9109User::class),
-                $this->_em->getClassMetadata(GH9109Product::class),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(GH9109User::class),
-                $this->_em->getClassMetadata(GH9109Product::class),
-            ]
-        );
-
-        parent::tearDown();
+        $this->createSchemaForModels(GH9109User::class, GH9109Product::class);
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -21,7 +21,6 @@ use Doctrine\ORM\Mapping\ReflectionEmbeddedProperty;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\Persistence\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function class_exists;
 use function sprintf;
@@ -35,19 +34,14 @@ class ValueObjectsTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC93Person::class),
-                    $this->_em->getClassMetadata(DDC93Address::class),
-                    $this->_em->getClassMetadata(DDC93Vehicle::class),
-                    $this->_em->getClassMetadata(DDC93Car::class),
-                    $this->_em->getClassMetadata(DDC3027Animal::class),
-                    $this->_em->getClassMetadata(DDC3027Dog::class),
-                ]
-            );
-        } catch (Exception $e) {
-        }
+        $this->createSchemaForModels(
+            DDC93Person::class,
+            DDC93Address::class,
+            DDC93Vehicle::class,
+            DDC93Car::class,
+            DDC3027Animal::class,
+            DDC3027Dog::class
+        );
     }
 
     public function testMetadataHasReflectionEmbeddablesAccessible(): void

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -19,8 +19,10 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\EventListener\CacheMetadataListener;
@@ -336,6 +338,22 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue5989\Issue5989Manager::class,
         ],
     ];
+
+    /**
+     * @param class-string ...$models
+     */
+    final protected function createSchemaForModels(string ...$models): void
+    {
+        try {
+            $this->_schemaTool->createSchema(array_map(
+                function (string $className): ClassMetadata {
+                    return $this->_em->getClassMetadata($className);
+                },
+                $models
+            ));
+        } catch (ToolsException $e) {
+        }
+    }
 
     protected function useModelSet(string $setName): void
     {


### PR DESCRIPTION
In https://github.com/doctrine/orm/pull/8962, I established that
swallowing exceptions while creating model was bad because it could hide
other helpful exceptions.
As it turns out however, swallowing exceptions is really the way to go
here, because of the performance implication of calling dropSchema(). It
is possible to catch a more precise exception as well, which should
preserve the benefits of not swallowing them.

It looks like I based my grep on the comment inside the catch and today,
I found many other occurrences of this pattern, without the easy to grep
comment.

I decided to fix them as well, but in a lazier way: one no longer has to
remember to call dropSchema in tearDown() now, it is automated.

Here is the `grep` I used this time: `rg  --multiline  '\} catch \(Exception \$e\) \{\n\s+\}'`

## TODO
- [x] fix other 25 occurrences
- [x] `grep` for `dropSchema` and improve tests changed in #8962 as well.