### PR TITLE
Deprecate omitting second argument to joinColumnName() 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade to 2.13
 
-# Deprecated methods related to named queries
+## Deprecated methods related to named queries
 
 The following methods have been deprecated:
 
@@ -9,7 +9,7 @@ The following methods have been deprecated:
 - `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativQueryResultSetMapping()`
 - `Doctrine\ORM\Query\ResultSetMappingBuilder::addNamedNativQueryEntityResultMapping()`
 
-# Deprecated classes related to Doctrine 1 and reverse engineering
+## Deprecated classes related to Doctrine 1 and reverse engineering
 
 The following classes have been deprecated:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,46 @@
 # Upgrade to 2.13
 
+## Deprecated omitting second argument to `NamingStrategy::joinColumnName`
+
+When implementing `NamingStrategy`, it is deprecated to implement
+`joinColumnName()` with only one argument.
+
+### Before
+
+```php
+<?php
+class MyStrategy implements NamingStrategy
+{
+    /**
+     * @param string $propertyName A property name.
+     */
+    public function joinColumnName($propertyName): string
+    {
+        // …
+    }
+}
+```
+
+### After
+
+For backward-compatibility reasons, the parameter has to be optional, but can
+be documented as guaranteed to be a `class-string`.
+
+```php
+<?php
+class MyStrategy implements NamingStrategy
+{
+    /**
+     * @param string       $propertyName A property name.
+     * @param class-string $className
+     */
+    public function joinColumnName($propertyName, $className = null): string
+    {
+        // …
+    }
+}
+```
+
 ## Deprecated methods related to named queries
 
 The following methods have been deprecated:

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -54,6 +54,9 @@ class DefaultNamingStrategy implements NamingStrategy
 
     /**
      * {@inheritdoc}
+     *
+     * @param string       $propertyName
+     * @param class-string $className
      */
     public function joinColumnName($propertyName, $className = null)
     {

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -56,7 +56,7 @@ interface NamingStrategy
      *
      * @return string A join column name.
      */
-    public function joinColumnName($propertyName);
+    public function joinColumnName($propertyName/*, $className = null */);
 
     /**
      * Returns a join table name.

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -112,6 +112,9 @@ class UnderscoreNamingStrategy implements NamingStrategy
 
     /**
      * {@inheritdoc}
+     *
+     * @param string       $propertyName
+     * @param class-string $className
      */
     public function joinColumnName($propertyName, $className = null)
     {


### PR DESCRIPTION
I don't think there is a sensible way to actually enforce that deprecation.