### PR TITLE
[RFC] add `HydrationFactory` as extension point for tracking hydrations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -181,8 +181,10 @@
     <PropertyTypeCoercion>
       <code><![CDATA[new $metadataFactoryClassName()]]></code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $hydrationMode]]></code>
+  </file>
+  <file src="src/Internal/Hydration/DefaultHydratorFactory.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $hydrationMode</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/EntityRepository.php">

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Internal\Hydration\DefaultHydratorFactory;
+use Doctrine\ORM\Internal\Hydration\HydratorFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\DefaultEntityListenerResolver;
@@ -43,6 +45,16 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /** @psalm-var array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> */
     private $identityGenerationPreferences = [];
+
+    public function setHydratorFactory(HydratorFactory $factory): void
+    {
+        $this->attributes['hydratorFactory'] = $factory;
+    }
+
+    public function getHydratorFactory(): HydratorFactory
+    {
+        return $this->attributes['hydratorFactory'] ?? new DefaultHydratorFactory();
+    }
 
     /** @psalm-param array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> $value */
     public function setIdentityGenerationPreferences(array $value): void

--- a/src/Internal/Hydration/DefaultHydratorFactory.php
+++ b/src/Internal/Hydration/DefaultHydratorFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\InvalidHydrationMode;
+use Doctrine\ORM\Query;
+
+final class DefaultHydratorFactory implements HydratorFactory
+{
+    public function create(EntityManagerInterface $em, Configuration $config, string|int $hydrationMode): AbstractHydrator
+    {
+        return match ($hydrationMode) {
+            Query::HYDRATE_OBJECT => new ObjectHydrator($em),
+            Query::HYDRATE_ARRAY => new ArrayHydrator($em),
+            Query::HYDRATE_SCALAR => new ScalarHydrator($em),
+            Query::HYDRATE_SINGLE_SCALAR => new SingleScalarHydrator($em),
+            Query::HYDRATE_SIMPLEOBJECT => new SimpleObjectHydrator($em),
+            Query::HYDRATE_SCALAR_COLUMN => new ScalarColumnHydrator($em),
+            default => $this->createCustomHydrator((string) $hydrationMode, $em, $config),
+        };
+    }
+
+    private function createCustomHydrator(string $hydrationMode, EntityManagerInterface $em, Configuration $config): AbstractHydrator
+    {
+        $class = $config->getCustomHydrationMode($hydrationMode);
+
+        if ($class !== null) {
+            return new $class($em);
+        }
+
+        throw InvalidHydrationMode::fromMode($hydrationMode);
+    }
+}

--- a/src/Internal/Hydration/HydratorFactory.php
+++ b/src/Internal/Hydration/HydratorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+
+interface HydratorFactory
+{
+    /**
+     * Create a new instance for the given hydration mode.
+     *
+     * @psalm-param string|AbstractQuery::HYDRATE_* $hydrationMode
+     */
+    public function create(EntityManagerInterface $em, Configuration $config, string|int $hydrationMode): AbstractHydrator;
+}


### PR DESCRIPTION
This is a proposed extension point to help solve https://github.com/doctrine/DoctrineBundle/issues/109. I'm thinking a `HydratorInterface` that `AbstractHydrator` implements should be added but wanted to get some feedback/input before going further.

The doctrine bundle could use this to add hydration times to the timeline:
![Symfony-Profiler](https://user-images.githubusercontent.com/127811/155747034-dfd7c399-3016-49ef-a270-939132cffd91.png)

The doctrine bundle could add something similar to https://github.com/debesha/DoctrineProfileExtraBundle#screenshots to the profiler panel.

You can see an example of how this could be used in DoctrineBundle here: https://github.com/kbond/symfony-reproducer/tree/hydration-profiler-poc (specifically https://github.com/kbond/symfony-reproducer/commit/9a4e91b783bbc653457d6d22410068e00b679eed).

I don't think this causes any performance problems for hydration (when using the `DefaultHydratorFactory`).