### PR TITLE
Move duplicate fixture into dedicated file

### DIFF
--- a/tests/Doctrine/Tests/Mocks/CustomTreeWalkerJoin.php
+++ b/tests/Doctrine/Tests/Mocks/CustomTreeWalkerJoin.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks;
+
+use Doctrine\ORM\Query\AST\IdentificationVariableDeclaration;
+use Doctrine\ORM\Query\AST\Join;
+use Doctrine\ORM\Query\AST\JoinAssociationDeclaration;
+use Doctrine\ORM\Query\AST\JoinAssociationPathExpression;
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsUser;
+
+class CustomTreeWalkerJoin extends TreeWalkerAdapter
+{
+    public function walkSelectStatement(SelectStatement $selectStatement): void
+    {
+        foreach ($selectStatement->fromClause->identificationVariableDeclarations as $identificationVariableDeclaration) {
+            $rangeVariableDecl = $identificationVariableDeclaration->rangeVariableDeclaration;
+
+            if ($rangeVariableDecl->abstractSchemaName !== CmsUser::class) {
+                continue;
+            }
+
+            $this->modifySelectStatement($selectStatement, $identificationVariableDeclaration);
+        }
+    }
+
+    private function modifySelectStatement(SelectStatement $selectStatement, IdentificationVariableDeclaration $identificationVariableDecl): void
+    {
+        $rangeVariableDecl       = $identificationVariableDecl->rangeVariableDeclaration;
+        $joinAssocPathExpression = new JoinAssociationPathExpression($rangeVariableDecl->aliasIdentificationVariable, 'address');
+        $joinAssocDeclaration    = new JoinAssociationDeclaration($joinAssocPathExpression, $rangeVariableDecl->aliasIdentificationVariable . 'a', null);
+        $join                    = new Join(Join::JOIN_TYPE_LEFT, $joinAssocDeclaration);
+        $selectExpression        = new SelectExpression($rangeVariableDecl->aliasIdentificationVariable . 'a', null, false);
+
+        $identificationVariableDecl->joins[]                = $join;
+        $selectStatement->selectClause->selectExpressions[] = $selectExpression;
+
+        $entityManager   = $this->_getQuery()->getEntityManager();
+        $userMetadata    = $entityManager->getClassMetadata(CmsUser::class);
+        $addressMetadata = $entityManager->getClassMetadata(CmsAddress::class);
+
+        $this->setQueryComponent(
+            $rangeVariableDecl->aliasIdentificationVariable . 'a',
+            [
+                'metadata'     => $addressMetadata,
+                'parent'       => $rangeVariableDecl->aliasIdentificationVariable,
+                'relation'     => $userMetadata->getAssociationMapping('address'),
+                'map'          => null,
+                'nestingLevel' => 0,
+                'token'        => null,
+            ]
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\ORM\Functional;
+namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TreeWalker;
-use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Mocks\CustomTreeWalkerJoin;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 
@@ -194,49 +194,5 @@ class CustomTreeWalker extends Query\TreeWalkerAdapter
             $whereClause                  = new Query\AST\WhereClause($condExpr);
             $selectStatement->whereClause = $whereClause;
         }
-    }
-}
-
-class CustomTreeWalkerJoin extends Query\TreeWalkerAdapter
-{
-    public function walkSelectStatement(Query\AST\SelectStatement $selectStatement): void
-    {
-        foreach ($selectStatement->fromClause->identificationVariableDeclarations as $identificationVariableDeclaration) {
-            $rangeVariableDecl = $identificationVariableDeclaration->rangeVariableDeclaration;
-
-            if ($rangeVariableDecl->abstractSchemaName !== CmsUser::class) {
-                continue;
-            }
-
-            $this->modifySelectStatement($selectStatement, $identificationVariableDeclaration);
-        }
-    }
-
-    private function modifySelectStatement(Query\AST\SelectStatement $selectStatement, $identificationVariableDecl): void
-    {
-        $rangeVariableDecl       = $identificationVariableDecl->rangeVariableDeclaration;
-        $joinAssocPathExpression = new Query\AST\JoinAssociationPathExpression($rangeVariableDecl->aliasIdentificationVariable, 'address');
-        $joinAssocDeclaration    = new Query\AST\JoinAssociationDeclaration($joinAssocPathExpression, $rangeVariableDecl->aliasIdentificationVariable . 'a', null);
-        $join                    = new Query\AST\Join(Query\AST\Join::JOIN_TYPE_LEFT, $joinAssocDeclaration);
-        $selectExpression        = new Query\AST\SelectExpression($rangeVariableDecl->aliasIdentificationVariable . 'a', null, false);
-
-        $identificationVariableDecl->joins[]                = $join;
-        $selectStatement->selectClause->selectExpressions[] = $selectExpression;
-
-        $entityManager   = $this->_getQuery()->getEntityManager();
-        $userMetadata    = $entityManager->getClassMetadata(CmsUser::class);
-        $addressMetadata = $entityManager->getClassMetadata(CmsAddress::class);
-
-        $this->setQueryComponent(
-            $rangeVariableDecl->aliasIdentificationVariable . 'a',
-            [
-                'metadata'     => $addressMetadata,
-                'parent'       => $rangeVariableDecl->aliasIdentificationVariable,
-                'relation'     => $userMetadata->getAssociationMapping('address'),
-                'map'          => null,
-                'nestingLevel' => 0,
-                'token'        => null,
-            ]
-        );
     }
 }


### PR DESCRIPTION
Two tests used the exact same fixture class `CustomTreeWalkerJoin`. This was only possible because one of the tests declared a namespace that did not match the directory structure. I've extracted that class into a dedicated file and fixed the namespace.