### PR TITLE
Deprecate passing null to Query::setDQL()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.13
 
+## Deprecated passing `null` to `Doctrine\ORM\Query::setDQL()`
+
+Doing `$query->setDQL(null);` achieves nothing.
+
 ## Deprecated omitting second argument to `NamingStrategy::joinColumnName`
 
 When implementing `NamingStrategy`, it is deprecated to implement

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -595,10 +595,19 @@ final class Query extends AbstractQuery
      */
     public function setDQL($dqlQuery): self
     {
-        if ($dqlQuery !== null) {
-            $this->dql    = $dqlQuery;
-            $this->_state = self::STATE_DIRTY;
+        if ($dqlQuery === null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9784',
+                'Calling %s with null is deprecated and will result in a TypeError in Doctrine 3.0',
+                __METHOD__
+            );
+
+            return $this;
         }
+
+        $this->dql    = $dqlQuery;
+        $this->_state = self::STATE_DIRTY;
 
         return $this;
     }

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
@@ -41,6 +42,8 @@ use const PHP_VERSION_ID;
 
 class QueryTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     /** @var EntityManagerMock */
     protected $entityManager;
 
@@ -127,6 +130,13 @@ class QueryTest extends OrmTestCase
           ->setMaxResults(10);
 
         self::assertSame($q2, $q);
+    }
+
+    public function testSettingNullDqlIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9784');
+        $q = $this->entityManager->createQuery();
+        $q->setDQL(null);
     }
 
     /**


### PR DESCRIPTION
It is a no-op.