### PR TITLE
Test MySQL DDL using explicit table options

### DIFF
--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -14,6 +14,9 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_default_table_option_charset" value="utf8mb4" />
+        <var name="db_default_table_option_collation" value="utf8mb4_unicode_ci" />
+        <var name="db_default_table_option_engine" value="InnoDB" />
 
         <!-- necessary change for some CLI/console output test assertions -->
         <env name="COLUMNS" value="120"/>

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -14,6 +14,9 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_default_table_option_charset" value="utf8mb4" />
+        <var name="db_default_table_option_collation" value="utf8mb4_unicode_ci" />
+        <var name="db_default_table_option_engine" value="InnoDB" />
 
         <!-- necessary change for some CLI/console output test assertions -->
         <env name="COLUMNS" value="120"/>

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -14,9 +14,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-use function method_exists;
-use function sprintf;
-
 class MySqlSchemaToolTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
@@ -38,18 +35,17 @@ class MySqlSchemaToolTest extends OrmFunctionalTestCase
             $this->_em->getClassMetadata(Models\CMS\CmsPhonenumber::class),
         ];
 
-        $tool      = new SchemaTool($this->_em);
-        $sql       = $tool->getCreateSchemaSql($classes);
-        $collation = $this->getColumnCollationDeclarationSQL('utf8_unicode_ci');
+        $tool = new SchemaTool($this->_em);
+        $sql  = $tool->getCreateSchemaSql($classes);
 
-        self::assertEquals('CREATE TABLE cms_groups (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[0]);
-        self::assertEquals('CREATE TABLE cms_users (id INT AUTO_INCREMENT NOT NULL, email_id INT DEFAULT NULL, status VARCHAR(50) DEFAULT NULL, username VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_3AF03EC5F85E0677 (username), UNIQUE INDEX UNIQ_3AF03EC5A832C1C9 (email_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[1]);
-        self::assertEquals('CREATE TABLE cms_users_groups (user_id INT NOT NULL, group_id INT NOT NULL, INDEX IDX_7EA9409AA76ED395 (user_id), INDEX IDX_7EA9409AFE54D947 (group_id), PRIMARY KEY(user_id, group_id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[2]);
-        self::assertEquals('CREATE TABLE cms_users_tags (user_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_93F5A1ADA76ED395 (user_id), INDEX IDX_93F5A1ADBAD26311 (tag_id), PRIMARY KEY(user_id, tag_id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[3]);
-        self::assertEquals('CREATE TABLE cms_tags (id INT AUTO_INCREMENT NOT NULL, tag_name VARCHAR(50) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[4]);
-        self::assertEquals('CREATE TABLE cms_addresses (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, country VARCHAR(50) NOT NULL, zip VARCHAR(50) NOT NULL, city VARCHAR(50) NOT NULL, UNIQUE INDEX UNIQ_ACAC157BA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[5]);
-        self::assertEquals('CREATE TABLE cms_emails (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(250) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[6]);
-        self::assertEquals('CREATE TABLE cms_phonenumbers (phonenumber VARCHAR(50) NOT NULL, user_id INT DEFAULT NULL, INDEX IDX_F21F790FA76ED395 (user_id), PRIMARY KEY(phonenumber)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[7]);
+        self::assertEquals('CREATE TABLE cms_groups (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[0]);
+        self::assertEquals('CREATE TABLE cms_users (id INT AUTO_INCREMENT NOT NULL, email_id INT DEFAULT NULL, status VARCHAR(50) DEFAULT NULL, username VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_3AF03EC5F85E0677 (username), UNIQUE INDEX UNIQ_3AF03EC5A832C1C9 (email_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[1]);
+        self::assertEquals('CREATE TABLE cms_users_groups (user_id INT NOT NULL, group_id INT NOT NULL, INDEX IDX_7EA9409AA76ED395 (user_id), INDEX IDX_7EA9409AFE54D947 (group_id), PRIMARY KEY(user_id, group_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[2]);
+        self::assertEquals('CREATE TABLE cms_users_tags (user_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_93F5A1ADA76ED395 (user_id), INDEX IDX_93F5A1ADBAD26311 (tag_id), PRIMARY KEY(user_id, tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[3]);
+        self::assertEquals('CREATE TABLE cms_tags (id INT AUTO_INCREMENT NOT NULL, tag_name VARCHAR(50) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[4]);
+        self::assertEquals('CREATE TABLE cms_addresses (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, country VARCHAR(50) NOT NULL, zip VARCHAR(50) NOT NULL, city VARCHAR(50) NOT NULL, UNIQUE INDEX UNIQ_ACAC157BA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[5]);
+        self::assertEquals('CREATE TABLE cms_emails (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(250) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[6]);
+        self::assertEquals('CREATE TABLE cms_phonenumbers (phonenumber VARCHAR(50) NOT NULL, user_id INT DEFAULT NULL, INDEX IDX_F21F790FA76ED395 (user_id), PRIMARY KEY(phonenumber)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[7]);
         self::assertEquals('ALTER TABLE cms_users ADD CONSTRAINT FK_3AF03EC5A832C1C9 FOREIGN KEY (email_id) REFERENCES cms_emails (id)', $sql[8]);
         self::assertEquals('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)', $sql[9]);
         self::assertEquals('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AFE54D947 FOREIGN KEY (group_id) REFERENCES cms_groups (id)', $sql[10]);
@@ -61,37 +57,26 @@ class MySqlSchemaToolTest extends OrmFunctionalTestCase
         self::assertCount(15, $sql);
     }
 
-    private function getColumnCollationDeclarationSQL(string $collation): string
-    {
-        if (method_exists($this->_em->getConnection()->getDatabasePlatform(), 'getColumnCollationDeclarationSQL')) {
-            return $this->_em->getConnection()->getDatabasePlatform()->getColumnCollationDeclarationSQL($collation);
-        }
-
-        return sprintf('COLLATE %s', $collation);
-    }
-
     public function testGetCreateSchemaSql2(): void
     {
         $classes = [$this->_em->getClassMetadata(Models\Generic\DecimalModel::class)];
 
-        $tool      = new SchemaTool($this->_em);
-        $sql       = $tool->getCreateSchemaSql($classes);
-        $collation = $this->getColumnCollationDeclarationSQL('utf8_unicode_ci');
+        $tool = new SchemaTool($this->_em);
+        $sql  = $tool->getCreateSchemaSql($classes);
 
         self::assertCount(1, $sql);
-        self::assertEquals('CREATE TABLE decimal_model (id INT AUTO_INCREMENT NOT NULL, `decimal` NUMERIC(5, 2) NOT NULL, `high_scale` NUMERIC(14, 4) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[0]);
+        self::assertEquals('CREATE TABLE decimal_model (id INT AUTO_INCREMENT NOT NULL, `decimal` NUMERIC(5, 2) NOT NULL, `high_scale` NUMERIC(14, 4) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[0]);
     }
 
     public function testGetCreateSchemaSql3(): void
     {
         $classes = [$this->_em->getClassMetadata(Models\Generic\BooleanModel::class)];
 
-        $tool      = new SchemaTool($this->_em);
-        $sql       = $tool->getCreateSchemaSql($classes);
-        $collation = $this->getColumnCollationDeclarationSQL('utf8_unicode_ci');
+        $tool = new SchemaTool($this->_em);
+        $sql  = $tool->getCreateSchemaSql($classes);
 
         self::assertCount(1, $sql);
-        self::assertEquals('CREATE TABLE boolean_model (id INT AUTO_INCREMENT NOT NULL, booleanField TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[0]);
+        self::assertEquals('CREATE TABLE boolean_model (id INT AUTO_INCREMENT NOT NULL, booleanField TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[0]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
@@ -13,9 +13,6 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-use function method_exists;
-use function sprintf;
-
 class DDC2182Test extends OrmFunctionalTestCase
 {
     public function testPassColumnOptionsToJoinColumns(): void
@@ -24,26 +21,15 @@ class DDC2182Test extends OrmFunctionalTestCase
             self::markTestSkipped('This test is useful for all databases, but designed only for mysql.');
         }
 
-        $sql       = $this->_schemaTool->getCreateSchemaSql(
+        $sql = $this->_schemaTool->getCreateSchemaSql(
             [
                 $this->_em->getClassMetadata(DDC2182OptionParent::class),
                 $this->_em->getClassMetadata(DDC2182OptionChild::class),
             ]
         );
-        $collation = $this->getColumnCollationDeclarationSQL('utf8_unicode_ci');
-
-        self::assertEquals('CREATE TABLE DDC2182OptionParent (id INT UNSIGNED NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[0]);
-        self::assertEquals('CREATE TABLE DDC2182OptionChild (id VARCHAR(255) NOT NULL, parent_id INT UNSIGNED DEFAULT NULL, INDEX IDX_B314D4AD727ACA70 (parent_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 ' . $collation . ' ENGINE = InnoDB', $sql[1]);
+        self::assertEquals('CREATE TABLE DDC2182OptionParent (id INT UNSIGNED NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[0]);
+        self::assertEquals('CREATE TABLE DDC2182OptionChild (id VARCHAR(255) NOT NULL, parent_id INT UNSIGNED DEFAULT NULL, INDEX IDX_B314D4AD727ACA70 (parent_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB', $sql[1]);
         self::assertEquals('ALTER TABLE DDC2182OptionChild ADD CONSTRAINT FK_B314D4AD727ACA70 FOREIGN KEY (parent_id) REFERENCES DDC2182OptionParent (id)', $sql[2]);
-    }
-
-    private function getColumnCollationDeclarationSQL(string $collation): string
-    {
-        if (method_exists($this->_em->getConnection()->getDatabasePlatform(), 'getColumnCollationDeclarationSQL')) {
-            return $this->_em->getConnection()->getDatabasePlatform()->getColumnCollationDeclarationSQL($collation);
-        }
-
-        return sprintf('COLLATE %s', $collation);
     }
 }
 

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -182,11 +182,15 @@ class TestUtil
         }
 
         foreach ($configuration as $param => $value) {
-            if (! str_starts_with($param, $prefix . 'driver_option_')) {
+            if (str_starts_with($param, $prefix . 'driver_option_')) {
+                $parameters['driverOptions'][substr($param, strlen($prefix . 'driver_option_'))] = $value;
+            }
+
+            if (! str_starts_with($param, $prefix . 'default_table_option_')) {
                 continue;
             }
 
-            $parameters['driverOptions'][substr($param, strlen($prefix . 'driver_option_'))] = $value;
+            $parameters['defaultTableOptions'][substr($param, strlen($prefix . 'default_table_option_'))] = $value;
         }
 
         $parameters['wrapperClass'] = DbalExtensions\Connection::class;


### PR DESCRIPTION
Currently, the test suite makes assertions against the DDL generated by the DBAL assuming the default table options (charset, collation, engine) implemented in DBAL 3. DBAL 4 will drop these defaults (https://github.com/doctrine/dbal/pull/4644), so these assumptions will be no longer valid.

In order to be compatible with both DBAL versions, the test suite should explicitly configure the default table options.