### PR TITLE
[GH-3519] Deprecate passing the same class with different discriminator values.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# Upgrade to 3.4
+
+Using the same class several times in a discriminator map is deprecated.
+In 4.0, this will be an error.
+
 # Upgrade to 3.3
 
 ## Deprecate `DatabaseDriver`
@@ -737,7 +742,7 @@ Use `toIterable()` instead.
 
 Output walkers should implement the new `\Doctrine\ORM\Query\OutputWalker` interface and create
 `Doctrine\ORM\Query\Exec\SqlFinalizer` instances instead of `Doctrine\ORM\Query\Exec\AbstractSqlExecutor`s.
-The output walker must not base its workings on the query `firstResult`/`maxResult` values, so that the 
+The output walker must not base its workings on the query `firstResult`/`maxResult` values, so that the
 `SqlFinalizer` can be kept in the query cache and used regardless of the actual `firstResult`/`maxResult` values.
 Any operation dependent on `firstResult`/`maxResult` should take place within the `SqlFinalizer::createExecutor()`
 method. Details can be found at https://github.com/doctrine/orm/pull/11188.
@@ -750,7 +755,7 @@ change in behavior.
 
 Progress on this is tracked at https://github.com/doctrine/orm/issues/11624 .
 
-## PARTIAL DQL syntax is undeprecated 
+## PARTIAL DQL syntax is undeprecated
 
 Use of the PARTIAL keyword is not deprecated anymore in DQL, because we will be
 able to support PARTIAL objects with PHP 8.4 Lazy Objects and

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1101,6 +1101,14 @@ class ClassMetadataTest extends OrmTestCase
             $xmlElement->children()->{'discriminator-map'}->{'discriminator-mapping'}[0]->attributes()['value'],
         );
     }
+
+    public function testDiscriminatorMapWithSameClassMultipleTimesDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/3519');
+
+        $cm = new ClassMetadata(CMS\CmsUser::class);
+        $cm->setDiscriminatorMap(['foo' => CMS\CmsUser::class, 'bar' => CMS\CmsUser::class]);
+    }
 }
 
 #[MappedSuperclass]


### PR DESCRIPTION
Prepares the deprecation for the later removal of this mapping inconsistency.

Related: #3519