### PR TITLE
added missing exception type for deletions

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\EntityManagerClosed;
@@ -381,6 +382,8 @@ use function strpos;
      * @throws OptimisticLockException If a version check on an entity that
      * makes use of optimistic locking fails.
      * @throws ORMException
+     * @throws ForeignKeyConstraintViolationException
+     * @throws Throwable
      */
     public function flush($entity = null)
     {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
@@ -39,7 +40,6 @@ use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\ObjectManagerAware;
 use Doctrine\Persistence\PropertyChangedListener;
-use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
@@ -337,7 +337,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @return void
      *
-     * @throws Exception
+     * @throws Throwable|ForeignKeyConstraintViolationException
      */
     public function commit($entity = null)
     {
@@ -456,7 +456,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 throw new OptimisticLockException('Commit failed', $object);
             }
-        } catch (Throwable $e) {
+        } catch (Throwable | ForeignKeyConstraintViolationException $e) {
             $this->em->close();
 
             if ($conn->isTransactionActive()) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -337,7 +337,8 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @return void
      *
-     * @throws Throwable|ForeignKeyConstraintViolationException
+     * @throws Throwable
+     * @throws ForeignKeyConstraintViolationException
      */
     public function commit($entity = null)
     {
@@ -456,7 +457,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 throw new OptimisticLockException('Commit failed', $object);
             }
-        } catch (Throwable | ForeignKeyConstraintViolationException $e) {
+        } catch (Throwable $e) {
             $this->em->close();
 
             if ($conn->isTransactionActive()) {


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

Deletions can potentially throw `Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException`. But in `UnitOfWork#commit()`, those are catched via `Throwable` and are rethrown after some closing operations.

So, currently, it's not evident for developers to see that they could get this type of exception.

This PR proposes to add the `ForeignKeyConstraintViolationException` in the catch():
```php
} catch (Throwable | ForeignKeyConstraintViolationException $e) {
```
(supported since PHP 7.1 : https://wiki.php.net/rfc/multiple-catch, so no BC break)

 and in the docBlock of `UnitOfWork#commit()`.

Like this, IDEs and quality tools can signal potential problems with this kind of exception.