### PR TITLE
Drop SymfonyStyle[listing] for sqls

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -90,7 +90,9 @@ EOT
         if ($dumpSql) {
             $ui->text('The following SQL statements will be executed:');
             $ui->newLine();
-            $ui->listing($sqls);
+            foreach ($sqls as $sql) {
+                $ui->text(sprintf('    %s;', $sql));
+            }
         }
 
         if ($force) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -81,7 +81,9 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
             if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
                 $sqls = $validator->getUpdateSchemaList();
                 $ui->comment(sprintf('<info>%d</info> schema diff(s) detected:', count($sqls)));
-                $ui->listing($sqls);
+                foreach ($sqls as $sql) {
+                    $ui->text(sprintf('    %s;', $sql));
+                }
             }
 
             $exit += 2;


### PR DESCRIPTION
This was super annoying as UpdateCommand printed sqls prefixed with `*` so it was not possible to copy statements anymore without manually removing those asterisks.

This removes prefixing sqls and makes it consistent with Create and Drop commands.

Also, semicolons at the end were missing.

![image](https://user-images.githubusercontent.com/327717/165111232-0a575959-ca9f-4839-a7e9-bddfa0e8ea8f.png)
<img width="189" alt="image" src="https://user-images.githubusercontent.com/327717/165114449-4c9cd889-93fd-44f7-8a15-5c4137fa68d9.png">
