### PR TITLE
Run builds with DBAL 4.0.x-dev

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -87,6 +87,7 @@ class AnnotationDriver implements MappingDriver
                 continue;
             }
 
+            unset($classAnnotations[$key]);
             $classAnnotations[get_class($annot)] = $annot;
         }
 

--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM;
 use DateTimeInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Exception;
+use Throwable;
 
 /**
  * An OptimisticLockException is thrown when a version check on an object
@@ -21,9 +22,9 @@ class OptimisticLockException extends Exception implements ORMException
      * @param string      $msg
      * @param object|null $entity
      */
-    public function __construct($msg, $entity)
+    public function __construct($msg, $entity, ?Throwable $previous = null)
     {
-        parent::__construct($msg);
+        parent::__construct($msg, 0, $previous);
         $this->entity = $entity;
     }
 

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -189,6 +189,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         foreach ($idColumnNames as $idColumnName) {
             $columnDefinitions[$idColumnName] = [
+                'name'    => $idColumnName,
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $this->em)),
             ];

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -135,13 +135,13 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $values = [];
 
         if ($this->class->discriminatorValue !== null) { // discriminators can be 0
-            $values[] = $this->conn->quote($this->class->discriminatorValue);
+            $values[] = $this->conn->quote((string) $this->class->discriminatorValue);
         }
 
         $discrValues = array_flip($this->class->discriminatorMap);
 
         foreach ($this->class->subClasses as $subclassName) {
-            $values[] = $this->conn->quote($discrValues[$subclassName]);
+            $values[] = $this->conn->quote((string) $discrValues[$subclassName]);
         }
 
         $discColumnName = $this->class->getDiscriminatorColumn()['name'];

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -92,6 +92,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $columnDefinitions = [];
         foreach ($idColumnNames as $idColumnName) {
             $columnDefinitions[$idColumnName] = [
+                'name'    => $idColumnName,
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $em)),
             ];

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -133,6 +133,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
 
         foreach ($idColumnNames as $idColumnName) {
             $columnDefinitions[$idColumnName] = [
+                'name'    => $idColumnName,
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $em)),
             ];

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -105,9 +105,7 @@ abstract class SQLFilter
             throw FilterException::cannotConvertListParameterIntoSingleValue($name);
         }
 
-        $param = $this->parameters[$name];
-
-        return $this->em->getConnection()->quote($param['value'], $param['type']);
+        return $this->em->getConnection()->quote((string) $this->parameters[$name]['value']);
     }
 
     /**
@@ -133,7 +131,7 @@ abstract class SQLFilter
         $connection = $this->em->getConnection();
 
         $quoted = array_map(
-            static fn (mixed $value): string => (string) $connection->quote($value, $param['type']),
+            static fn (mixed $value): string => $connection->quote((string) $value),
             $param['value']
         );
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2225,7 +2225,7 @@ class SqlWalker implements TreeWalker
 
         if ($parameter) {
             $type = $parameter->getType();
-            if (Type::hasType($type)) {
+            if (is_string($type) && Type::hasType($type)) {
                 return Type::getType($type)->convertToDatabaseValueSQL('?', $this->platform);
             }
         }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -461,7 +461,7 @@ class SqlWalker implements TreeWalker
             }
 
             foreach ($class->subClasses as $subclassName) {
-                $values[] = $conn->quote($this->em->getClassMetadata($subclassName)->discriminatorValue);
+                $values[] = $conn->quote((string) $this->em->getClassMetadata($subclassName)->discriminatorValue);
             }
 
             $sqlTableAlias = $this->useSqlTableAliases
@@ -1812,7 +1812,7 @@ class SqlWalker implements TreeWalker
                 break;
 
             default:
-                $sql .= $this->conn->quote($newValue);
+                $sql .= $this->conn->quote((string) $newValue);
                 break;
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1063,6 +1063,9 @@
     <PossiblyUndefinedVariable occurrences="1">
       <code>$columnList</code>
     </PossiblyUndefinedVariable>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $discrValues[$subclassName]</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
     <ArgumentTypeCoercion occurrences="2">

--- a/psalm.xml
+++ b/psalm.xml
@@ -94,6 +94,8 @@
             <errorLevel type="suppress">
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+                <!-- DBAL 3 compatibility -->
+                <file name="lib/Doctrine/ORM/UnitOfWork.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
         <UndefinedClass>

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -203,7 +203,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
 
         $connection->expects($this->atLeast(2))
             ->method('delete')
-            ->will($this->onConsecutiveCalls(
+            ->withConsecutive(
                 [
                     'customtype_parent_friends',
                     ['friend_customtypeparent_id' => 1],
@@ -214,7 +214,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
                     ['customtypeparent_id' => 1],
                     ['integer'],
                 ]
-            ));
+            );
 
         $persister->delete($parent);
     }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -595,7 +596,7 @@ class UnitOfWorkTest extends OrmTestCase
     /**
      * @group #7946 Throw OptimisticLockException when connection::commit() returns false.
      */
-    public function testCommitThrowOptimisticLockExceptionWhenConnectionCommitReturnFalse(): void
+    public function testCommitThrowOptimisticLockExceptionWhenConnectionCommitFails(): void
     {
         $platform = $this->getMockBuilder(AbstractPlatform::class)
             ->onlyMethods(['supportsIdentityColumns'])
@@ -618,7 +619,8 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
 
-        $this->connection->method('commit')->willReturn(false);
+        $this->connection->method('commit')
+            ->willThrowException(new DBAL\Exception());
 
         // Setup fake persister and id generator
         $userPersister = new EntityPersisterMock($this->_emMock, $this->_emMock->getClassMetadata(ForumUser::class));

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\CacheFactory;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -181,11 +182,15 @@ abstract class OrmTestCase extends DoctrineTestCase
         $connection->method('query')
             ->willReturn($result);
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('createSchemaConfig')
+            ->willReturn(new SchemaConfig());
+
         $driver = $this->createMock(Driver::class);
         $driver->method('connect')
             ->willReturn($connection);
         $driver->method('getSchemaManager')
-            ->willReturn($this->createMock(AbstractSchemaManager::class));
+            ->willReturn($schemaManager);
         $driver->method('getDatabasePlatform')
             ->willReturn($platform);
 


### PR DESCRIPTION
Relevant changes from DBAL 4.0.x:
1. https://github.com/doctrine/dbal/pull/3488
2. https://github.com/doctrine/dbal/pull/3569
3. https://github.com/doctrine/dbal/pull/3583

**TODO**:
- [x] Backport what's possible to 2.13.x and rebase: https://github.com/doctrine/orm/pull/9730
- [x] Address static analysis issues when testing against DBAL 3.4.x-dev.
- [x] ~~Why do discriminator maps have numeric keys despite their `<string,class-string>` type?~~ Known issue to be baselined.
- [x] Improve MySQL test suite compatibility with DBAL 4 (https://github.com/doctrine/orm/pull/9728).

**Improve DBAL upgrade path**:
- [x] Get https://github.com/doctrine/dbal/pull/5373 merged.
- [x] Get https://github.com/doctrine/dbal/pull/5377 merged.

**Next steps**:
1. https://github.com/doctrine/orm/pull/9735.
2. Test the build with `^4@dev` on PostgreSQL.
3. Run static analysis with `^4@dev`.
4. Bump DBAL version constraint to `^3.4` once it's released.