### PR TITLE
Deprecate custom `ObjectRepository` implementations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade to 2.12
 
+## Deprecate custom repository classes that don't extend `EntityRepository`
+
+Although undocumented, it is currently possible to configure a custom repository
+class that implements `ObjectRepository` but does not extend the
+`EntityRepository` base class.
+
+This is now deprecated. Please extend `EntityRepository` instead.
+
 ## Deprecated more APIs related to entity namespace aliases
 
 ```diff

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -803,7 +803,18 @@ use function strpos;
             }
         }
 
-        return $this->repositoryFactory->getRepository($this, $entityName);
+        $repository = $this->repositoryFactory->getRepository($this, $entityName);
+        if (! $repository instanceof EntityRepository) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9533',
+                'Not returning an instance of %s from %s::getRepository() is deprecated and will cause a TypeError on 3.0.',
+                EntityRepository::class,
+                get_debug_type($this->repositoryFactory)
+            );
+        }
+
+        return $repository;
     }
 
     /**

--- a/lib/Doctrine/ORM/Exception/InvalidEntityRepository.php
+++ b/lib/Doctrine/ORM/Exception/InvalidEntityRepository.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Exception;
 
-use Doctrine\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
 
 final class InvalidEntityRepository extends ORMException implements ConfigurationException
 {
     public static function fromClassName(string $className): self
     {
         return new self(
-            "Invalid repository class '" . $className . "'. It must be a " . ObjectRepository::class . '.'
+            "Invalid repository class '" . $className . "'. It must be a " . EntityRepository::class . '.'
         );
     }
 }

--- a/lib/Doctrine/ORM/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/RepositoryFactory.php
@@ -18,7 +18,7 @@ interface RepositoryFactory
      * @param EntityManagerInterface $entityManager The EntityManager instance.
      * @param class-string<T>        $entityName    The name of the entity.
      *
-     * @return ObjectRepository<T>
+     * @return ObjectRepository<T> This type will change to {@see EntityRepository} in 3.0.
      *
      * @template T of object
      */

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -224,8 +224,7 @@
     </NoInterfaceProperties>
   </file>
   <file src="lib/Doctrine/ORM/Configuration.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$className</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
     <DeprecatedClass occurrences="2">
@@ -297,15 +296,9 @@
       <code>getPartialReference</code>
       <code>getReference</code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;repositoryFactory-&gt;getRepository($this, $entityName)</code>
-    </LessSpecificReturnStatement>
     <MissingReturnType occurrences="1">
       <code>wrapInTransaction</code>
     </MissingReturnType>
-    <MoreSpecificReturnType occurrences="1">
-      <code>EntityRepository&lt;T&gt;</code>
-    </MoreSpecificReturnType>
     <ParamNameMismatch occurrences="8">
       <code>$entity</code>
       <code>$entity</code>
@@ -2677,12 +2670,12 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <TypeDoesNotContainType occurrences="1">
+      <code>$repository instanceof EntityRepository</code>
+    </TypeDoesNotContainType>
+    <UnsafeInstantiation occurrences="1">
       <code>new $repositoryClassName($entityManager, $metadata)</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>ObjectRepository</code>
-    </MoreSpecificReturnType>
+    </UnsafeInstantiation>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php">
     <MissingReturnType occurrences="1">

--- a/tests/Doctrine/Performance/Hydration/SimpleHydrationBench.php
+++ b/tests/Doctrine/Performance/Hydration/SimpleHydrationBench.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Performance\Hydration;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\Performance\EntityManagerFactory;
-use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Tests\Models\CMS;
 
 /**
@@ -17,7 +17,7 @@ final class SimpleHydrationBench
     /** @var EntityManagerInterface */
     private $entityManager;
 
-    /** @var ObjectRepository */
+    /** @var EntityRepository */
     private $repository;
 
     public function init(): void

--- a/tests/Doctrine/Performance/Hydration/SingleTableInheritanceHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/SingleTableInheritanceHydrationPerformanceBench.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Performance\Hydration;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\Performance\EntityManagerFactory;
-use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Tests\Models\Company;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 
@@ -14,16 +14,16 @@ use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
  */
 final class SingleTableInheritanceHydrationPerformanceBench
 {
-    /** @var ObjectRepository */
+    /** @var EntityRepository */
     private $contractsRepository;
 
-    /** @var ObjectRepository */
+    /** @var EntityRepository */
     private $fixContractsRepository;
 
-    /** @var ObjectRepository */
+    /** @var EntityRepository */
     private $flexContractRepository;
 
-    /** @var ObjectRepository */
+    /** @var EntityRepository */
     private $ultraContractRepository;
 
     public function init(): void

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Cache\Exception\QueryCacheNotConfigured;
 use Doctrine\ORM\Cache\Exception\QueryCacheUsesNonPersistentCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\ProxyClassesAlwaysRegenerating;
 use Doctrine\ORM\Mapping as AnnotationNamespace;
@@ -25,10 +26,12 @@ use Doctrine\ORM\Mapping\PrePersist;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
+use stdClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function class_exists;
@@ -388,8 +391,17 @@ class ConfigurationTest extends DoctrineTestCase
         self::assertSame(EntityRepository::class, $this->configuration->getDefaultRepositoryClassName());
         $this->configuration->setDefaultRepositoryClassName(DDC753CustomRepository::class);
         self::assertSame(DDC753CustomRepository::class, $this->configuration->getDefaultRepositoryClassName());
-        $this->expectException(ORMException::class);
+        $this->expectException(InvalidEntityRepository::class);
+        $this->expectExceptionMessage('Invalid repository class \'Doctrine\Tests\ORM\ConfigurationTest\'. It must be a Doctrine\ORM\EntityRepository.');
         $this->configuration->setDefaultRepositoryClassName(self::class);
+    }
+
+    public function testSetDeprecatedDefaultRepositoryClassName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9533');
+
+        $this->configuration->setDefaultRepositoryClassName(DeprecatedRepository::class);
+        self::assertSame(DeprecatedRepository::class, $this->configuration->getDefaultRepositoryClassName());
     }
 
     public function testSetGetNamingStrategy(): void
@@ -443,5 +455,39 @@ class ConfigurationTestAnnotationReaderChecker
     /** @AnnotationNamespace\PrePersist */
     public function namespacedAnnotationMethod(): void
     {
+    }
+}
+
+class DeprecatedRepository implements ObjectRepository
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        return null;
+    }
+
+    public function findAll(): array
+    {
+        return [];
+    }
+
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findOneBy(array $criteria)
+    {
+        return null;
+    }
+
+    public function getClassName(): string
+    {
+        return stdClass::class;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/CustomRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomRepositoryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectRepository;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class CustomRepositoryTest extends OrmFunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9533');
+        $this->createSchemaForModels(MinimalEntity::class, OtherMinimalEntity::class);
+    }
+
+    public function testMinimalRepository(): void
+    {
+        $this->_em->persist(new MinimalEntity('foo'));
+        $this->_em->persist(new MinimalEntity('bar'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(MinimalEntity::class);
+        self::assertInstanceOf(MinimalRepository::class, $repository);
+        self::assertSame('foo', $repository->find('foo')->id);
+    }
+
+    public function testMinimalDefaultRepository(): void
+    {
+        $this->_em->getConfiguration()->setDefaultRepositoryClassName(MinimalRepository::class);
+
+        $this->_em->persist(new OtherMinimalEntity('foo'));
+        $this->_em->persist(new OtherMinimalEntity('bar'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(OtherMinimalEntity::class);
+        self::assertInstanceOf(MinimalRepository::class, $repository);
+        self::assertSame('foo', $repository->find('foo')->id);
+    }
+}
+
+/**
+ * @ORM\Entity(repositoryClass="MinimalRepository")
+ */
+class MinimalEntity
+{
+    /**
+     * @ORM\Column
+     * @ORM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class OtherMinimalEntity
+{
+    /**
+     * @ORM\Column
+     * @ORM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @template TEntity of object
+ * @implements ObjectRepository<TEntity>
+ */
+class MinimalRepository implements ObjectRepository
+{
+    /** @var EntityManagerInterface */
+    private $em;
+    /** @var ClassMetadata<TEntity> */
+    private $class;
+
+    /**
+     * @psalm-param ClassMetadata<TEntity> $class
+     */
+    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
+    {
+        $this->em    = $em;
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        return $this->em->find($this->class->name, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAll(): array
+    {
+        return $this->findBy([]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
+    {
+        $persister = $this->em->getUnitOfWork()->getEntityPersister($this->class->name);
+
+        return $persister->loadAll($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findOneBy(array $criteria)
+    {
+        $persister = $this->em->getUnitOfWork()->getEntityPersister($this->class->name);
+
+        return $persister->load($criteria, null, null, [], null, 1);
+    }
+
+    public function getClassName(): string
+    {
+        return $this->class->name;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Logging\Middleware as LoggingMiddleware;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnrecognizedIdentifierFields;
@@ -33,7 +32,6 @@ use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
 use Doctrine\Tests\Models\DDC753\DDC753DefaultRepository;
 use Doctrine\Tests\Models\DDC753\DDC753EntityWithCustomRepository;
 use Doctrine\Tests\Models\DDC753\DDC753EntityWithDefaultCustomRepository;
-use Doctrine\Tests\Models\DDC753\DDC753InvalidRepository;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function array_fill;
@@ -661,17 +659,6 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         self::assertEquals($this->_em->getConfiguration()->getDefaultRepositoryClassName(), DDC753DefaultRepository::class);
         $this->_em->getConfiguration()->setDefaultRepositoryClassName(EntityRepository::class);
         self::assertEquals($this->_em->getConfiguration()->getDefaultRepositoryClassName(), EntityRepository::class);
-    }
-
-    /**
-     * @group DDC-753
-     */
-    public function testSetDefaultRepositoryInvalidClassError(): void
-    {
-        $this->expectException(InvalidEntityRepository::class);
-        $this->expectExceptionMessage('Invalid repository class \'Doctrine\Tests\Models\DDC753\DDC753InvalidRepository\'. It must be a Doctrine\Persistence\ObjectRepository.');
-        self::assertEquals($this->_em->getConfiguration()->getDefaultRepositoryClassName(), EntityRepository::class);
-        $this->_em->getConfiguration()->setDefaultRepositoryClassName(DDC753InvalidRepository::class);
     }
 
     /**


### PR DESCRIPTION
Alternative approach to #9531.

Although the documentation never mentions it, it is currently possible to use an implementation of `ObjectRepository` as repository class that does not extend `EntityRepository`. A caller of `EntityManager::getRepository()` will probably not expect not getting an `EntityRepository` as return value.

This is why I'd like to deprecate that possibility. This will also allow us to safely use `EntityRepository` as a native return type in 3.0.