### PR TITLE
Fix HydrationException::invalidDiscriminatorValue parameter type

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -84,17 +84,17 @@ class HydrationException extends ORMException
 
     /**
      * @param string   $discrValue
-     * @param string[] $discrMap
-     * @psalm-param array<string, string> $discrMap
+     * @param string[] $discrValues
+     * @psalm-param list<string> $discrValues
      *
      * @return HydrationException
      */
-    public static function invalidDiscriminatorValue($discrValue, $discrMap)
+    public static function invalidDiscriminatorValue($discrValue, $discrValues)
     {
         return new self(sprintf(
             'The discriminator value "%s" is invalid. It must be one of "%s".',
             $discrValue,
-            implode('", "', $discrMap)
+            implode('", "', $discrValues)
         ));
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,16 +171,6 @@ parameters:
 			path: lib/Doctrine/ORM/Id/TableGenerator.php
 
 		-
-			message: "#^Parameter \\#2 \\$discrMap of static method Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\HydrationException\\:\\:invalidDiscriminatorValue\\(\\) expects array\\<string, string\\>, array\\<int, string\\> given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
-
-		-
-			message: "#^Parameter \\#2 \\$discrMap of static method Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\HydrationException\\:\\:invalidDiscriminatorValue\\(\\) expects array\\<string, string\\>, array\\<int, string\\> given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
-
-		-
 			message: "#^Offset 'indexes' on array\\{name\\: string, schema\\: string, indexes\\: array, uniqueConstraints\\: array, options\\: array\\<string, mixed\\>, quoted\\?\\: bool\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -421,9 +421,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>array_keys($discrMap)</code>
-    </InvalidScalarArgument>
     <PossiblyFalseArgument occurrences="1">
       <code>$index</code>
     </PossiblyFalseArgument>
@@ -452,9 +449,6 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>array_keys($discrMap)</code>
-    </InvalidScalarArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$class</code>
     </PropertyNotSetInConstructor>


### PR DESCRIPTION
Ref https://github.com/doctrine/orm/pull/9675#discussion_r857144377

The calls to `HydrationException::invalidDiscriminatorValue` are using `array_keys`:

https://github.com/doctrine/orm/blob/1ac05f5e4e2819d092e7c9605d0758370f6acfc8/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L241

https://github.com/doctrine/orm/blob/1ac05f5e4e2819d092e7c9605d0758370f6acfc8/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php#L108

So what `invalidDiscriminatorValue` is receiving are the possible discriminator values.