### PR TITLE
Use literal types for `JOIN_TYPE_*` constants

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Join.php
+++ b/lib/Doctrine/ORM/Query/AST/Join.php
@@ -16,7 +16,10 @@ class Join extends Node
     public const JOIN_TYPE_LEFTOUTER = 2;
     public const JOIN_TYPE_INNER     = 3;
 
-    /** @var int */
+    /**
+     * @var int
+     * @psalm-var self::JOIN_TYPE_*
+     */
     public $joinType = self::JOIN_TYPE_INNER;
 
     /** @var Node|null */
@@ -28,6 +31,7 @@ class Join extends Node
     /**
      * @param int  $joinType
      * @param Node $joinAssociationDeclaration
+     * @psalm-param self::JOIN_TYPE_* $joinType
      */
     public function __construct($joinType, $joinAssociationDeclaration)
     {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -958,6 +958,7 @@ class SqlWalker implements TreeWalker
      * @param AST\JoinAssociationDeclaration $joinAssociationDeclaration
      * @param int                            $joinType
      * @param AST\ConditionalExpression      $condExpr
+     * @psalm-param AST\Join::JOIN_TYPE_* $joinType
      *
      * @return string
      *


### PR DESCRIPTION
A small backport from #9551.