### PR TITLE
Only put `collation` on join columns, never `charset`

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -730,15 +730,6 @@ class SchemaTool
 
                 // Only do this for DBAL v3 or higher.
                 if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
-                    $theJoinTableCharset = $theJoinTable->hasOption('charset') ? $theJoinTable->getOption('charset') : null;
-                    if (
-                        ! isset($columnOptions['customSchemaOptions']['charset'])
-                        && isset($class->table['options']['charset'])
-                        && $theJoinTableCharset !== $class->table['options']['charset']
-                    ) {
-                        $columnOptions['customSchemaOptions']['charset'] = $class->table['options']['charset'];
-                    }
-
                     $theJoinTableCollation = $theJoinTable->hasOption('collation') ? $theJoinTable->getOption('collation') : null;
                     if (
                         ! isset($columnOptions['customSchemaOptions']['collation'])

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
@@ -30,14 +30,17 @@ class GH6823Test extends OrmFunctionalTestCase
         $this->createSchemaForModels(
             GH6823User::class,
             GH6823Group::class,
-            GH6823Status::class
+            GH6823Status::class,
+            GH6823Tag::class
         );
 
-        self::assertSQLEquals('CREATE TABLE gh6823_user (id VARCHAR(255) NOT NULL, group_id VARCHAR(255) CHARACTER SET ascii DEFAULT NULL COLLATE `ascii_general_ci`, status_id VARCHAR(255) CHARACTER SET latin1 DEFAULT NULL COLLATE `latin1_bin`, INDEX idx_70dd1774fe54d947 (group_id), INDEX idx_70dd17746bf700bd (status_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(4)['sql']);
-        self::assertSQLEquals('CREATE TABLE gh6823_group (id VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(3)['sql']);
-        self::assertSQLEquals('CREATE TABLE gh6823_status (id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, PRIMARY KEY(id)) DEFAULT CHARACTER SET koi8r COLLATE `koi8r_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(2)['sql']);
-        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd1774fe54d947 FOREIGN KEY (group_id) REFERENCES gh6823_group (id)', $this->getLastLoggedQuery(1)['sql']);
-        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd17746bf700bd FOREIGN KEY (status_id) REFERENCES gh6823_status (id)', $this->getLastLoggedQuery(0)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_user (id VARCHAR(255) NOT NULL, group_id VARCHAR(255) DEFAULT NULL COLLATE `ascii_general_ci`, status_id VARCHAR(255) CHARACTER SET latin1 DEFAULT NULL COLLATE `latin1_bin`, tag_id INT DEFAULT NULL COLLATE `utf8mb4_unicode_ci`, INDEX IDX_70DD1774FE54D947 (group_id), INDEX IDX_70DD17746BF700BD (status_id), INDEX IDX_70DD1774BAD26311 (tag_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(6)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_group (id VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(5)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_status (id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, PRIMARY KEY(id)) DEFAULT CHARACTER SET koi8r COLLATE `koi8r_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(4)['sql']);
+        self::assertSQLEquals('CREATE TABLE gh6823_tag (id INT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(3)['sql']);
+        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd1774fe54d947 FOREIGN KEY (group_id) REFERENCES gh6823_group (id)', $this->getLastLoggedQuery(2)['sql']);
+        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT fk_70dd17746bf700bd FOREIGN KEY (status_id) REFERENCES gh6823_status (id)', $this->getLastLoggedQuery(1)['sql']);
+        self::assertSQLEquals('ALTER TABLE gh6823_user ADD CONSTRAINT FK_70DD1774BAD26311 FOREIGN KEY (tag_id) REFERENCES gh6823_tag (id)', $this->getLastLoggedQuery(0)['sql']);
     }
 }
 
@@ -68,6 +71,12 @@ class GH6823User
      * @ManyToOne(targetEntity="GH6823Status")
      */
     public $status;
+
+    /**
+     * @var GH6823Tag
+     * @ManyToOne(targetEntity="GH6823Tag")
+     */
+    public $tag;
 }
 
 /**
@@ -100,6 +109,23 @@ class GH6823Status
      * @var string
      * @Id
      * @Column(type="string", options={"charset"="latin1", "collation"="latin1_bin"})
+     */
+    public $id;
+}
+
+/**
+ * @Entity
+ * @Table(name="gh6823_tag", options={
+ *     "charset"="utf8mb4",
+ *     "collation"="utf8mb4_unicode_ci"
+ * })
+ */
+class GH6823Tag
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
      */
     public $id;
 }


### PR DESCRIPTION
The fix introduced in #9636 now breaks when working with integer relations.

Putting `charset` and `collation` on a text join column works fine, but when the
column is an integer, MySQL won't accept it:

```sql
CREATE TABLE table_name (
  // ..
  user_id INT CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`
  // ..
)
```

produces this error:
```
Query 1 ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`, type VARCHAR(255) NOT NUL' at line 1
```

Luckily the solution is simple. The charset is not needed as MySQL automatically derives that from
the `collation` when specified. It's also clever enough to ignore `collation` when the type is an integer.

Therefore the following works fine:
```sql
CREATE TABLE table_name (
  // ..
  user_id INT NOT NULL COLLATE `utf8_unicode_ci`,
  string_user_id VARCHAR(255) NOT NULL COLLATE `utf8_unicode_ci`,
  // ..
)
```

/cc @greg0ire 