### PR TITLE
Improve exception message

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 2.12
 
+## Deprecate omitting `$class` argument to `ORMInvalidArgumentException::invalidIdentifierBindingEntity()`
+
+To make it easier to identify understand the cause for that exception, it is
+deprecated to omit the class name when calling
+`ORMInvalidArgumentException::invalidIdentifierBindingEntity()`.
+
 ## Deprecate `Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper`
 
 Using a console helper to provide the ORM's console commands with one or
@@ -7,7 +13,6 @@ multiple entity managers had been deprecated with 2.9 already. This leaves
 The `EntityManagerHelper` class with no purpose which is why it is now
 deprecated too. Applications that still rely on the `em` console helper, can
 easily recreate that class in their own codebase.
-
 ## Deprecate custom repository classes that don't extend `EntityRepository`
 
 Although undocumented, it is currently possible to configure a custom repository

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Result;
 use Doctrine\Deprecations\Deprecation;
@@ -434,10 +435,11 @@ abstract class AbstractQuery
         }
 
         try {
+            $class = ClassUtils::getClass($value);
             $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
 
             if ($value === null) {
-                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity($class);
             }
         } catch (MappingException | ORMMappingException $e) {
             /* Silence any mapping exceptions. These can occur if the object in

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -296,11 +296,14 @@ class DefaultCache implements Cache
      */
     private function toIdentifierArray(ClassMetadata $metadata, $identifier): array
     {
-        if (is_object($identifier) && $this->em->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($identifier))) {
-            $identifier = $this->uow->getSingleIdentifierValue($identifier);
+        if (is_object($identifier)) {
+            $class = ClassUtils::getClass($identifier);
+            if ($this->em->getMetadataFactory()->hasMetadataFor($class)) {
+                $identifier = $this->uow->getSingleIdentifierValue($identifier);
 
-            if ($identifier === null) {
-                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+                if ($identifier === null) {
+                    throw ORMInvalidArgumentException::invalidIdentifierBindingEntity($class);
+                }
             }
         }
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -438,11 +438,14 @@ use function strpos;
         }
 
         foreach ($id as $i => $value) {
-            if (is_object($value) && $this->metadataFactory->hasMetadataFor(ClassUtils::getClass($value))) {
-                $id[$i] = $this->unitOfWork->getSingleIdentifierValue($value);
+            if (is_object($value)) {
+                $className = ClassUtils::getClass($value);
+                if ($this->metadataFactory->hasMetadataFor($className)) {
+                    $id[$i] = $this->unitOfWork->getSingleIdentifierValue($value);
 
-                if ($id[$i] === null) {
-                    throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+                    if ($id[$i] === null) {
+                        throw ORMInvalidArgumentException::invalidIdentifierBindingEntity($className);
+                    }
                 }
             }
         }

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -10,6 +10,8 @@ use InvalidArgumentException;
 
 use function array_map;
 use function count;
+use function func_get_arg;
+use function func_num_args;
 use function get_debug_type;
 use function gettype;
 use function implode;
@@ -198,9 +200,27 @@ class ORMInvalidArgumentException extends InvalidArgumentException
     /**
      * @return ORMInvalidArgumentException
      */
-    public static function invalidIdentifierBindingEntity()
+    public static function invalidIdentifierBindingEntity(/* string $class */)
     {
-        return new self('Binding entities to query parameters only allowed for entities that have an identifier.');
+        if (func_num_args() === 0) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9642',
+                'Omitting the class name in the exception method %s is deprecated.',
+                __METHOD__
+            );
+
+            return new self('Binding entities to query parameters only allowed for entities that have an identifier.');
+        }
+
+        return new self(sprintf(
+            <<<'EXCEPTION'
+Binding entities to query parameters only allowed for entities that have an identifier.
+Class "%s" does not have an identifier.
+EXCEPTION
+            ,
+            func_get_arg(0)
+        ));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
@@ -54,10 +54,15 @@ class DDC2084Test extends OrmFunctionalTestCase
         self::assertEquals('Foo', $e->getMyEntity2()->getValue());
     }
 
-    public function testinvalidIdentifierBindingEntityException(): void
+    public function testInvalidIdentifierBindingEntityException(): void
     {
         $this->expectException('Doctrine\ORM\ORMInvalidArgumentException');
-        $this->expectExceptionMessage('Binding entities to query parameters only allowed for entities that have an identifier.');
+        $this->expectExceptionMessage(
+            <<<'EXCEPTION'
+Binding entities to query parameters only allowed for entities that have an identifier.
+Class "Doctrine\Tests\ORM\Functional\Ticket\DDC2084\MyEntity2" does not have an identifier.
+EXCEPTION
+        );
         $this->_em->find(__NAMESPACE__ . '\DDC2084\MyEntity1', new DDC2084\MyEntity2('Foo'));
     }
 }


### PR DESCRIPTION
This was done in reaction to this discussion: https://github.com/doctrine/orm/discussions/9645

In setups where you have many parameters, or do not even realise you are
using an entity, that additional piece of context can be helpful. The
parameter name is not always available where the old exception was
called though.