### PR TITLE
Remove override phpdoc tag

### DIFF
--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -35,8 +35,6 @@ final class NativeQuery extends AbstractQuery
      * Gets the SQL query.
      *
      * @return mixed The built SQL query or an array of all SQL queries.
-     *
-     * @override
      */
     public function getSQL()
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -73,8 +73,6 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      * @param string $fieldName
      *
      * @return string
-     *
-     * @override
      */
     public function getOwningTable($fieldName)
     {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -189,8 +189,6 @@ final class Query extends AbstractQuery
      * Gets the SQL query/queries that correspond to this DQL query.
      *
      * @return mixed The built sql query or an array of all sql queries.
-     *
-     * @override
      */
     public function getSQL()
     {
@@ -582,9 +580,6 @@ final class Query extends AbstractQuery
         return $this->expireQueryCache;
     }
 
-    /**
-     * @override
-     */
     public function free(): void
     {
         parent::free();

--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -20,7 +20,6 @@ class AbsFunction extends FunctionNode
     public $simpleArithmeticExpression;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -31,7 +30,6 @@ class AbsFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php
@@ -23,7 +23,6 @@ class BitAndFunction extends FunctionNode
     public $secondArithmetic;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -37,7 +36,6 @@ class BitAndFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php
@@ -23,7 +23,6 @@ class BitOrFunction extends FunctionNode
     public $secondArithmetic;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -37,7 +36,6 @@ class BitOrFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -26,7 +26,6 @@ class ConcatFunction extends FunctionNode
     public $concatExpressions = [];
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -43,7 +42,6 @@ class ConcatFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentDateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentDateFunction.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Query\SqlWalker;
 class CurrentDateFunction extends FunctionNode
 {
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -25,7 +24,6 @@ class CurrentDateFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimeFunction.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Query\SqlWalker;
 class CurrentTimeFunction extends FunctionNode
 {
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -25,7 +24,6 @@ class CurrentTimeFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimestampFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimestampFunction.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Query\SqlWalker;
 class CurrentTimestampFunction extends FunctionNode
 {
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -25,7 +24,6 @@ class CurrentTimestampFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -29,7 +29,6 @@ class DateAddFunction extends FunctionNode
     public $unit = null;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -85,7 +84,6 @@ class DateAddFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
@@ -23,7 +23,6 @@ class DateDiffFunction extends FunctionNode
     public $date2;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -35,7 +34,6 @@ class DateDiffFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -17,7 +17,6 @@ use function strtolower;
 class DateSubFunction extends DateAddFunction
 {
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)

--- a/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
@@ -23,7 +23,6 @@ class LengthFunction extends FunctionNode implements TypedExpression
     public $stringPrimary;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -34,7 +33,6 @@ class LengthFunction extends FunctionNode implements TypedExpression
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -27,7 +27,6 @@ class LocateFunction extends FunctionNode
     public $simpleArithmeticExpression = false;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -49,7 +48,6 @@ class LocateFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
@@ -22,7 +22,6 @@ class LowerFunction extends FunctionNode
     public $stringPrimary;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -34,7 +33,6 @@ class LowerFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -23,7 +23,6 @@ class ModFunction extends FunctionNode
     public $secondSimpleArithmeticExpression;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -35,7 +34,6 @@ class ModFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -23,7 +23,6 @@ class SizeFunction extends FunctionNode
     public $collectionPathExpression;
 
     /**
-     * @override
      * @inheritdoc
      * @todo If the collection being counted is already joined, the SQL can be simpler (more efficient).
      */
@@ -104,7 +103,6 @@ class SizeFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -22,7 +22,6 @@ class SqrtFunction extends FunctionNode
     public $simpleArithmeticExpression;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -34,7 +33,6 @@ class SqrtFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -27,7 +27,6 @@ class SubstringFunction extends FunctionNode
     public $secondSimpleArithmeticExpression = null;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -45,7 +44,6 @@ class SubstringFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
@@ -22,7 +22,6 @@ class UpperFunction extends FunctionNode
     public $stringPrimary;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -34,7 +33,6 @@ class UpperFunction extends FunctionNode
     }
 
     /**
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -23,7 +23,6 @@ class RowNumberOverFunction extends FunctionNode
     public $orderByClause;
 
     /**
-     * @override
      * @inheritdoc
      */
     public function getSql(SqlWalker $sqlWalker)
@@ -36,7 +35,6 @@ class RowNumberOverFunction extends FunctionNode
     /**
      * @throws RowNumberOverFunctionNotEnabled
      *
-     * @override
      * @inheritdoc
      */
     public function parse(Parser $parser)

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -557,8 +557,6 @@ class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
 
     /**
      * @psalm-param class-string<object> $className
-     *
-     * @override
      */
     protected function newClassMetadataInstance($className): ClassMetadata
     {

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2345,17 +2345,11 @@ class MyAbsFunction extends FunctionNode
     /** @var SimpleArithmeticExpression */
     public $simpleArithmeticExpression;
 
-    /**
-     * @override
-     */
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'ABS(' . $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression) . ')';
     }
 
-    /**
-     * @override
-     */
     public function parse(Parser $parser): void
     {
         $lexer = $parser->getLexer();


### PR DESCRIPTION
Given how little occurrences there are, signalling method overrides with
this tag is probably not something we do everywhere. Besides, it does
not seem to be standard.

See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/index.html#tag-reference