### PR TITLE
Document unofficial parameter in phpdoc

### DIFF
--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -54,9 +54,6 @@ class DefaultNamingStrategy implements NamingStrategy
 
     /**
      * {@inheritdoc}
-     *
-     * @param string       $propertyName
-     * @param class-string $className
      */
     public function joinColumnName($propertyName, $className = null)
     {

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -52,7 +52,8 @@ interface NamingStrategy
     /**
      * Returns a join column name for a property.
      *
-     * @param string $propertyName A property name.
+     * @param string       $propertyName A property name.
+     * @param class-string $className    The fully-qualified class name.
      *
      * @return string A join column name.
      */

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -112,9 +112,6 @@ class UnderscoreNamingStrategy implements NamingStrategy
 
     /**
      * {@inheritdoc}
-     *
-     * @param string       $propertyName
-     * @param class-string $className
      */
     public function joinColumnName($propertyName, $className = null)
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -265,6 +265,8 @@
     <rule ref="Squiz.Commenting.FunctionComment.ExtraParamComment">
         <!-- https://github.com/doctrine/orm/issues/8537 -->
         <exclude-pattern>lib/Doctrine/ORM/QueryBuilder.php</exclude-pattern>
+        <!-- To be removed in 3.0 -->
+        <exclude-pattern>lib/Doctrine/ORM/Mapping/NamingStrategy.php</exclude-pattern>
     </rule>
 
     <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1284,3 +1284,7 @@ parameters:
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$subClasses\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+
+		-
+			message: '#PHPDoc tag @param references unknown parameter: \$className#'
+			path: lib/Doctrine/ORM/Mapping/NamingStrategy.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -115,6 +115,9 @@
                 <file name="lib/Doctrine/ORM/EntityManager.php"/>
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
+                <!-- Backward compatibility -->
+                <file name="lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php"/>
+                <file name="lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php"/>
             </errorLevel>
         </MissingParamType>
         <RedundantCastGivenDocblockType>


### PR DESCRIPTION
This is a follow-up for https://github.com/doctrine/orm/pull/9747#issuecomment-1122645899

Pros:
- The DebugClassLoader of Symfony can emit a deprecation about that
- The phpdoc no longer needs to be repeated in implementing classes

Cons:
- PHP_CodeSniffer is unhappy about this.
- PHPStan is unhappy about this.
- Psalm does not take into account the inherited phpdoc.