### PR TITLE
Document callable as possible

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -608,7 +608,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
-     * @psalm-return ?class-string
+     * @psalm-return class-string|callable|null
      */
     public function getCustomStringFunction($name)
     {
@@ -625,8 +625,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * Any previously added string functions are discarded.
      *
-     * @psalm-param array<string, class-string> $functions The map of custom
-     *                                                     DQL string functions.
+     * @psalm-param array<string, class-string|callable> $functions The map of custom DQL string functions.
      *
      * @return void
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -477,7 +477,7 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 3
+			count: 2
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2061,8 +2061,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$stringPattern</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="3">
-      <code>call_user_func($functionClass, $functionName)</code>
+    <DocblockTypeContradiction occurrences="2">
       <code>call_user_func($functionClass, $functionName)</code>
       <code>call_user_func($functionClass, $functionName)</code>
     </DocblockTypeContradiction>
@@ -2117,6 +2116,9 @@
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
     </InvalidScalarArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $functionClass($functionName)</code>
+    </InvalidStringClass>
     <LessSpecificReturnStatement occurrences="4">
       <code>$function</code>
       <code>$function</code>
@@ -2250,9 +2252,8 @@
     <PossiblyUndefinedVariable occurrences="1">
       <code>$args</code>
     </PossiblyUndefinedVariable>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="3">
       <code>$AST instanceof AST\SelectStatement</code>
-      <code>is_string($functionClass)</code>
       <code>is_string($functionClass)</code>
       <code>is_string($functionClass)</code>
     </RedundantConditionGivenDocblockType>


### PR DESCRIPTION
Custom string functions can either be a class string or a callable
returning the function.


https://github.com/doctrine/orm/blob/8f7701279de84411020304f668cc8b49a5afbf5a/lib/Doctrine/ORM/Query/Parser.php#L3636-L3654

As a follow up, I will make this more precise in 2.13.x (using `class-string<FunctionNode>`, and describing the callable more precisely.