### PR TITLE
Un-deprecate the current proxy mechanism

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,22 @@
 # Upgrade to 2.12
 
+## Un-deprecate `Doctrine\ORM\Proxy\Proxy`
+
+Because no forward-compatible new proxy solution had been implemented yet, the
+current proxy mechanism is not considered deprecated anymore for the time
+being. This applies to the following interfaces/classes:
+
+* `Doctrine\ORM\Proxy\Proxy`
+* `Doctrine\ORM\Proxy\ProxyFactory`
+
+These methods have been un-deprecated:
+
+* `Doctrine\ORM\Configuration::getAutoGenerateProxyClasses()`
+* `Doctrine\ORM\Configuration::getProxyDir()`
+* `Doctrine\ORM\Configuration::getProxyNamespace()`
+
+Note that the `Doctrine\ORM\Proxy\Autoloader` remains deprecated and will be removed in 3.0.
+
 ## Deprecate helper methods from `AbstractCollectionPersister`
 
 The following protected methods of

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -34,6 +34,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
@@ -55,6 +56,8 @@ use function trim;
  * It combines all configuration options from DBAL & ORM.
  *
  * Internal note: When adding a new configuration option just write a getter/setter pair.
+ *
+ * @psalm-import-type AutogenerateMode from ProxyFactory
  */
 class Configuration extends \Doctrine\DBAL\Configuration
 {
@@ -76,10 +79,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Gets the directory where Doctrine generates any necessary proxy class files.
      *
-     * @deprecated 2.7 We're switch to `ocramius/proxy-manager` and this method isn't applicable any longer
-     *
-     * @see https://github.com/Ocramius/ProxyManager
-     *
      * @return string|null
      */
     public function getProxyDir()
@@ -90,11 +89,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Gets the strategy for automatically generating proxy classes.
      *
-     * @deprecated 2.7 We're switch to `ocramius/proxy-manager` and this method isn't applicable any longer
-     *
-     * @see https://github.com/Ocramius/ProxyManager
-     *
      * @return int Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
+     * @psalm-return AutogenerateMode
      */
     public function getAutoGenerateProxyClasses()
     {
@@ -116,10 +112,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /**
      * Gets the namespace where proxy classes reside.
-     *
-     * @deprecated 2.7 We're switch to `ocramius/proxy-manager` and this method isn't applicable any longer
-     *
-     * @see https://github.com/Ocramius/ProxyManager
      *
      * @return string|null
      */
@@ -559,7 +551,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
             throw QueryCacheUsesNonPersistentCache::fromDriver($queryCacheImpl);
         }
 
-        if ($this->getAutoGenerateProxyClasses()) {
+        if ($this->getAutoGenerateProxyClasses() !== AbstractProxyFactory::AUTOGENERATE_NEVER) {
             throw ProxyClassesAlwaysRegenerating::create();
         }
 

--- a/lib/Doctrine/ORM/Proxy/Proxy.php
+++ b/lib/Doctrine/ORM/Proxy/Proxy.php
@@ -8,8 +8,6 @@ use Doctrine\Common\Proxy\Proxy as BaseProxy;
 
 /**
  * Interface for proxy classes.
- *
- * @deprecated 2.7 This interface is being removed from the ORM and won't have any replacement, proxies will no longer implement it.
  */
 interface Proxy extends BaseProxy
 {

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -20,7 +20,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 /**
  * This factory is used to create proxy objects for entities at runtime.
  *
- * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
+ * @psalm-type AutogenerateMode = AbstractProxyFactory::AUTOGENERATE_NEVER|AbstractProxyFactory::AUTOGENERATE_ALWAYS|AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS|AbstractProxyFactory::AUTOGENERATE_EVAL|AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED
  */
 class ProxyFactory extends AbstractProxyFactory
 {
@@ -48,7 +48,8 @@ class ProxyFactory extends AbstractProxyFactory
      * @param string                 $proxyDir     The directory to use for the proxy classes. It must exist.
      * @param string                 $proxyNs      The namespace to use for the proxy classes.
      * @param bool|int               $autoGenerate The strategy for automatically generating proxy classes. Possible
-     *               values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
+     *                                             values are constants of {@see AbstractProxyFactory}.
+     * @psalm-param bool|AutogenerateMode $autoGenerate
      */
     public function __construct(EntityManagerInterface $em, $proxyDir, $proxyNs, $autoGenerate = AbstractProxyFactory::AUTOGENERATE_NEVER)
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -232,9 +232,8 @@
       <code>new CachedReader($reader, new ArrayCache())</code>
       <code>new SimpleAnnotationReader()</code>
     </DeprecatedClass>
-    <DeprecatedMethod occurrences="4">
+    <DeprecatedMethod occurrences="3">
       <code>AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php')</code>
-      <code>getAutoGenerateProxyClasses</code>
       <code>getMetadataCacheImpl</code>
       <code>getQueryCacheImpl</code>
     </DeprecatedMethod>
@@ -266,14 +265,8 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$connection</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="2">
-      <code>ProxyFactory</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="5">
-      <code>getAutoGenerateProxyClasses</code>
+    <DeprecatedMethod occurrences="2">
       <code>getMetadataCacheImpl</code>
-      <code>getProxyDir</code>
-      <code>getProxyNamespace</code>
       <code>merge</code>
     </DeprecatedMethod>
     <DocblockTypeContradiction occurrences="6">
@@ -346,11 +339,6 @@
     <UnsafeInstantiation occurrences="1">
       <code>new $class($this)</code>
     </UnsafeInstantiation>
-  </file>
-  <file src="lib/Doctrine/ORM/EntityManagerInterface.php">
-    <DeprecatedClass occurrences="1">
-      <code>ProxyFactory</code>
-    </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/EntityRepository.php">
     <InvalidReturnStatement occurrences="2">
@@ -2828,10 +2816,6 @@
     </NoInterfaceProperties>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php">
-    <DeprecatedMethod occurrences="2">
-      <code>getProxyDir</code>
-      <code>getProxyDir</code>
-    </DeprecatedMethod>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>


### PR DESCRIPTION
As discussed on #9502: Since there is no implemented alterantive to the current proxy mechanisms, it is impossible to use the ORM without tapping the deprecated proxy methods.

If we still plan to switch to ProxyManager, a future PR that adds the actual implementation for ProxyManager including a forward compatibility layer might deprecate parts of those methods again. Until that happens, we prepare for shipping 3.0 with the current proxy implementation.