### PR TITLE
Fix type errors with XML export on PHP 8.1

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -73,7 +73,7 @@ class XmlExporter extends AbstractExporter
             $discriminatorColumnXml->addAttribute('type', $metadata->discriminatorColumn['type']);
 
             if (isset($metadata->discriminatorColumn['length'])) {
-                $discriminatorColumnXml->addAttribute('length', $metadata->discriminatorColumn['length']);
+                $discriminatorColumnXml->addAttribute('length', (string) $metadata->discriminatorColumn['length']);
             }
         }
 
@@ -339,7 +339,7 @@ class XmlExporter extends AbstractExporter
                     }
 
                     if (isset($inverseJoinColumn['nullable'])) {
-                        $inverseJoinColumnXml->addAttribute('nullable', $inverseJoinColumn['nullable']);
+                        $inverseJoinColumnXml->addAttribute('nullable', $inverseJoinColumn['nullable'] ? 'true' : 'false');
                     }
 
                     if (isset($inverseJoinColumn['orderBy'])) {
@@ -365,7 +365,7 @@ class XmlExporter extends AbstractExporter
                     }
 
                     if (isset($joinColumn['nullable'])) {
-                        $joinColumnXml->addAttribute('nullable', $joinColumn['nullable']);
+                        $joinColumnXml->addAttribute('nullable', $joinColumn['nullable'] ? 'true' : 'false');
                     }
                 }
             }


### PR DESCRIPTION
Please see PHP interface SimpleXMLElement::addAttribute(string $name, string $value = null, string $namespace = null): void .... 
The $value must be string or null.