### PR TITLE
Baseline Psalm errors caused by DBAL 3.3.3

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1459,6 +1459,14 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>int|null</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidReturnStatement occurrences="2">
+      <code>$numDeleted</code>
+      <code>$this-&gt;conn-&gt;executeStatement($statement, $parameters)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2">
+      <code>int</code>
+      <code>int</code>
+    </InvalidReturnType>
     <PossiblyNullArgument occurrences="14">
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
@@ -2199,6 +2207,12 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$numDeleted</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>int</code>
+    </InvalidReturnType>
     <PossiblyInvalidIterator occurrences="1">
       <code>$this-&gt;_sqlStatements</code>
     </PossiblyInvalidIterator>
@@ -2211,6 +2225,12 @@
     </UninitializedProperty>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$numUpdated</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>int</code>
+    </InvalidReturnType>
     <PossiblyInvalidIterator occurrences="1">
       <code>$this-&gt;_sqlStatements</code>
     </PossiblyInvalidIterator>
@@ -2227,6 +2247,12 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$conn-&gt;executeStatement($this-&gt;_sqlStatements, $params, $types)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>int</code>
+    </InvalidReturnType>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;_sqlStatements</code>
     </PossiblyInvalidArgument>


### PR DESCRIPTION
DBAL has changed the return type for affected rows from `int` to `int|string`.