### PR TITLE
Parser: SimpleArithmeticExpression should return ArithmeticTerm

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2809,7 +2809,7 @@ class Parser
     /**
      * SimpleArithmeticExpression ::= ArithmeticTerm {("+" | "-") ArithmeticTerm}*
      *
-     * @return SimpleArithmeticExpression
+     * @return SimpleArithmeticExpression|ArithmeticTerm
      */
     public function SimpleArithmeticExpression()
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -891,11 +891,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\Parser\\:\\:SimpleArithmeticExpression\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\AST\\\\SimpleArithmeticExpression but returns Doctrine\\\\ORM\\\\Query\\\\AST\\\\ArithmeticTerm\\|int\\|string\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
 			message: """
 				#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
 				        AST\\\\CollectionMemberExpression\\|

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -823,9 +823,6 @@
       <code>joinColumnName</code>
       <code>joinColumnName</code>
     </TooManyArguments>
-    <UndefinedMethod occurrences="1">
-      <code>isReadOnly</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ColumnResult.php">
     <MissingConstructor occurrences="1">
@@ -1262,11 +1259,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $embeddedClass</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php">
-    <UndefinedMethod occurrences="1">
-      <code>isReadOnly</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/SequenceGenerator.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -823,6 +823,9 @@
       <code>joinColumnName</code>
       <code>joinColumnName</code>
     </TooManyArguments>
+    <UndefinedMethod occurrences="1">
+      <code>isReadOnly</code>
+    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ColumnResult.php">
     <MissingConstructor occurrences="1">
@@ -1259,6 +1262,11 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $embeddedClass</code>
     </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php">
+    <UndefinedMethod occurrences="1">
+      <code>isReadOnly</code>
+    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/SequenceGenerator.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">
@@ -1740,6 +1748,9 @@
     </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$simpleArithmeticExpression</code>
     </PropertyNotSetInConstructor>
@@ -1862,6 +1873,9 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;simpleArithmeticExpression</code>
     </PossiblyInvalidArgument>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$firstStringPrimary</code>
       <code>$secondStringPrimary</code>
@@ -1886,6 +1900,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$firstSimpleArithmeticExpression</code>
       <code>$secondSimpleArithmeticExpression</code>
@@ -1900,11 +1918,18 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$simpleArithmeticExpression</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+      <code>$parser-&gt;SimpleArithmeticExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$firstSimpleArithmeticExpression</code>
       <code>$stringPrimary</code>
@@ -2333,6 +2358,7 @@
       <code>AST\BetweenExpression|</code>
       <code>ArithmeticFactor</code>
       <code>ArithmeticTerm</code>
+      <code>SimpleArithmeticExpression|ArithmeticTerm</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -2377,10 +2403,11 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strrpos($fromClassName, '\\')</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="13">
+    <PossiblyInvalidArgument occurrences="14">
       <code>$AST</code>
       <code>$conditionalExpression</code>
       <code>$expr</code>
+      <code>$pathExp</code>
       <code>$stringExpr</code>
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
@@ -2392,9 +2419,10 @@
       <code>$token['value']</code>
       <code>$token['value']</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="3">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="4">
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
+      <code>$this-&gt;SimpleArithmeticExpression()</code>
       <code>$value</code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument occurrences="6">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2333,7 +2333,6 @@
       <code>AST\BetweenExpression|</code>
       <code>ArithmeticFactor</code>
       <code>ArithmeticTerm</code>
-      <code>SimpleArithmeticExpression</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>


### PR DESCRIPTION
Bugfix of return type error.

The `SimpleArithmeticExpression()` method can also return an `ArithmeticTerm` type that is not defined in the annotation.

Example:

![Snímek obrazovky 2022-03-02 v 14 13 59](https://user-images.githubusercontent.com/4738758/156368337-295305e5-fc43-49e5-809f-f19bc70be3f9.png)

