### PR TITLE
Remove non-API DriverConnectionMock methods

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -14,14 +14,6 @@ use Doctrine\DBAL\ParameterType;
  */
 class DriverConnectionMock implements Connection
 {
-    /** @var Result|null */
-    private $resultMock;
-
-    public function setResultMock(?Result $resultMock): void
-    {
-        $this->resultMock = $resultMock;
-    }
-
     public function prepare(string $sql): Statement
     {
         return new StatementMock();
@@ -29,7 +21,7 @@ class DriverConnectionMock implements Connection
 
     public function query(string $sql): Result
     {
-        return $this->resultMock ?? new DriverResultMock();
+        return new DriverResultMock();
     }
 
     /**


### PR DESCRIPTION
Similar to https://github.com/doctrine/orm/pull/9707, this patch reworks the tests that use hard-coded `DriverMock` in favor of a PHPUnit-generated mock and removes the no longer used methods from `DriverMock`.

Note that the reworked version of the test uses the internal `Cache\ArrayResult` class from the DBAL. While it's not ideal, it's acceptable. If this class changes upstream, it can be easily copy-pasted to the test suite.

I'll continue reworking tests only for 3.0.x since mocking both the DBAL 2.x and 3.x APIs in ORM 2.x tests requires extra effort.