### PR TITLE
Deprecate or throw on namespace alias usage

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade to 2.12
 
+## Deprecated more APIs related to entity namespace aliases
+
+```diff
+-$config = $entityManager->getConfiguration();
+-$config->addEntityNamespace('CMS', 'My\App\Cms');
++use My\App\Cms\CmsUser;
+
+-$entityManager->getRepository('CMS:CmsUser');
++$entityManager->getRepository(CmsUser::class);
+```
+
+
 ## BC Break: `AttributeDriver` and `AnnotationDriver` no longer extends parent class from `doctrine/persistence`
 
 Both these classes used to extend an abstract `AnnotationDriver` class defined

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache as CacheDriver;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\CacheConfiguration;
@@ -23,6 +24,7 @@ use Doctrine\ORM\Cache\Exception\QueryCacheUsesNonPersistentCache;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Exception\NamedNativeQueryNotFound;
 use Doctrine\ORM\Exception\NamedQueryNotFound;
+use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ProxyClassesAlwaysRegenerating;
 use Doctrine\ORM\Exception\UnknownEntityNamespace;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
@@ -196,6 +198,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
+     * @deprecated No replacement planned.
+     *
      * Adds a namespace under a certain alias.
      *
      * @param string $alias
@@ -205,6 +209,21 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addEntityNamespace($alias, $namespace)
     {
+        if (class_exists(PersistentObject::class)) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8818',
+                'Short namespace aliases such as "%s" are deprecated and will be removed in Doctrine ORM 3.0.',
+                $alias
+            );
+        } else {
+            NotSupported::createForPersistence3(sprintf(
+                'Using short namespace alias "%s" by calling %s',
+                $alias,
+                __METHOD__
+            ));
+        }
+
         $this->_attributes['entityNamespaces'][$alias] = $namespace;
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -287,6 +287,12 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
     public function testFindByAlias(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            $this->markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
+
         $user1Id = $this->loadFixture();
         $repos   = $this->_em->getRepository(CmsUser::class);
 
@@ -673,6 +679,11 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testSingleRepositoryInstanceForDifferentEntityAliases(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            $this->markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
         $config = $this->_em->getConfiguration();
 
         $config->addEntityNamespace('Aliased', 'Doctrine\Tests\Models\CMS');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Persistence\PersistentObject;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -18,11 +20,15 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function class_exists;
+
 /**
  * @group DDC-2256
  */
 class DDC2256Test extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,6 +43,11 @@ class DDC2256Test extends OrmFunctionalTestCase
 
     public function testIssue(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            $this->markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
         $config = $this->_em->getConfiguration();
         $config->addEntityNamespace('MyNamespace', __NAMESPACE__);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
@@ -45,11 +47,14 @@ use stdClass;
 
 use function array_search;
 use function assert;
+use function class_exists;
 use function count;
 use function sprintf;
 
 class ClassMetadataFactoryTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     public function testGetMetadataForSingleClass(): void
     {
         $platform = $this->createMock(AbstractPlatform::class);
@@ -196,6 +201,12 @@ class ClassMetadataFactoryTest extends OrmTestCase
      */
     public function testIsTransientEntityNamespace(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            $this->markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
+
         $cmf    = new ClassMetadataFactory();
         $driver = $this->createMock(MappingDriver::class);
         $driver->expects(self::exactly(2))


### PR DESCRIPTION
This feature has been deprecated and removed in `doctrine/persistence`.
[It was already deprecated in `doctrine/orm` for other APIs](https://github.com/doctrine/orm/pull/8820).

This PR fixes the build by skipping tests related to namespace aliases when appropriate.