### PR TITLE
Allow custom repository implementations to skip EntityRepository

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -824,6 +824,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Sets default repository class.
      *
      * @param string $className
+     * @psalm-param class-string<ObjectRepository> $className
      *
      * @return void
      *
@@ -844,7 +845,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Get default repository class.
      *
      * @return string
-     * @psalm-return class-string
+     * @psalm-return class-string<ObjectRepository>
      */
     public function getDefaultRepositoryClassName()
     {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -26,7 +26,6 @@ use Doctrine\ORM\Query\FilterCollection;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\MappingException;
-use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Throwable;
 
@@ -770,15 +769,7 @@ use function sprintf;
     }
 
     /**
-     * Gets the repository for an entity class.
-     *
-     * @param string $entityName The name of the entity.
-     * @psalm-param class-string<T> $entityName
-     *
-     * @return ObjectRepository|EntityRepository The repository class.
-     * @psalm-return EntityRepository<T>
-     *
-     * @template T of object
+     * {@inheritdoc}
      */
     public function getRepository($entityName)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -25,17 +25,6 @@ use Doctrine\Persistence\ObjectManager;
 interface EntityManagerInterface extends ObjectManager
 {
     /**
-     * {@inheritdoc}
-     *
-     * @psalm-param class-string<T> $className
-     *
-     * @psalm-return EntityRepository<T>
-     *
-     * @template T of object
-     */
-    public function getRepository($className);
-
-    /**
      * Returns the cache API for managing the second level cache regions or NULL if the cache is not enabled.
      *
      * @return Cache|null

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -16,10 +16,10 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ORM\Cache\Exception\NonCacheableEntityAssociation;
-use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ReflectionService;
+use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
@@ -323,7 +323,7 @@ class ClassMetadataInfo implements ClassMetadata
      * (Optional).
      *
      * @var string|null
-     * @psalm-var ?class-string<EntityRepository>
+     * @psalm-var ?class-string<ObjectRepository>
      */
     public $customRepositoryClassName;
 
@@ -3018,7 +3018,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Registers a custom repository class for the entity class.
      *
      * @param string|null $repositoryClassName The class name of the custom mapper.
-     * @psalm-param class-string<EntityRepository>|null $repositoryClassName
+     * @psalm-param class-string<ObjectRepository>|null $repositoryClassName
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -6,7 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ObjectRepository;
 
 /**
  * @Annotation
@@ -18,7 +18,7 @@ final class Entity implements Annotation
 {
     /**
      * @var string|null
-     * @psalm-var class-string<EntityRepository>|null
+     * @psalm-var class-string<ObjectRepository>|null
      */
     public $repositoryClass;
 
@@ -26,7 +26,7 @@ final class Entity implements Annotation
     public $readOnly = false;
 
     /**
-     * @psalm-param class-string<EntityRepository>|null $repositoryClass
+     * @psalm-param class-string<ObjectRepository>|null $repositoryClass
      */
     public function __construct(?string $repositoryClass = null, bool $readOnly = false)
     {

--- a/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
+++ b/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
@@ -6,7 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ObjectRepository;
 
 /**
  * @Annotation
@@ -18,12 +18,12 @@ final class MappedSuperclass implements Annotation
 {
     /**
      * @var string|null
-     * @psalm-var class-string<EntityRepository>|null
+     * @psalm-var class-string<ObjectRepository>|null
      */
     public $repositoryClass;
 
     /**
-     * @psalm-param class-string<EntityRepository>|null $repositoryClass
+     * @psalm-param class-string<ObjectRepository>|null $repositoryClass
      */
     public function __construct(?string $repositoryClass = null)
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -224,8 +224,7 @@
     </NoInterfaceProperties>
   </file>
   <file src="lib/Doctrine/ORM/Configuration.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$className</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
     <DeprecatedClass occurrences="2">
@@ -297,15 +296,9 @@
       <code>getPartialReference</code>
       <code>getReference</code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;repositoryFactory-&gt;getRepository($this, $entityName)</code>
-    </LessSpecificReturnStatement>
     <MissingReturnType occurrences="1">
       <code>wrapInTransaction</code>
     </MissingReturnType>
-    <MoreSpecificReturnType occurrences="1">
-      <code>EntityRepository&lt;T&gt;</code>
-    </MoreSpecificReturnType>
     <ParamNameMismatch occurrences="8">
       <code>$entity</code>
       <code>$entity</code>
@@ -2712,14 +2705,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>self::SELECT</code>
     </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>new $repositoryClassName($entityManager, $metadata)</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>ObjectRepository</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php">
     <MissingReturnType occurrences="1">

--- a/tests/Doctrine/Tests/ORM/Functional/CustomRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomRepositoryTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectRepository;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class CustomRepositoryTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(MinimalEntity::class, OtherMinimalEntity::class);
+    }
+
+    public function testMinimalRepository(): void
+    {
+        $this->_em->persist(new MinimalEntity('foo'));
+        $this->_em->persist(new MinimalEntity('bar'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(MinimalEntity::class);
+        self::assertInstanceOf(MinimalRepository::class, $repository);
+        self::assertSame('foo', $repository->find('foo')->id);
+    }
+
+    public function testMinimalDefaultRepository(): void
+    {
+        $this->_em->getConfiguration()->setDefaultRepositoryClassName(MinimalRepository::class);
+
+        $this->_em->persist(new OtherMinimalEntity('foo'));
+        $this->_em->persist(new OtherMinimalEntity('bar'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(OtherMinimalEntity::class);
+        self::assertInstanceOf(MinimalRepository::class, $repository);
+        self::assertSame('foo', $repository->find('foo')->id);
+    }
+}
+
+/**
+ * @ORM\Entity(repositoryClass="MinimalRepository")
+ */
+class MinimalEntity
+{
+    /**
+     * @ORM\Column
+     * @ORM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class OtherMinimalEntity
+{
+    /**
+     * @ORM\Column
+     * @ORM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @template TEntity of object
+ * @implements ObjectRepository<TEntity>
+ */
+class MinimalRepository implements ObjectRepository
+{
+    /** @var EntityManagerInterface */
+    private $em;
+    /** @var ClassMetadata<TEntity> */
+    private $class;
+
+    /**
+     * @psalm-param ClassMetadata<TEntity> $class
+     */
+    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
+    {
+        $this->em    = $em;
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        return $this->em->find($this->class->name, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAll(): array
+    {
+        return $this->findBy([]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
+    {
+        $persister = $this->em->getUnitOfWork()->getEntityPersister($this->class->name);
+
+        return $persister->loadAll($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findOneBy(array $criteria)
+    {
+        $persister = $this->em->getUnitOfWork()->getEntityPersister($this->class->name);
+
+        return $persister->load($criteria, null, null, [], null, 1);
+    }
+
+    public function getClassName(): string
+    {
+        return $this->class->name;
+    }
+}


### PR DESCRIPTION
This change might be controversial.

Currently, the ORM requires repositories to be implementations of the generic `ObjectRepository` interface only. The ORM's own `EntityRepository` class is the default and can be used as base class for custom implementations, but we don't have to use it.

On the other hand, `EntityManagerInterface::getRepository()` promises to always return a `EntityRepository`. This works fine now, but will fail if we migrate to native return types.

This PR widens all return types to hint at the more generic `ObjectRepository` interface. It also adds a functional test that makes sure, generic `ObjectRepository` implementations can be used.

However, I'm unsure if using generic `ObjectRepository` implementations is a case that we actually want to support. The alternative could be to deprecate not using an `EntityRepository` sub-class and trigger an error on 3.0.