### PR TITLE
Fix type on `SqlWalker::walkPathExpression()`

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
@@ -26,12 +26,4 @@ class JoinAssociationPathExpression extends Node
         $this->identificationVariable = $identificationVariable;
         $this->associationField       = $associationField;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
-    {
-        return $sqlWalker->walkPathExpression($this);
-    }
 }

--- a/lib/Doctrine/ORM/Query/AST/PathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PathExpression.php
@@ -19,7 +19,10 @@ class PathExpression extends Node
     public const TYPE_SINGLE_VALUED_ASSOCIATION     = 4;
     public const TYPE_STATE_FIELD                   = 8;
 
-    /** @var int */
+    /**
+     * @var int|null
+     * @psalm-var self::TYPE_*|null
+     */
     public $type;
 
     /** @var int */

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -127,7 +127,7 @@ class QueryException extends ORMException
     }
 
     /**
-     * @param object $pathExpr
+     * @param PathExpression $pathExpr
      *
      * @return QueryException
      */

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -655,6 +655,7 @@ class SqlWalker implements TreeWalker
     public function walkPathExpression($pathExpr)
     {
         $sql = '';
+        assert($pathExpr->field !== null);
 
         switch ($pathExpr->type) {
             case AST\PathExpression::TYPE_STATE_FIELD:
@@ -869,6 +870,7 @@ class SqlWalker implements TreeWalker
     {
         $pathExpression = $indexBy->singleValuedPathExpression;
         $alias          = $pathExpression->identificationVariable;
+        assert($pathExpression->field !== null);
 
         switch ($pathExpression->type) {
             case AST\PathExpression::TYPE_STATE_FIELD:
@@ -1328,6 +1330,7 @@ class SqlWalker implements TreeWalker
                     throw QueryException::invalidPathExpression($expr);
                 }
 
+                assert($expr->field !== null);
                 $fieldName = $expr->field;
                 $dqlAlias  = $expr->identificationVariable;
                 $class     = $this->getMetadataForDqlAlias($dqlAlias);
@@ -1595,11 +1598,12 @@ class SqlWalker implements TreeWalker
                     break;
 
                 case $e instanceof AST\PathExpression:
+                    assert($e->field !== null);
                     $dqlAlias     = $e->identificationVariable;
                     $class        = $this->getMetadataForDqlAlias($dqlAlias);
-                    $fieldType    = $class->fieldMappings[$e->field]['type'];
                     $fieldName    = $e->field;
                     $fieldMapping = $class->fieldMappings[$fieldName];
+                    $fieldType    = $fieldMapping['type'];
                     $col          = trim($e->dispatch($this));
 
                     if (isset($fieldMapping['requireSQLConversion'])) {
@@ -1941,6 +1945,7 @@ class SqlWalker implements TreeWalker
 
         $entityExpr   = $collMemberExpr->entityExpression;
         $collPathExpr = $collMemberExpr->collectionValuedPathExpression;
+        assert($collPathExpr->field !== null);
 
         $fieldName = $collPathExpr->field;
         $dqlAlias  = $collPathExpr->identificationVariable;

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -434,7 +434,7 @@ interface TreeWalker
     /**
      * Walks down a PathExpression AST node, thereby generating the appropriate SQL.
      *
-     * @param mixed $pathExpr
+     * @param AST\PathExpression $pathExpr
      *
      * @return string The SQL.
      */

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\OrderByClause;
 use Doctrine\ORM\Query\AST\PartialObjectExpression;
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\Parser;
@@ -27,6 +28,7 @@ use RuntimeException;
 
 use function array_diff;
 use function array_keys;
+use function assert;
 use function count;
 use function implode;
 use function in_array;
@@ -75,7 +77,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     private $quoteStrategy;
 
-    /** @var mixed[] */
+    /** @var list<PathExpression> */
     private $orderByPathExpressions = [];
 
     /**
@@ -306,6 +308,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
         // Get a map of referenced identifiers to field names.
         $selects = [];
         foreach ($orderByPathExpressions as $pathExpression) {
+            assert($pathExpression->field !== null);
             $idVar = $pathExpression->identificationVariable;
             $field = $pathExpression->field;
             if (! isset($selects[$idVar])) {
@@ -460,7 +463,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * getter for $orderByPathExpressions
      *
-     * @return mixed[]
+     * @return list<PathExpression>
      */
     public function getOrderByPathExpressions()
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1868,11 +1868,6 @@
       <code>$sqlWalker</code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod occurrences="1">
       <code>walkJoinPathExpression</code>
@@ -1926,11 +1921,6 @@
     <ParamNameMismatch occurrences="1">
       <code>$sqlWalker</code>
     </ParamNameMismatch>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$type</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/PathExpression.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
@@ -2402,9 +2392,7 @@
     <InvalidNullableReturnType occurrences="1">
       <code>walkConditionalPrimary</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="9">
-      <code>$this-&gt;scalarFields</code>
-      <code>$this-&gt;scalarResultAliasMap</code>
+    <InvalidPropertyAssignmentValue occurrences="7">
       <code>$this-&gt;scalarResultAliasMap</code>
       <code>$this-&gt;scalarResultAliasMap</code>
       <code>$this-&gt;scalarResultAliasMap</code>
@@ -2429,28 +2417,17 @@
       <code>$aggExpression-&gt;pathExpression</code>
       <code>$whereClause-&gt;conditionalExpression</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="12">
+    <PossiblyNullArgument occurrences="8">
       <code>$AST-&gt;whereClause</code>
       <code>$AST-&gt;whereClause</code>
       <code>$AST-&gt;whereClause</code>
       <code>$arithmeticExpr-&gt;simpleArithmeticExpression</code>
       <code>$arithmeticExpr-&gt;subselect</code>
       <code>$condExpr</code>
-      <code>$field</code>
-      <code>$fieldName</code>
-      <code>$fieldName</code>
       <code>$identificationVariableDecl-&gt;rangeVariableDeclaration</code>
-      <code>$resultAlias</code>
       <code>$subselect-&gt;whereClause</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayOffset occurrences="9">
-      <code>$class-&gt;associationMappings</code>
-      <code>$class-&gt;associationMappings</code>
-      <code>$class-&gt;fieldMappings</code>
-      <code>$class-&gt;fieldMappings</code>
-      <code>$class-&gt;fieldMappings</code>
-      <code>$this-&gt;scalarFields[$dqlAlias]</code>
-      <code>$this-&gt;scalarResultAliasMap</code>
+    <PossiblyNullArrayOffset occurrences="2">
       <code>$this-&gt;scalarResultAliasMap</code>
       <code>$this-&gt;scalarResultAliasMap</code>
     </PossiblyNullArrayOffset>


### PR DESCRIPTION
The parameter of `SqlWalker::walkPathExpression()` is annotated as `mixed`, but passing anything but a `PathExpression` to it would result in an error because the method accesses properties on the passed value.