### PR TITLE
Use correct charset/collation from column/table defaults when creating relationships

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -728,6 +728,27 @@ class SchemaTool
                     $columnOptions['precision'] = $fieldMapping['precision'];
                 }
 
+                // Only do this for DBAL v3 or higher.
+                if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+                    $theJoinTableCharset = $theJoinTable->hasOption('charset') ? $theJoinTable->getOption('charset') : null;
+                    if (
+                        ! isset($columnOptions['customSchemaOptions']['charset'])
+                        && isset($class->table['options']['charset'])
+                        && $theJoinTableCharset !== $class->table['options']['charset']
+                    ) {
+                        $columnOptions['customSchemaOptions']['charset'] = $class->table['options']['charset'];
+                    }
+
+                    $theJoinTableCollation = $theJoinTable->hasOption('collation') ? $theJoinTable->getOption('collation') : null;
+                    if (
+                        ! isset($columnOptions['customSchemaOptions']['collation'])
+                        && isset($class->table['options']['collation'])
+                        && $theJoinTableCollation !== $class->table['options']['collation']
+                    ) {
+                        $columnOptions['customSchemaOptions']['collation'] = $class->table['options']['collation'];
+                    }
+                }
+
                 $theJoinTable->addColumn($quotedColumnName, $fieldMapping['type'], $columnOptions);
             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function method_exists;
+
+class GH6823Test extends OrmFunctionalTestCase
+{
+    public function testCharsetCollationWhenCreatingForeignRelations(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+            self::markTestSkipped('This test is useful for all databases, but designed only for mysql.');
+        }
+
+        if (method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+            self::markTestSkipped('Test valid for doctrine/dbal:3.x only.');
+        }
+
+        $this->createSchemaForModels(
+            GH6823User::class,
+            GH6823Group::class,
+            GH6823Status::class
+        );
+
+        self::assertSQLEquals('CREATE TABLE gh6823_user (id VARCHAR(255) NOT NULL, group_id VARCHAR(255) CHARACTER SET ascii DEFAULT NULL COLLATE `ascii_general_ci`, status_id VARCHAR(255) CHARACTER SET latin1 DEFAULT NULL COLLATE `latin1_bin`, INDEX idx_70dd1774fe54d947 (group_id), INDEX idx_70dd17746bf700bd (status_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(4)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_group (id VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(3)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_status (id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, PRIMARY KEY(id)) DEFAULT CHARACTER SET koi8r COLLATE `koi8r_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(2)['sql']);
+        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd1774fe54d947 FOREIGN KEY (group_id) REFERENCES gh6823_group (id)', $this->getLastLoggedQuery(1)['sql']);
+        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd17746bf700bd FOREIGN KEY (status_id) REFERENCES gh6823_status (id)', $this->getLastLoggedQuery(0)['sql']);
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh6823_user", options={
+ *     "charset"="utf8mb4",
+ *     "collation"="utf8mb4_bin"
+ * })
+ */
+class GH6823User
+{
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string")
+     */
+    public $id;
+
+    /**
+     * @var GH6823Group
+     * @ManyToOne(targetEntity="GH6823Group")
+     */
+    public $group;
+
+    /**
+     * @var GH6823Status
+     * @ManyToOne(targetEntity="GH6823Status")
+     */
+    public $status;
+}
+
+/**
+ * @Entity
+ * @Table(name="gh6823_group", options={
+ *     "charset"="ascii",
+ *     "collation"="ascii_general_ci"
+ * })
+ */
+class GH6823Group
+{
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string")
+     */
+    public $id;
+}
+
+/**
+ * @Entity
+ * @Table(name="gh6823_status", options={
+ *     "charset"="koi8r",
+ *     "collation"="koi8r_bin"
+ * })
+ */
+class GH6823Status
+{
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string", options={"charset"="latin1", "collation"="latin1_bin"})
+     */
+    public $id;
+}


### PR DESCRIPTION
Fixes #6823

When you have entities and columns with different charset/collation the SchemaTool should be smart and use the correct charset/collection for the column that references the other table. 

In the tests I created the following entities:
| **User table** | Relation | _Default charset utf8mb4_ | _Default collation utf8mb4_bin_ |
|----------------|-|---------------------------|-------------------------------|
| id             | | _default_                 | _default_                     |
| group_id       | References Group table | ascii                     | ascii_general_ci              |
| status_id      | References Status table | latin1                    | latin1_bin                    |

👉 As you can see, the `group_id` column uses the charset/collation from the `group` table default.
For the `status_id`, it uses the charset/collation from the `id` column because that was set explicitly.

| **Group table** | _Default charset ascii | _Default collation ascii_general_ci |
|-----------------|------------------------|-----------------------------------|
| id              | _default_              | _default_                         |

👉 As you can see, the `id` column of `group` uses the table default.

| **Status table** | _Default charset koi8r | _Default collation koi8r_bin |
|------------------|------------------------|----------------------------|
| id               | latin1                 | latin1_bin                 |

👉 As you can see, the `id` column of `status` is different than the table default.

When I disable the fix in SchemaTool, the following errors would be produced:
```
// ALTER TABLE user ADD CONSTRAINT FK_8D93D649FE54D947 FOREIGN KEY (group_id) REFERENCES `group` (id)

An exception occurred while executing a query: SQLSTATE[HY000]: General error: 3780 Referencing column 'group_id' and referenced column 'id' in foreign key constraint 'FK_8D93D649FE54D947' are incompatible.
```
