### PR TITLE
Fix exception message in "missingFieldName" MappingException method

### DIFF
--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -80,7 +80,7 @@ class MappingException extends ORMException
     public static function missingFieldName($entity)
     {
         return new self(sprintf(
-            "The field or association mapping misses the 'fieldName' attribute in entity '%s'.",
+            "The field or association mapping misses the 'field' attribute in entity '%s'.",
             $entity
         ));
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -630,7 +630,7 @@ class ClassMetadataTest extends OrmTestCase
     public function testEmptyFieldNameThrowsException(): void
     {
         $this->expectException(MappingException::class);
-        $this->expectExceptionMessage("The field or association mapping misses the 'fieldName' attribute in entity '" . CMS\CmsUser::class . "'.");
+        $this->expectExceptionMessage("The field or association mapping misses the 'field' attribute in entity '" . CMS\CmsUser::class . "'.");
 
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());


### PR DESCRIPTION
I encountered a legitimate ``MappingException`` with XML mapping :

```
In MappingException.php line 82:
The field or association mapping misses the 'fieldName' attribute in entity 'App\Modules\Athena\Model\OrbitalBase'
```

Indeed I used `name` attribute by mistake for my `many-to-one` relationship. So I apply the suggested change :

```xml
<many-to-one fieldName="rPlayer" target-entity="App\Modules\Zeus\Model\Player">
  <!-- ... -->
</many-to-one>
```

But then I still have the same error message. Comparing to the documentation, I find out that the real attribute to use is `field`. Once I replaced `fieldName` with it, it works ! But it seemed to me that the exception message was misleading.

I found out in `ClassMetadataInfo.php` that indeed we look for a `fieldName` key in the mapping data:

https://github.com/doctrine/orm/blob/1ffb9152f76bd3d332d5275bd2272d3984bcf3d6/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1777-L1781

Seemed that the mapping was modified when parsing the XML file. I found the culprit in `XmlDriver.php`:

https://github.com/doctrine/orm/blob/1ffb9152f76bd3d332d5275bd2272d3984bcf3d6/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php#L507-L509

The same transformation is performed for `one-to-one` and `many-to-many` associations. As I suppose there's a reason to do it, I just changed in this PR the suggested correction in `MappingException` by replacing `fieldName` with `field` in the exception message.

I didn't found relevant to change the `missingFieldName` method to fit that change because `missingField` could imply something else imho.

