### PR TITLE
Leverage the `Stringable` interface

### DIFF
--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -6,13 +6,13 @@ namespace Doctrine\ORM;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use InvalidArgumentException;
+use Stringable;
 
 use function array_map;
 use function count;
 use function get_debug_type;
 use function gettype;
 use function implode;
-use function method_exists;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -223,19 +223,16 @@ class ORMInvalidArgumentException extends InvalidArgumentException
 
     /**
      * Helper method to show an object as string.
-     *
-     * @param object $obj
      */
-    private static function objToStr($obj): string
+    private static function objToStr(object $obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
+        return $obj instanceof Stringable ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
     }
 
     /**
-     * @param object $entity
      * @psalm-param array<string,string> $associationMapping
      */
-    private static function newEntityFoundThroughRelationshipMessage(array $associationMapping, $entity): string
+    private static function newEntityFoundThroughRelationshipMessage(array $associationMapping, object $entity): string
     {
         return 'A new entity was found through the relationship \''
             . $associationMapping['sourceEntity'] . '#' . $associationMapping['fieldName'] . '\' that was not'
@@ -243,7 +240,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
             . ' To solve this issue: Either explicitly call EntityManager#persist()'
             . ' on this unknown entity or configure cascade persist'
             . ' this association in the mapping for example @ManyToOne(..,cascade={"persist"}).'
-            . (method_exists($entity, '__toString')
+            . ($entity instanceof Stringable
                 ? ''
                 : ' If you cannot find out which entity causes the problem implement \''
                 . $associationMapping['targetEntity'] . '#__toString()\' to get a clue.'

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -40,6 +40,7 @@ use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
+use Stringable;
 use Throwable;
 use UnexpectedValueException;
 
@@ -60,7 +61,6 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_object;
-use function method_exists;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -2836,7 +2836,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private static function objToStr(object $obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
+        return $obj instanceof Stringable ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Stringable;
 
 use function spl_object_id;
 use function uniqid;
@@ -46,7 +47,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
         $stringEntity3 = uniqid('entity3', true);
         $entity1       = new stdClass();
         $entity2       = new stdClass();
-        $entity3       = $this->getMockBuilder(stdClass::class)->setMethods(['__toString'])->getMock();
+        $entity3       = $this->createMock(Stringable::class);
         $association1  = [
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
@@ -63,7 +64,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
             'targetEntity' => 'baz3',
         ];
 
-        $entity3->expects(self::any())->method('__toString')->willReturn($stringEntity3);
+        $entity3->method('__toString')->willReturn($stringEntity3);
 
         return [
             'one entity found' => [


### PR DESCRIPTION
In PHP 8, classes that implement the `__toString()` method automagically implement a new interface called `Stringable`. This means that we can rewrite `method_exists()` checks for `__toString()` to `instanceof` checks.

We could also consider announcing the `Stringable` interface explicitly on our own classes with a `__toString()` method. But that would be pure documentation because, as already mentioned, PHP will add the interface whether we announce it or not.