### PR TITLE
Remove "Description of" PHPDoc

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
-/**
- * Description of AggregateExpression.
- *
- * @link    www.doctrine-project.org
- */
 class AggregateExpression extends Node
 {
     /** @var string */

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -10,11 +10,6 @@ use function is_numeric;
 use function strlen;
 use function substr;
 
-/**
- * Description of InputParameter.
- *
- * @link    www.doctrine-project.org
- */
 class InputParameter extends Node
 {
     /** @var bool */

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -8,11 +8,6 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Exception;
 
-/**
- * Description of QueryException.
- *
- * @link    www.doctrine-project.org
- */
 class QueryException extends ORMException
 {
     /**


### PR DESCRIPTION
I believe that those PHPDoc descriptions are placeholder texts generated by some IDE. They don't add much value, so let's remove them.