### PR TITLE
Document QueryComponent array shape

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -17,12 +17,14 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
 use Doctrine\ORM\Utility\PersisterHelper;
+use LogicException;
 
 use function array_diff;
 use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
+use function assert;
 use function count;
 use function implode;
 use function in_array;
@@ -40,6 +42,8 @@ use function trim;
 /**
  * The SqlWalker is a TreeWalker that walks over a DQL AST and constructs
  * the corresponding SQL.
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 class SqlWalker implements TreeWalker
 {
@@ -127,21 +131,14 @@ class SqlWalker implements TreeWalker
     /**
      * Map of all components/classes that appear in the DQL query.
      *
-     * @psalm-var array<string, array{
-     *                metadata: ClassMetadata,
-     *                parent: string,
-     *                relation: mixed[],
-     *                map: mixed,
-     *                nestingLevel: int,
-     *                token: array
-     *            }>
+     * @psalm-var array<string, QueryComponent>
      */
     private $queryComponents;
 
     /**
      * A list of classes that appear in non-scalar SelectExpressions.
      *
-     * @psalm-var list<array{class: ClassMetadata, dqlAlias: string, resultAlias: string}>
+     * @psalm-var array<string, array{class: ClassMetadata, dqlAlias: string, resultAlias: string|null}>
      */
     private $selectedClasses = [];
 
@@ -225,18 +222,20 @@ class SqlWalker implements TreeWalker
      * @param string $dqlAlias The DQL alias.
      *
      * @return mixed[]
-     * @psalm-return array{
-     *     metadata: ClassMetadata,
-     *     parent: string,
-     *     relation: mixed[],
-     *     map: mixed,
-     *     nestingLevel: int,
-     *     token: array
-     * }
+     * @psalm-return QueryComponent
      */
     public function getQueryComponent($dqlAlias)
     {
         return $this->queryComponents[$dqlAlias];
+    }
+
+    public function getMetadataForDqlAlias(string $dqlAlias): ClassMetadata
+    {
+        if (! isset($this->queryComponents[$dqlAlias]['metadata'])) {
+            throw new LogicException(sprintf('No metadata for DQL alias: %s', $dqlAlias));
+        }
+
+        return $this->queryComponents[$dqlAlias]['metadata'];
     }
 
     /**
@@ -411,6 +410,7 @@ class SqlWalker implements TreeWalker
                 continue;
             }
 
+            assert(isset($qComp['metadata']));
             $persister = $this->em->getUnitOfWork()->getEntityPersister($qComp['metadata']->name);
 
             foreach ($qComp['relation']['orderBy'] as $fieldName => $orientation) {
@@ -444,7 +444,7 @@ class SqlWalker implements TreeWalker
         $sqlParts = [];
 
         foreach ($dqlAliases as $dqlAlias) {
-            $class = $this->queryComponents[$dqlAlias]['metadata'];
+            $class = $this->getMetadataForDqlAlias($dqlAlias);
 
             if (! $class->isInheritanceTypeSingleTable()) {
                 continue;
@@ -613,7 +613,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkEntityIdentificationVariable($identVariable)
     {
-        $class      = $this->queryComponents[$identVariable]['metadata'];
+        $class      = $this->getMetadataForDqlAlias($identVariable);
         $tableAlias = $this->getSQLTableAlias($class->getTableName(), $identVariable);
         $sqlParts   = [];
 
@@ -634,7 +634,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkIdentificationVariable($identificationVariable, $fieldName = null)
     {
-        $class = $this->queryComponents[$identificationVariable]['metadata'];
+        $class = $this->getMetadataForDqlAlias($identificationVariable);
 
         if (
             $fieldName !== null && $class->isInheritanceTypeJoined() &&
@@ -657,7 +657,7 @@ class SqlWalker implements TreeWalker
             case AST\PathExpression::TYPE_STATE_FIELD:
                 $fieldName = $pathExpr->field;
                 $dqlAlias  = $pathExpr->identificationVariable;
-                $class     = $this->queryComponents[$dqlAlias]['metadata'];
+                $class     = $this->getMetadataForDqlAlias($dqlAlias);
 
                 if ($this->useSqlTableAliases) {
                     $sql .= $this->walkIdentificationVariable($dqlAlias, $fieldName) . '.';
@@ -671,7 +671,7 @@ class SqlWalker implements TreeWalker
                 //    Just use the foreign key, i.e. u.group_id
                 $fieldName = $pathExpr->field;
                 $dqlAlias  = $pathExpr->identificationVariable;
-                $class     = $this->queryComponents[$dqlAlias]['metadata'];
+                $class     = $this->getMetadataForDqlAlias($dqlAlias);
 
                 if (isset($class->associationMappings[$fieldName]['inherited'])) {
                     $class = $this->em->getClassMetadata($class->associationMappings[$fieldName]['inherited']);
@@ -724,9 +724,11 @@ class SqlWalker implements TreeWalker
             $resultAlias = $selectedClass['resultAlias'];
 
             // Register as entity or joined entity result
-            if ($this->queryComponents[$dqlAlias]['relation'] === null) {
+            if (! isset($this->queryComponents[$dqlAlias]['relation'])) {
                 $this->rsm->addEntityResult($class->name, $dqlAlias, $resultAlias);
             } else {
+                assert(isset($this->queryComponents[$dqlAlias]['parent']));
+
                 $this->rsm->addJoinedEntityResult(
                     $class->name,
                     $dqlAlias,
@@ -873,7 +875,7 @@ class SqlWalker implements TreeWalker
             case AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION:
                 // Just use the foreign key, i.e. u.group_id
                 $fieldName = $pathExpression->field;
-                $class     = $this->queryComponents[$alias]['metadata'];
+                $class     = $this->getMetadataForDqlAlias($alias);
 
                 if (isset($class->associationMappings[$fieldName]['inherited'])) {
                     $class = $this->em->getClassMetadata($class->associationMappings[$fieldName]['inherited']);
@@ -969,7 +971,8 @@ class SqlWalker implements TreeWalker
         $joinedDqlAlias            = $joinAssociationDeclaration->aliasIdentificationVariable;
         $indexBy                   = $joinAssociationDeclaration->indexBy;
 
-        $relation        = $this->queryComponents[$joinedDqlAlias]['relation'];
+        $relation = $this->queryComponents[$joinedDqlAlias]['relation'] ?? null;
+        assert($relation !== null);
         $targetClass     = $this->em->getClassMetadata($relation['targetEntity']);
         $sourceClass     = $this->em->getClassMetadata($relation['sourceEntity']);
         $targetTableName = $this->quoteStrategy->getTableName($targetClass, $this->platform);
@@ -1323,8 +1326,7 @@ class SqlWalker implements TreeWalker
 
                 $fieldName = $expr->field;
                 $dqlAlias  = $expr->identificationVariable;
-                $qComp     = $this->queryComponents[$dqlAlias];
-                $class     = $qComp['metadata'];
+                $class     = $this->getMetadataForDqlAlias($dqlAlias);
 
                 $resultAlias = $selectExpression->fieldIdentificationVariable ?: $fieldName;
                 $tableName   = $class->isInheritanceTypeJoined()
@@ -1418,8 +1420,7 @@ class SqlWalker implements TreeWalker
                     $partialFieldSet = [];
                 }
 
-                $queryComp   = $this->queryComponents[$dqlAlias];
-                $class       = $queryComp['metadata'];
+                $class       = $this->getMetadataForDqlAlias($dqlAlias);
                 $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
 
                 if (! isset($this->selectedClasses[$dqlAlias])) {
@@ -1591,8 +1592,7 @@ class SqlWalker implements TreeWalker
 
                 case $e instanceof AST\PathExpression:
                     $dqlAlias     = $e->identificationVariable;
-                    $qComp        = $this->queryComponents[$dqlAlias];
-                    $class        = $qComp['metadata'];
+                    $class        = $this->getMetadataForDqlAlias($dqlAlias);
                     $fieldType    = $class->fieldMappings[$e->field]['type'];
                     $fieldName    = $e->field;
                     $fieldMapping = $class->fieldMappings[$fieldName];
@@ -1730,7 +1730,7 @@ class SqlWalker implements TreeWalker
                 return $this->walkPathExpression($resultVariable);
             }
 
-            if (isset($resultVariable->pathExpression)) {
+            if ($resultVariable instanceof AST\Node && isset($resultVariable->pathExpression)) {
                 return $this->walkPathExpression($resultVariable->pathExpression);
             }
 
@@ -1740,14 +1740,14 @@ class SqlWalker implements TreeWalker
         // IdentificationVariable
         $sqlParts = [];
 
-        foreach ($this->queryComponents[$groupByItem]['metadata']->fieldNames as $field) {
+        foreach ($this->getMetadataForDqlAlias($groupByItem)->fieldNames as $field) {
             $item       = new AST\PathExpression(AST\PathExpression::TYPE_STATE_FIELD, $groupByItem, $field);
             $item->type = AST\PathExpression::TYPE_STATE_FIELD;
 
             $sqlParts[] = $this->walkPathExpression($item);
         }
 
-        foreach ($this->queryComponents[$groupByItem]['metadata']->associationMappings as $mapping) {
+        foreach ($this->getMetadataForDqlAlias($groupByItem)->associationMappings as $mapping) {
             if ($mapping['isOwningSide'] && $mapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $item       = new AST\PathExpression(AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $groupByItem, $mapping['fieldName']);
                 $item->type = AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
@@ -1830,7 +1830,7 @@ class SqlWalker implements TreeWalker
         if ($this->em->hasFilters()) {
             $filterClauses = [];
             foreach ($this->rootAliases as $dqlAlias) {
-                $class      = $this->queryComponents[$dqlAlias]['metadata'];
+                $class      = $this->getMetadataForDqlAlias($dqlAlias);
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
 
                 $filterExpr = $this->generateFilterConditionSQL($class, $tableAlias);
@@ -1941,7 +1941,7 @@ class SqlWalker implements TreeWalker
         $fieldName = $collPathExpr->field;
         $dqlAlias  = $collPathExpr->identificationVariable;
 
-        $class = $this->queryComponents[$dqlAlias]['metadata'];
+        $class = $this->getMetadataForDqlAlias($dqlAlias);
 
         switch (true) {
             // InputParameter
@@ -2081,7 +2081,7 @@ class SqlWalker implements TreeWalker
         $sql = '';
 
         $dqlAlias   = $instanceOfExpr->identificationVariable;
-        $discrClass = $class = $this->queryComponents[$dqlAlias]['metadata'];
+        $discrClass = $class = $this->getMetadataForDqlAlias($dqlAlias);
 
         if ($class->discriminatorColumn) {
             $discrClass = $this->em->getClassMetadata($class->rootEntityName);

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * Interface for walkers of DQL ASTs (abstract syntax trees).
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 interface TreeWalker
 {
@@ -18,6 +19,7 @@ interface TreeWalker
      * @param AbstractQuery $query           The parsed Query.
      * @param ParserResult  $parserResult    The result of the parsing process.
      * @param mixed[]       $queryComponents The query components (symbol table).
+     * @psalm-param array<string, QueryComponent> $queryComponents The query components (symbol table).
      */
     public function __construct($query, $parserResult, array $queryComponents);
 
@@ -25,14 +27,7 @@ interface TreeWalker
      * Returns internal queryComponents array.
      *
      * @return array<string, array<string, mixed>>
-     * @psalm-return array<string, array{
-     *                   metadata: ClassMetadata,
-     *                   parent: string,
-     *                   relation: mixed[],
-     *                   map: mixed,
-     *                   nestingLevel: int,
-     *                   token: array
-     *               }>
+     * @psalm-return array<string, QueryComponent>
      */
     public function getQueryComponents();
 
@@ -41,6 +36,7 @@ interface TreeWalker
      *
      * @param string               $dqlAlias       The DQL alias.
      * @param array<string, mixed> $queryComponent
+     * @psalm-param QueryComponent $queryComponent
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 use function array_diff;
 use function array_keys;
@@ -13,6 +12,8 @@ use function array_keys;
 /**
  * An adapter implementation of the TreeWalker interface. The methods in this class
  * are empty. This class exists as convenience for creating tree walkers.
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 abstract class TreeWalkerAdapter implements TreeWalker
 {
@@ -33,14 +34,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * The query components of the original query (the "symbol table") that was produced by the Parser.
      *
-     * @psalm-var array<string, array{
-     *                metadata: ClassMetadata,
-     *                parent: string,
-     *                relation: mixed[],
-     *                map: mixed,
-     *                nestingLevel: int,
-     *                token: array
-     *            }>
+     * @psalm-var array<string, QueryComponent>
      */
     private $_queryComponents;
 

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Generator;
 
 use function array_diff;
@@ -15,6 +14,8 @@ use function array_keys;
  * Represents a chain of tree walkers that modify an AST and finally emit output.
  * Only the last walker in the chain can emit output. Any previous walkers can modify
  * the AST to influence the final output produced by the last walker.
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 class TreeWalkerChain implements TreeWalker
 {
@@ -36,14 +37,7 @@ class TreeWalkerChain implements TreeWalker
      * The query components of the original query (the "symbol table") that was produced by the Parser.
      *
      * @var array<string, array<string, mixed>>
-     * @psalm-var array<string, array{
-     *                metadata: ClassMetadata,
-     *                parent: string,
-     *                relation: mixed[],
-     *                map: mixed,
-     *                nestingLevel: int,
-     *                token: array
-     *            }>
+     * @psalm-var array<string, QueryComponent>
      */
     private $queryComponents;
 

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\SqlWalker;
@@ -28,6 +29,8 @@ use function sprintf;
  *
  * Works with composite keys but cannot deal with queries that have multiple
  * root entities (e.g. `SELECT f, b from Foo, Bar`)
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 class CountOutputWalker extends SqlWalker
 {
@@ -37,9 +40,6 @@ class CountOutputWalker extends SqlWalker
     /** @var ResultSetMapping */
     private $rsm;
 
-    /** @var mixed[] */
-    private $queryComponents;
-
     /**
      * Stores various parameters that are otherwise unavailable
      * because Doctrine\ORM\Query\SqlWalker keeps everything private without
@@ -48,12 +48,12 @@ class CountOutputWalker extends SqlWalker
      * @param Query        $query
      * @param ParserResult $parserResult
      * @param mixed[]      $queryComponents
+     * @psalm-param array<string, QueryComponent> $queryComponents
      */
     public function __construct($query, $parserResult, array $queryComponents)
     {
-        $this->platform        = $query->getEntityManager()->getConnection()->getDatabasePlatform();
-        $this->rsm             = $parserResult->getResultSetMapping();
-        $this->queryComponents = $queryComponents;
+        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->rsm      = $parserResult->getResultSetMapping();
 
         parent::__construct($query, $parserResult, $queryComponents);
     }
@@ -97,7 +97,7 @@ class CountOutputWalker extends SqlWalker
 
         $fromRoot       = reset($from);
         $rootAlias      = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-        $rootClass      = $this->queryComponents[$rootAlias]['metadata'];
+        $rootClass      = $this->getMetadataForDqlAlias($rootAlias);
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Query\AST\OrderByClause;
 use Doctrine\ORM\Query\AST\PartialObjectExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -45,6 +46,8 @@ use function substr;
  *
  * Works with composite keys but cannot deal with queries that have multiple
  * root entities (e.g. `SELECT f, b from Foo, Bar`)
+ *
+ * @psalm-import-type QueryComponent from Parser
  */
 class LimitSubqueryOutputWalker extends SqlWalker
 {
@@ -55,9 +58,6 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
     /** @var ResultSetMapping */
     private $rsm;
-
-    /** @var mixed[] */
-    private $queryComponents;
 
     /** @var int */
     private $firstResult;
@@ -92,12 +92,12 @@ class LimitSubqueryOutputWalker extends SqlWalker
      * @param Query        $query
      * @param ParserResult $parserResult
      * @param mixed[]      $queryComponents
+     * @psalm-param array<string, QueryComponent> $queryComponents
      */
     public function __construct($query, $parserResult, array $queryComponents)
     {
-        $this->platform        = $query->getEntityManager()->getConnection()->getDatabasePlatform();
-        $this->rsm             = $parserResult->getResultSetMapping();
-        $this->queryComponents = $queryComponents;
+        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->rsm      = $parserResult->getResultSetMapping();
 
         // Reset limit and offset
         $this->firstResult = $query->getFirstResult();
@@ -413,7 +413,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
         // Generate DQL alias -> SQL table alias mapping
         foreach (array_keys($this->rsm->aliasMap) as $dqlAlias) {
-            $metadataList[$dqlAlias] = $class = $this->queryComponents[$dqlAlias]['metadata'];
+            $metadataList[$dqlAlias] = $class = $this->getMetadataForDqlAlias($dqlAlias);
             $aliasMap[$dqlAlias]     = $this->getSQLTableAlias($class->getTableName(), $dqlAlias);
         }
 
@@ -511,7 +511,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
         $fromRoot       = reset($from);
         $rootAlias      = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-        $rootClass      = $this->queryComponents[$rootAlias]['metadata'];
+        $rootClass      = $this->getMetadataForDqlAlias($rootAlias);
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -134,6 +134,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                     $queryComponent = $queryComponents[$expression->identificationVariable];
                     if (
                         isset($queryComponent['parent'])
+                        && isset($queryComponent['relation'])
                         && $queryComponent['relation']['type'] & ClassMetadataInfo::TO_MANY
                     ) {
                         throw new RuntimeException('Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -976,16 +976,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-
-			message: "#^Offset 'resultVariable' on array\\{metadata\\: Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, parent\\: string, relation\\: array, map\\: mixed, nestingLevel\\: int, token\\: array\\} in isset\\(\\) does not exist\\.$#"
-			count: 3
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
-
-		-
-			message: "#^Offset string on array\\<int, array\\{class\\: Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, dqlAlias\\: string, resultAlias\\: string\\}\\> in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
-
-		-
 			message: "#^Parameter \\#1 \\$entity of static method Doctrine\\\\ORM\\\\OptimisticLockException\\:\\:lockFailed\\(\\) expects object, class\\-string\\<object\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1003,11 +993,6 @@ parameters:
 		-
 			message: "#^Result of && is always false\\.$#"
 			count: 2
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
-			count: 1
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-
@@ -1714,16 +1699,6 @@ parameters:
 			message: "#^Return type \\(void\\) of method Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\CountWalker\\:\\:walkSelectStatement\\(\\) should be compatible with return type \\(string\\) of method Doctrine\\\\ORM\\\\Query\\\\TreeWalker\\:\\:walkSelectStatement\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$name\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
-
-		-
-			message: "#^Offset 'parent' on array\\{metadata\\: Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, parent\\: string, relation\\: array, map\\: mixed, nestingLevel\\: int, token\\: array\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
 
 		-
 			message: "#^Return type \\(void\\) of method Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\LimitSubqueryWalker\\:\\:walkSelectStatement\\(\\) should be compatible with return type \\(string\\) of method Doctrine\\\\ORM\\\\Query\\\\TreeWalker\\:\\:walkSelectStatement\\(\\)$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1696,19 +1696,9 @@
     <PossiblyNullArrayAccess occurrences="1">
       <code>$parser-&gt;getLexer()-&gt;token['value']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$class-&gt;associationMappings</code>
-    </PossiblyNullArrayOffset>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$parser-&gt;getLexer()-&gt;token['value']</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$fieldMapping</code>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$pathExpression</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;fieldMapping !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1752,9 +1742,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php">
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$class-&gt;associationMappings</code>
-    </PossiblyNullArrayOffset>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$collectionPathExpression</code>
     </PropertyNotSetInConstructor>
@@ -2214,10 +2201,9 @@
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArgument occurrences="22">
+    <PossiblyNullArgument occurrences="21">
       <code>$aliasIdentVariable</code>
       <code>$dql</code>
-      <code>$field</code>
       <code>$fromClassName</code>
       <code>$functionName</code>
       <code>$functionName</code>
@@ -2238,7 +2224,7 @@
       <code>$token['value']</code>
       <code>$token['value']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="74">
+    <PossiblyNullArrayAccess occurrences="73">
       <code>$glimpse['type']</code>
       <code>$glimpse['value']</code>
       <code>$lookahead['type']</code>
@@ -2280,7 +2266,6 @@
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
@@ -2378,10 +2363,9 @@
     </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
-    <DocblockTypeContradiction occurrences="6">
+    <DocblockTypeContradiction occurrences="5">
       <code>$likeExpr-&gt;stringPattern instanceof AST\Functions\FunctionNode</code>
       <code>$likeExpr-&gt;stringPattern instanceof AST\PathExpression</code>
-      <code>$this-&gt;queryComponents[$dqlAlias]['relation'] === null</code>
       <code>''</code>
       <code>is_string($expression)</code>
       <code>is_string($stringExpr)</code>
@@ -2395,9 +2379,6 @@
       <code>$factor</code>
       <code>$selectedClass['class']-&gt;name</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
-      <code>$this-&gt;selectedClasses[$joinedDqlAlias]</code>
-    </InvalidArrayOffset>
     <InvalidNullableReturnType occurrences="1">
       <code>walkConditionalPrimary</code>
     </InvalidNullableReturnType>
@@ -2450,10 +2431,8 @@
     <PossiblyNullReference occurrences="1">
       <code>dispatch</code>
     </PossiblyNullReference>
-    <PropertyTypeCoercion occurrences="3">
+    <PropertyTypeCoercion occurrences="1">
       <code>$query</code>
-      <code>$this-&gt;queryComponents</code>
-      <code>$this-&gt;selectedClasses</code>
     </PropertyTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="3">
       <code>$likeExpr-&gt;stringPattern instanceof AST\InputParameter</code>
@@ -2559,9 +2538,6 @@
     <MissingReturnType occurrences="1">
       <code>_getQueryComponents</code>
     </MissingReturnType>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;_queryComponents</code>
-    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/TreeWalkerChain.php">
     <ImplementedReturnTypeMismatch occurrences="47">


### PR DESCRIPTION
I'm currently improving the types on SqlWalkers/TreeWalkers for 3.0. One issue I found was that the knowledge over the structure of the parser's internal `$queryComponents` array was spread/copied over multiple classes.

With this PR, I'm introducing a reusalbe Psalm type to streamline the type declarations.