### PR TITLE
Skip tests requiring ObjectManagerAware

### DIFF
--- a/phpstan-persistence3.neon
+++ b/phpstan-persistence3.neon
@@ -6,3 +6,9 @@ parameters:
         -
             message: '/clear.*invoked with 1 parameter/'
             path: lib/Doctrine/ORM/EntityRepository.php
+        -
+            message: '#^Class Doctrine\\Persistence\\ObjectManagerAware not found\.$#'
+            path: lib/Doctrine/ORM/UnitOfWork.php
+        -
+            message: '#^Call to method injectObjectManager\(\) on an unknown class Doctrine\\Persistence\\ObjectManagerAware\.$#'
+            path: lib/Doctrine/ORM/UnitOfWork.php

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -16,6 +16,7 @@ use Doctrine\Persistence\ObjectManagerAware;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
+use function interface_exists;
 
 /**
  * @group DDC-2231
@@ -24,6 +25,10 @@ class DDC2231Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
+        if (! interface_exists(ObjectManagerAware::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         parent::setUp();
         $this->_schemaTool->createSchema(
             [
@@ -53,35 +58,36 @@ class DDC2231Test extends OrmFunctionalTestCase
     }
 }
 
-
-/**
- * @Entity
- * @Table(name="ddc2231_y")
- */
-class DDC2231EntityY implements ObjectManagerAware
-{
+if (interface_exists(ObjectManagerAware::class)) {
     /**
-     * @var int
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
+     * @Entity
+     * @Table(name="ddc2231_y")
      */
-    public $id;
-
-    /** @var ObjectManager */
-    public $om;
-
-    public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata): void
+    class DDC2231EntityY implements ObjectManagerAware
     {
-        $this->om = $objectManager;
-    }
+        /**
+         * @var int
+         * @Id
+         * @Column(type="integer")
+         * @GeneratedValue
+         */
+        public $id;
 
-    public function getId(): int
-    {
-        return $this->id;
-    }
+        /** @var ObjectManager */
+        public $om;
 
-    public function doSomething(): void
-    {
+        public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata): void
+        {
+            $this->om = $objectManager;
+        }
+
+        public function getId(): int
+        {
+            return $this->id;
+        }
+
+        public function doSomething(): void
+        {
+        }
     }
 }


### PR DESCRIPTION
`ObjectManagerAware` has been removed from the 3.0 branch of doctrine/persistence. This PR should make our tests green again.