### PR TITLE
Conditionally extend the old `AnnotationDriver` class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,11 +41,6 @@ This is now deprecated. Please extend `EntityRepository` instead.
 +$entityManager->getRepository(CmsUser::class);
 ```
 
-## BC Break: `AttributeDriver` and `AnnotationDriver` no longer extends parent class from `doctrine/persistence`
-
-Both these classes used to extend an abstract `AnnotationDriver` class defined
-in `doctrine/persistence`, and no longer do.
-
 ## Deprecate `AttributeDriver::getReader()` and `AnnotationDriver::getReader()`
 
 That method was inherited from the abstract `AnnotationDriver` class of

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -32,7 +31,7 @@ use function is_numeric;
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
  */
-class AnnotationDriver implements MappingDriver
+class AnnotationDriver extends CompatibilityAnnotationDriver
 {
     use ColocatedMappingDriver;
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
@@ -27,7 +26,7 @@ use function sprintf;
 
 use const PHP_VERSION_ID;
 
-class AttributeDriver implements MappingDriver
+class AttributeDriver extends CompatibilityAnnotationDriver
 {
     use ColocatedMappingDriver;
 

--- a/lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping\Driver;
+
+use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as PersistenceAnnotationDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+
+use function class_exists;
+
+if (class_exists(PersistenceAnnotationDriver::class)) {
+    /**
+     * @internal This class will be removed in ORM 3.0.
+     */
+    abstract class CompatibilityAnnotationDriver extends PersistenceAnnotationDriver
+    {
+    }
+} else {
+    /**
+     * @internal This class will be removed in ORM 3.0.
+     */
+    abstract class CompatibilityAnnotationDriver implements MappingDriver
+    {
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,7 +43,8 @@
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
-        <exclude-pattern>*/tests/*</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php</exclude-pattern>
+        <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">

--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -41,3 +41,14 @@ parameters:
 
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
+
+        # Compatibility layer for AttributeDriver
+        -
+            message: "#^PHPDoc type Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeReader of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$reader is not covariant with PHPDoc type Doctrine\\\\Common\\\\Annotations\\\\Reader of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$reader\\.$#"
+            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+        -
+            message: "#^PHPDoc type array\\<string, int\\> of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$entityAnnotationClasses is not covariant with PHPDoc type array\\<class\\-string, bool\\|int\\> of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$entityAnnotationClasses\\.$#"
+            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+        -
+            message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeReader\\) of method Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:getReader\\(\\) should be compatible with return type \\(Doctrine\\\\Common\\\\Annotations\\\\Reader\\) of method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:getReader\\(\\)$#"
+            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\PostLoad;
 use Doctrine\ORM\Mapping\PreUpdate;
+use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as PersistenceAnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -35,6 +36,9 @@ use Doctrine\Tests\Models\DirectoryTree\Directory;
 use Doctrine\Tests\Models\DirectoryTree\File;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Generator;
+
+use function class_exists;
+use function is_subclass_of;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
@@ -302,6 +306,15 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         yield [DiscriminatorColumnWithNoLength::class, 255];
         yield [DiscriminatorColumnWithZeroLength::class, 0];
         yield [DiscriminatorColumnWithNonZeroLength::class, 60];
+    }
+
+    public function testLegacyInheritance(): void
+    {
+        if (! class_exists(PersistenceAnnotationDriver::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2.');
+        }
+
+        self::assertTrue(is_subclass_of(AnnotationDriver::class, PersistenceAnnotationDriver::class));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -8,8 +8,12 @@ use Attribute;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Annotation;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as PersistenceAnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use stdClass;
+
+use function class_exists;
+use function is_subclass_of;
 
 use const PHP_VERSION_ID;
 
@@ -109,6 +113,15 @@ class AttributeDriverTest extends AbstractMappingDriverTest
         self::assertFalse($driver->isTransient(AttributeEntityWithoutOriginalParents::class));
 
         self::assertFalse($driver->isTransient(AttributeEntityStartingWithRepeatableAttributes::class));
+    }
+
+    public function testLegacyInheritance(): void
+    {
+        if (! class_exists(PersistenceAnnotationDriver::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2.');
+        }
+
+        self::assertTrue(is_subclass_of(AttributeDriver::class, PersistenceAnnotationDriver::class));
     }
 }
 


### PR DESCRIPTION
Fixes #9668.
Replaces #9670.

This PR restores the old inheritance chain of `AnnotationDriver` and `AttributeDriver` if Persistence 2 is installed. Unfortunately, DoctrineModule uses a flawed logic to determine the constructor arguments of a mapping driver class, see doctrine/DoctrineModule#774. With this change, that logic should work again.

When merging this PR up to 3.0.x, I would simply revert it.