### PR TITLE
Use ClassMetadata over ClassMetadataInfo in tests

### DIFF
--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\ColumnResult;
 use Doctrine\ORM\Mapping\Entity;
@@ -157,7 +157,7 @@ class CmsAddress
         }
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setPrimaryTable(
             ['name' => 'company_person']

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\ColumnResult;
 use Doctrine\ORM\Mapping\Entity;
@@ -336,7 +336,7 @@ class CmsUser
         }
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setPrimaryTable(
             ['name' => 'cms_users']

--- a/tests/Doctrine/Tests/Models/Cache/City.php
+++ b/tests/Doctrine/Tests/Models/Cache/City.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Cache;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -136,7 +136,7 @@ class City
         return $this->attractions;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         include __DIR__ . '/../../ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php';
     }

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -170,7 +169,7 @@ abstract class CompanyContract
 
     abstract public function calculatePrice(): int;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_JOINED);
         $metadata->setTableName('company_contracts');

--- a/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 
@@ -36,7 +36,7 @@ class CompanyFixContract extends CompanyContract
         $this->fixPrice = $fixPrice;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\EntityResult;
@@ -140,7 +140,7 @@ class CompanyFlexContract extends CompanyContract
         $this->managers->removeElement($manager);
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\EntityListeners;
@@ -42,7 +42,7 @@ class CompanyFlexUltraContract extends CompanyFlexContract
         $this->maxPrice = $maxPrice;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -153,7 +153,7 @@ class CompanyPerson
         }
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setPrimaryTable(
             ['name' => 'company_person']

--- a/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC1476;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -48,7 +48,7 @@ class DDC1476EntityWithDefaultFieldType
         $this->name = $name;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -60,6 +60,6 @@ class DDC1476EntityWithDefaultFieldType
             ['fieldName' => 'name']
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC3579;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
@@ -105,6 +105,6 @@ class DDC3579User
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 
@@ -22,7 +22,7 @@ class DDC869ChequePayment extends DDC869Payment
     #[ORM\Column(type: 'string')]
     protected $serialNumber;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 
@@ -22,7 +22,7 @@ class DDC869CreditCardPayment extends DDC869Payment
     #[ORM\Column(type: 'string')]
     protected $creditCardNumber;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
@@ -33,7 +33,7 @@ class DDC869Payment
     #[ORM\Column(type: 'float')]
     protected $value;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -51,6 +51,6 @@ class DDC869Payment
         );
         $metadata->isMappedSuperclass = true;
         $metadata->setCustomRepositoryClass(DDC869PaymentRepository::class);
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\DDC889;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
@@ -19,7 +19,7 @@ class DDC889Class extends DDC889SuperClass
      */
     protected $id;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -30,6 +30,6 @@ class DDC889Class extends DDC889SuperClass
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Entity;
 
 /**
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping\Entity;
 #[ORM\Entity]
 class DDC889Entity extends DDC889SuperClass
 {
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 
@@ -22,13 +22,13 @@ class DDC889SuperClass
     #[ORM\Column]
     protected $name;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             ['fieldName' => 'name']
         );
 
         $metadata->isMappedSuperclass = true;
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\ORM\Mapping\AssociationOverride;
 use Doctrine\ORM\Mapping\AssociationOverrides;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping\JoinTable;
 #[AssociationOverrides([new AssociationOverride(name: 'groups', joinTable: new JoinTable(name: 'ddc964_users_admingroups'), joinColumns: [new JoinColumn(name: 'adminuser_id')], inverseJoinColumns: [new JoinColumn(name: 'admingroup_id')]), new AssociationOverride(name: 'address', joinColumns: [new JoinColumn(name: 'adminaddress_id', referencedColumnName: 'id')])])]
 class DDC964Admin extends DDC964User
 {
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setAssociationOverride(
             'address',

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\ORM\Mapping\AttributeOverride;
 use Doctrine\ORM\Mapping\AttributeOverrides;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 
@@ -34,7 +34,7 @@ use Doctrine\ORM\Mapping\Entity;
 #[AttributeOverrides([new AttributeOverride(name: 'id', column: new Column(name: 'guest_id', type: 'integer', length: 140)), new AttributeOverride(name: 'name', column: new Column(name: 'guest_name', nullable: false, unique: true, length: 240))])]
 class DDC964Guest extends DDC964User
 {
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setAttributeOverride('id', [
             'columnName'    => 'guest_id',

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
@@ -107,7 +107,7 @@ class DDC964User
         $this->address = $address;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->isMappedSuperclass = true;
 
@@ -164,6 +164,6 @@ class DDC964User
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/Enums/Card.php
+++ b/tests/Doctrine/Tests/Models/Enums/Card.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\Enums;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -28,7 +28,7 @@ class Card
     #[Column(type: 'string', enumType: Suit::class)]
     public $suit;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Enums/CardWithNullable.php
+++ b/tests/Doctrine/Tests/Models/Enums/CardWithNullable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\Enums;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -28,7 +28,7 @@ class CardWithNullable
     #[Column(type: 'string', nullable: true, enumType: Suit::class)]
     public $suit;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Enums/Scale.php
+++ b/tests/Doctrine/Tests/Models/Enums/Scale.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\Enums;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -28,7 +28,7 @@ class Scale
     #[Column(type: 'simple_array', enumType: Unit::class)]
     public $supportedUnits;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -8,7 +8,7 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embedded;
 use Doctrine\ORM\Mapping\Entity;
@@ -82,9 +82,9 @@ class UserTyped
     #[ORM\Embedded]
     public ?Contact $contact = null;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable(
             ['name' => 'cms_users_typed']
         );
@@ -95,7 +95,7 @@ class UserTyped
                 'fieldName' => 'id',
             ]
         );
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/Models/Upsertable/Insertable.php
+++ b/tests/Doctrine/Tests/Models/Upsertable/Insertable.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\Upsertable;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -62,7 +61,7 @@ class Insertable
                 'fieldName' => 'nonInsertableContent',
                 'notInsertable' => true,
                 'options' => ['default' => '1234'],
-                'generated' => ClassMetadataInfo::GENERATED_INSERT,
+                'generated' => ClassMetadata::GENERATED_INSERT,
             ]
         );
         $metadata->mapField(

--- a/tests/Doctrine/Tests/Models/Upsertable/Updatable.php
+++ b/tests/Doctrine/Tests/Models/Upsertable/Updatable.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\Upsertable;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -60,7 +59,7 @@ class Updatable
             [
                 'fieldName' => 'nonUpdatableContent',
                 'notUpdatable' => true,
-                'generated' => ClassMetadataInfo::GENERATED_ALWAYS,
+                'generated' => ClassMetadata::GENERATED_ALWAYS,
             ]
         );
         $metadata->mapField(

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 use function array_change_key_case;
 use function count;
@@ -117,7 +117,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $bazMetadata->associationMappings = array_change_key_case($bazMetadata->associationMappings, CASE_LOWER);
 
         self::assertArrayHasKey('bar', $bazMetadata->associationMappings);
-        self::assertEquals(ClassMetadataInfo::MANY_TO_ONE, $bazMetadata->associationMappings['bar']['type']);
+        self::assertEquals(ClassMetadata::MANY_TO_ONE, $bazMetadata->associationMappings['bar']['type']);
     }
 
     public function testDetectManyToManyTables(): void

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -21,7 +21,7 @@ use function strtolower;
 abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
 {
     /**
-     * @psalm-return array<string, ClassMetadataInfo>
+     * @psalm-return array<string, ClassMetadata>
      */
     protected function convertToClassMetadata(array $entityTables, array $manyTables = []): array
     {
@@ -42,7 +42,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
     /**
      * @param string[] $classNames
      *
-     * @psalm-return array<class-string, ClassMetadataInfo>
+     * @psalm-return array<class-string, ClassMetadata>
      */
     protected function extractClassMetadata(array $classNames): array
     {

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
@@ -59,11 +59,11 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $class                                                 = $this->_em->getClassMetadata(CmsUser::class);
-        $class->associationMappings['groups']['fetch']         = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['groups']['fetch']         = ClassMetadata::FETCH_EXTRA_LAZY;
         $class->associationMappings['groups']['indexBy']       = 'name';
-        $class->associationMappings['articles']['fetch']       = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['articles']['fetch']       = ClassMetadata::FETCH_EXTRA_LAZY;
         $class->associationMappings['articles']['indexBy']     = 'topic';
-        $class->associationMappings['phonenumbers']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['phonenumbers']['fetch']   = ClassMetadata::FETCH_EXTRA_LAZY;
         $class->associationMappings['phonenumbers']['indexBy'] = 'phonenumber';
 
         foreach (['phonenumbers', 'articles', 'users'] as $field) {
@@ -75,7 +75,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         }
 
         $class                                          = $this->_em->getClassMetadata(CmsGroup::class);
-        $class->associationMappings['users']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['users']['fetch']   = ClassMetadata::FETCH_EXTRA_LAZY;
         $class->associationMappings['users']['indexBy'] = 'username';
 
         $this->loadFixture();
@@ -86,9 +86,9 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         parent::tearDown();
 
         $class                                               = $this->_em->getClassMetadata(CmsUser::class);
-        $class->associationMappings['groups']['fetch']       = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['articles']['fetch']     = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['phonenumbers']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['groups']['fetch']       = ClassMetadata::FETCH_LAZY;
+        $class->associationMappings['articles']['fetch']     = ClassMetadata::FETCH_LAZY;
+        $class->associationMappings['phonenumbers']['fetch'] = ClassMetadata::FETCH_LAZY;
 
         foreach (['phonenumbers', 'articles', 'users'] as $field) {
             if (isset($this->previousCacheConfig[$field])) {
@@ -102,7 +102,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         unset($class->associationMappings['phonenumbers']['indexBy']);
 
         $class                                        = $this->_em->getClassMetadata(CmsGroup::class);
-        $class->associationMappings['users']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['users']['fetch'] = ClassMetadata::FETCH_LAZY;
 
         unset($class->associationMappings['users']['indexBy']);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query\Filter\FilterException;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\ORM\Query\FilterCollection;
@@ -93,8 +92,8 @@ class SQLFilterTest extends OrmFunctionalTestCase
         parent::tearDown();
 
         $class                                           = $this->_em->getClassMetadata(CmsUser::class);
-        $class->associationMappings['groups']['fetch']   = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['groups']['fetch']   = ClassMetadata::FETCH_LAZY;
+        $class->associationMappings['articles']['fetch'] = ClassMetadata::FETCH_LAZY;
     }
 
     public function testConfigureFilter(): void
@@ -589,8 +588,8 @@ class SQLFilterTest extends OrmFunctionalTestCase
     private function loadLazyFixtureData(): void
     {
         $class                                           = $this->_em->getClassMetadata(CmsUser::class);
-        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
-        $class->associationMappings['groups']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['articles']['fetch'] = ClassMetadata::FETCH_EXTRA_LAZY;
+        $class->associationMappings['groups']['fetch']   = ClassMetadata::FETCH_EXTRA_LAZY;
         $this->loadFixtureData();
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -23,9 +23,9 @@ class DDC1301Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $class                                             = $this->_em->getClassMetadata(Models\Legacy\LegacyUser::class);
-        $class->associationMappings['articles']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
-        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
-        $class->associationMappings['cars']['fetch']       = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['articles']['fetch']   = ClassMetadata::FETCH_EXTRA_LAZY;
+        $class->associationMappings['references']['fetch'] = ClassMetadata::FETCH_EXTRA_LAZY;
+        $class->associationMappings['cars']['fetch']       = ClassMetadata::FETCH_EXTRA_LAZY;
 
         $this->loadFixture();
     }
@@ -35,9 +35,9 @@ class DDC1301Test extends OrmFunctionalTestCase
         parent::tearDown();
 
         $class                                             = $this->_em->getClassMetadata(Models\Legacy\LegacyUser::class);
-        $class->associationMappings['articles']['fetch']   = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['cars']['fetch']       = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['articles']['fetch']   = ClassMetadata::FETCH_LAZY;
+        $class->associationMappings['references']['fetch'] = ClassMetadata::FETCH_LAZY;
+        $class->associationMappings['cars']['fetch']       = ClassMetadata::FETCH_LAZY;
     }
 
     public function testCountNotInitializesLegacyCollection(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2387Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\ORM\Functional\DatabaseDriverTestCase;
 
 class DDC2387Test extends DatabaseDriverTestCase
@@ -27,7 +27,7 @@ class DDC2387Test extends DatabaseDriverTestCase
 
         $metadata = $this->convertToClassMetadata([$product, $attributes], []);
 
-        self::assertEquals(ClassMetadataInfo::GENERATOR_TYPE_NONE, $metadata['Ddc2387Attributes']->generatorType);
-        self::assertEquals(ClassMetadataInfo::GENERATOR_TYPE_AUTO, $metadata['Ddc2387Product']->generatorType);
+        self::assertEquals(ClassMetadata::GENERATOR_TYPE_NONE, $metadata['Ddc2387Attributes']->generatorType);
+        self::assertEquals(ClassMetadata::GENERATOR_TYPE_AUTO, $metadata['Ddc2387Product']->generatorType);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Driver\StaticPHPDriver;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -63,7 +63,7 @@ class DDC2415ParentEntity
         return $this->id;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -73,7 +73,7 @@ class DDC2415ParentEntity
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $metadata->setCustomGeneratorDefinition(['class' => DDC2415Generator::class]);
 
         $metadata->isMappedSuperclass = true;
@@ -95,7 +95,7 @@ class DDC2415ChildEntity extends DDC2415ParentEntity
         return $this->name;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3103Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3103Test.php
@@ -18,7 +18,7 @@ use function unserialize;
 class DDC3103Test extends OrmFunctionalTestCase
 {
     /**
-     * @covers \Doctrine\ORM\Mapping\ClassMetadataInfo::__sleep
+     * @covers \Doctrine\ORM\Mapping\ClassMetadata::__sleep
      */
     public function testIssue(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6682Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6682Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Test\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 final class GH6682Test extends OrmFunctionalTestCase
@@ -20,7 +20,7 @@ final class GH6682Test extends OrmFunctionalTestCase
             'initialValue'   => '',
         ];
 
-        $classMetadataInfo = new ClassMetadataInfo('test_entity');
+        $classMetadataInfo = new ClassMetadata('test_entity');
         $classMetadataInfo->setSequenceGeneratorDefinition($parsedDefinition);
 
         self::assertSame(

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\CustomIdGenerator;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
@@ -556,7 +555,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals('id', $class->fieldMappings['id']['columnName']);
         self::assertEquals('name', $class->fieldMappings['name']['columnName']);
 
-        self::assertEquals(ClassMetadataInfo::GENERATOR_TYPE_NONE, $class->generatorType);
+        self::assertEquals(ClassMetadata::GENERATOR_TYPE_NONE, $class->generatorType);
     }
 
     /**
@@ -1155,7 +1154,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertArrayHasKey('notInsertable', $mapping);
         self::assertArrayHasKey('generated', $mapping);
-        self::assertSame(ClassMetadataInfo::GENERATED_INSERT, $mapping['generated']);
+        self::assertSame(ClassMetadata::GENERATED_INSERT, $mapping['generated']);
         self::assertArrayNotHasKey('notInsertable', $metadata->getFieldMapping('insertableContent'));
     }
 
@@ -1167,7 +1166,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertArrayHasKey('notUpdatable', $mapping);
         self::assertArrayHasKey('generated', $mapping);
-        self::assertSame(ClassMetadataInfo::GENERATED_ALWAYS, $mapping['generated']);
+        self::assertSame(ClassMetadata::GENERATED_ALWAYS, $mapping['generated']);
         self::assertArrayNotHasKey('notUpdatable', $metadata->getFieldMapping('updatableContent'));
     }
 
@@ -1289,16 +1288,16 @@ class User
     {
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable(
             [
                 'name' => 'cms_users',
                 'options' => ['foo' => 'bar', 'baz' => ['key' => 'val']],
             ]
         );
-        $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
+        $metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
         $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
         $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
         $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
@@ -1333,7 +1332,7 @@ class User
         $mapping = ['fieldName' => 'version', 'type' => 'integer'];
         $metadata->setVersionMapping($mapping);
         $metadata->mapField($mapping);
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
         $metadata->mapOneToOne(
             [
                 'fieldName' => 'address',
@@ -1458,9 +1457,9 @@ class UserIncorrectIndex
      */
     public $email;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable([]);
         $metadata->mapField(
             [
@@ -1517,9 +1516,9 @@ class UserIncorrectUniqueConstraint
      */
     public $email;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable([]);
         $metadata->mapField(
             [
@@ -1569,9 +1568,9 @@ abstract class Animal
     #[ORM\CustomIdGenerator(class: 'stdClass')]
     public $id;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $metadata->setCustomGeneratorDefinition(['class' => 'stdClass']);
     }
 }
@@ -1580,7 +1579,7 @@ abstract class Animal
 #[ORM\Entity]
 class Cat extends Animal
 {
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
     }
 }
@@ -1589,7 +1588,7 @@ class Cat extends Animal
 #[ORM\Entity]
 class Dog extends Animal
 {
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
     }
 }
@@ -1632,7 +1631,7 @@ class DDC1170Entity
         return $this->value;
     }
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -1649,7 +1648,7 @@ class DDC1170Entity
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }
 
@@ -1673,7 +1672,7 @@ class DDC807Entity
     #[ORM\Id, ORM\Column(type: 'integer'), ORM\GeneratedValue(strategy: 'NONE')]
     public $id;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
          $metadata->mapField(
              [
@@ -1690,7 +1689,7 @@ class DDC807Entity
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }
 
@@ -1726,9 +1725,9 @@ class Comment
     #[ORM\Column(type: 'text')]
     private $content;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
-        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable(
             [
                 'indexes' => [
@@ -1773,7 +1772,7 @@ class SingleTableEntityNoDiscriminatorColumnMapping
     #[ORM\Id, ORM\Column(type: 'integer'), ORM\GeneratedValue(strategy: 'NONE')]
     public $id;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -1782,7 +1781,7 @@ class SingleTableEntityNoDiscriminatorColumnMapping
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }
 
@@ -1816,7 +1815,7 @@ class SingleTableEntityIncompleteDiscriminatorColumnMapping
     #[ORM\Id, ORM\Column(type: 'integer'), ORM\GeneratedValue(strategy: 'NONE')]
     public $id;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -1825,7 +1824,7 @@ class SingleTableEntityIncompleteDiscriminatorColumnMapping
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
     }
 }
 
@@ -1856,7 +1855,7 @@ class ReservedWordInTableColumn
     #[ORM\Column(name: '`count`', type: 'integer')]
     public $count;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 
@@ -13,7 +13,7 @@ class FieldBuilderTest extends OrmTestCase
 {
     public function testCustomIdGeneratorCanBeSet(): void
     {
-        $cmBuilder = new ClassMetadataBuilder(new ClassMetadataInfo(CmsUser::class));
+        $cmBuilder = new ClassMetadataBuilder(new ClassMetadata(CmsUser::class));
 
         $fieldBuilder = $cmBuilder->createField('aField', 'string');
 
@@ -22,7 +22,7 @@ class FieldBuilderTest extends OrmTestCase
 
         $fieldBuilder->build();
 
-        self::assertEquals(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM, $cmBuilder->getClassMetadata()->generatorType);
+        self::assertEquals(ClassMetadata::GENERATOR_TYPE_CUSTOM, $cmBuilder->getClassMetadata()->generatorType);
         self::assertEquals(['class' => 'stdClass'], $cmBuilder->getClassMetadata()->customGeneratorDefinition);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -22,7 +22,7 @@ class PHPMappingDriverTest extends AbstractMappingDriverTest
         // Convert Annotation mapping information to PHP
         // Uncomment this code if annotations changed and you want to update the PHP code
         // for the same mapping information
-//        $meta = new \Doctrine\ORM\Mapping\ClassMetadataInfo("Doctrine\Tests\ORM\Mapping\Animal");
+//        $meta = new \Doctrine\ORM\Mapping\ClassMetadata("Doctrine\Tests\ORM\Mapping\Animal");
 //        $driver = $this->createAnnotationDriver();
 //        $driver->loadMetadataForClass("Doctrine\Tests\ORM\Mapping\Animal", $meta);
 //        $exporter = $cme->getExporter('php', $path);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\Cache\Attraction;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\Models\Cache\Travel;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(['name' => 'cache_city']);
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_IDENTITY);
-$metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_IDENTITY);
+$metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
 
 $metadata->enableCache(
     [
-        'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY,
+        'usage' => ClassMetadata::CACHE_USAGE_READ_ONLY,
     ]
 );
 
@@ -49,7 +49,7 @@ $metadata->mapOneToOne(
     ]
 );
 $metadata->enableAssociationCache('state', [
-    'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY,
+    'usage' => ClassMetadata::CACHE_USAGE_READ_ONLY,
 ]);
 
 $metadata->mapManyToMany(
@@ -69,5 +69,5 @@ $metadata->mapOneToMany(
     ]
 );
 $metadata->enableAssociationCache('attractions', [
-    'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY,
+    'usage' => ClassMetadata::CACHE_USAGE_READ_ONLY,
 ]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Doctrine\ORM\Events;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_JOINED);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_JOINED);
 $metadata->setTableName('company_contracts');
 $metadata->setDiscriminatorColumn(
     [

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->mapField(
     [
@@ -13,4 +13,4 @@ $metadata->mapField(
 $metadata->mapField(
     ['fieldName' => 'name']
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579User.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->isMappedSuperclass = true;
 
@@ -34,4 +34,4 @@ $metadata->mapManyToMany(
     ]
 );
 
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\DDC869\DDC869PaymentRepository;
 
 $metadata->mapField(
@@ -21,4 +21,4 @@ $metadata->mapField(
 );
 $metadata->isMappedSuperclass = true;
 $metadata->setCustomRepositoryClass(DDC869PaymentRepository::class);
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889Class.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889Class.php
@@ -11,4 +11,4 @@ $metadata->mapField(
     ]
 );
 
-//$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+//$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\DDC889\DDC889SuperClass;
 
 $metadata->mapField(
@@ -13,4 +13,4 @@ $metadata->mapField(
 );
 $metadata->isMappedSuperclass = true;
 $metadata->setCustomRepositoryClass(DDC889SuperClass::class);
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->isMappedSuperclass = true;
 
@@ -59,4 +59,4 @@ $metadata->mapManyToMany(
     ]
 );
 
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(
     ['name' => 'cms_users_typed']
 );
@@ -15,7 +15,7 @@ $metadata->mapField(
         'fieldName' => 'id',
     ]
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
 $metadata->mapField(
     [

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Insertable.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Insertable.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->setPrimaryTable(
     ['name' => 'insertable_column']
@@ -14,14 +14,14 @@ $metadata->mapField(
         'fieldName' => 'id',
     ]
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
 $metadata->mapField(
     [
         'fieldName' => 'nonInsertableContent',
         'notInsertable' => true,
         'options' => ['default' => '1234'],
-        'generated' => ClassMetadataInfo::GENERATED_INSERT,
+        'generated' => ClassMetadata::GENERATED_INSERT,
     ]
 );
 $metadata->mapField(

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Updatable.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Updatable.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->setPrimaryTable(
     ['name' => 'updatable_column']
@@ -14,13 +14,13 @@ $metadata->mapField(
         'fieldName' => 'id',
     ]
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
 $metadata->mapField(
     [
         'fieldName' => 'nonUpdatableContent',
         'notUpdatable' => true,
-        'generated' => ClassMetadataInfo::GENERATED_ALWAYS,
+        'generated' => ClassMetadata::GENERATED_ALWAYS,
     ]
 );
 $metadata->mapField(

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\ORM\Mapping\Cat;
 use Doctrine\Tests\ORM\Mapping\Dog;
 
-/** @var ClassMetadataInfo $metadata */
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE);
+/** @var ClassMetadata $metadata */
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE);
 $metadata->setDiscriminatorColumn(
     [
         'name' => 'dtype',
@@ -22,7 +22,7 @@ $metadata->setDiscriminatorMap(
         'dog' => Dog::class,
     ]
 );
-$metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
+$metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->mapField(
     [
         'fieldName' => 'id',
@@ -36,5 +36,5 @@ $metadata->mapField(
         'columnName' => 'id',
     ]
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
 $metadata->setCustomGeneratorDefinition(['class' => 'stdClass']);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(
     [
         'indexes' => [

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->mapField(
     [
@@ -19,4 +19,4 @@ $metadata->mapField(
     ]
 );
 
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->mapField(
     [
@@ -18,4 +18,4 @@ $metadata->setDiscriminatorColumn(
     ]
 );
 
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.PHPSLC.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.PHPSLC.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 $metadata->enableCache(
     [
-        'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY,
+        'usage' => ClassMetadata::CACHE_USAGE_READ_ONLY,
     ]
 );
 $metadata->mapManyToOne(

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\ORM\Mapping\Address;
 use Doctrine\Tests\ORM\Mapping\Group;
 use Doctrine\Tests\ORM\Mapping\Phonenumber;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(
     ['name' => 'cms_users']
 );
-$metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
+$metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
 $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
 $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
@@ -52,7 +52,7 @@ $metadata->mapField(
 $mapping = ['fieldName' => 'version', 'type' => 'integer'];
 $metadata->setVersionMapping($mapping);
 $metadata->mapField($mapping);
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 $metadata->mapOneToOne(
     [
         'fieldName' => 'address',

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
@@ -137,7 +136,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testExportDirectoryAndFilesAreCreated
      */
-    public function testExportedMetadataCanBeReadBackIn(): ClassMetadataInfo
+    public function testExportedMetadataCanBeReadBackIn(): ClassMetadata
     {
         $type = $this->getType();
 
@@ -158,7 +157,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testExportedMetadataCanBeReadBackIn
      */
-    public function testTableIsExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testTableIsExported(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('cms_users', $class->table['name']);
         self::assertEquals(
@@ -172,7 +171,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testTableIsExported
      */
-    public function testTypeIsExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testTypeIsExported(ClassMetadata $class): ClassMetadata
     {
         self::assertFalse($class->isMappedSuperclass);
 
@@ -182,9 +181,9 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testTypeIsExported
      */
-    public function testIdentifierIsExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testIdentifierIsExported(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals(ClassMetadataInfo::GENERATOR_TYPE_IDENTITY, $class->generatorType, 'Generator Type wrong');
+        self::assertEquals(ClassMetadata::GENERATOR_TYPE_IDENTITY, $class->generatorType, 'Generator Type wrong');
         self::assertEquals(['id'], $class->identifier);
         self::assertTrue(isset($class->fieldMappings['id']['id']) && $class->fieldMappings['id']['id'] === true);
 
@@ -194,7 +193,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testIdentifierIsExported
      */
-    public function testFieldsAreExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testFieldsAreExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->fieldMappings['id']['id']) && $class->fieldMappings['id']['id'] === true);
         self::assertEquals('id', $class->fieldMappings['id']['fieldName']);
@@ -240,7 +239,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testFieldsAreExported
      */
-    public function testOneToOneAssociationsAreExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testOneToOneAssociationsAreExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->associationMappings['address']));
         self::assertEquals(Address::class, $class->associationMappings['address']['targetEntity']);
@@ -254,7 +253,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
         self::assertFalse($class->associationMappings['address']['isCascadeMerge']);
         self::assertFalse($class->associationMappings['address']['isCascadeDetach']);
         self::assertTrue($class->associationMappings['address']['orphanRemoval']);
-        self::assertEquals(ClassMetadataInfo::FETCH_EAGER, $class->associationMappings['address']['fetch']);
+        self::assertEquals(ClassMetadata::FETCH_EAGER, $class->associationMappings['address']['fetch']);
 
         return $class;
     }
@@ -271,7 +270,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testOneToOneAssociationsAreExported
      */
-    public function testOneToManyAssociationsAreExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testOneToManyAssociationsAreExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->associationMappings['phonenumbers']));
         self::assertEquals(Phonenumber::class, $class->associationMappings['phonenumbers']['targetEntity']);
@@ -284,7 +283,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
         self::assertTrue($class->associationMappings['phonenumbers']['isCascadeMerge']);
         self::assertFalse($class->associationMappings['phonenumbers']['isCascadeDetach']);
         self::assertTrue($class->associationMappings['phonenumbers']['orphanRemoval']);
-        self::assertEquals(ClassMetadataInfo::FETCH_LAZY, $class->associationMappings['phonenumbers']['fetch']);
+        self::assertEquals(ClassMetadata::FETCH_LAZY, $class->associationMappings['phonenumbers']['fetch']);
 
         return $class;
     }
@@ -292,7 +291,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testOneToManyAssociationsAreExported
      */
-    public function testManyToManyAssociationsAreExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testManyToManyAssociationsAreExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->associationMappings['groups']));
         self::assertEquals(Group::class, $class->associationMappings['groups']['targetEntity']);
@@ -310,7 +309,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
         self::assertTrue($class->associationMappings['groups']['isCascadeRefresh']);
         self::assertTrue($class->associationMappings['groups']['isCascadeMerge']);
         self::assertTrue($class->associationMappings['groups']['isCascadeDetach']);
-        self::assertEquals(ClassMetadataInfo::FETCH_EXTRA_LAZY, $class->associationMappings['groups']['fetch']);
+        self::assertEquals(ClassMetadata::FETCH_EXTRA_LAZY, $class->associationMappings['groups']['fetch']);
 
         return $class;
     }
@@ -318,7 +317,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testManyToManyAssociationsAreExported
      */
-    public function testLifecycleCallbacksAreExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testLifecycleCallbacksAreExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->lifecycleCallbacks['prePersist']));
         self::assertCount(2, $class->lifecycleCallbacks['prePersist']);
@@ -335,7 +334,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testLifecycleCallbacksAreExported
      */
-    public function testCascadeIsExported(ClassMetadataInfo $class): ClassMetadataInfo
+    public function testCascadeIsExported(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue($class->associationMappings['phonenumbers']['isCascadePersist']);
         self::assertTrue($class->associationMappings['phonenumbers']['isCascadeMerge']);
@@ -350,7 +349,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     /**
      * @depends testCascadeIsExported
      */
-    public function testInversedByIsExported(ClassMetadataInfo $class): void
+    public function testInversedByIsExported(ClassMetadata $class): void
     {
         self::assertEquals('user', $class->associationMappings['address']['inversedBy']);
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Tools\Export;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\Export\Driver\XmlExporter;
 
 /**
@@ -37,7 +36,7 @@ class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
             ]
         );
 
-        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_SEQUENCE);
         $metadata->setSequenceGeneratorDefinition(
             [
                 'sequenceName' => 'seq_entity_test_id',

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -3,20 +3,20 @@
 declare(strict_types=1);
 
 use Doctrine\ORM\Events;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\ORM\Tools\Export;
 use Doctrine\Tests\ORM\Tools\Export\AddressListener;
 use Doctrine\Tests\ORM\Tools\Export\GroupListener;
 use Doctrine\Tests\ORM\Tools\Export\UserListener;
 
-$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(
     [
         'name' => 'cms_users',
         'options' => ['engine' => 'MyISAM', 'foo' => ['bar' => 'baz']],
     ]
 );
-$metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
+$metadata->setChangeTrackingPolicy(ClassMetadata::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->addLifecycleCallback('doStuffOnPrePersist', Events::prePersist);
 $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', Events::prePersist);
 $metadata->addLifecycleCallback('doStuffOnPostPersist', Events::postPersist);
@@ -53,7 +53,7 @@ $metadata->mapField(
         'options' => ['unsigned' => true],
     ]
 );
-$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 $metadata->mapManyToOne(
     [
         'fieldName' => 'mainGroup',
@@ -78,7 +78,7 @@ $metadata->mapOneToOne(
             ],
         ],
         'orphanRemoval' => true,
-        'fetch' => ClassMetadataInfo::FETCH_EAGER,
+        'fetch' => ClassMetadata::FETCH_EAGER,
     ]
 );
 $metadata->mapOneToOne(
@@ -90,7 +90,7 @@ $metadata->mapOneToOne(
         [0 => 'persist'],
         'inversedBy' => null,
         'orphanRemoval' => false,
-        'fetch' => ClassMetadataInfo::FETCH_EAGER,
+        'fetch' => ClassMetadata::FETCH_EAGER,
     ]
 );
 $metadata->mapOneToMany(
@@ -104,7 +104,7 @@ $metadata->mapOneToMany(
         ],
         'mappedBy' => 'user',
         'orphanRemoval' => true,
-        'fetch' => ClassMetadataInfo::FETCH_LAZY,
+        'fetch' => ClassMetadata::FETCH_LAZY,
         'orderBy' =>
         ['number' => 'ASC'],
     ]
@@ -113,7 +113,7 @@ $metadata->mapManyToMany(
     [
         'fieldName' => 'groups',
         'targetEntity' => Export\Group::class,
-        'fetch' => ClassMetadataInfo::FETCH_EXTRA_LAZY,
+        'fetch' => ClassMetadata::FETCH_EXTRA_LAZY,
         'cascade' =>
         [
             0 => 'remove',

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
@@ -588,7 +587,7 @@ class IncorrectIndexByFieldEntity
     /** @var string */
     public $fieldName;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [
@@ -627,7 +626,7 @@ class IncorrectUniqueConstraintByFieldEntity
     /** @var string */
     public $fieldName;
 
-    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->mapField(
             [


### PR DESCRIPTION
ClassMetadataInfo is deprecated in favor of ClassMetadata.

This is a follow up to #9691, this time for tests (so it's not risky, and 2.12.x can be targeted).