### PR TITLE
Indicate what feature is deprecated

### DIFF
--- a/lib/Doctrine/ORM/Exception/NotSupported.php
+++ b/lib/Doctrine/ORM/Exception/NotSupported.php
@@ -13,9 +13,16 @@ final class NotSupported extends ORMException
         return new self('This behaviour is (currently) not supported by Doctrine 2');
     }
 
-    public static function createForDbal3(): self
+    public static function createForDbal3(string $context): self
     {
-        return new self('Feature was deprecated in doctrine/dbal 2.x and is not supported by installed doctrine/dbal:3.x, please see the doctrine/deprecations logs for new alternative approaches.');
+        return new self(sprintf(
+            <<<'EXCEPTION'
+Context: %s
+Problem: Feature was deprecated in doctrine/dbal 2.x and is not supported by installed doctrine/dbal:3.x
+Solution: See the doctrine/deprecations logs for new alternative approaches.
+EXCEPTION,
+            $context
+        ));
     }
 
     public static function createForPersistence3(string $context): self

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\NotSupported;
 
 use function method_exists;
+use function sprintf;
 
 /**
  * Represents an ID generator that uses the database UUID expression
@@ -29,7 +30,10 @@ class UuidGenerator extends AbstractIdGenerator
         );
 
         if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
-            throw NotSupported::createForDbal3();
+            throw NotSupported::createForDbal3(sprintf(
+                'Using the database to generate a UUID through %s',
+                self::class
+            ));
         }
     }
 


### PR DESCRIPTION
This is prompted by a question from somebody on the Symfony Slack: they could not figure out what was deprecated because they did not know they could get a stack trace by using `-vvv`