### PR TITLE
Improve compatibility with DBAL 4 for MySQL, MariaDB and PostgreSQL

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -208,7 +208,7 @@ class XmlDriver extends FileDriver
                         [
                             'name' => isset($discrColumn['name']) ? (string) $discrColumn['name'] : null,
                             'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
-                            'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : 255,
+                            'length' => isset($discrColumn['length']) ? (int) $discrColumn['length'] : 255,
                             'columnDefinition' => isset($discrColumn['column-definition']) ? (string) $discrColumn['column-definition'] : null,
                         ]
                     );
@@ -383,7 +383,7 @@ class XmlDriver extends FileDriver
             }
 
             if (isset($idElement['length'])) {
-                $mapping['length'] = (string) $idElement['length'];
+                $mapping['length'] = (int) $idElement['length'];
             }
 
             if (isset($idElement['column'])) {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -726,9 +726,11 @@ class SchemaTool
 
                 $columnOptions += $this->gatherColumnOptions($fieldMapping);
 
-                if ($fieldMapping['type'] === 'string' && isset($fieldMapping['length'])) {
+                if (isset($fieldMapping['length'])) {
                     $columnOptions['length'] = $fieldMapping['length'];
-                } elseif ($fieldMapping['type'] === 'decimal') {
+                }
+
+                if ($fieldMapping['type'] === 'decimal') {
                     $columnOptions['scale']     = $fieldMapping['scale'];
                     $columnOptions['precision'] = $fieldMapping['precision'];
                 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsComment.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsComment.php
@@ -34,7 +34,7 @@ class CmsComment
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $text;
 

--- a/tests/Doctrine/Tests/Models/Cache/Action.php
+++ b/tests/Doctrine/Tests/Models/Cache/Action.php
@@ -22,7 +22,7 @@ class Action
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $name;

--- a/tests/Doctrine/Tests/Models/Cache/Token.php
+++ b/tests/Doctrine/Tests/Models/Cache/Token.php
@@ -31,7 +31,7 @@ class Token
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $token;
 

--- a/tests/Doctrine/Tests/Models/Company/CompanyAuction.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyAuction.php
@@ -16,7 +16,7 @@ class CompanyAuction extends CompanyEvent
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $data;
 

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -33,7 +33,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="company_contracts")
  * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @EntityListeners({"CompanyContractListener"})
  * @DiscriminatorMap({
  *     "fix"       = "CompanyFixContract",

--- a/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="company_events")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="event_type", type="string")
+ * @DiscriminatorColumn(name="event_type", type="string", length=255)
  * @DiscriminatorMap({"auction"="CompanyAuction", "raffle"="CompanyRaffle"})
  */
 abstract class CompanyEvent

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="company_persons")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({
  *      "person"    = "CompanyPerson",
  *      "manager"   = "CompanyManager",

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedChildClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedChildClass.php
@@ -15,13 +15,13 @@ class JoinedChildClass extends JoinedRootClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $extension = 'ext';
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     private $additionalId = 'additional';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedChildClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedChildClass.php
@@ -17,13 +17,13 @@ class JoinedDerivedChildClass extends JoinedDerivedRootClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $extension = 'ext';
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     private $additionalId = 'additional';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedIdentityClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedIdentityClass.php
@@ -18,7 +18,7 @@ class JoinedDerivedIdentityClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $id = 'part-0';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedRootClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedRootClass.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name = "joined_derived_root")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({"child" = "JoinedDerivedChildClass", "root" = "JoinedDerivedRootClass"})
  */
 class JoinedDerivedRootClass
@@ -34,7 +34,7 @@ class JoinedDerivedRootClass
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $keyPart2 = 'part-2';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedRootClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedRootClass.php
@@ -21,14 +21,14 @@ class JoinedRootClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $keyPart1 = 'part-1';
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $keyPart2 = 'part-2';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleChildClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleChildClass.php
@@ -15,13 +15,13 @@ class SingleChildClass extends SingleRootClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $extension = 'ext';
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     private $additionalId = 'additional';

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleRootClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleRootClass.php
@@ -14,21 +14,21 @@ use Doctrine\ORM\Mapping\InheritanceType;
 /**
  * @Entity
  * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({"child" = "SingleChildClass", "root" = "SingleRootClass"})
  */
 class SingleRootClass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $keyPart1 = 'part-1';
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @Id
      */
     protected $keyPart2 = 'part-2';

--- a/tests/Doctrine/Tests/Models/CustomType/CustomIdObjectTypeChild.php
+++ b/tests/Doctrine/Tests/Models/CustomType/CustomIdObjectTypeChild.php
@@ -19,7 +19,7 @@ class CustomIdObjectTypeChild
 {
     /**
      * @Id
-     * @Column(type="CustomIdObject")
+     * @Column(type="CustomIdObject", length=255)
      * @var CustomIdObject
      */
     public $id;

--- a/tests/Doctrine/Tests/Models/CustomType/CustomIdObjectTypeParent.php
+++ b/tests/Doctrine/Tests/Models/CustomType/CustomIdObjectTypeParent.php
@@ -21,7 +21,7 @@ class CustomIdObjectTypeParent
 {
     /**
      * @Id
-     * @Column(type="CustomIdObject")
+     * @Column(type="CustomIdObject", length=255)
      * @var CustomIdObject
      */
     public $id;

--- a/tests/Doctrine/Tests/Models/CustomType/CustomTypeChild.php
+++ b/tests/Doctrine/Tests/Models/CustomType/CustomTypeChild.php
@@ -26,7 +26,7 @@ class CustomTypeChild
 
     /**
      * @var string
-     * @Column(type="upper_case_string")
+     * @Column(type="upper_case_string", length=255)
      */
     public $lowerCaseString = 'foo';
 }

--- a/tests/Doctrine/Tests/Models/CustomType/CustomTypeUpperCase.php
+++ b/tests/Doctrine/Tests/Models/CustomType/CustomTypeUpperCase.php
@@ -26,13 +26,13 @@ class CustomTypeUpperCase
 
     /**
      * @var string
-     * @Column(type="upper_case_string")
+     * @Column(type="upper_case_string", length=255)
      */
     public $lowerCaseString;
 
     /**
      * @var string
-     * @Column(type="upper_case_string", name="named_lower_case_string", nullable = true)
+     * @Column(type="upper_case_string", length=255, name="named_lower_case_string", nullable = true)
      */
     public $namedLowerCaseString;
 }

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Editor.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Editor.php
@@ -31,7 +31,7 @@ class DDC117Editor
 
     /**
      * @var string|null
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Reference.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Reference.php
@@ -34,7 +34,7 @@ class DDC117Reference
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $description;
 

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Translation.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Translation.php
@@ -30,13 +30,13 @@ class DDC117Translation
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $language;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $title;
 

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
@@ -17,7 +17,7 @@ class DDC1590User extends DDC1590Entity
 {
     /**
      * @var string
-     * @Column(type="string", length=255)
+     * @Column(type="string", length=255, length=255)
      */
     protected $name;
 }

--- a/tests/Doctrine/Tests/Models/DDC1872/DDC1872Bar.php
+++ b/tests/Doctrine/Tests/Models/DDC1872/DDC1872Bar.php
@@ -16,7 +16,7 @@ class DDC1872Bar
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $id;
 }

--- a/tests/Doctrine/Tests/Models/DDC1872/DDC1872ExampleTrait.php
+++ b/tests/Doctrine/Tests/Models/DDC1872/DDC1872ExampleTrait.php
@@ -14,7 +14,7 @@ trait DDC1872ExampleTrait
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $id;
 

--- a/tests/Doctrine/Tests/Models/DDC2504/DDC2504RootClass.php
+++ b/tests/Doctrine/Tests/Models/DDC2504/DDC2504RootClass.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 /**
  * @Entity
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({
  *     "root"  = "DDC2504RootClass",
  *     "child" = "DDC2504ChildClass"

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
@@ -21,7 +21,7 @@ use Doctrine\ORM\Mapping\PreUpdate;
  *
  * @Entity
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discriminator", type="string")
+ * @DiscriminatorColumn(name="discriminator", type="string", length=255)
  * @DiscriminatorMap({ "image" = "DDC3597Image"})
  * @HasLifecycleCallbacks
  */

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
@@ -27,7 +27,7 @@ class DDC3699Child extends DDC3699Parent
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $childField;
 

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
@@ -12,7 +12,7 @@ abstract class DDC3699Parent
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $parentField;
 }

--- a/tests/Doctrine/Tests/Models/DDC3899/DDC3899Contract.php
+++ b/tests/Doctrine/Tests/Models/DDC3899/DDC3899Contract.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="dc3899_contracts")
  * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({
  *     "fix"       = "DDC3899FixContract",
  *     "flexible"  = "DDC3899FlexContract"

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithCustomRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithCustomRepository.php
@@ -24,7 +24,7 @@ class DDC753EntityWithCustomRepository
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $name;
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithDefaultCustomRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithDefaultCustomRepository.php
@@ -24,7 +24,7 @@ class DDC753EntityWithDefaultCustomRepository
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $name;
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithInvalidRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithInvalidRepository.php
@@ -24,7 +24,7 @@ class DDC753EntityWithInvalidRepository
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $name;
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
@@ -17,7 +17,7 @@ class DDC869ChequePayment extends DDC869Payment
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     #[ORM\Column(type: 'string')]
     protected $serialNumber;

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
@@ -17,7 +17,7 @@ class DDC869CreditCardPayment extends DDC869Payment
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     #[ORM\Column(type: 'string')]
     protected $creditCardNumber;

--- a/tests/Doctrine/Tests/Models/DirectoryTree/AbstractContentItem.php
+++ b/tests/Doctrine/Tests/Models/DirectoryTree/AbstractContentItem.php
@@ -31,7 +31,7 @@ abstract class AbstractContentItem
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $name;
 

--- a/tests/Doctrine/Tests/Models/DirectoryTree/Directory.php
+++ b/tests/Doctrine/Tests/Models/DirectoryTree/Directory.php
@@ -14,7 +14,7 @@ class Directory extends AbstractContentItem
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $path;
 

--- a/tests/Doctrine/Tests/Models/DirectoryTree/File.php
+++ b/tests/Doctrine/Tests/Models/DirectoryTree/File.php
@@ -16,7 +16,7 @@ class File extends AbstractContentItem
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $extension = 'html';
 

--- a/tests/Doctrine/Tests/Models/Enums/Card.php
+++ b/tests/Doctrine/Tests/Models/Enums/Card.php
@@ -22,7 +22,7 @@ class Card
     public $id;
 
     /**
-     * @Column(type="string", enumType=Suit::class)
+     * @Column(type="string", length=255, enumType=Suit::class)
      * @var Suit
      */
     #[Column(type: 'string', enumType: Suit::class)]

--- a/tests/Doctrine/Tests/Models/Enums/CardWithNullable.php
+++ b/tests/Doctrine/Tests/Models/Enums/CardWithNullable.php
@@ -22,7 +22,7 @@ class CardWithNullable
     public $id;
 
     /**
-     * @Column(type="string", enumType=Suit::class, nullable=true)
+     * @Column(type="string", length=255, enumType=Suit::class, nullable=true)
      * @var ?Suit
      */
     #[Column(type: 'string', nullable: true, enumType: Suit::class)]

--- a/tests/Doctrine/Tests/Models/GH8565/GH8565Person.php
+++ b/tests/Doctrine/Tests/Models/GH8565/GH8565Person.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="gh8565_persons")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({
  *      "person"    = "GH8565Person",
  *      "manager"   = "GH8565Manager",

--- a/tests/Doctrine/Tests/Models/Generic/NonAlphaColumnsEntity.php
+++ b/tests/Doctrine/Tests/Models/Generic/NonAlphaColumnsEntity.php
@@ -26,7 +26,7 @@ class NonAlphaColumnsEntity
 
     /**
      * @var string
-     * @Column(type="string", name="`simple-entity-value`")
+     * @Column(type="string", length=255, name="`simple-entity-value`")
      */
     public $value;
 

--- a/tests/Doctrine/Tests/Models/Global/GlobalNamespaceModel.php
+++ b/tests/Doctrine/Tests/Models/Global/GlobalNamespaceModel.php
@@ -26,7 +26,7 @@ class DoctrineGlobalArticle
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     protected $headline;
 

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="issue5989_persons")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({
  *      "person"    = "Issue5989Person",
  *      "manager"   = "Issue5989Manager",

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
@@ -36,7 +36,7 @@ class LegacyUserReference
 
     /**
      * @var string
-     * @Column(type="string", name="description")
+     * @Column(type="string", length=255, name="description")
      */
     private $_description;
 

--- a/tests/Doctrine/Tests/Models/MixedToOneIdentity/CompositeToOneKeyState.php
+++ b/tests/Doctrine/Tests/Models/MixedToOneIdentity/CompositeToOneKeyState.php
@@ -17,7 +17,7 @@ class CompositeToOneKeyState
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $state;

--- a/tests/Doctrine/Tests/Models/MixedToOneIdentity/Country.php
+++ b/tests/Doctrine/Tests/Models/MixedToOneIdentity/Country.php
@@ -15,7 +15,7 @@ class Country
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $country;

--- a/tests/Doctrine/Tests/Models/Navigation/NavCountry.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavCountry.php
@@ -28,7 +28,7 @@ class NavCountry
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 

--- a/tests/Doctrine/Tests/Models/Navigation/NavPhotos.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavPhotos.php
@@ -39,7 +39,7 @@ class NavPhotos
 
     /**
      * @var string
-     * @Column(type="string", name="file_name")
+     * @Column(type="string", length=255, name="file_name")
      */
     private $file;
 

--- a/tests/Doctrine/Tests/Models/Navigation/NavPointOfInterest.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavPointOfInterest.php
@@ -37,7 +37,7 @@ class NavPointOfInterest
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 

--- a/tests/Doctrine/Tests/Models/Navigation/NavTour.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavTour.php
@@ -31,7 +31,7 @@ class NavTour
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 

--- a/tests/Doctrine/Tests/Models/Navigation/NavUser.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavUser.php
@@ -26,7 +26,7 @@ class NavUser
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 

--- a/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/InverseSide.php
+++ b/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/InverseSide.php
@@ -20,7 +20,7 @@ class InverseSide
     /**
      * @var string
      * @Id()
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $id;

--- a/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/OwningSide.php
+++ b/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/OwningSide.php
@@ -21,7 +21,7 @@ class OwningSide
     /**
      * @var string
      * @Id()
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $id;

--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -31,13 +31,13 @@ class Company
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
     /**
      * @var string
-     * @Column(type="string", name="jurisdiction_code", nullable=true)
+     * @Column(type="string", length=255, name="jurisdiction_code", nullable=true)
      */
     public $jurisdiction;
 

--- a/tests/Doctrine/Tests/Models/Pagination/Department.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Department.php
@@ -29,7 +29,7 @@ class Department
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/Pagination/Logo.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Logo.php
@@ -30,7 +30,7 @@ class Logo
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $image;
 

--- a/tests/Doctrine/Tests/Models/Pagination/User.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="pagination_user")
  * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorColumn(name="type", type="string")
+ * @DiscriminatorColumn(name="type", type="string", length=255)
  * @DiscriminatorMap({"user1"="User1"})
  */
 abstract class User
@@ -32,7 +32,7 @@ abstract class User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 }

--- a/tests/Doctrine/Tests/Models/Pagination/User1.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User1.php
@@ -14,7 +14,7 @@ class User1 extends User
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $email;
 }

--- a/tests/Doctrine/Tests/Models/PersistentObject/PersistentEntity.php
+++ b/tests/Doctrine/Tests/Models/PersistentObject/PersistentEntity.php
@@ -25,7 +25,7 @@ class PersistentEntity extends PersistentObject
     protected $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     protected $name;

--- a/tests/Doctrine/Tests/Models/Quote/Address.php
+++ b/tests/Doctrine/Tests/Models/Quote/Address.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table(name="`quote-address`")
  * @InheritanceType("SINGLE_TABLE")
- * @DiscriminatorColumn(name="type", type="string")
+ * @DiscriminatorColumn(name="type", type="string", length=255)
  * @DiscriminatorMap({"simple" = Address::class, "full" = FullAddress::class})
  */
 class Address

--- a/tests/Doctrine/Tests/Models/Quote/NumericEntity.php
+++ b/tests/Doctrine/Tests/Models/Quote/NumericEntity.php
@@ -26,7 +26,7 @@ class NumericEntity
 
     /**
      * @var string
-     * @Column(type="string", name="`2:2`")
+     * @Column(type="string", length=255, name="`2:2`")
      */
     public $value;
 

--- a/tests/Doctrine/Tests/Models/Quote/User.php
+++ b/tests/Doctrine/Tests/Models/Quote/User.php
@@ -33,7 +33,7 @@ class User
 
     /**
      * @var string
-     * @Column(type="string", name="`user-name`")
+     * @Column(type="string", length=255, name="`user-name`")
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/Routing/RoutingLocation.php
+++ b/tests/Doctrine/Tests/Models/Routing/RoutingLocation.php
@@ -24,7 +24,7 @@ class RoutingLocation
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/Routing/RoutingRouteBooking.php
+++ b/tests/Doctrine/Tests/Models/Routing/RoutingRouteBooking.php
@@ -33,7 +33,7 @@ class RoutingRouteBooking
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $passengerName = null;
 

--- a/tests/Doctrine/Tests/Models/StockExchange/Bond.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Bond.php
@@ -30,7 +30,7 @@ class Bond
     private $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     private $name;

--- a/tests/Doctrine/Tests/Models/StockExchange/Market.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Market.php
@@ -27,7 +27,7 @@ class Market
     private $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     private $name;

--- a/tests/Doctrine/Tests/Models/StockExchange/Stock.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Stock.php
@@ -28,7 +28,7 @@ class Stock
     /**
      * @var string
      * For real this column would have to be unique=true. But I want to test behavior of non-unique overrides.
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $symbol;
 

--- a/tests/Doctrine/Tests/Models/Tweet/Tweet.php
+++ b/tests/Doctrine/Tests/Models/Tweet/Tweet.php
@@ -27,7 +27,7 @@ class Tweet
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $content;
 

--- a/tests/Doctrine/Tests/Models/Tweet/User.php
+++ b/tests/Doctrine/Tests/Models/Tweet/User.php
@@ -29,7 +29,7 @@ class User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/Tweet/UserList.php
+++ b/tests/Doctrine/Tests/Models/Tweet/UserList.php
@@ -27,7 +27,7 @@ class UserList
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $listName;
 

--- a/tests/Doctrine/Tests/Models/Upsertable/Insertable.php
+++ b/tests/Doctrine/Tests/Models/Upsertable/Insertable.php
@@ -30,14 +30,14 @@ class Insertable
 
     /**
      * @var string
-     * @Column(type="string", insertable=false, options={"default": "1234"}, generated="INSERT")
+     * @Column(type="string", length=255, insertable=false, options={"default": "1234"}, generated="INSERT")
      */
     #[Column(type: 'string', insertable: false, options: ['default' => '1234'], generated: 'INSERT')]
     public $nonInsertableContent;
 
     /**
      * @var string
-     * @Column(type="string", insertable=true)
+     * @Column(type="string", length=255, insertable=true)
      */
     #[Column(type: 'string', insertable: true)]
     public $insertableContent;

--- a/tests/Doctrine/Tests/Models/Upsertable/Updatable.php
+++ b/tests/Doctrine/Tests/Models/Upsertable/Updatable.php
@@ -29,16 +29,16 @@ class Updatable
 
     /**
      * @var string
-     * @Column(type="string", name="non_updatable_content", updatable=false, generated="ALWAYS")
+     * @Column(type="string", length=255, name="non_updatable_content", updatable=false, generated="ALWAYS")
      */
-    #[Column(type: 'string', name: 'non_updatable_content', updatable: false, generated: 'ALWAYS')]
+    #[Column(name: 'non_updatable_content', type: 'string', length: 255, updatable: false, generated: 'ALWAYS')]
     public $nonUpdatableContent;
 
     /**
      * @var string
-     * @Column(type="string", updatable=true)
+     * @Column(type="string", length=255, updatable=true)
      */
-    #[Column(type: 'string', updatable: true)]
+    #[Column(type: 'string', length: 255, updatable: true)]
     public $updatableContent;
 
     public static function loadMetadata(ClassMetadata $metadata): ClassMetadata

--- a/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
@@ -17,7 +17,7 @@ class AuxiliaryEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id4;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdEntity.php
@@ -20,14 +20,14 @@ class InversedManyToManyCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
 
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
@@ -22,7 +22,7 @@ class InversedManyToManyCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
@@ -20,7 +20,7 @@ class InversedManyToManyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyExtraLazyEntity.php
@@ -20,7 +20,7 @@ class InversedManyToManyExtraLazyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdEntity.php
@@ -20,21 +20,21 @@ class InversedOneToManyCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
 
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", length=255, name="some_property")
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
@@ -22,7 +22,7 @@ class InversedOneToManyCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
@@ -37,7 +37,7 @@ class InversedOneToManyCompositeIdForeignKeyEntity
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", length=255, name="some_property")
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
@@ -20,7 +20,7 @@ class InversedOneToManyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
@@ -33,7 +33,7 @@ class InversedOneToManyEntity
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", name="some_property", length=255)
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyExtraLazyEntity.php
@@ -20,7 +20,7 @@ class InversedOneToManyExtraLazyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdEntity.php
@@ -18,21 +18,21 @@ class InversedOneToOneCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
 
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", length=255, name="some_property")
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
@@ -20,7 +20,7 @@ class InversedOneToOneCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
@@ -35,7 +35,7 @@ class InversedOneToOneCompositeIdForeignKeyEntity
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", length=255, name="some_property")
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
@@ -18,14 +18,14 @@ class InversedOneToOneEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id1;
 
     /**
      * @var string
-     * @Column(type="string", name="some_property")
+     * @Column(type="string", length=255, name="some_property")
      */
     public $someProperty;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
@@ -22,7 +22,7 @@ class OwningManyToManyCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id3;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
@@ -22,7 +22,7 @@ class OwningManyToManyCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
@@ -22,7 +22,7 @@ class OwningManyToManyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyExtraLazyEntity.php
@@ -22,7 +22,7 @@ class OwningManyToManyExtraLazyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
@@ -20,7 +20,7 @@ class OwningManyToOneCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id3;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
@@ -20,7 +20,7 @@ class OwningManyToOneCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
@@ -19,7 +19,7 @@ class OwningManyToOneEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneExtraLazyEntity.php
@@ -19,7 +19,7 @@ class OwningManyToOneExtraLazyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
@@ -20,7 +20,7 @@ class OwningOneToOneCompositeIdEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id3;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
@@ -26,7 +26,7 @@ class OwningOneToOneCompositeIdForeignKeyEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneEntity.php
@@ -19,7 +19,7 @@ class OwningOneToOneEntity
 {
     /**
      * @var string
-     * @Column(type="rot13")
+     * @Column(type="rot13", length=255)
      * @Id
      */
     public $id2;

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
@@ -132,7 +132,7 @@ class CTIChild extends CTIParent
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $data;
 

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -171,16 +171,16 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $table->addColumn('id', 'integer', ['unsigned' => true]);
         $table->setPrimaryKey(['id']);
         $table->addColumn('column_unsigned', 'integer', ['unsigned' => true]);
-        $table->addColumn('column_comment', 'string', ['comment' => 'test_comment']);
-        $table->addColumn('column_default', 'string', ['default' => 'test_default']);
+        $table->addColumn('column_comment', 'string', ['length' => 16, 'comment' => 'test_comment']);
+        $table->addColumn('column_default', 'string', ['length' => 16, 'default' => 'test_default']);
         $table->addColumn('column_decimal', 'decimal', ['precision' => 4, 'scale' => 3]);
 
-        $table->addColumn('column_index1', 'string');
-        $table->addColumn('column_index2', 'string');
+        $table->addColumn('column_index1', 'string', ['length' => 16]);
+        $table->addColumn('column_index2', 'string', ['length' => 16]);
         $table->addIndex(['column_index1', 'column_index2'], 'index1');
 
-        $table->addColumn('column_unique_index1', 'string');
-        $table->addColumn('column_unique_index2', 'string');
+        $table->addColumn('column_unique_index1', 'string', ['length' => 16]);
+        $table->addColumn('column_unique_index2', 'string', ['length' => 16]);
         $table->addUniqueIndex(['column_unique_index1', 'column_unique_index2'], 'unique_index1');
 
         $this->dropAndCreateTable($table);

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -66,7 +66,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $table->setPrimaryKey(['id']);
         $table->addColumn('bar', 'string', ['notnull' => false, 'length' => 200]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $metadatas = $this->extractClassMetadata(['DbdriverFoo']);
 
@@ -96,7 +96,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $tableB->addColumn('id', 'integer');
         $tableB->setPrimaryKey(['id']);
 
-        $this->schemaManager->dropAndCreateTable($tableB);
+        $this->dropAndCreateTable($tableB);
 
         $tableA = new Table('dbdriver_baz');
         $tableA->addColumn('id', 'integer');
@@ -104,7 +104,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $tableA->addColumn('bar_id', 'integer');
         $tableA->addForeignKeyConstraint('dbdriver_bar', ['bar_id'], ['id']);
 
-        $this->schemaManager->dropAndCreateTable($tableA);
+        $this->dropAndCreateTable($tableA);
 
         $metadatas = $this->extractClassMetadata(['DbdriverBar', 'DbdriverBaz']);
 
@@ -183,7 +183,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $table->addColumn('column_unique_index2', 'string');
         $table->addUniqueIndex(['column_unique_index1', 'column_unique_index2'], 'unique_index1');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $metadatas = $this->extractClassMetadata(['DbdriverFoo']);
 

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -106,12 +106,12 @@ class DefaultValueUser
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name = '';
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $type = 'Poweruser';
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/GH5988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH5988Test.php
@@ -106,7 +106,7 @@ abstract class GH5988CustomIdObjectTypeParent
 {
     /**
      * @Id
-     * @Column(type="Doctrine\Tests\ORM\Functional\GH5988CustomIdObjectHashType")
+     * @Column(type="Doctrine\Tests\ORM\Functional\GH5988CustomIdObjectHashType", length=255)
      * @var CustomIdObject
      */
     public $id;

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -436,13 +436,13 @@ class LifecycleCallbackTestUser
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $value;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -288,7 +288,7 @@ class OptimisticTest extends OrmFunctionalTestCase
  * @Entity
  * @Table(name="optimistic_joined_parent")
  * @InheritanceType("JOINED")
- * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string", length=255)
  * @DiscriminatorMap({"parent" = "OptimisticJoinedParent", "child" = "OptimisticJoinedChild"})
  */
 class OptimisticJoinedParent

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -310,7 +310,7 @@ class TrainDriver
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -348,7 +348,7 @@ class TrainOwner
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
@@ -153,7 +153,7 @@ class ReadOnlyEntity
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -72,7 +72,7 @@ class SequenceEmulatedIdentityEntity
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $value;
 

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -39,7 +38,7 @@ class SequenceEmulatedIdentityStrategyTest extends OrmFunctionalTestCase
         // drop sequence manually due to dependency
         $connection->executeStatement(
             $platform->getDropSequenceSQL(
-                new Sequence($platform->getIdentitySequenceName('seq_identity', 'id'))
+                $platform->getIdentitySequenceName('seq_identity', 'id')
             )
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -96,7 +96,7 @@ class DDC1080Foo
 
     /**
      * @var string
-     * @Column(name="fooTitle", type="string")
+     * @Column(name="fooTitle", type="string", length=255)
      */
     protected $fooTitle;
 
@@ -162,7 +162,7 @@ class DDC1080Bar
 
     /**
      * @var string
-     * @Column(name="barTitle", type="string")
+     * @Column(name="barTitle", type="string", length=255)
      */
     protected $barTitle;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -200,7 +200,7 @@ class DDC1163Tag
     private $id;
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     private $name;
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -89,7 +89,7 @@ class DDC1228User
     public $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $name = 'Bar';
@@ -120,7 +120,7 @@ class DDC1228Profile
     public $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -169,13 +169,13 @@ class DDC1335User
 
     /**
      * @var string
-     * @Column(type="string", unique=true)
+     * @Column(type="string", length=255, unique=true)
      */
     public $email;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -161,7 +161,7 @@ class DDC1430Order
 
     /**
      * @var string
-     * @Column(name="order_status", type="string")
+     * @Column(name="order_status", type="string", length=255)
      */
     private $status;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -55,7 +55,7 @@ class DDC192User
 
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     public $name;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
@@ -59,7 +59,7 @@ class DDC1998Entity
     /**
      * @var string
      * @Id
-     * @Column(type="ddc1998")
+     * @Column(type="ddc1998", length=255)
      */
     public $id;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
@@ -84,7 +84,7 @@ class DDC199ParentClass
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $parentData;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -107,7 +107,7 @@ class DDC2012Item
 
     /**
      * @psalm-var list<string>
-     * @Column(name="tsv", type="tsvector", nullable=true)
+     * @Column(name="tsv", type="tsvector", length=255, nullable=true)
      */
     public $tsv;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -72,7 +72,7 @@ class DDC211User
 
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     protected $name;
 
@@ -121,7 +121,7 @@ class DDC211Group
 
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     protected $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
@@ -67,7 +67,7 @@ class DDC2175Entity
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $field;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2224Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2224Test.php
@@ -100,7 +100,7 @@ class DDC2224Entity
 
     /**
      * @var mixed
-     * @Column(type="DDC2224Type")
+     * @Column(type="DDC2224Type", length=255)
      */
     public $field;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -90,7 +90,7 @@ class DDC237EntityX
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
     /**
@@ -117,7 +117,7 @@ class DDC237EntityY
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 }
@@ -137,7 +137,7 @@ class DDC237EntityZ
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -91,7 +91,7 @@ class DDC2494Currency
     /**
      * @var int
      * @Id
-     * @Column(type="integer", type="ddc2494_tinyint")
+     * @Column(type="ddc2494_tinyint")
      */
     protected $id;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
@@ -78,7 +78,7 @@ class DDC2579Entity
     /**
      * @var DDC2579Id
      * @Id
-     * @Column(type="ddc2579")
+     * @Column(type="ddc2579", length=255)
      */
     public $id;
 
@@ -131,7 +131,7 @@ class DDC2579AssocAssoc
     /**
      * @var DDC2579Id
      * @Id
-     * @Column(type="ddc2579")
+     * @Column(type="ddc2579", length=255)
      */
     public $associationId;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
@@ -139,7 +139,7 @@ class DDC2660CustomerOrder
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
@@ -89,7 +89,7 @@ abstract class DDC279EntityXAbstract
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 }
@@ -122,7 +122,7 @@ class DDC279EntityY
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 
@@ -149,7 +149,7 @@ class DDC279EntityZ
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
@@ -138,7 +138,7 @@ class DDC2862Driver
     protected $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     protected $name;
@@ -198,7 +198,7 @@ class DDC2862User
     protected $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     protected $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
@@ -78,7 +78,7 @@ class DDC2984User
 {
     /**
      * @Id
-     * @Column(type="ddc2984_domain_user_id")
+     * @Column(type="ddc2984_domain_user_id", length=255)
      * @GeneratedValue(strategy="NONE")
      * @var DDC2984DomainUserId
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php
@@ -83,7 +83,7 @@ class DDC2996UserPreference
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $value;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -86,7 +86,7 @@ class DDC3300HumanBoss extends DDC3300Person implements DDC3300Boss
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $bossCol;
 
@@ -105,7 +105,7 @@ class DDC3300HumanEmployee extends DDC3300Person implements DDC3300Employee
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $employeeCol;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
@@ -53,7 +53,7 @@ abstract class DDC3303Person
      * @var string
      * @Id
      * @GeneratedValue(strategy="NONE")
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 
@@ -77,7 +77,7 @@ class DDC3303Address
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $street;
 
@@ -89,7 +89,7 @@ class DDC3303Address
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $city;
 
@@ -109,7 +109,7 @@ class DDC3303Employee extends DDC3303Person
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $company;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -86,7 +86,7 @@ class DDC345User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -117,7 +117,7 @@ class DDC345Group
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -166,7 +166,7 @@ class DDC345Membership
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $state;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
@@ -155,7 +155,7 @@ class DDC3644User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -212,7 +212,7 @@ class DDC3644Address
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $address;
 
@@ -240,7 +240,7 @@ abstract class DDC3644Animal
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -76,7 +76,7 @@ class DDC371Child
     private $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
     /**
@@ -99,7 +99,7 @@ class DDC371Parent
     private $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -129,13 +129,13 @@ class DDC3785Attribute
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $value;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -110,7 +110,7 @@ class DDC440Phone
 
     /**
      * @var string
-     * @Column(name="phonenumber", type="string")
+     * @Column(name="phonenumber", type="string", length=255)
      */
     protected $number;
 
@@ -180,7 +180,7 @@ class DDC440Client
 
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     protected $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
@@ -83,7 +83,7 @@ class DDC444User
 
     /**
      * @var string
-     * @Column(name="name", type="string")
+     * @Column(name="name", type="string", length=255)
      */
     public $name;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
@@ -85,7 +85,7 @@ class DDC493Contact
     public $id;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
@@ -87,7 +87,7 @@ class DDC513Price
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $data;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -131,7 +131,7 @@ class DDC599Subitem extends DDC599Item
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $elem;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -149,7 +149,7 @@ class DDC618Author
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -186,7 +186,7 @@ class DDC618Book
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $title;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
@@ -108,7 +108,7 @@ abstract class DDC6303BaseClass
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $id;
@@ -122,7 +122,7 @@ class DDC6303ChildA extends DDC6303BaseClass
 {
     /**
      * @var mixed
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $originalData;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6460Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6460Test.php
@@ -80,7 +80,7 @@ class DDC6460Embeddable
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $field;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
@@ -52,13 +52,13 @@ class DDC656Entity
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $type;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -162,7 +162,7 @@ class DDC832Like
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $word;
 
@@ -198,7 +198,7 @@ class DDC832JoinedIndex
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -208,7 +208,7 @@ class DDC837Aggregate
 
     /**
      * @var string
-     * @Column(name="sysname", type="string")
+     * @Column(name="sysname", type="string", length=255)
      */
     protected $sysname;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -117,7 +117,7 @@ class DDC881User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 
@@ -159,7 +159,7 @@ class DDC881PhoneNumber
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $phonenumber;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -80,7 +80,7 @@ class DDC960Root
 class DDC960Child extends DDC960Root
 {
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     private $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -107,7 +107,7 @@ class GH5804Article
     /**
      * @var string
      * @Id
-     * @Column(type="GH5804Type")
+     * @Column(type="GH5804Type", length=255)
      * @GeneratedValue(strategy="CUSTOM")
      * @CustomIdGenerator(class=\Doctrine\Tests\ORM\Functional\Ticket\GH5804Generator::class)
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
@@ -120,7 +120,7 @@ class GH5887Customer
     /**
      * @var GH5887CustomIdObject
      * @Id
-     * @Column(type="GH5887CustomIdObject")
+     * @Column(type="GH5887CustomIdObject", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     private $id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
@@ -173,7 +173,7 @@ abstract class GH6141Person
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -69,7 +69,7 @@ class GH6217AssociatedEntity
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     public $id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
@@ -89,7 +89,7 @@ class B
     public $a;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $something;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6531Test.php
@@ -157,13 +157,13 @@ class GH6531ArticleAttribute
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $attribute;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $value;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
@@ -59,7 +59,7 @@ class GH6823User
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $id;
 
@@ -101,7 +101,7 @@ class GH6823Group
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $id;
 }
@@ -118,7 +118,7 @@ class GH6823Status
     /**
      * @var string
      * @Id
-     * @Column(type="string", options={"charset"="latin1", "collation"="latin1_bin"})
+     * @Column(type="string", length=255, options={"charset"="latin1", "collation"="latin1_bin"})
      */
     public $id;
 }
@@ -135,7 +135,7 @@ class GH6823Tag
     /**
      * @var string
      * @Id
-     * @Column(type="string", options={"charset"="latin1", "collation"="latin1_bin"})
+     * @Column(type="string", length=255, options={"charset"="latin1", "collation"="latin1_bin"})
      */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6937Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6937Test.php
@@ -109,7 +109,7 @@ abstract class GH6937Person
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 }
@@ -121,7 +121,7 @@ abstract class GH6937Employee extends GH6937Person
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $phoneNumber;
 }
@@ -133,7 +133,7 @@ class GH6937Manager extends GH6937Employee
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $department;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7062Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7062Test.php
@@ -139,7 +139,7 @@ class GH7062Season
 {
     /**
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $id;
@@ -166,7 +166,7 @@ class GH7062Team
 {
     /**
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithToIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithToIterableTest.php
@@ -77,7 +77,7 @@ class GH7496EntityA
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -102,7 +102,7 @@ class GH7496EntityB
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7505Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7505Test.php
@@ -94,7 +94,7 @@ class GH7505ArrayResponse extends GH7505AbstractResponse
 class GH7505TextResponse extends GH7505AbstractResponse
 {
     /**
-     * @Column(name="value_string", type="string")
+     * @Column(name="value_string", type="string", length=255)
      * @var string|null
      */
     public $value;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -120,7 +120,7 @@ class GH7820Line
     /**
      * @var GH7820LineText
      * @Id()
-     * @Column(type="Doctrine\Tests\ORM\Functional\Ticket\GH7820LineTextType")
+     * @Column(type="Doctrine\Tests\ORM\Functional\Ticket\GH7820LineTextType", length=255)
      */
     private $text;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7836Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7836Test.php
@@ -139,7 +139,7 @@ class GH7836ChildEntity
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7864Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7864Test.php
@@ -80,7 +80,7 @@ class GH7864User
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -117,7 +117,7 @@ class GH7864Tweet
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $content;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
@@ -102,7 +102,7 @@ class GH7941Product
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
@@ -71,7 +71,7 @@ class GH8055BaseClass
 class GH8055SubClass extends GH8055BaseClass
 {
     /**
-     * @Column(name="test", type="string")
+     * @Column(name="test", type="string", length=255)
      * @var string
      */
     public $value;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
@@ -50,7 +50,7 @@ final class GH8061Entity
 
     /**
      * @var mixed
-     * @Column(type="GH8061Type")
+     * @Column(type="GH8061Type", length=255)
      */
     public $field;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8499Test.php
@@ -127,13 +127,13 @@ class GH8499VersionableEntity
     public $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $name;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string
      */
     public $description;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9109Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9109Test.php
@@ -163,13 +163,13 @@ class GH9109User
 
     /**
      * @var string
-     * @Column(name="`first_name`", type="string")
+     * @Column(name="`first_name`", type="string", length=255)
      */
     private $firstName;
 
     /**
      * @var string
-     * @Column(name="last_name", type="string")
+     * @Column(name="last_name", type="string", length=255)
      */
     private $lastName;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -376,7 +376,7 @@ class DDC93Person
 
     /**
      * @var string|null
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
@@ -478,19 +478,19 @@ class DDC93Address
 {
     /**
      * @var string|null
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $street;
 
     /**
      * @var string|null
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $zip;
 
     /**
      * @var string|null
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $city;
 
@@ -536,7 +536,7 @@ class DDC93ContactInfo
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $email;
 
@@ -620,7 +620,7 @@ class DDC3028Id
     /**
      * @var string|null
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $id;
 

--- a/tests/Doctrine/Tests/ORM/Functional/xml/Doctrine.Tests.Models.OrnementalOrphanRemoval.Person.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Functional/xml/Doctrine.Tests.Models.OrnementalOrphanRemoval.Person.dcm.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                             https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Doctrine\Tests\Models\OrnementalOrphanRemoval\Person" table="ornemental_orphan_removal_person">
-        <id name="id" column="id">
+        <id name="id" column="id" length="255">
             <generator strategy="NONE" />
         </id>
     </entity>

--- a/tests/Doctrine/Tests/ORM/Functional/xml/Doctrine.Tests.Models.OrnementalOrphanRemoval.PhoneNumber.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Functional/xml/Doctrine.Tests.Models.OrnementalOrphanRemoval.PhoneNumber.dcm.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                             https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Doctrine\Tests\Models\OrnementalOrphanRemoval\PhoneNumber" table="ornemental_orphan_removal_phone_number">
-        <id name="id" column="id">
+        <id name="id" column="id" length="255">
             <generator strategy="NONE" />
         </id>
         <many-to-one target-entity="Doctrine\Tests\Models\OrnementalOrphanRemoval\Person" field="person" orphan-removal="true" >

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1560,7 +1560,7 @@ abstract class Animal
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="CUSTOM")
      * @CustomIdGenerator(class="stdClass")
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -415,7 +415,7 @@ class SuperEntity
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $id;
 }
@@ -427,7 +427,7 @@ class MiddleMappedSuperclass extends SuperEntity
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 }
@@ -439,7 +439,7 @@ class ChildEntity extends MiddleMappedSuperclass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $text;
 }
@@ -476,7 +476,7 @@ class AnnotationSLCFoo
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -249,7 +249,7 @@ class EntitySubClass extends TransientBaseClass
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 }
@@ -265,7 +265,7 @@ class MappedSuperclassBase
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $mapped2;
 
@@ -296,7 +296,7 @@ class EntitySubClass2 extends MappedSuperclassBase
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 }
@@ -312,12 +312,12 @@ class MappedSuperclassBaseIndex
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $mapped1;
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $mapped2;
 }
@@ -337,7 +337,7 @@ class EntityIndexSubClass extends MappedSuperclassBaseIndex
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $name;
 }
@@ -369,7 +369,7 @@ abstract class HierarchyASuperclass extends HierarchyBase
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $a;
 }
@@ -379,7 +379,7 @@ class HierarchyBEntity extends HierarchyBase
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $b;
 }
@@ -389,7 +389,7 @@ class HierarchyC extends HierarchyBase
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $c;
 }
@@ -399,7 +399,7 @@ class HierarchyD extends HierarchyASuperclass
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $d;
 }
@@ -409,7 +409,7 @@ class HierarchyE extends HierarchyBEntity
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $e;
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -535,7 +535,7 @@ abstract class Shape
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="AUTO")
      */
     public $id;

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginationTestCase.php
@@ -58,7 +58,7 @@ class MyBlogPost
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $title;
 }
@@ -133,7 +133,7 @@ class Author
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 }
@@ -153,13 +153,13 @@ class Person
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $biography;
 }
@@ -294,7 +294,7 @@ class Banner extends Identified
 {
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $name;
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -897,7 +897,7 @@ class NotifyChangedEntity implements NotifyPropertyChanged
 
     /**
      * @var string
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     private $data;
 
@@ -1028,7 +1028,7 @@ class EntityWithStringIdentifier
 {
     /**
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string|null
      */
     public $id;
@@ -1050,14 +1050,14 @@ class EntityWithCompositeStringIdentifier
 {
     /**
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string|null
      */
     public $id1;
 
     /**
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @var string|null
      */
     public $id2;
@@ -1069,7 +1069,7 @@ class EntityWithRandomlyGeneratedField
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      */
     public $id;
 
@@ -1092,7 +1092,7 @@ class CascadePersistedEntity
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     private $id;
@@ -1109,7 +1109,7 @@ class EntityWithCascadingAssociation
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     private $id;
@@ -1132,7 +1132,7 @@ class EntityWithNonCascadingAssociation
     /**
      * @var string
      * @Id
-     * @Column(type="string")
+     * @Column(type="string", length=255)
      * @GeneratedValue(strategy="NONE")
      */
     private $id;

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\Tests;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -916,5 +918,35 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         return $lastQuery;
+    }
+
+    /**
+     * Drops the table with the specified name, if it exists.
+     *
+     * @throws Exception
+     */
+    protected function dropTableIfExists(string $name): void
+    {
+        $schemaManager = $this->createSchemaManager();
+
+        try {
+            $schemaManager->dropTable($name);
+        } catch (DatabaseObjectNotFoundException $e) {
+        }
+    }
+
+    /**
+     * Drops and creates a new table.
+     *
+     * @throws Exception
+     */
+    protected function dropAndCreateTable(Table $table): void
+    {
+        $schemaManager = $this->createSchemaManager();
+        $platform      = $schemaManager->getDatabasePlatform();
+        $tableName     = $table->getQuotedName($platform);
+
+        $this->dropTableIfExists($tableName);
+        $schemaManager->createTable($table);
     }
 }


### PR DESCRIPTION
This is a partial backport of https://github.com/doctrine/orm/pull/9735. The relevant changes from DBAL 4.0.x are:

1. https://github.com/doctrine/dbal/pull/4933
2. https://github.com/doctrine/dbal/pull/3511
3. https://github.com/doctrine/dbal/pull/3586
4. https://github.com/doctrine/dbal/pull/4797
