### PR TITLE
Add use statement

### DIFF
--- a/docs/en/reference/php-mapping.rst
+++ b/docs/en/reference/php-mapping.rst
@@ -96,6 +96,8 @@ For this you just need to use the ``StaticPHPDriver``:
 .. code-block:: php
 
     <?php
+    use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+
     $driver = new StaticPHPDriver('/path/to/entities');
     $em->getConfiguration()->setMetadataDriverImpl($driver);
 


### PR DESCRIPTION
We are supposed to use the driver from `doctrine/persistence`, and not the
deprecated one from this package.