### PR TITLE
Fix phpdoc and tests for NamingStrategy

### DIFF
--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -78,7 +78,10 @@ interface NamingStrategy
      * Returns the foreign key column name for the given parameters.
      *
      * @param class-string $entityName           An entity.
-     * @param string       $referencedColumnName A property.
+     * @param string|null  $referencedColumnName A property name or null in
+     *                                           case of a self-referencing
+     *                                           entity with join columns
+     *                                           defined in the mapping
      *
      * @return string A join column name.
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -88,46 +88,50 @@ class NamingStrategyTest extends OrmTestCase
     /**
      * Data Provider for NamingStrategy#propertyToColumnName
      *
-     * @return array<array{NamingStrategy, string, string}>
+     * @return array<array{NamingStrategy, string, string, string}>
      */
     public static function dataPropertyToColumnName(): array
     {
         return [
             // DefaultNamingStrategy
-            [self::defaultNaming(), 'someProperty', 'someProperty'],
-            [self::defaultNaming(), 'SOME_PROPERTY', 'SOME_PROPERTY'],
-            [self::defaultNaming(), 'some_property', 'some_property'],
-            [self::defaultNaming(), 'base64Encoded', 'base64Encoded'],
-            [self::defaultNaming(), 'base64_encoded', 'base64_encoded'],
+            [self::defaultNaming(), 'someProperty', 'someProperty', 'Some\Class'],
+            [self::defaultNaming(), 'SOME_PROPERTY', 'SOME_PROPERTY', 'Some\Class'],
+            [self::defaultNaming(), 'some_property', 'some_property', 'Some\Class'],
+            [self::defaultNaming(), 'base64Encoded', 'base64Encoded', 'Some\Class'],
+            [self::defaultNaming(), 'base64_encoded', 'base64_encoded', 'Some\Class'],
 
             // UnderscoreNamingStrategy
-            [self::underscoreNamingLower(), 'some_property', 'someProperty'],
-            [self::underscoreNamingLower(), 'base64encoded', 'base64Encoded'],
-            [self::underscoreNamingLower(), 'base64encoded', 'base64encoded'],
-            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'someProperty'],
-            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'some_property'],
-            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY'],
-            [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64Encoded'],
-            [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded'],
+            [self::underscoreNamingLower(), 'some_property', 'someProperty', 'Some\Class'],
+            [self::underscoreNamingLower(), 'base64encoded', 'base64Encoded', 'Some\Class'],
+            [self::underscoreNamingLower(), 'base64encoded', 'base64encoded', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'someProperty', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'some_property', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64Encoded', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded', 'Some\Class'],
 
             // NumberAwareUnderscoreNamingStrategy
-            [self::numberAwareUnderscoreNamingLower(), 'some_property', 'someProperty'],
-            [self::numberAwareUnderscoreNamingLower(), 'base64_encoded', 'base64Encoded'],
-            [self::numberAwareUnderscoreNamingLower(), 'base64encoded', 'base64encoded'],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'someProperty'],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'some_property'],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY'],
-            [self::numberAwareUnderscoreNamingUpper(), 'BASE64_ENCODED', 'base64Encoded'],
-            [self::numberAwareUnderscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded'],
+            [self::numberAwareUnderscoreNamingLower(), 'some_property', 'someProperty', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingLower(), 'base64_encoded', 'base64Encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingLower(), 'base64encoded', 'base64encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'someProperty', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'some_property', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'BASE64_ENCODED', 'base64Encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded', 'Some\Class'],
         ];
     }
 
     /**
      * @dataProvider dataPropertyToColumnName
      */
-    public function testPropertyToColumnName(NamingStrategy $strategy, string $expected, string $propertyName): void
-    {
-        self::assertSame($expected, $strategy->propertyToColumnName($propertyName));
+    public function testPropertyToColumnName(
+        NamingStrategy $strategy,
+        string $expected,
+        string $propertyName,
+        string $className
+    ): void {
+        self::assertSame($expected, $strategy->propertyToColumnName($propertyName, $className));
     }
 
     /**
@@ -216,29 +220,29 @@ class NamingStrategyTest extends OrmTestCase
     {
         return [
             // DefaultNamingStrategy
-            [self::defaultNaming(), 'someclassname_classname', 'SomeClassName', 'Some\ClassName', null],
-            [self::defaultNaming(), 'someclassname_classname', '\SomeClassName', 'ClassName', null],
-            [self::defaultNaming(), 'name_classname', '\Some\Class\Name', 'ClassName', null],
+            [self::defaultNaming(), 'someclassname_classname', 'SomeClassName', 'Some\ClassName', 'some_property'],
+            [self::defaultNaming(), 'someclassname_classname', '\SomeClassName', 'ClassName', 'some_property'],
+            [self::defaultNaming(), 'name_classname', '\Some\Class\Name', 'ClassName', 'some_property'],
 
             // UnderscoreNamingStrategy
-            [self::underscoreNamingLower(), 'some_class_name_class_name', 'SomeClassName', 'Some\ClassName', null],
-            [self::underscoreNamingLower(), 'class1test_class2test', 'Class1Test', 'Some\Class2Test', null],
-            [self::underscoreNamingLower(), 'some_class_name_class_name', '\SomeClassName', 'ClassName', null],
-            [self::underscoreNamingLower(), 'name_class_name', '\Some\Class\Name', 'ClassName', null],
-            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', 'SomeClassName', 'Some\ClassName', null],
-            [self::underscoreNamingUpper(), 'CLASS1TEST_CLASS2TEST', 'Class1Test', 'Some\Class2Test', null],
-            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', '\SomeClassName', 'ClassName', null],
-            [self::underscoreNamingUpper(), 'NAME_CLASS_NAME', '\Some\Class\Name', 'ClassName', null],
+            [self::underscoreNamingLower(), 'some_class_name_class_name', 'SomeClassName', 'Some\ClassName', 'some_property'],
+            [self::underscoreNamingLower(), 'class1test_class2test', 'Class1Test', 'Some\Class2Test', 'some_property'],
+            [self::underscoreNamingLower(), 'some_class_name_class_name', '\SomeClassName', 'ClassName', 'some_property'],
+            [self::underscoreNamingLower(), 'name_class_name', '\Some\Class\Name', 'ClassName', 'some_property'],
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', 'SomeClassName', 'Some\ClassName', 'some_property'],
+            [self::underscoreNamingUpper(), 'CLASS1TEST_CLASS2TEST', 'Class1Test', 'Some\Class2Test', 'some_property'],
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', '\SomeClassName', 'ClassName', 'some_property'],
+            [self::underscoreNamingUpper(), 'NAME_CLASS_NAME', '\Some\Class\Name', 'ClassName', 'some_property'],
 
             // NumberAwareUnderscoreNamingStrategy
-            [self::numberAwareUnderscoreNamingLower(), 'some_class_name_class_name', 'SomeClassName', 'Some\ClassName', null],
-            [self::numberAwareUnderscoreNamingLower(), 'class1_test_class2_test', 'Class1Test', 'Some\Class2Test', null],
-            [self::numberAwareUnderscoreNamingLower(), 'some_class_name_class_name', '\SomeClassName', 'ClassName', null],
-            [self::numberAwareUnderscoreNamingLower(), 'name_class_name', '\Some\Class\Name', 'ClassName', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', 'SomeClassName', 'Some\ClassName', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'CLASS1_TEST_CLASS2_TEST', 'Class1Test', 'Some\Class2Test', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', '\SomeClassName', 'ClassName', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'NAME_CLASS_NAME', '\Some\Class\Name', 'ClassName', null],
+            [self::numberAwareUnderscoreNamingLower(), 'some_class_name_class_name', 'SomeClassName', 'Some\ClassName', 'some_property'],
+            [self::numberAwareUnderscoreNamingLower(), 'class1_test_class2_test', 'Class1Test', 'Some\Class2Test', 'some_property'],
+            [self::numberAwareUnderscoreNamingLower(), 'some_class_name_class_name', '\SomeClassName', 'ClassName', 'some_property'],
+            [self::numberAwareUnderscoreNamingLower(), 'name_class_name', '\Some\Class\Name', 'ClassName', 'some_property'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', 'SomeClassName', 'Some\ClassName', 'some_property'],
+            [self::numberAwareUnderscoreNamingUpper(), 'CLASS1_TEST_CLASS2_TEST', 'Class1Test', 'Some\Class2Test', 'some_property'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME', '\SomeClassName', 'ClassName', 'some_property'],
+            [self::numberAwareUnderscoreNamingUpper(), 'NAME_CLASS_NAME', '\Some\Class\Name', 'ClassName', 'some_property'],
         ];
     }
 
@@ -250,7 +254,7 @@ class NamingStrategyTest extends OrmTestCase
         string $expected,
         string $ownerEntity,
         string $associatedEntity,
-        ?string $propertyName = null
+        string $propertyName
     ): void {
         self::assertSame($expected, $strategy->joinTableName($ownerEntity, $associatedEntity, $propertyName));
     }


### PR DESCRIPTION
While working on https://github.com/doctrine/orm/pull/9758, I noticed 2 things that need to be fixed.

When computing a foreign key column name, the referenced column name
may be null in the case of a self referencing entity with join columns
defined in the mapping. I wrongly introduced that phpdoc in #9756.
Also, some tests were using the fact that some arguments of some methods of
the naming strategy interface are optional or nullable for now to avoid
providing some. In practice, these arguments are always provided, and
that should also be the case in tests.

For `propertyToColumnName`, I think `ClassMetadataInfo::$name` is always a non-nullable string
See https://github.com/doctrine/orm/blob/45e196eb57034a90d0e4a7afb9109d9537132c24/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1635

For `joinTableName()` I think related mapping are always defined based on some property and cannot be null either. 
https://github.com/doctrine/orm/blob/45e196eb57034a90d0e4a7afb9109d9537132c24/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2050