### PR TITLE
Deprecate calling setters without arguments

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.13
 
+## Deprecated calling setters without arguments
+
+The following methods will require an argument in 3.0. Pass `null` instead of
+omitting the argument.
+
+* `Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs::setFoundMetadata()`
+* `Doctrine\ORM\AbstractQuery::setHydrationCacheProfile()`
+* `Doctrine\ORM\AbstractQuery::setResultCache()`
+* `Doctrine\ORM\AbstractQuery::setResultCacheProfile()`
+
 ## Deprecated passing invalid fetch modes to `AbstractQuery::setFetchMode()`
 
 Calling `AbstractQuery::setFetchMode()` with anything else than

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -32,6 +32,7 @@ use function array_map;
 use function array_shift;
 use function assert;
 use function count;
+use function func_num_args;
 use function in_array;
 use function is_array;
 use function is_numeric;
@@ -548,6 +549,15 @@ abstract class AbstractQuery
     public function setHydrationCacheProfile(?QueryCacheProfile $profile = null)
     {
         if ($profile === null) {
+            if (func_num_args() < 1) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/pull/9791',
+                    'Calling %s without arguments is deprecated, pass null instead.',
+                    __METHOD__
+                );
+            }
+
             $this->_hydrationCacheProfile = null;
 
             return $this;
@@ -592,6 +602,15 @@ abstract class AbstractQuery
     public function setResultCacheProfile(?QueryCacheProfile $profile = null)
     {
         if ($profile === null) {
+            if (func_num_args() < 1) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/pull/9791',
+                    'Calling %s without arguments is deprecated, pass null instead.',
+                    __METHOD__
+                );
+            }
+
             $this->_queryCacheProfile = null;
 
             return $this;
@@ -646,6 +665,15 @@ abstract class AbstractQuery
     public function setResultCache(?CacheItemPoolInterface $resultCache = null)
     {
         if ($resultCache === null) {
+            if (func_num_args() < 1) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/pull/9791',
+                    'Calling %s without arguments is deprecated, pass null instead.',
+                    __METHOD__
+                );
+            }
+
             if ($this->_queryCacheProfile) {
                 $this->_queryCacheProfile = new QueryCacheProfile($this->_queryCacheProfile->getLifetime(), $this->_queryCacheProfile->getCacheKey());
             }

--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
+
+use function func_num_args;
 
 /**
  * Class that holds event arguments for a `onClassMetadataNotFound` event.
@@ -41,6 +44,15 @@ class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
      */
     public function setFoundMetadata(?ClassMetadata $classMetadata = null)
     {
+        if (func_num_args() < 1) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9791',
+                'Calling %s without arguments is deprecated, pass null instead.',
+                __METHOD__
+            );
+        }
+
         $this->foundMetadata = $classMetadata;
     }
 

--- a/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
@@ -70,6 +70,31 @@ final class AbstractQueryTest extends TestCase
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
     }
 
+    /**
+     * @dataProvider provideSettersWithDeprecatedDefault
+     */
+    public function testCallingSettersWithoutArgumentsIsDeprecated(string $setter): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn(new Configuration());
+        $query = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9791');
+        $query->$setter();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function provideSettersWithDeprecatedDefault(): array
+    {
+        return [
+            'setHydrationCacheProfile' => ['setHydrationCacheProfile'],
+            'setResultCache' => ['setResultCache'],
+            'setResultCacheProfile' => ['setResultCacheProfile'],
+        ];
+    }
+
     public function testSettingTheResultCacheIsPossibleWithoutCallingDeprecatedMethods(): void
     {
         $cache = $this->createMock(CacheItemPoolInterface::class);


### PR DESCRIPTION
Calling a setter without anything to set does not really make sense semantically. However, declaring `null` as the default value for a parameter used to be a common workaround to get a nullable typed parameter. This workaround is obsolete since PHP 7.1 introduced actual nullable types.

This is why I'd like to get rid of those default values on setters.