### PR TITLE
Reference ClassMetadataInfo less and less

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,15 @@
+# Upgrade to 2.13
+
+## Deprecate `ClassMetadataInfo` usage
+
+It is deprecated to pass `Doctrine\ORM\Mapping\ClassMetadataInfo` instances
+that are not also instances of `Doctrine\ORM\ClassMetadata` to the following
+methods:
+
+- `Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder::__construct()`
+- `Doctrine\ORM\Mapping\Driver\DatabaseDriver::loadMetadataForClass()`
+- `Doctrine\ORM\Tools\SchemaValidator::validateClass()`
+
 # Upgrade to 2.12
 
 ## Deprecated the `doctrine` binary.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,21 @@
 # Upgrade to 2.13
 
+# Deprecated methods related to named queries
+
+The following methods have been deprecated:
+
+- `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativeQueryMapping()`
+- `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativeQueryResultClassMapping()`
+- `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativQueryResultSetMapping()`
+- `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativQueryEntityResultMapping()`
+
+# Deprecated classes related to Doctrine 1 and reverse engineering
+
+The following classes have been deprecated:
+
+- `Doctrine\ORM\Tools\ConvertDoctrine1Schema`
+- `Doctrine\ORM\Tools\DisconnectedClassMetadataFactory`
+
 ## Deprecate `ClassMetadataInfo` usage
 
 It is deprecated to pass `Doctrine\ORM\Mapping\ClassMetadataInfo` instances

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Builder;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+use function get_class;
 
 /**
  * Builder Object for ClassMetadata
@@ -19,6 +22,17 @@ class ClassMetadataBuilder
 
     public function __construct(ClassMetadataInfo $cm)
     {
+        if (! $cm instanceof ClassMetadata) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/249',
+                'Passing an instance of %s to %s is deprecated, please pass a ClassMetadata instance instead.',
+                get_class($cm),
+                __METHOD__,
+                ClassMetadata::class
+            );
+        }
+
         $this->cm = $cm;
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -225,7 +225,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $this->evm->dispatchEvent(Events::loadClassMetadata, $eventArgs);
         }
 
-        if ($class->changeTrackingPolicy === ClassMetadataInfo::CHANGETRACKING_NOTIFY) {
+        if ($class->changeTrackingPolicy === ClassMetadata::CHANGETRACKING_NOTIFY) {
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/issues/8383',

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -381,7 +381,7 @@ class DatabaseDriver implements MappingDriver
 
         // We need to check for the columns here, because we might have associations as id as well.
         if ($ids && count($primaryKeys) === 1) {
-            $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+            $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
         }
 
         foreach ($fieldMappings as $fieldMapping) {

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -24,6 +25,7 @@ use function array_keys;
 use function array_merge;
 use function count;
 use function current;
+use function get_class;
 use function in_array;
 use function preg_replace;
 use function sort;
@@ -175,6 +177,17 @@ class DatabaseDriver implements MappingDriver
      */
     public function loadMetadataForClass($className, PersistenceClassMetadata $metadata)
     {
+        if (! $metadata instanceof ClassMetadata) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/249',
+                'Passing an instance of %s to %s is deprecated, please pass a ClassMetadata instance instead.',
+                get_class($metadata),
+                __METHOD__,
+                ClassMetadata::class
+            );
+        }
+
         $this->reverseEngineerMappingFromDatabase();
 
         if (! isset($this->classToTableNames[$className])) {

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -261,6 +261,8 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds the mappings of the results of native SQL queries to the result set.
      *
+     * @deprecated This method is deprecated and will be removed in Doctrine ORM 3.0.
+     *
      * @param mixed[] $queryMapping
      *
      * @return ResultSetMappingBuilder
@@ -276,6 +278,8 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
     /**
      * Adds the class mapping of the results of native SQL queries to the result set.
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine ORM 3.0.
      *
      * @param string $resultClassName
      *
@@ -322,6 +326,8 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
     /**
      * Adds the result set mapping of the results of native SQL queries to the result set.
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine ORM 3.0.
      *
      * @param string $resultSetMappingName
      *
@@ -375,6 +381,8 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
     /**
      * Adds the entity result mapping of the results of native SQL queries to the result set.
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine ORM 3.0.
      *
      * @param mixed[] $entityMapping
      * @param string  $alias

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Query;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\SQLResultCasing;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
@@ -156,7 +157,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         }
 
         foreach ($classMetadata->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
+            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadata::TO_ONE) {
                 $targetClass  = $this->em->getClassMetadata($associationMapping['targetEntity']);
                 $isIdentifier = isset($associationMapping['id']) && $associationMapping['id'] === true;
 
@@ -246,7 +247,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         }
 
         foreach ($class->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
+            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadata::TO_ONE) {
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     $columnName               = $joinColumn['name'];
                     $columnAlias[$columnName] = $this->getColumnAlias($columnName, $mode, $customRenameColumns);
@@ -304,7 +305,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         }
 
         foreach ($classMetadata->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
+            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadata::TO_ONE) {
                 $targetClass = $this->em->getClassMetadata($associationMapping['targetEntity']);
 
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -179,7 +179,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         }
     }
 
-    private function isInheritanceSupported(ClassMetadataInfo $classMetadata): bool
+    private function isInheritanceSupported(ClassMetadata $classMetadata): bool
     {
         if (
             $classMetadata->isInheritanceTypeSingleTable()

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
@@ -1761,7 +1760,7 @@ class SqlWalker implements TreeWalker
         }
 
         foreach ($this->getMetadataForDqlAlias($groupByItem)->associationMappings as $mapping) {
-            if ($mapping['isOwningSide'] && $mapping['type'] & ClassMetadataInfo::TO_ONE) {
+            if ($mapping['isOwningSide'] && $mapping['type'] & ClassMetadata::TO_ONE) {
                 $item       = new AST\PathExpression(AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $groupByItem, $mapping['fieldName']);
                 $item->type = AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2361,7 +2361,7 @@ class SqlWalker implements TreeWalker
      * @throws QueryException
      */
     private function getChildDiscriminatorsFromClassMetadata(
-        ClassMetadataInfo $rootClass,
+        ClassMetadata $rootClass,
         AST\InstanceOfExpression $instanceOfExpr
     ): string {
         $sqlParameterList = [];

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -25,6 +25,8 @@ use function strtolower;
 /**
  * Class to help with converting Doctrine 1 schema files to Doctrine 2 mapping files
  *
+ * @deprecated This class is being removed from the ORM and won't have any replacement
+ *
  * @link    www.doctrine-project.org
  */
 class ConvertDoctrine1Schema

--- a/lib/Doctrine/ORM/Tools/DisconnectedClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Tools/DisconnectedClassMetadataFactory.php
@@ -13,6 +13,8 @@ use Doctrine\Persistence\Mapping\StaticReflectionService;
  * load some mapping information and use it to do things like generate code
  * from the mapping information.
  *
+ * @deprecated This class is being removed from the ORM and will be removed in 3.0.
+ *
  * @link    www.doctrine-project.org
  */
 class DisconnectedClassMetadataFactory extends ClassMetadataFactory

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
 use Doctrine\ORM\Query\AST\Node;
@@ -135,7 +135,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                     if (
                         isset($queryComponent['parent'])
                         && isset($queryComponent['relation'])
-                        && $queryComponent['relation']['type'] & ClassMetadataInfo::TO_MANY
+                        && $queryComponent['relation']['type'] & ClassMetadata::TO_MANY
                     ) {
                         throw new RuntimeException('Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.');
                     }

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 use function array_diff;
@@ -15,6 +17,7 @@ use function array_values;
 use function class_exists;
 use function class_parents;
 use function count;
+use function get_class;
 use function implode;
 use function in_array;
 
@@ -69,6 +72,17 @@ class SchemaValidator
      */
     public function validateClass(ClassMetadataInfo $class)
     {
+        if (! $class instanceof ClassMetadata) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/249',
+                'Passing an instance of %s to %s is deprecated, please pass a ClassMetadata instance instead.',
+                get_class($class),
+                __METHOD__,
+                ClassMetadata::class
+            );
+        }
+
         $ce  = [];
         $cmf = $this->em->getMetadataFactory();
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -160,13 +160,13 @@ class SchemaValidator
                 // Verify inverse side/owning side match each other
                 if (array_key_exists($assoc['inversedBy'], $targetMetadata->associationMappings)) {
                     $targetAssoc = $targetMetadata->associationMappings[$assoc['inversedBy']];
-                    if ($assoc['type'] === ClassMetadataInfo::ONE_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_ONE) {
+                    if ($assoc['type'] === ClassMetadata::ONE_TO_ONE && $targetAssoc['type'] !== ClassMetadata::ONE_TO_ONE) {
                         $ce[] = 'If association ' . $class->name . '#' . $fieldName . ' is one-to-one, then the inversed ' .
                                 'side ' . $targetMetadata->name . '#' . $assoc['inversedBy'] . ' has to be one-to-one as well.';
-                    } elseif ($assoc['type'] === ClassMetadataInfo::MANY_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_MANY) {
+                    } elseif ($assoc['type'] === ClassMetadata::MANY_TO_ONE && $targetAssoc['type'] !== ClassMetadata::ONE_TO_MANY) {
                         $ce[] = 'If association ' . $class->name . '#' . $fieldName . ' is many-to-one, then the inversed ' .
                                 'side ' . $targetMetadata->name . '#' . $assoc['inversedBy'] . ' has to be one-to-many.';
-                    } elseif ($assoc['type'] === ClassMetadataInfo::MANY_TO_MANY && $targetAssoc['type'] !== ClassMetadataInfo::MANY_TO_MANY) {
+                    } elseif ($assoc['type'] === ClassMetadata::MANY_TO_MANY && $targetAssoc['type'] !== ClassMetadata::MANY_TO_MANY) {
                         $ce[] = 'If association ' . $class->name . '#' . $fieldName . ' is many-to-many, then the inversed ' .
                                 'side ' . $targetMetadata->name . '#' . $assoc['inversedBy'] . ' has to be many-to-many as well.';
                     }
@@ -174,7 +174,7 @@ class SchemaValidator
             }
 
             if ($assoc['isOwningSide']) {
-                if ($assoc['type'] === ClassMetadataInfo::MANY_TO_MANY) {
+                if ($assoc['type'] === ClassMetadata::MANY_TO_MANY) {
                     $identifierColumns = $class->getIdentifierColumnNames();
                     foreach ($assoc['joinTable']['joinColumns'] as $joinColumn) {
                         if (! in_array($joinColumn['referencedColumnName'], $identifierColumns, true)) {
@@ -206,7 +206,7 @@ class SchemaValidator
                                 "however '" . implode(', ', array_diff($class->getIdentifierColumnNames(), array_values($assoc['relationToSourceKeyColumns']))) .
                                 "' are missing.";
                     }
-                } elseif ($assoc['type'] & ClassMetadataInfo::TO_ONE) {
+                } elseif ($assoc['type'] & ClassMetadata::TO_ONE) {
                     $identifierColumns = $targetMetadata->getIdentifierColumnNames();
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         if (! in_array($joinColumn['referencedColumnName'], $identifierColumns, true)) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -340,6 +340,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="lib/Doctrine/ORM/EntityRepository.php">
+    <DeprecatedMethod occurrences="1">
+      <code>addNamedNativeQueryMapping</code>
+    </DeprecatedMethod>
     <InvalidReturnStatement occurrences="2">
       <code>$persister-&gt;load($criteria, null, null, [], null, 1, $orderBy)</code>
       <code>new LazyCriteriaCollection($persister, $criteria)</code>
@@ -773,6 +776,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$metadata instanceof ClassMetadata</code>
+    </DocblockTypeContradiction>
     <LessSpecificReturnStatement occurrences="2">
       <code>$this-&gt;namespace . $this-&gt;classNamesForTables[$tableName]</code>
       <code>$this-&gt;namespace . $this-&gt;inflector-&gt;classify(strtolower($tableName))</code>
@@ -2276,6 +2282,12 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$class</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="4">
+      <code>addNamedNativeQueryEntityResultMapping</code>
+      <code>addNamedNativeQueryEntityResultMapping</code>
+      <code>addNamedNativeQueryResultClassMapping</code>
+      <code>addNamedNativeQueryResultSetMapping</code>
+    </DeprecatedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
     <DocblockTypeContradiction occurrences="2">
@@ -2634,7 +2646,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$metadata</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="10">
+    <DeprecatedClass occurrences="11">
       <code>ClassMetadataExporter</code>
       <code>ClassMetadataExporter</code>
       <code>ClassMetadataExporter|null</code>
@@ -2642,6 +2654,7 @@
       <code>EntityGenerator</code>
       <code>EntityGenerator|null</code>
       <code>new ClassMetadataExporter()</code>
+      <code>new ConvertDoctrine1Schema($fromPaths)</code>
       <code>new EntityGenerator()</code>
       <code>private $entityGenerator = null;</code>
       <code>private $metadataExporter = null;</code>
@@ -2654,9 +2667,10 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$metadata</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="3">
+    <DeprecatedClass occurrences="4">
       <code>AbstractExporter</code>
       <code>new ClassMetadataExporter()</code>
+      <code>new DisconnectedClassMetadataFactory()</code>
       <code>new EntityGenerator()</code>
     </DeprecatedClass>
     <MissingReturnType occurrences="1">
@@ -2675,7 +2689,8 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$metadatas</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass occurrences="2">
+      <code>new DisconnectedClassMetadataFactory()</code>
       <code>new EntityGenerator()</code>
     </DeprecatedClass>
     <MissingReturnType occurrences="1">


### PR DESCRIPTION
There will still be references to `ClassMetadataInfo` in this PR, but only:
- in classes that are deprecated;
- in method signatures that cannot be changed without a BC-break.

This time, I'm targeting 2.13.x, since I'm introducing deprecations and touching `lib`.