### PR TITLE
Kill call_user_func(_array)

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -35,7 +35,6 @@ use InvalidArgumentException;
 use Throwable;
 
 use function array_keys;
-use function call_user_func;
 use function class_exists;
 use function get_debug_type;
 use function gettype;
@@ -242,7 +241,7 @@ use function strpos;
         $this->conn->beginTransaction();
 
         try {
-            $return = call_user_func($func, $this);
+            $return = $func($this);
 
             $this->flush();
             $this->conn->commit();

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -12,7 +12,6 @@ use function array_combine;
 use function array_filter;
 use function array_map;
 use function array_merge;
-use function call_user_func_array;
 
 /**
  * Utility class to retrieve all reflection instance properties of a given class, including
@@ -45,10 +44,9 @@ final class ReflectionPropertiesGetter
             return $this->properties[$className];
         }
 
-        return $this->properties[$className] = call_user_func_array(
-            'array_merge',
+        return $this->properties[$className] = array_merge(
             // first merge because `array_merge` expects >= 1 params
-            array_merge(
+            ...array_merge(
                 [[]],
                 array_map(
                     [$this, 'getClassProperties'],

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -67,7 +67,6 @@ use ReflectionClass;
 use function array_intersect;
 use function array_search;
 use function assert;
-use function call_user_func;
 use function class_exists;
 use function count;
 use function explode;
@@ -3563,7 +3562,7 @@ class Parser
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)
-            : call_user_func($functionClass, $functionName);
+            : $functionClass($functionName);
 
         $function->parse($this);
 
@@ -3604,7 +3603,7 @@ class Parser
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)
-            : call_user_func($functionClass, $functionName);
+            : $functionClass($functionName);
 
         $function->parse($this);
 
@@ -3646,7 +3645,7 @@ class Parser
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)
-            : call_user_func($functionClass, $functionName);
+            : $functionClass($functionName);
 
         $function->parse($this);
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2049,10 +2049,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$stringPattern</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="2">
-      <code>call_user_func($functionClass, $functionName)</code>
-      <code>call_user_func($functionClass, $functionName)</code>
-    </DocblockTypeContradiction>
+    <DocblockTypeContradiction occurrences="2"/>
     <InvalidArgument occurrences="1">
       <code>$lookaheadType</code>
     </InvalidArgument>

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -13,7 +13,6 @@ use Doctrine\Tests\Models\Cache\State;
 use Exception;
 use RuntimeException;
 
-use function call_user_func;
 use function uniqid;
 
 /**
@@ -354,7 +353,7 @@ class ListenerSecondLevelCacheTest
     private function dispatch(string $eventName, EventArgs $args): void
     {
         if (isset($this->callbacks[$eventName])) {
-            call_user_func($this->callbacks[$eventName], $args);
+            ($this->callbacks[$eventName])($args);
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -20,7 +20,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-use function call_user_func_array;
 use function debug_backtrace;
 
 use const PHP_INT_MAX;
@@ -149,7 +148,7 @@ class DDC3634LastInsertIdMockingConnection extends Connection
     {
         $trace = debug_backtrace(0, 2)[1];
 
-        return call_user_func_array([$this->realConnection, $trace['function']], $trace['args']);
+        return $this->realConnection->{$trace['function']}(...$trace['args']);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
In modern PHP, there should be no reason to use `call_user_func()` or `call_user_func_array()` anymore. Let's get rid of that.