### PR TITLE
Fix check for associations declared in MappedSuperclasses

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -377,7 +377,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedRelations(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->associationMappings as $field => $mapping) {
-            if ($parentClass->isMappedSuperclass) {
+            if (! isset($mapping['declared'])) {
+                $mapping['declared'] = $parentClass->name;
+            }
+
+            $declaredInMappedSuperclass = $parentClass->isMappedSuperclass && $mapping['declared'] === $parentClass->name;
+            if ($declaredInMappedSuperclass) {
                 if ($mapping['type'] & ClassMetadata::TO_MANY && ! $mapping['isOwningSide']) {
                     throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->name, $field);
                 }
@@ -386,12 +391,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             }
 
             //$subclassMapping = $mapping;
-            if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
+            if (! isset($mapping['inherited']) && ! $declaredInMappedSuperclass) {
                 $mapping['inherited'] = $parentClass->name;
-            }
-
-            if (! isset($mapping['declared'])) {
-                $mapping['declared'] = $parentClass->name;
             }
 
             $subClass->addInheritedAssociationMapping($mapping);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -381,8 +381,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 $mapping['declared'] = $parentClass->name;
             }
 
-            $declaredInMappedSuperclass = $parentClass->isMappedSuperclass && $mapping['declared'] === $parentClass->name;
-            if ($declaredInMappedSuperclass) {
+            $declaredInParent = $mapping['declared'] === $parentClass->name;
+            if ($parentClass->isMappedSuperclass && $declaredInParent) {
                 if ($mapping['type'] & ClassMetadata::TO_MANY && ! $mapping['isOwningSide']) {
                     throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->name, $field);
                 }
@@ -391,7 +391,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             }
 
             //$subclassMapping = $mapping;
-            if (! isset($mapping['inherited']) && ! $declaredInMappedSuperclass) {
+            if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
                 $mapping['inherited'] = $parentClass->name;
             }
 

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/ChildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/ChildMappedSuperclass.php
@@ -13,6 +13,9 @@ use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
  */
 abstract class ChildMappedSuperclass extends RootEntity
 {
-    /** @OneToMany(targetEntity=InvalidAssociatedEntity::class, mappedBy="childMappedSuperclass") */
-    private InvalidAssociatedEntity $invalidToManyAssociation;
+    /**
+     * @var InvalidAssociatedEntity
+     * @OneToMany(targetEntity=InvalidAssociatedEntity::class, mappedBy="childMappedSuperclass")
+     */
+    private $invalidToManyAssociation;
 }

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/ChildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/ChildMappedSuperclass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class ChildMappedSuperclass extends RootEntity
+{
+    /** @OneToMany(targetEntity=InvalidAssociatedEntity::class, mappedBy="childMappedSuperclass") */
+    private InvalidAssociatedEntity $invalidToManyAssociation;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/GrandchildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/GrandchildMappedSuperclass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class GrandchildMappedSuperclass extends ChildMappedSuperclass
+{
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/GreatGrandchildEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/GreatGrandchildEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class GreatGrandchildEntity extends GrandchildMappedSuperclass
+{
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+/**
+ * @Entity
+ */
+class InvalidAssociatedEntity
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /** @ManyToOne(targetEntity=ChildMappedSuperclass::class, inversedBy="invalidToManyAssociation") */
+    private ChildMappedSuperclass $childMappedSuperclass;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
@@ -23,6 +23,9 @@ class InvalidAssociatedEntity
      */
     public $id;
 
-    /** @ManyToOne(targetEntity=ChildMappedSuperclass::class, inversedBy="invalidToManyAssociation") */
-    private ChildMappedSuperclass $childMappedSuperclass;
+    /**
+     * @var ChildMappedSuperclass
+     * @ManyToOne(targetEntity=ChildMappedSuperclass::class, inversedBy="invalidToManyAssociation")
+     */
+    private $childMappedSuperclass;
 }

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/InvalidToManyOnMappedSuperclass/InvalidAssociatedEntity.php
@@ -16,11 +16,12 @@ use Doctrine\ORM\Mapping\ManyToOne;
 class InvalidAssociatedEntity
 {
     /**
+     * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
-    public int $id;
+    public $id;
 
     /** @ManyToOne(targetEntity=ChildMappedSuperclass::class, inversedBy="invalidToManyAssociation") */
     private ChildMappedSuperclass $childMappedSuperclass;

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
@@ -24,11 +24,12 @@ use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot
 class RootEntity
 {
     /**
+     * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
-    public int $id;
+    public $id;
 
     /** @OneToMany(targetEntity=AssociatedEntity::class, mappedBy="root") */
     public AssociatedEntity $toManyAssociation;

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
@@ -16,7 +16,8 @@ use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot
 /**
  * @DiscriminatorMap({
  *     "validToManyOnRoot" = ValidToManyOnRoot\GrandchildEntity::class,
- *     "invalidToManyOnMappedSuperclass" = InvalidToManyOnMappedSuperclass\GreatGrandchildEntity::class
+ *     "invalidToManyOnMappedSuperclass" = InvalidToManyOnMappedSuperclass\GreatGrandchildEntity::class,
+ *     "toOneOnMappedSuperclass" = ToOneOnMappedSuperclass\GreatGrandchildEntity::class
  * })
  * @Entity
  * @InheritanceType("JOINED")

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
@@ -31,6 +31,9 @@ class RootEntity
      */
     public $id;
 
-    /** @OneToMany(targetEntity=AssociatedEntity::class, mappedBy="root") */
-    public AssociatedEntity $toManyAssociation;
+    /**
+     * @var AssociatedEntity
+     * @OneToMany(targetEntity=AssociatedEntity::class, mappedBy="root")
+     */
+    public $toManyAssociation;
 }

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/RootEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot\AssociatedEntity;
+
+/**
+ * @DiscriminatorMap({
+ *     "validToManyOnRoot" = ValidToManyOnRoot\GrandchildEntity::class,
+ *     "invalidToManyOnMappedSuperclass" = InvalidToManyOnMappedSuperclass\GreatGrandchildEntity::class
+ * })
+ * @Entity
+ * @InheritanceType("JOINED")
+ */
+class RootEntity
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /** @OneToMany(targetEntity=AssociatedEntity::class, mappedBy="root") */
+    public AssociatedEntity $toManyAssociation;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/AssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/AssociatedEntity.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ToOneOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToOne;
+
+/**
+ * @Entity
+ */
+class AssociatedEntity
+{
+    /**
+     * @var int
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var ChildMappedSuperclass
+     * @OneToOne(targetEntity=ChildMappedSuperclass::class, inversedBy="toOneAssociation")
+     */
+    private $childMappedSuperclass;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/ChildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/ChildMappedSuperclass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ToOneOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class ChildMappedSuperclass extends RootEntity
+{
+    /**
+     * @var AssociatedEntity
+     * @OneToOne(targetEntity=AssociatedEntity::class, mappedBy="childMappedSuperclass")
+     */
+    private $toOneAssociation;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/GrandchildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/GrandchildMappedSuperclass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ToOneOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class GrandchildMappedSuperclass extends ChildMappedSuperclass
+{
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/GreatGrandchildEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ToOneOnMappedSuperclass/GreatGrandchildEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ToOneOnMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class GreatGrandchildEntity extends GrandchildMappedSuperclass
+{
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+
+/**
+ * @Entity
+ */
+class AssociatedEntity
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /** @ManyToOne(targetEntity=RootEntity::class, inversedBy="toManyAssociation") */
+    private RootEntity $root;
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
@@ -24,6 +24,9 @@ class AssociatedEntity
      */
     public $id;
 
-    /** @ManyToOne(targetEntity=RootEntity::class, inversedBy="toManyAssociation") */
-    private RootEntity $root;
+    /**
+     * @var RootEntity
+     * @ManyToOne(targetEntity=RootEntity::class, inversedBy="toManyAssociation")
+     */
+    private $root;
 }

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/AssociatedEntity.php
@@ -17,11 +17,12 @@ use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
 class AssociatedEntity
 {
     /**
+     * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
-    public int $id;
+    public $id;
 
     /** @ManyToOne(targetEntity=RootEntity::class, inversedBy="toManyAssociation") */
     private RootEntity $root;

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/ChildMappedSuperclass.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/ChildMappedSuperclass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class ChildMappedSuperclass extends RootEntity
+{
+}

--- a/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/GrandchildEntity.php
+++ b/tests/Doctrine/Tests/Models/JoinedInheritanceTypeWithAssociation/ValidToManyOnRoot/GrandchildEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class GrandchildEntity extends ChildMappedSuperclass
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -39,6 +39,7 @@ use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
 use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ToOneOnMappedSuperclass;
 use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot;
 use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\OrmTestCase;
@@ -182,6 +183,17 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $mappedSuperclass1Metadata = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\ChildMappedSuperclass::class);
         $mappedSuperclass2Metadata = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\GrandchildMappedSuperclass::class);
         $grandchildMetadata        = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\GreatGrandchildEntity::class);
+    }
+
+    public function testInheritedNotSetForToOneOnGrandparentMappedSuperclass(): void
+    {
+        $cmf    = new ClassMetadataFactory();
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/JoinedInheritanceType/']);
+        $em     = $this->createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $grandchildMetadata = $cmf->getMetadataFor(ToOneOnMappedSuperclass\GreatGrandchildEntity::class);
+        self::assertFalse($grandchildMetadata->isInheritedAssociation('toOneAssociation'));
     }
 
     public function testHasGetMetadataNamespaceSeparatorIsNotNormalized(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -37,6 +37,9 @@ use Doctrine\Tests\Models\DDC4006\DDC4006User;
 use Doctrine\Tests\Models\JoinedInheritanceType\AnotherChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\InvalidToManyOnMappedSuperclass;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\RootEntity;
+use Doctrine\Tests\Models\JoinedInheritanceTypeWithAssociation\ValidToManyOnRoot;
 use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\OrmTestCase;
 use DoctrineGlobalArticle;
@@ -149,6 +152,36 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $this->expectException(ORMException::class);
 
         $actual = $cmf->getMetadataFor($cm1->name);
+    }
+
+    public function testGetMetadataForJoinedSuperclassWithToManyAssociationAndChildMappedSuperclass(): void
+    {
+        $cmf    = new ClassMetadataFactory();
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/JoinedInheritanceType/']);
+        $em     = $this->createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $rootMetadata       = $cmf->getMetadataFor(RootEntity::class);
+        $childMetadata      = $cmf->getMetadataFor(ValidToManyOnRoot\ChildMappedSuperclass::class);
+        $grandchildMetadata = $cmf->getMetadataFor(ValidToManyOnRoot\GrandchildEntity::class);
+
+        self::assertTrue($rootMetadata->hasAssociation('toManyAssociation'));
+        self::assertTrue($childMetadata->hasAssociation('toManyAssociation'));
+        self::assertTrue($grandchildMetadata->hasAssociation('toManyAssociation'));
+    }
+
+    public function testThrowsExceptionForToManyOnGrandparentMappedSuperclass(): void
+    {
+        $cmf    = new ClassMetadataFactory();
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/JoinedInheritanceType/']);
+        $em     = $this->createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $rootMetadata = $cmf->getMetadataFor(RootEntity::class);
+        self::expectException(MappingException::class);
+        $mappedSuperclass1Metadata = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\ChildMappedSuperclass::class);
+        $mappedSuperclass2Metadata = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\GrandchildMappedSuperclass::class);
+        $grandchildMetadata        = $cmf->getMetadataFor(InvalidToManyOnMappedSuperclass\GreatGrandchildEntity::class);
     }
 
     public function testHasGetMetadataNamespaceSeparatorIsNotNormalized(): void


### PR DESCRIPTION
Doctrine does not allow toMany associations to be declared on MappedSuperclasses. The check for this occurs on the child class, which correctly checks whether the parent is a MappedSuperclass.
However, it does not check that the field in question was actually declared on that class. This causes an incorrect exception if there is an inheritance structure like so:

```
  Root:        Joined/Single Table Inheritance Entity
  Child:       Mapped Superclass
  Grandchild:  Entity
```

When there is a toMany association on Root, the Grandchild throws an exception, assuming that the association has come from Child.

This fix updates the check to also include whether the association has come from the parent MappedSuperclass in question.

I have added two tests. The first test is simply to check that an exception is not thrown in the case described above. The second check was to confirm that this change does not break the following case:

```
  Root:             Joined/Single Table Inheritance Entity
  Child:            Mapped Superclass
  Grandchild:       Mapped Superclass
  GreatGrandChild:  Entity
```

If the toMany association is on the Child, an exception should be thrown. I was worried my changes might prevent this from happening, but that is not the case and the test passes.