### PR TITLE
Remove dynamic property declarations

### DIFF
--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -51,9 +51,6 @@ class ConnectionMock extends Connection
         $this->_platformMock = new DatabasePlatformMock();
 
         parent::__construct($params, $driver ?? new DriverMock(), $config, $eventManager);
-
-        // Override possible assignment of platform to database platform mock
-        $this->_platform = $this->_platformMock;
     }
 
     public function getDatabase(): string

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -1209,7 +1209,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $article1         = new CmsArticle();
         $article1->topic  = 'Foo';
         $article1->text   = 'Foo Text';
-        $article1->author = $user;
+        $article1->user   = $user;
         $user->articles[] = $article1;
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -23,8 +23,6 @@ class LockTest extends OrmFunctionalTestCase
     {
         $this->useModelSet('cms');
         parent::setUp();
-
-        $this->handles = [];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Util\ClassUtils;
-use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
@@ -31,12 +30,6 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $this->useModelSet('ecommerce');
         $this->useModelSet('company');
         parent::setUp();
-        $this->_factory = new ProxyFactory(
-            $this->_em,
-            __DIR__ . '/../../Proxies',
-            'Doctrine\Tests\Proxies',
-            true
-        );
     }
 
     public function createProduct(): int

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DBAL483Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DBAL483Test.php
@@ -16,6 +16,9 @@ use function str_contains;
 
 class DBAL483Test extends OrmFunctionalTestCase
 {
+    /** @var Tools\SchemaTool */
+    private $schemaTool;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -26,6 +26,12 @@ use function get_class;
  */
 class DDC1163Test extends OrmFunctionalTestCase
 {
+    /** @var int|null */
+    private $productId;
+
+    /** @var int|null */
+    private $proxyHolderId;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -38,16 +38,12 @@ class DDC1193Test extends OrmFunctionalTestCase
         $account = new DDC1193Account();
 
         $person->account = $account;
-        $person->company = $company;
-
         $company->member = $person;
 
         $this->_em->persist($company);
-
         $this->_em->flush();
 
         $companyId = $company->id;
-        $accountId = $account->id;
         $this->_em->clear();
 
         $company = $this->_em->find(get_class($company), $companyId);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -90,17 +90,14 @@ class DDC1301Test extends OrmFunctionalTestCase
         $user1           = new Models\Legacy\LegacyUser();
         $user1->username = 'beberlei';
         $user1->name     = 'Benjamin';
-        $user1->_status  = 'active';
 
         $user2           = new Models\Legacy\LegacyUser();
         $user2->username = 'jwage';
         $user2->name     = 'Jonathan';
-        $user2->_status  = 'active';
 
         $user3           = new Models\Legacy\LegacyUser();
         $user3->username = 'romanb';
         $user3->name     = 'Roman';
-        $user3->_status  = 'active';
 
         $this->_em->persist($user1);
         $this->_em->persist($user2);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
@@ -25,7 +25,6 @@ class DDC1885Test extends OrmFunctionalTestCase
 
         $user           = new User();
         $user->name     = 'FabioBatSilva';
-        $user->email    = 'fabio.bat.silva@gmail.com';
         $user->groups[] = new Group('G 1');
         $user->groups[] = new Group('G 2');
         $this->user     = $user;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
@@ -60,17 +60,14 @@ class DDC2519Test extends OrmFunctionalTestCase
         $user1           = new LegacyUser();
         $user1->username = 'FabioBatSilva';
         $user1->name     = 'Fabio B. Silva';
-        $user1->_status  = 'active';
 
         $user2           = new LegacyUser();
         $user2->username = 'doctrinebot';
         $user2->name     = 'Doctrine Bot';
-        $user2->_status  = 'active';
 
         $user3           = new LegacyUser();
         $user3->username = 'test';
         $user3->name     = 'Tester';
-        $user3->_status  = 'active';
 
         $this->_em->persist($user1);
         $this->_em->persist($user2);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -77,7 +77,6 @@ class DDC522Test extends OrmFunctionalTestCase
     public function testJoinColumnWithNullSameNameAssociationField(): void
     {
         $fkCust       = new DDC522ForeignKeyTest();
-        $fkCust->name = 'name';
         $fkCust->cart = null;
 
         $this->_em->persist($fkCust);
@@ -153,13 +152,13 @@ class DDC522ForeignKeyTest
     public $id;
 
     /**
-     * @var int
+     * @var int|null
      * @Column(type="integer", name="cart_id", nullable=true)
      */
     public $cartId;
 
     /**
-     * @var DDC522Cart
+     * @var DDC522Cart|null
      * @OneToOne(targetEntity="DDC522Cart")
      * @JoinColumn(name="cart_id", referencedColumnName="id")
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
@@ -135,7 +135,6 @@ class Lemma
 
     public function __construct()
     {
-        $this->types     = new ArrayCollection();
         $this->relations = new ArrayCollection();
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
@@ -20,8 +20,6 @@ class Ticket2481Test extends OrmFunctionalTestCase
         $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(Ticket2481Product::class),
         ]);
-
-        $this->_conn = $this->_em->getConnection();
     }
 
     public function testEmptyInsert(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -21,6 +21,9 @@ use function unlink;
  */
 abstract class AbstractDriverTest extends TestCase
 {
+    /** @var string */
+    private $dir;
+
     public function testFindMappingFile(): void
     {
         $driver = $this->getDriver(

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -734,8 +734,8 @@ class UnitOfWorkTest extends OrmTestCase
         // the cascading association not set. Having the "cascading path" involve
         // a non-new object is important to show that the ORM should be considering
         // cascades across entity changesets in subsequent flushes.
-        $cascading->cascaded    = $cascadePersisted;
-        $nonCascading->cascaded = $cascadePersisted;
+        $cascading->cascaded       = $cascadePersisted;
+        $nonCascading->nonCascaded = $cascadePersisted;
 
         $this->_unitOfWork->persist($cascading);
         $this->_unitOfWork->persist($nonCascading);
@@ -1115,7 +1115,7 @@ class EntityWithCascadingAssociation
     private $id;
 
     /**
-     * @var CascadePersistedEntity
+     * @var CascadePersistedEntity|null
      * @ManyToOne(targetEntity=CascadePersistedEntity::class, cascade={"persist"})
      */
     public $cascaded;
@@ -1138,7 +1138,7 @@ class EntityWithNonCascadingAssociation
     private $id;
 
     /**
-     * @var CascadePersistedEntity
+     * @var CascadePersistedEntity|null
      * @ManyToOne(targetEntity=CascadePersistedEntity::class)
      */
     public $nonCascaded;


### PR DESCRIPTION
This PR fixes test failures on PHP 8.2. Declaring properties dynamically by simply assigning a value to it now emits a runtime deprecation. All cases that I could find were in our test suite only and they were 100% mistakes: Either the property did not exist by accident or we assigned to wrong property or the assignment was just unnecessary.