### PR TITLE
ScalarColumnHydrator: prevent early-bail on falsy values

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\ORM\Exception\MultipleSelectorsFoundException;
 
+use function array_column;
 use function count;
 
 /**
@@ -26,12 +27,8 @@ final class ScalarColumnHydrator extends AbstractHydrator
             throw MultipleSelectorsFoundException::create($this->resultSetMapping()->fieldMappings);
         }
 
-        $result = [];
+        $result = $this->statement()->fetchAllNumeric();
 
-        while ($row = $this->statement()->fetchOne()) {
-            $result[] = $row;
-        }
-
-        return $result;
+        return array_column($result, 0);
     }
 }

--- a/tests/Doctrine/Tests/Mocks/DriverResultMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverResultMock.php
@@ -64,7 +64,12 @@ class DriverResultMock implements Result, ResultStatement
 
     public function fetchAllNumeric(): array
     {
-        throw new BadMethodCallException('Not implemented');
+        $values = [];
+        while (($row = $this->fetchNumeric()) !== false) {
+            $values[] = $row;
+        }
+
+        return $values;
     }
 
     public function fetchAllAssociative(): array

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-9230
+ */
+class GH9230Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // ensure entity table exists
+        $this->setUpEntitySchema([GH9230Entity::class]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $connection = static::$sharedConn;
+        if ($connection === null) {
+            return;
+        }
+
+        // remove persisted entities
+        $connection->executeStatement('DELETE FROM GH9230Entity');
+    }
+
+    /**
+     * This does not work before the fix in PR#9663, but is does work after the fix is applied
+     */
+    public function failingValuesBeforeFix(): array
+    {
+        return [
+            'string=""' => ['name', '', 'test name'],
+            'string="0"' => ['name', '0', 'test name'],
+            'string=null' => ['name', null, 'test name'],
+
+            'int=0' => ['counter', 0, 1],
+            'int=null' => ['counter', null, 1],
+
+            'bool=false' => ['enabled', false, true],
+            'bool=null' => ['enabled', null, true],
+
+            'float=0.0' => ['price', 0.0, 1.1],
+            'float=-0.0' => ['price', -0.0, 1.1],
+            'float=null' => ['price', null, 1.1],
+
+            'json=[]' => ['extra', [], 1],
+            'json=0' => ['extra', 0, 1],
+            'json=0.0' => ['extra', 0.0, 1],
+            'json=false' => ['extra', false, 1],
+            'json=""' => ['extra', '', 1, ['""', '1']],
+            'json=null' => ['enabled', null, 1],
+        ];
+    }
+
+    /**
+     * This already works before the fix in PR#9663 is applied because none of these are falsy values in php
+     */
+    public function succeedingValuesBeforeFix(): array
+    {
+        return [
+            'string="test"' => ['name', 'test', 'test2'],
+            'int=1' => ['counter', 1, 1],
+            'bool=true' => ['enabled', true, 1],
+            'json=[null]' => ['extra', [null], 1],
+            'json=1' => ['extra', 1, 1],
+            'json=1.1' => ['extra', 1.1, 1],
+            'json=true' => ['extra', true, 1],
+            'json="test"' => ['extra', 'test', 'test'],
+            'json="1"' => ['extra', '1', 1],
+        ];
+    }
+
+    /**
+     * @dataProvider failingValuesBeforeFix
+     * @dataProvider succeedingValuesBeforeFix
+     */
+    public function testIssue(string $property, $falsyValue, $truthyValue): void
+    {
+        $counter1            = new GH9230Entity();
+        $counter1->$property = $falsyValue;
+
+        $counter2            = new GH9230Entity();
+        $counter2->$property = $truthyValue;
+
+        $this->_em->persist($counter1);
+        $this->_em->persist($counter2);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $persistedCounter1 = $this->_em->find(GH9230Entity::class, $counter1->id);
+        $persistedCounter2 = $this->_em->find(GH9230Entity::class, $counter2->id);
+
+        // Assert entities were persisted
+        self::assertInstanceOf(GH9230Entity::class, $persistedCounter1);
+        self::assertInstanceOf(GH9230Entity::class, $persistedCounter2);
+        self::assertEquals($falsyValue, $persistedCounter1->$property);
+        self::assertEquals($truthyValue, $persistedCounter2->$property);
+
+        $this->_em->clear();
+
+        $counterRepository = $this->_em->getRepository(GH9230Entity::class);
+
+        $query = $counterRepository->createQueryBuilder('counter')
+            ->select('counter.' . $property)
+            ->orderBy('counter.position')
+            ->getQuery();
+
+        $values = $query->getSingleColumnResult();
+
+        // Assert that there are 2 values returned.
+        // This fails when there is a falsy value in the array,
+        // because the first falsy value halts the hydration process (before the fix is applied).
+        self::assertCount(2, $values);
+    }
+}
+
+
+/**
+ * @Entity
+ */
+class GH9230Entity
+{
+    /** @var int */
+    private static $POSITION = 0;
+
+    /**
+     * @var int
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var int
+     * @Column(name="position", type="integer", nullable=false)
+     */
+    public $position;
+
+    /**
+     * @var ?string
+     * @Column(name="name", type="string", nullable=true)
+     */
+    public $name;
+
+    /**
+     * @var ?int
+     * @Column(name="counter", type="integer", nullable=true)
+     */
+    public $counter;
+
+    /**
+     * @var ?bool
+     * @Column(name="enabled", type="boolean", nullable=true)
+     */
+    public $enabled;
+
+    /**
+     * @var ?float
+     * @Column(name="price", type="decimal", scale=1, precision=2, nullable=true)
+     */
+    public $price;
+
+    /**
+     * @var mixed[]
+     * @Column(name="extra", type="json", nullable=true)
+     */
+    public $extra;
+
+    public function __construct()
+    {
+        $this->position = ++self::$POSITION;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
@@ -116,7 +116,6 @@ class GH9230Test extends OrmFunctionalTestCase
 
         $query = $counterRepository->createQueryBuilder('counter')
             ->select('counter.' . $property)
-            ->orderBy('counter.position')
             ->getQuery();
 
         $values = $query->getSingleColumnResult();
@@ -134,9 +133,6 @@ class GH9230Test extends OrmFunctionalTestCase
  */
 class GH9230Entity
 {
-    /** @var int */
-    private static $POSITION = 0;
-
     /**
      * @var int
      * @Column(name="id", type="integer")
@@ -144,12 +140,6 @@ class GH9230Entity
      * @GeneratedValue(strategy="AUTO")
      */
     public $id;
-
-    /**
-     * @var int
-     * @Column(name="position", type="integer", nullable=false)
-     */
-    public $position;
 
     /**
      * @var ?string
@@ -180,9 +170,4 @@ class GH9230Entity
      * @Column(name="extra", type="json", nullable=true)
      */
     public $extra;
-
-    public function __construct()
-    {
-        $this->position = ++self::$POSITION;
-    }
 }


### PR DESCRIPTION
Hi !

This is my first contribution to Doctrine, please let me know if there is anything I can do to facilitate the review process.

--

Fix #9230

Falsy values stop the hydration process in `$query->getSingleColumnResult()`. If the array of values fetched from the database contains a value that is "falsy", every value after that value and including that value is missing from the array that is returned.

This is because of the way the database values are retreived in ScalarColumnHydrator : https://github.com/doctrine/orm/blob/f4d5283f705f6ac51e81c8299ace074a619b40d7/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php#L31-L33


This PR fixes that by fetching all the values and returning them as is. As before, and to keep things consistent with the previous behavior of both ScalarHydrator and ScalarColumnHydrator, no type conversion is done between the database value and the PHP value. According to a comment in `AbstractHydrator`, this is the expected behavior for scalar hydrators that is a legacy behavior from 2.0 : https://github.com/doctrine/orm/blob/f4d5283f705f6ac51e81c8299ace074a619b40d7/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php#L498-L505