### PR TITLE
Document types as they are passed

### DIFF
--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -14,7 +14,7 @@ interface NamingStrategy
     /**
      * Returns a table name for an entity class.
      *
-     * @param string $className The fully-qualified class name.
+     * @param class-string $className
      *
      * @return string A table name.
      */
@@ -23,8 +23,8 @@ interface NamingStrategy
     /**
      * Returns a column name for a property.
      *
-     * @param string      $propertyName A property name.
-     * @param string|null $className    The fully-qualified class name.
+     * @param string       $propertyName A property name.
+     * @param class-string $className    The fully-qualified class name.
      *
      * @return string A column name.
      */
@@ -33,14 +33,19 @@ interface NamingStrategy
     /**
      * Returns a column name for an embedded property.
      *
-     * @param string $propertyName
-     * @param string $embeddedColumnName
-     * @param string $className
-     * @param string $embeddedClassName
+     * @param string       $propertyName
+     * @param string       $embeddedColumnName
+     * @param class-string $className
+     * @param class-string $embeddedClassName
      *
      * @return string
      */
-    public function embeddedFieldToColumnName($propertyName, $embeddedColumnName, $className = null, $embeddedClassName = null);
+    public function embeddedFieldToColumnName(
+        $propertyName,
+        $embeddedColumnName,
+        $className = null,
+        $embeddedClassName = null
+    );
 
     /**
      * Returns the default reference column name.
@@ -61,9 +66,9 @@ interface NamingStrategy
     /**
      * Returns a join table name.
      *
-     * @param string      $sourceEntity The source entity.
-     * @param string      $targetEntity The target entity.
-     * @param string|null $propertyName A property name.
+     * @param class-string $sourceEntity The source entity.
+     * @param class-string $targetEntity The target entity.
+     * @param string       $propertyName A property name.
      *
      * @return string A join table name.
      */
@@ -72,8 +77,8 @@ interface NamingStrategy
     /**
      * Returns the foreign key column name for the given parameters.
      *
-     * @param string      $entityName           An entity.
-     * @param string|null $referencedColumnName A property.
+     * @param class-string $entityName           An entity.
+     * @param string       $referencedColumnName A property.
      *
      * @return string A join column name.
      */

--- a/psalm.xml
+++ b/psalm.xml
@@ -176,5 +176,11 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
             </errorLevel>
         </UndefinedMethod>
+        <ArgumentTypeCoercion>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/JetBrains/phpstorm-stubs/pull/1383 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
+            </errorLevel>
+        </ArgumentTypeCoercion>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Some arguments have been added afterwards which was a BC break for
implementing classes. I do not think they should have been introduced as
optional, since it was still possible to implement them as optional: https://3v4l.org/BVrHu

See

- https://github.com/doctrine/orm/pull/241
- https://github.com/doctrine/orm/pull/391
- https://github.com/doctrine/orm/pull/835