### PR TITLE
Remove reference to removed class

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -195,10 +195,7 @@ SQL Logger (***Optional***)
 
 Gets or sets the logger to use for logging all SQL statements
 executed by Doctrine. The logger class must implement the
-``Doctrine\DBAL\Logging\SQLLogger`` interface. A simple default
-implementation that logs to the standard output using ``echo`` and
-``var_dump`` can be found at
-``Doctrine\DBAL\Logging\EchoSQLLogger``.
+deprecated ``Doctrine\DBAL\Logging\SQLLogger`` interface.
 
 Auto-generating Proxy Classes (***OPTIONAL***)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -113,7 +113,6 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     public function testBasicOneToOne(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $user           = new CmsUser();
         $user->name     = 'Roman';
         $user->username = 'romanb';
@@ -658,8 +657,6 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->persist($user);
 
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $this->_em->flush();
         $this->_em->clear();
 
@@ -685,8 +682,6 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $user->name     = 'Guilherme';
         $user->username = 'gblanco';
         $user->status   = 'developer';
-
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
 
         $this->_em->persist($user);
         $this->_em->flush();
@@ -720,8 +715,6 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
             $em->persist($user);
         });
         $this->_em->clear();
-
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
 
         $userRef  = $this->_em->getReference(CmsUser::class, $user->getId());
         $address2 = $this->_em->createQuery('select a from Doctrine\Tests\Models\CMS\CmsAddress a where a.user = :user')

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
@@ -65,7 +65,6 @@ class ClassTableInheritanceSecondTest extends OrmFunctionalTestCase
 
     public function testManyToManyToCTIHierarchy(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
         $mmrel = new CTIRelated2();
         $child = new CTIChild();
         $child->setData('child');

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -25,7 +25,6 @@ class FlushEventTest extends OrmFunctionalTestCase
 
     public function testPersistNewEntitiesOnPreFlush(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_em->getEventManager()->addEventListener(Events::onFlush, new OnFlushListener());
 
         $user           = new CmsUser();

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -160,8 +160,6 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
      */
     public function testCascadedEntitiesCallsPrePersist(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $e1 = new LifecycleCallbackTestEntity();
         $e2 = new LifecycleCallbackTestEntity();
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -79,7 +79,6 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
 
     public function testEagerLoadFromInverseSideAndLazyLoadFromOwningSide(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->createLoadingFixture();
         $categories = $this->findCategories();
         $this->assertLazyLoadFromOwningSide($categories);
@@ -87,7 +86,6 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
 
     public function testEagerLoadFromOwningSideAndLazyLoadFromInverseSide(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->createLoadingFixture();
         $products = $this->findProducts();
         $this->assertLazyLoadFromInverseSide($products);

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -133,7 +133,6 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
 
     public function testLazyLoadsObjectsOnTheInverseSide2(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->createFixture();
 
         $query    = $this->_em->createQuery('select f,p from Doctrine\Tests\Models\ECommerce\ECommerceFeature f join f.product p');

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
@@ -15,7 +15,6 @@ class QueryBuilderParenthesisTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->createSchemaForModels(QueryBuilderParenthesisEntity::class);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -522,7 +522,6 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
         $this->_em->clear();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $q = $this->_em->createQuery('select a from Doctrine\Tests\Models\CMS\CmsArticle a where a.topic = :topic and a.user = :user')
                 ->setParameter('user', $this->_em->getReference(CmsUser::class, $author->id))
                 ->setParameter('topic', 'dr. dolittle');

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -519,7 +519,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
     public function testToOneFilter(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->loadFixtureData();
 
         $query = $this->_em->createQuery('select ux, ua from Doctrine\Tests\Models\CMS\CmsUser ux JOIN ux.address ua');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -29,7 +29,6 @@ class DDC1163Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC1163Product::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -18,7 +18,6 @@ class DDC1193Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC1193Company::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
@@ -38,8 +38,6 @@ class DDC168Test extends OrmFunctionalTestCase
      */
     public function testJoinedSubclassPersisterRequiresSpecificOrderOfMetadataReflFieldsArray(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $spouse = new CompanyEmployee();
         $spouse->setName('Blub');
         $spouse->setDepartment('Accounting');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -31,8 +31,6 @@ class DDC211Test extends OrmFunctionalTestCase
 
     public function testIssue(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $user = new DDC211User();
         $user->setName('John Doe');
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
@@ -34,8 +34,6 @@ class DDC258Test extends OrmFunctionalTestCase
      */
     public function testIssue(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $c1              = new DDC258Class1();
         $c1->title       = 'Foo';
         $c1->description = 'Foo';

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -26,7 +26,6 @@ class DDC345Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC345User::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -25,7 +25,6 @@ class DDC371Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC371Parent::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -26,7 +26,6 @@ class DDC422Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC422Guest::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
@@ -29,8 +29,6 @@ class DDC425Test extends OrmFunctionalTestCase
      */
     public function testIssue(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $num = $this->_em->createQuery('DELETE ' . __NAMESPACE__ . '\DDC425Entity e WHERE e.someDatetimeField > ?1')
                 ->setParameter(1, new DateTime(), Types::DATETIME_MUTABLE)
                 ->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
@@ -19,7 +19,6 @@ class DDC444Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC444User::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -24,7 +24,6 @@ class DDC599Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         try {
             $this->_schemaTool->createSchema(
                 [

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -23,7 +23,6 @@ class DDC719Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC719Group::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC812Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC812Test.php
@@ -23,7 +23,6 @@ class DDC812Test extends OrmFunctionalTestCase
      */
     public function testFetchJoinInitializesPreviouslyUninitializedCollectionOfManagedEntity(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $article        = new CmsArticle();
         $article->topic = 'hello';
         $article->text  = 'talk talk talk';

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -36,8 +36,6 @@ class DDC837Test extends OrmFunctionalTestCase
      */
     public function testIssue(): void
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $c1              = new DDC837Class1();
         $c1->title       = 'Foo';
         $c1->description = 'Foo';


### PR DESCRIPTION


`EchoSQLLogger` is deprecated in DBAL 2, and removed in DBAL 3.


Fixes #9562