### PR TITLE
Add missing import

### DIFF
--- a/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use stdClass;
 
 final class AbstractQueryTest extends TestCase
 {


### PR DESCRIPTION
This PR fixes a test added in #9777. In the end, it does not matter that we reference `stdClass` without import because that class reference is not actually used. But I don't think that it was actually intended to work with an undefined class here.