### PR TITLE
Update IdentifierFlattener.php

### DIFF
--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -55,7 +55,7 @@ final class IdentifierFlattener
         $flatId = [];
 
         foreach ($class->identifier as $field) {
-            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_object($id[$field])) {
+            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_a($id[$field], $class->associationMappings[$field]['targetEntity'])) {
                 $targetClassMetadata = $this->metadataFactory->getMetadataFor(
                     $class->associationMappings[$field]['targetEntity']
                 );

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -11,7 +11,7 @@ use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 
 use function assert;
 use function implode;
-use function is_object;
+use function is_a;
 
 /**
  * The IdentifierFlattener utility now houses some of the identifier manipulation logic from unit of work, so that it


### PR DESCRIPTION
Hello, I would like to make a small change.
The need arose when using \Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator in "symfony/doctrine-bridge" composite foreign keys
I'm sure these changes will not hurt performance
and allow other objects to be used as identifiers