### PR TITLE
Document that entity names have to be FQCNs now

### DIFF
--- a/lib/Doctrine/ORM/Cache.php
+++ b/lib/Doctrine/ORM/Cache.php
@@ -38,22 +38,34 @@ interface Cache
      */
     public const MODE_REFRESH = 4;
 
+    /**
+     * @psalm-param class-string $className
+     */
     public function getEntityCacheRegion(string $className): ?Region;
 
+    /**
+     * @psalm-param class-string $className
+     */
     public function getCollectionCacheRegion(string $className, string $association): ?Region;
 
     /**
      * Determine whether the cache contains data for the given entity "instance".
+     *
+     * @psalm-param class-string $className
      */
     public function containsEntity(string $className, mixed $identifier): bool;
 
     /**
      * Evicts the entity data for a particular entity "instance".
+     *
+     * @psalm-param class-string $className
      */
     public function evictEntity(string $className, mixed $identifier): void;
 
     /**
      * Evicts all entity data from the given region.
+     *
+     * @psalm-param class-string $className
      */
     public function evictEntityRegion(string $className): void;
 
@@ -64,16 +76,22 @@ interface Cache
 
     /**
      * Determine whether the cache contains data for the given collection.
+     *
+     * @psalm-param class-string $className
      */
     public function containsCollection(string $className, string $association, mixed $ownerIdentifier): bool;
 
     /**
      * Evicts the cache data for the given identified collection instance.
+     *
+     * @psalm-param class-string $className
      */
     public function evictCollection(string $className, string $association, mixed $ownerIdentifier): void;
 
     /**
      * Evicts all entity data from the given region.
+     *
+     * @psalm-param class-string $className
      */
     public function evictCollectionRegion(string $className, string $association): void;
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -381,7 +381,7 @@ class DefaultQueryCache implements QueryCache
     }
 
     /**
-     * @psalm-param array<array-key, array{field: string, class: string}> $path
+     * @psalm-param array<array-key, array{field: string, class: class-string}> $path
      *
      * @psalm-return list<mixed>|object|null
      */

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -244,7 +244,7 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param string|class-string<T> $className
+     * @psalm-param class-string<T> $className
      *
      * @psalm-return Mapping\ClassMetadata<T>
      *

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -52,7 +52,8 @@ abstract class AbstractHydrator
     /**
      * Local ClassMetadata cache to avoid going to the EntityManager all the time.
      *
-     * @var array<string, ClassMetadata<object>>
+     * @var ClassMetadata[]
+     * @psalm-var class-string-map<T, ClassMetadata<T>>
      */
     protected array $_metadataCache = [];
 
@@ -482,6 +483,12 @@ abstract class AbstractHydrator
 
     /**
      * Retrieve ClassMetadata associated to entity class name.
+     *
+     * @psalm-param class-string<T> $className
+     *
+     * @psalm-return ClassMetadata<T>
+     *
+     * @template T of object
      */
     protected function getClassMetadata(string $className): ClassMetadata
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -250,12 +250,14 @@ class ObjectHydrator extends AbstractHydrator
     }
 
     /**
-     * @psalm-param class-string $className
+     * @psalm-param class-string<T> $className
      * @psalm-param array<string, mixed> $data
      *
-     * @return mixed
+     * @psalm-return T|false
+     *
+     * @template T of object
      */
-    private function getEntityFromIdentityMap(string $className, array $data)
+    private function getEntityFromIdentityMap(string $className, array $data): object|false
     {
         // TODO: Abstract this code and UnitOfWork::createEntity() equivalent?
         $class = $this->_metadataCache[$className];

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -95,6 +95,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *                                 with the joined entity result.
      * @param string[] $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
+     * @psalm-param class-string $class
      * @psalm-param array<string, string> $renamedColumns
      *
      * @return void
@@ -114,6 +115,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param string   $class
      * @param string   $alias
      * @param string[] $columnAliasMap
+     * @psalm-param class-string $class
      * @psalm-param array<string, string> $columnAliasMap
      *
      * @return void

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -38,8 +38,11 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * Create a new repository instance for an entity class.
      *
-     * @param EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string                 $entityName    The name of the entity.
+     * @psalm-param class-string<T> $entityName
+     *
+     * @psalm-return ObjectRepository<T>
+     *
+     * @template T of object
      */
     private function createRepository(
         EntityManagerInterface $entityManager,

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -74,7 +74,7 @@ EOT
     /**
      * Display all the mapping information for a single Entity.
      *
-     * @param string $entityName Full or partial entity class name
+     * @psalm-param class-string $entityName
      */
     private function displayEntity(
         string $entityName,
@@ -148,7 +148,7 @@ EOT
      * Return the class metadata for the given entity
      * name
      *
-     * @param string $entityName Full or partial entity name
+     * @psalm-param class-string $entityName
      */
     private function getClassMetadata(
         string $entityName,

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -112,7 +112,7 @@ class UnitOfWork implements PropertyChangedListener
      * Since all classes in a hierarchy must share the same identifier set,
      * we always take the root class name of the hierarchy.
      *
-     * @psalm-var array<class-string, array<string, object|null>>
+     * @psalm-var class-string-map<T, array<string, T|null>>
      */
     private array $identityMap = [];
 
@@ -1525,10 +1525,15 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * INTERNAL:
      * Gets an entity in the identity map by its identifier hash.
      *
-     * @ignore
+     * @internal
+     *
+     * @psalm-param class-string<T> $rootClassName
+     *
+     * @psalm-return T
+     *
+     * @template T of object
      */
     public function getByIdHash(string $idHash, string $rootClassName): object
     {
@@ -1536,17 +1541,19 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * INTERNAL:
-     * Tries to get an entity by its identifier hash. If no entity is found for
-     * the given hash, FALSE is returned.
+     * Tries to get an entity by its identifier hash.
      *
-     * @param mixed $idHash (must be possible to cast it to string)
+     * If no entity is found for the given hash, FALSE is returned.
      *
-     * @return false|object The found entity or FALSE.
+     * @internal
      *
-     * @ignore
+     * @psalm-param class-string<T> $rootClassName
+     *
+     * @psalm-return T|false
+     *
+     * @template T of object
      */
-    public function tryGetByIdHash(mixed $idHash, string $rootClassName): object|false
+    public function tryGetByIdHash(int|string|Stringable $idHash, string $rootClassName): object|false
     {
         $stringIdHash = (string) $idHash;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,11 +121,6 @@ parameters:
 			path: lib/Doctrine/ORM/EntityManagerInterface.php
 
 		-
-			message: "#^Template type T of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getClassMetadata\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/EntityManagerInterface.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\EntityRepository\\:\\:matching\\(\\) should return Doctrine\\\\Common\\\\Collections\\\\AbstractLazyCollection\\<int, T of object\\>&Doctrine\\\\Common\\\\Collections\\\\Selectable\\<int, T of object\\> but returns Doctrine\\\\ORM\\\\LazyCriteriaCollection\\<\\(int\\|string\\), object\\>\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityRepository.php
@@ -1314,3 +1309,4 @@ parameters:
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$subClasses\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -301,6 +301,14 @@
     </ReferenceConstraintViolation>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php">
+    <InvalidReturnStatement occurrences="3">
+      <code>$this-&gt;_uow-&gt;tryGetByIdHash($data[$class-&gt;associationMappings[$class-&gt;identifier[0]]['joinColumns'][0]['name']], $class-&gt;rootEntityName)</code>
+      <code>$this-&gt;_uow-&gt;tryGetByIdHash($data[$class-&gt;identifier[0]], $class-&gt;rootEntityName)</code>
+      <code>$this-&gt;_uow-&gt;tryGetByIdHash(ltrim($idHash), $class-&gt;rootEntityName)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>T|false</code>
+    </InvalidReturnType>
     <InvalidScalarArgument occurrences="1">
       <code>array_keys($discrMap)</code>
     </InvalidScalarArgument>
@@ -319,12 +327,10 @@
     <PossiblyNullArgument occurrences="1">
       <code>$objectClass</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="6">
+    <PossiblyNullReference occurrences="4">
       <code>getValue</code>
       <code>getValue</code>
       <code>getValue</code>
-      <code>setValue</code>
-      <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset occurrences="1">
@@ -404,7 +410,6 @@
       <code>$this-&gt;em-&gt;getConfiguration()-&gt;getMetadataDriverImpl()</code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullReference occurrences="5">
-      <code>getConfiguration</code>
       <code>getConfiguration</code>
       <code>getConfiguration</code>
       <code>getConfiguration</code>
@@ -1167,6 +1172,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </ArgumentTypeCoercion>
     <InvalidScalarArgument occurrences="1">
       <code>$sqlParams</code>
     </InvalidScalarArgument>
@@ -1722,6 +1730,9 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$AST-&gt;deleteClause-&gt;abstractSchemaName</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1">
       <code>$numDeleted</code>
     </InvalidReturnStatement>
@@ -1740,6 +1751,9 @@
     </UninitializedProperty>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$updateClause-&gt;abstractSchemaName</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1">
       <code>$numUpdated</code>
     </InvalidReturnStatement>
@@ -1834,7 +1848,10 @@
     </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/Parser.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$abstractSchemaName</code>
+      <code>$abstractSchemaName</code>
+      <code>$deleteClause-&gt;abstractSchemaName</code>
       <code>$stringPattern</code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="3">
@@ -2010,7 +2027,6 @@
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$token['type']</code>
       <code>$token['type']</code>
       <code>$token['type']</code>
@@ -2065,6 +2081,14 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>$AST-&gt;deleteClause-&gt;abstractSchemaName</code>
+      <code>$AST-&gt;updateClause-&gt;abstractSchemaName</code>
+      <code>$deleteClause-&gt;abstractSchemaName</code>
+      <code>$joinDeclaration-&gt;abstractSchemaName</code>
+      <code>$rangeVariableDeclaration-&gt;abstractSchemaName</code>
+      <code>$updateClause-&gt;abstractSchemaName</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="5">
       <code>$likeExpr-&gt;stringPattern instanceof AST\Functions\FunctionNode</code>
       <code>$likeExpr-&gt;stringPattern instanceof AST\PathExpression</code>
@@ -2367,7 +2391,7 @@
       <code>new $repositoryClassName($entityManager, $metadata)</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType occurrences="1">
-      <code>ObjectRepository</code>
+      <code>ObjectRepository&lt;T&gt;</code>
     </MoreSpecificReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php">
@@ -2532,12 +2556,12 @@
     <InvalidArgument occurrences="1">
       <code>$em-&gt;getMetadataFactory()</code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
-      <code>object</code>
-    </InvalidNullableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="2">
+    <InvalidPropertyAssignmentValue occurrences="5">
       <code>$this-&gt;entityChangeSets</code>
       <code>$this-&gt;entityChangeSets</code>
+      <code>$this-&gt;identityMap</code>
+      <code>$this-&gt;identityMap</code>
+      <code>$this-&gt;identityMap</code>
     </InvalidPropertyAssignmentValue>
     <MissingClosureReturnType occurrences="4">
       <code>static function (array $assoc) {</code>
@@ -2545,13 +2569,7 @@
       <code>static function (array $assoc) {</code>
       <code>static function (array $assoc) {</code>
     </MissingClosureReturnType>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
-    </NullableReturnStatement>
-    <PossiblyInvalidArrayOffset occurrences="1">
-      <code>$this-&gt;identityMap[$rootClassName]</code>
-    </PossiblyInvalidArrayOffset>
-    <PossiblyNullArgument occurrences="9">
+    <PossiblyNullArgument occurrences="8">
       <code>$assoc</code>
       <code>$assoc</code>
       <code>$assoc['targetEntity']</code>
@@ -2559,7 +2577,6 @@
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$collectionToDelete-&gt;getMapping()</code>
-      <code>$entity</code>
       <code>$owner</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="2">

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -37,6 +37,9 @@ class DefaultCacheTest extends OrmTestCase
         $this->cache = new DefaultCache($this->em);
     }
 
+    /**
+     * @psalm-param class-string $className
+     */
     private function putEntityCacheEntry(string $className, array $identifier, array $data): void
     {
         $metadata   = $this->em->getClassMetadata($className);
@@ -47,6 +50,9 @@ class DefaultCacheTest extends OrmTestCase
         $persister->getCacheRegion()->put($cacheKey, $cacheEntry);
     }
 
+    /**
+     * @psalm-param class-string $className
+     */
     private function putCollectionCacheEntry(string $className, string $association, array $ownerIdentifier, array $data): void
     {
         $metadata   = $this->em->getClassMetadata($className);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -36,6 +36,8 @@ class DDC2825Test extends OrmFunctionalTestCase
     }
 
     /**
+     * @psalm-param class-string $className
+     *
      * @dataProvider getTestedClasses
      */
     public function testClassSchemaMappingsValidity(string $className, string $expectedSchemaName, string $expectedTableName): void
@@ -64,6 +66,8 @@ class DDC2825Test extends OrmFunctionalTestCase
     }
 
     /**
+     * @psalm-param class-string $className
+     *
      * @dataProvider getTestedClasses
      */
     public function testPersistenceOfEntityWithSchemaMapping(string $className): void
@@ -85,6 +89,7 @@ class DDC2825Test extends OrmFunctionalTestCase
      * Data provider
      *
      * @return string[][]
+     * @psalm-return list<array{class-string, string, string}>
      */
     public function getTestedClasses(): array
     {


### PR DESCRIPTION
Because we have removed support for short/aliased entity names, we can now boldly declare that an entity name is in fact a `class-string`.