### PR TITLE
Implement colocated mapping driver

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.12
 
+## BC Break: `AttributeDriver` and `AnnotationDriver` no longer extends parent class from `doctrine/persistence`
+
+Both these classes used to extend an abstract `AnnotationDriver` class defined
+in `doctrine/persistence`, and no longer do.
+
+## Deprecate `AttributeDriver::getReader()` and `AnnotationDriver::getReader()`
+
+That method was inherited from the abstract `AnnotationDriver` class of
+`doctrine/persistence`, and does not seem to serve any purpose.
+
 ## Un-deprecate `Doctrine\ORM\Proxy\Proxy`
 
 Because no forward-compatible new proxy solution had been implemented yet, the

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/inflector": "^1.4 || ^2.0",
         "doctrine/instantiator": "^1.3",
         "doctrine/lexer": "^1.2.3",
-        "doctrine/persistence": "^2.2",
+        "doctrine/persistence": "^2.4",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/polyfill-php72": "^1.23",

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
+use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -29,8 +32,19 @@ use function is_numeric;
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
  */
-class AnnotationDriver extends AbstractAnnotationDriver
+class AnnotationDriver implements MappingDriver
 {
+    use ColocatedMappingDriver;
+
+    /**
+     * The annotation reader.
+     *
+     * @internal this property will be private in 3.0
+     *
+     * @var Reader
+     */
+    protected $reader;
+
     /**
      * @var int[]
      * @psalm-var array<class-string, int>
@@ -39,6 +53,20 @@ class AnnotationDriver extends AbstractAnnotationDriver
         Mapping\Entity::class => 1,
         Mapping\MappedSuperclass::class => 2,
     ];
+
+    /**
+     * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
+     * docblock annotations.
+     *
+     * @param Reader               $reader The AnnotationReader to use
+     * @param string|string[]|null $paths  One or multiple paths where mapping classes can be found.
+     */
+    public function __construct($reader, $paths = null)
+    {
+        $this->reader = $reader;
+
+        $this->addPaths((array) $paths);
+    }
 
     /**
      * {@inheritDoc}
@@ -784,6 +812,39 @@ class AnnotationDriver extends AbstractAnnotationDriver
         }
 
         return $mapping;
+    }
+
+    /**
+     * Retrieve the current annotation reader
+     *
+     * @return Reader
+     */
+    public function getReader()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9587',
+            '%s is deprecated with no replacement',
+            __METHOD__
+        );
+
+        return $this->reader;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isTransient($className)
+    {
+        $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
+
+        foreach ($classAnnotations as $annot) {
+            if (isset($this->entityAnnotationClasses[get_class($annot)])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Driver;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
@@ -25,8 +27,10 @@ use function sprintf;
 
 use const PHP_VERSION_ID;
 
-class AttributeDriver extends AnnotationDriver
+class AttributeDriver implements MappingDriver
 {
+    use ColocatedMappingDriver;
+
     /** @var array<string,int> */
     // @phpcs:ignore
     protected $entityAnnotationClasses = [
@@ -36,6 +40,8 @@ class AttributeDriver extends AnnotationDriver
 
     /**
      * The annotation reader.
+     *
+     * @internal this property will be private in 3.0
      *
      * @var AttributeReader
      */
@@ -55,6 +61,25 @@ class AttributeDriver extends AnnotationDriver
 
         $this->reader = new AttributeReader();
         $this->addPaths($paths);
+    }
+
+    /**
+     * Retrieve the current annotation reader
+     *
+     * @deprecated no replacement planned.
+     *
+     * @return AttributeReader
+     */
+    public function getReader()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9587',
+            '%s is deprecated with no replacement',
+            __METHOD__
+        );
+
+        return $this->reader;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -261,16 +261,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
 
 		-
-			message: "#^PHPDoc type Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeReader of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$reader is not covariant with PHPDoc type Doctrine\\\\Common\\\\Annotations\\\\Reader of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$reader\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-
-		-
-			message: "#^PHPDoc type array\\<string, int\\> of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$entityAnnotationClasses is not covariant with PHPDoc type array\\<class\\-string, bool\\|int\\> of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$entityAnnotationClasses\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-
-		-
 			message: "#^Parameter \\#1 \\$metadata of static method Doctrine\\\\ORM\\\\Mapping\\\\Builder\\\\EntityListenerBuilder\\:\\:bindEntityListener\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo&Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<T of object\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -747,9 +747,6 @@
       <code>$mapping</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType occurrences="1"/>
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$entityAnnotationClasses</code>
-    </NonInvariantDocblockPropertyType>
     <PossiblyNullArgument occurrences="1">
       <code>$listenerClassName</code>
     </PossiblyNullArgument>
@@ -782,10 +779,6 @@
       <code>$mapping</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType occurrences="1"/>
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$entityAnnotationClasses</code>
-      <code>$reader</code>
-    </NonInvariantDocblockPropertyType>
     <PossiblyNullArgument occurrences="1">
       <code>$listenerClassName</code>
     </PossiblyNullArgument>


### PR DESCRIPTION
This allows us to decouple further from `doctrine/annotations`, and to fix
some static analysis issues.

The assumption being made here is that the abstract class we are no
longer extending is not used in type declarations and `instanceof` checks.