### PR TITLE
Fix IdentifierFlattenerEnumIdTest

### DIFF
--- a/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
@@ -44,10 +44,11 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
 
         $this->_em->persist($typedCardEnumIdEntity);
         $this->_em->flush();
+        $this->_em->clear();
 
         $findTypedCardEnumIdEntityNotFound = $this->_em->getRepository(TypedCardEnumId::class)->find(Suit::Diamonds);
 
-        self::assertNull($findTypedCardEnumIdEntityNotFound, 'Search by non-cached Enum ID does not work');
+        self::assertNull($findTypedCardEnumIdEntityNotFound, 'Search by non-persisted Enum ID does not work');
 
         $findTypedCardEnumIdEntity = $this->_em->getRepository(TypedCardEnumId::class)->find(Suit::Clubs);
 
@@ -73,10 +74,11 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
 
         $this->_em->persist($typedCardEnumCompositeIdEntity);
         $this->_em->flush();
+        $this->_em->clear();
 
         $findTypedCardEnumCompositeIdEntityNotFound = $this->_em->getRepository(TypedCardEnumCompositeId::class)->find(['suit' => Suit::Diamonds, 'unit' => Unit::Gram]);
 
-        self::assertNull($findTypedCardEnumCompositeIdEntityNotFound, 'Search by non-cached composite Enum ID does not work');
+        self::assertNull($findTypedCardEnumCompositeIdEntityNotFound, 'Search by non-persisted composite Enum ID does not work');
 
         $findTypedCardEnumCompositeIdEntity = $this->_em->getRepository(TypedCardEnumCompositeId::class)->find(['suit' => Suit::Clubs, 'unit' => Unit::Gram]);
 


### PR DESCRIPTION
The tests were using cached values, not actually fetching from DB. Related to https://github.com/doctrine/orm/pull/9629