### PR TITLE
Exclude /ci from distribution packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
+/.github export-ignore
+/ci export-ignore
+/docs export-ignore
 /tests export-ignore
 /tools export-ignore
-/docs export-ignore
-/.github export-ignore
 .doctrine-project.json export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
The `ci` folder contains PHPUnit configurations for running tests against various database engines. Since we don't ship the tests, it does not make much sense that we ship those configuration files.