### PR TITLE
Make Reflection available to ConvertMappingCommand

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -108,7 +108,10 @@ class AttributeDriver extends CompatibilityAnnotationDriver
      */
     public function loadMetadataForClass($className, PersistenceClassMetadata $metadata): void
     {
-        $reflectionClass = $metadata->getReflectionClass();
+        $reflectionClass = $metadata->getReflectionClass()
+            // this happens when running annotation driver in combination with
+            // static reflection services. This is not the nicest fix
+            ?? new ReflectionClass($metadata->name);
 
         $classAttributes = $this->reader->getClassAnnotations($reflectionClass);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\Tools\Export\Driver\AbstractExporter;
@@ -109,7 +109,7 @@ EOT
             }
         }
 
-        $cmf = new ClassMetadataFactory();
+        $cmf = new DisconnectedClassMetadataFactory();
         $cmf->setEntityManager($em);
         $metadata = $cmf->getAllMetadata();
         $metadata = MetadataFilter::filter($metadata, $input->getOption('filter'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
-use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\Tools\Export\Driver\AbstractExporter;
@@ -109,7 +109,7 @@ EOT
             }
         }
 
-        $cmf = new DisconnectedClassMetadataFactory();
+        $cmf = new ClassMetadataFactory();
         $cmf->setEntityManager($em);
         $metadata = $cmf->getAllMetadata();
         $metadata = MetadataFilter::filter($metadata, $input->getOption('filter'));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,6 +226,11 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
 
 		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+
+		-
 			message: "#^Empty array passed to foreach\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -747,6 +747,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>new ReflectionClass($metadata-&gt;name)</code>
+    </DocblockTypeContradiction>
     <InvalidArrayAccess occurrences="4">
       <code>$value[0]</code>
       <code>$value[0]</code>
@@ -770,6 +773,7 @@
     </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assert($cacheAttribute instanceof Mapping\Cache)</code>
+      <code>$metadata-&gt;getReflectionClass()</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -771,7 +771,7 @@
       <code>assert($method instanceof ReflectionMethod)</code>
       <code>assert($property instanceof ReflectionProperty)</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>assert($cacheAttribute instanceof Mapping\Cache)</code>
       <code>$metadata-&gt;getReflectionClass()</code>
     </RedundantConditionGivenDocblockType>


### PR DESCRIPTION
Fixes #9659

This fixes an exception when exporting mapping information using the
ConvertMappingCommand from Attributes. The AttributeDriver needs a
ReflectionClass in the loadMetadataForClass method. The
ConvertMappingCommand sets up the ClassMetadataFactory as an instance of
DisconnectedClassMetadataFactory which does not return ReflectionClasses