### PR TITLE
Make error message suggestion accurate

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -134,9 +134,9 @@ class SchemaValidator
                             'field ' . $assoc['targetEntity'] . '#' . $assoc['inversedBy'] . ' which does not exist.';
                 } elseif ($targetMetadata->associationMappings[$assoc['inversedBy']]['mappedBy'] === null) {
                     $ce[] = 'The field ' . $class->name . '#' . $fieldName . ' is on the owning side of a ' .
-                            'bi-directional relationship, but the specified mappedBy association on the target-entity ' .
-                            $assoc['targetEntity'] . '#' . $assoc['mappedBy'] . ' does not contain the required ' .
-                            "'inversedBy' attribute.";
+                            'bi-directional relationship, but the specified inversedBy association on the target-entity ' .
+                            $assoc['targetEntity'] . '#' . $assoc['inversedBy'] . ' does not contain the required ' .
+                            "'mappedBy=\"" . $fieldName . "\"' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc['inversedBy']]['mappedBy'] !== $fieldName) {
                     $ce[] = 'The mappings ' . $class->name . '#' . $fieldName . ' and ' .
                             $assoc['targetEntity'] . '#' . $assoc['inversedBy'] . ' are ' .

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -152,6 +152,25 @@ class SchemaValidatorTest extends OrmTestCase
     }
 
     /**
+     * @group 9536
+     */
+    public function testInvalidBiDirectionalRelationMappingMissingMappedByAttribute(): void
+    {
+        $class = $this->em->getClassMetadata(Issue9536Owner::class);
+        $ce    = $this->validator->validateClass($class);
+
+        self::assertEquals(
+            [
+                'The field Doctrine\Tests\ORM\Tools\Issue9536Owner#one is on the owning side of a bi-directional ' .
+                'relationship, but the specified inversedBy association on the target-entity ' .
+                "Doctrine\Tests\ORM\Tools\Issue9536Target#two does not contain the required 'mappedBy=\"one\"' " .
+                'attribute.',
+            ],
+            $ce
+        );
+    }
+
+    /**
      * @group DDC-3322
      */
     public function testInvalidOrderByInvalidField(): void
@@ -431,6 +450,46 @@ class DDC3274Two
      * @var DDC3274One
      * @Id
      * @ManyToOne(targetEntity="DDC3274One")
+     */
+    private $one;
+}
+
+/**
+ * @Entity
+ */
+class Issue9536Target
+{
+    /**
+     * @var mixed
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var Issue9536Owner
+     * @OneToOne(targetEntity="Issue9536Owner")
+     */
+    private $two;
+}
+
+/**
+ * @Entity
+ */
+class Issue9536Owner
+{
+    /**
+     * @var mixed
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var Issue9536Target
+     * @OneToOne(targetEntity="Issue9536Target", inversedBy="two")
      */
     private $one;
 }


### PR DESCRIPTION
Wrong validation message is displayed when an incorrect bidirectional
one-to-one mapping is set up. When the owning side is configured
correctly and the target side is missing the back reference the ORM
suggests adding inverseBy instead of mappedBy, with the field name
missing.

Fixes https://github.com/doctrine/orm/issues/9536