### PR TITLE
Document future argument better

### DIFF
--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -61,7 +61,7 @@ interface NamingStrategy
      *
      * @return string A join column name.
      */
-    public function joinColumnName($propertyName/*, $className = null */);
+    public function joinColumnName($propertyName/*, string $className */);
 
     /**
      * Returns a join table name.

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -172,24 +172,24 @@ class NamingStrategyTest extends OrmTestCase
     {
         return [
             // DefaultNamingStrategy
-            [self::defaultNaming(), 'someColumn_id', 'someColumn', null],
-            [self::defaultNaming(), 'some_column_id', 'some_column', null],
-            [self::defaultNaming(), 'base64Encoded_id', 'base64Encoded', null],
-            [self::defaultNaming(), 'base64_encoded_id', 'base64_encoded', null],
+            [self::defaultNaming(), 'someColumn_id', 'someColumn', 'Some\Class'],
+            [self::defaultNaming(), 'some_column_id', 'some_column', 'Some\Class'],
+            [self::defaultNaming(), 'base64Encoded_id', 'base64Encoded', 'Some\Class'],
+            [self::defaultNaming(), 'base64_encoded_id', 'base64_encoded', 'Some\Class'],
 
             // UnderscoreNamingStrategy
-            [self::underscoreNamingLower(), 'some_column_id', 'someColumn', null],
-            [self::underscoreNamingLower(), 'base64encoded_id', 'base64Encoded', null],
-            [self::underscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', null],
-            [self::underscoreNamingUpper(), 'BASE64ENCODED_ID', 'base64Encoded', null],
+            [self::underscoreNamingLower(), 'some_column_id', 'someColumn', 'Some\Class'],
+            [self::underscoreNamingLower(), 'base64encoded_id', 'base64Encoded', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', 'Some\Class'],
+            [self::underscoreNamingUpper(), 'BASE64ENCODED_ID', 'base64Encoded', 'Some\Class'],
 
             // NumberAwareUnderscoreNamingStrategy
-            [self::numberAwareUnderscoreNamingLower(), 'some_column_id', 'someColumn', null],
-            [self::numberAwareUnderscoreNamingLower(), 'base64_encoded_id', 'base64Encoded', null],
-            [self::numberAwareUnderscoreNamingLower(), 'base64encoded_id', 'base64encoded', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'BASE64_ENCODED_ID', 'base64Encoded', null],
-            [self::numberAwareUnderscoreNamingUpper(), 'BASE64ENCODED_ID', 'base64encoded', null],
+            [self::numberAwareUnderscoreNamingLower(), 'some_column_id', 'someColumn', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingLower(), 'base64_encoded_id', 'base64Encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingLower(), 'base64encoded_id', 'base64encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'BASE64_ENCODED_ID', 'base64Encoded', 'Some\Class'],
+            [self::numberAwareUnderscoreNamingUpper(), 'BASE64ENCODED_ID', 'base64encoded', 'Some\Class'],
 
             // JoinColumnClassNamingStrategy
             [new JoinColumnClassNamingStrategy(), 'classname_someColumn_id', 'someColumn', 'Some\ClassName'],


### PR DESCRIPTION
That argument is always provided, so the tests should provide it and the
commented out argument should reflect the future.

This should have been done as part of #9761 but I confused this method with another one and overlooked it.