### PR TITLE
Remove some ConnectionMock methods

### DIFF
--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -62,7 +62,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
                 $connection->ensureConnectedToPrimary();
             }
 
-            $this->_nextValue = (int) $connection->executeQuery($sql)->fetchOne();
+            $this->_nextValue = (int) $connection->fetchOne($sql);
             $this->_maxValue  = $this->_nextValue + $this->_allocationSize;
         }
 

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -6,13 +6,11 @@ namespace Doctrine\Tests\Mocks;
 
 use BadMethodCallException;
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
-use Exception;
 
 use function is_string;
 use function sprintf;
@@ -22,23 +20,8 @@ use function sprintf;
  */
 class ConnectionMock extends Connection
 {
-    /** @var mixed */
-    private $_fetchOneResult;
-
-    /** @var Exception|null */
-    private $_fetchOneException;
-
-    /** @var Result|null */
-    private $_queryResult;
-
     /** @var DatabasePlatformMock */
     private $_platformMock;
-
-    /** @var int */
-    private $_lastInsertId = 0;
-
-    /** @var array */
-    private $_inserts = [];
 
     /** @var array */
     private $_executeStatements = [];
@@ -71,7 +54,6 @@ class ConnectionMock extends Connection
      */
     public function insert($tableName, array $data, array $types = [])
     {
-        $this->_inserts[$tableName][] = $data;
     }
 
     /**
@@ -103,26 +85,6 @@ class ConnectionMock extends Connection
     /**
      * {@inheritdoc}
      */
-    public function lastInsertId($seqName = null)
-    {
-        return $this->_lastInsertId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetchOne(string $sql, array $params = [], array $types = [])
-    {
-        if ($this->_fetchOneException !== null) {
-            throw $this->_fetchOneException;
-        }
-
-        return $this->_fetchOneResult;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function fetchColumn($statement, array $params = [], $colunm = 0, array $types = [])
     {
         throw new BadMethodCallException('Call to deprecated method.');
@@ -131,11 +93,6 @@ class ConnectionMock extends Connection
     public function query(?string $sql = null): Result
     {
         throw new BadMethodCallException('Call to deprecated method.');
-    }
-
-    public function executeQuery($sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null): Result
-    {
-        return $this->_queryResult ?? parent::executeQuery($sql, $params, $types, $qcp);
     }
 
     /**
@@ -150,42 +107,9 @@ class ConnectionMock extends Connection
         return $input;
     }
 
-    /* Mock API */
-
-    /**
-     * @param mixed $fetchOneResult
-     */
-    public function setFetchOneResult($fetchOneResult): void
-    {
-        $this->_fetchOneResult = $fetchOneResult;
-    }
-
-    public function setFetchOneException(?Exception $exception = null): void
-    {
-        $this->_fetchOneException = $exception;
-    }
-
     public function setDatabasePlatform(AbstractPlatform $platform): void
     {
         $this->_platformMock = $platform;
-    }
-
-    public function setLastInsertId(int $id): void
-    {
-        $this->_lastInsertId = $id;
-    }
-
-    public function setQueryResult(Result $result): void
-    {
-        $this->_queryResult = $result;
-    }
-
-    /**
-     * @return array
-     */
-    public function getInserts(): array
-    {
-        return $this->_inserts;
     }
 
     /**
@@ -202,11 +126,5 @@ class ConnectionMock extends Connection
     public function getDeletes(): array
     {
         return $this->_deletes;
-    }
-
-    public function reset(): void
-    {
-        $this->_inserts      = [];
-        $this->_lastInsertId = 0;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -4,52 +4,46 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Id;
 
-use BadMethodCallException;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Id\SequenceGenerator;
-use Doctrine\Tests\Mocks\ArrayResultFactory;
-use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\OrmTestCase;
 
 class SequenceGeneratorTest extends OrmTestCase
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
-    /** @var SequenceGenerator */
-    private $sequenceGenerator;
-
-    /** @var ConnectionMock */
-    private $connection;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->entityManager     = $this->getTestEntityManager();
-        $this->sequenceGenerator = new SequenceGenerator('seq', 10);
-        $this->connection        = $this->entityManager->getConnection();
-
-        self::assertInstanceOf(ConnectionMock::class, $this->connection);
-    }
-
     public function testGeneration(): void
     {
-        $this->connection->setFetchOneException(new BadMethodCallException(
-            'Fetch* method used. Query method should be used instead, '
-            . 'as NEXTVAL should be run on a master server in master-slave setup.'
-        ));
+        $sequenceGenerator = new SequenceGenerator('seq', 10);
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('getSequenceNextValSQL')
+            ->willReturn('');
+
+        $connection = $this->getMockBuilder(Connection::class)
+            ->setConstructorArgs([[], $this->createMock(Driver::class)])
+            ->setMethods(['fetchOne', 'getDatabasePlatform'])
+            ->getMock();
+        $connection->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        // Sequence values should be generated once per ten identifiers
+        $connection->expects($this->exactly(5))
+            ->method('fetchOne')
+            ->willReturnCallback(static function () use (&$i) {
+                self::assertEquals(0, $i % 10);
+
+                return $i;
+            });
+
+        $entityManager = $this->getTestEntityManager($connection);
 
         for ($i = 0; $i < 42; ++$i) {
-            if ($i % 10 === 0) {
-                $this->connection->setQueryResult(ArrayResultFactory::createFromArray([[(int) ($i / 10) * 10]]));
-            }
-
-            $id = $this->sequenceGenerator->generateId($this->entityManager, null);
+            $id = $sequenceGenerator->generateId($entityManager, null);
 
             self::assertSame($i, $id);
-            self::assertSame((int) ($i / 10) * 10 + 10, $this->sequenceGenerator->getCurrentMaxValue());
-            self::assertSame($i + 1, $this->sequenceGenerator->getNextValue());
+            self::assertSame((int) ($i / 10) * 10 + 10, $sequenceGenerator->getCurrentMaxValue());
+            self::assertSame($i + 1, $sequenceGenerator->getNextValue());
         }
     }
 }


### PR DESCRIPTION
This patch is another step towards getting rid of using hard-coded mocks in the test suite for compatibility with DBAL 4:
1. Do not use `ConnectionMock` in `SequenceGeneratorTest`.
2. Remove unused `ConnectionMock` methods.