### PR TITLE
Implement int-mask-of where appropriate

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/PathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PathExpression.php
@@ -25,7 +25,10 @@ class PathExpression extends Node
      */
     public $type;
 
-    /** @var int */
+    /**
+     * @var int
+     * @psalm-var int-mask-of<self::TYPE_*>
+     */
     public $expectedType;
 
     /** @var string */
@@ -38,6 +41,7 @@ class PathExpression extends Node
      * @param int         $expectedType
      * @param string      $identificationVariable
      * @param string|null $field
+     * @psalm-param int-mask-of<self::TYPE_*> $expectedType
      */
     public function __construct($expectedType, $identificationVariable, $field = null)
     {

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1137,6 +1137,7 @@ class Parser
      * PathExpression ::= IdentificationVariable {"." identifier}*
      *
      * @param int $expectedTypes
+     * @psalm-param int-mask-of<PathExpression::TYPE_*> $expectedTypes
      *
      * @return PathExpression
      */


### PR DESCRIPTION
With Psalm, you can specify that an integer should be a bitmask of
constants. Doing so allows to make some types more precise.

This annotation appears to be specific to Psalm.

I've been looking for places where to implement this by using `rg -F ' | '`