### PR TITLE
Rename Abstract*Test to *TestCase

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -15,10 +15,10 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function array_map;
 
 /**
- * @extends AbstractRegionTest<DefaultRegion>
+ * @extends RegionTestCase<DefaultRegion>
  * @group DDC-2183
  */
-class DefaultRegionTest extends AbstractRegionTest
+class DefaultRegionTest extends RegionTestCase
 {
     protected function createRegion(): Region
     {

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -29,10 +29,10 @@ use function unlink;
 use const E_WARNING;
 
 /**
- * @extends AbstractRegionTest<FileLockRegion>
+ * @extends RegionTestCase<FileLockRegion>
  * @group DDC-2183
  */
-class FileLockRegionTest extends AbstractRegionTest
+class FileLockRegionTest extends RegionTestCase
 {
     /** @var string */
     protected $directory;

--- a/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
@@ -11,9 +11,9 @@ use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
 
 /**
- * @extends AbstractRegionTest<DefaultMultiGetRegion>
+ * @extends RegionTestCase<DefaultMultiGetRegion>
  */
-class MultiGetRegionTest extends AbstractRegionTest
+class MultiGetRegionTest extends RegionTestCase
 {
     protected function createRegion(): Region
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/CollectionPersisterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/CollectionPersisterTestCase.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @group DDC-2183
  */
-abstract class AbstractCollectionPersisterTest extends OrmTestCase
+abstract class CollectionPersisterTestCase extends OrmTestCase
 {
     /** @var Region&MockObject */
     protected $region;

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 /**
  * @group DDC-2183
  */
-class NonStrictReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersisterTest
+class NonStrictReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 /**
  * @group DDC-2183
  */
-class ReadOnlyCachedCollectionPersisterTest extends AbstractCollectionPersisterTest
+class ReadOnlyCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
     protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
 /**
  * @group DDC-2183
  */
-class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersisterTest
+class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
     protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @group DDC-2183
  */
-abstract class AbstractEntityPersisterTest extends OrmTestCase
+abstract class EntityPersisterTestCase extends OrmTestCase
 {
     /** @var Region&MockObject */
     protected $region;

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
 /**
  * @group DDC-2183
  */
-class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
+class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
 {
     protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
@@ -16,7 +16,7 @@ use Doctrine\Tests\Models\Cache\Country;
 /**
  * @group DDC-2183
  */
-class ReadOnlyCachedEntityPersisterTest extends AbstractEntityPersisterTest
+class ReadOnlyCachedEntityPersisterTest extends EntityPersisterTestCase
 {
     protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -19,7 +19,7 @@ use ReflectionProperty;
 /**
  * @group DDC-2183
  */
-class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
+class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
 {
     protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata): AbstractEntityPersister
     {

--- a/tests/Doctrine/Tests/ORM/Cache/RegionTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/RegionTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  * @template TRegion of Region
  * @group DDC-2183
  */
-abstract class AbstractRegionTest extends OrmFunctionalTestCase
+abstract class RegionTestCase extends OrmFunctionalTestCase
 {
     /**
      * @var Region

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\Models\Cache\Flight;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testPutAndLoadCompositPrimaryKeyEntities(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -21,7 +21,7 @@ use function assert;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheConcurrentTest extends SecondLevelCacheFunctionalTestCase
 {
     /** @var CacheFactorySecondLevelCacheConcurrentTest */
     private $cacheFactory;

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
@@ -12,7 +12,7 @@ use Doctrine\Tests\Models\Cache\State;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testMatchingPut(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
@@ -12,7 +12,7 @@ use Doctrine\Tests\Models\Cache\Travel;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheExtraLazyCollectionTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheExtraLazyCollectionTest extends SecondLevelCacheFunctionalTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheFunctionalTestCase.php
@@ -26,7 +26,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 /**
  * @group DDC-2183
  */
-abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
+abstract class SecondLevelCacheFunctionalTestCase extends OrmFunctionalTestCase
 {
     /** @psalm-var list<Person> */
     protected $people = [];

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
@@ -16,7 +16,7 @@ use function get_class;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testUseSameRegion(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\Models\Cache\Traveler;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheManyToManyTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testShouldPutManyToManyCollectionOwningSideOnPersist(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php
@@ -15,7 +15,7 @@ use Doctrine\Tests\Models\Cache\Token;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheManyToOneTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheManyToOneTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testPutOnPersist(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
@@ -17,7 +17,7 @@ use function sprintf;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheOneToManyTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheOneToManyTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testShouldPutCollectionInverseSideOnPersist(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
@@ -16,7 +16,7 @@ use Doctrine\Tests\Models\Cache\TravelerProfileInfo;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheOneToOneTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testPutOneToOneOnUnidirectionalPersist(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -22,7 +22,7 @@ use ReflectionMethod;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testBasicQueryCache(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\Models\Cache\State;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testRepositoryCacheFind(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
@@ -17,7 +17,7 @@ use function get_class;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testUseSameRegion(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -18,7 +18,7 @@ use function uniqid;
 /**
  * @group DDC-2183
  */
-class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
+class SecondLevelCacheTest extends SecondLevelCacheFunctionalTestCase
 {
     public function testPutOnPersist(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3967Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3967Test.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Cache\Country;
-use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheFunctionalTestCase;
 
 use function array_pop;
 use function assert;
 
-class DDC3967Test extends SecondLevelCacheAbstractTest
+class DDC3967Test extends SecondLevelCacheFunctionalTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC4003Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC4003Test.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Cache\Bar;
-use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheFunctionalTestCase;
 
 use function assert;
 use function uniqid;
 
-class DDC4003Test extends SecondLevelCacheAbstractTest
+class DDC4003Test extends SecondLevelCacheFunctionalTestCase
 {
     public function testReadsThroughRepositorySameDataThatItWroteInCache(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -6,11 +6,11 @@ namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Cache\Attraction;
 use Doctrine\Tests\Models\Cache\Bar;
-use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheFunctionalTestCase;
 
 use function assert;
 
-class DDC7969Test extends SecondLevelCacheAbstractTest
+class DDC7969Test extends SecondLevelCacheFunctionalTestCase
 {
     public function testChildEntityRetrievedFromCache(): void
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -40,7 +40,7 @@ use Generator;
 use function class_exists;
 use function is_subclass_of;
 
-class AnnotationDriverTest extends AbstractMappingDriverTest
+class AnnotationDriverTest extends MappingDriverTestCase
 {
     /**
      * @group DDC-268

--- a/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -17,7 +17,7 @@ use function is_subclass_of;
 
 use const PHP_VERSION_ID;
 
-class AttributeDriverTest extends AbstractMappingDriverTest
+class AttributeDriverTest extends MappingDriverTestCase
 {
     /** @before */
     public function requiresPhp8Assertion(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -81,7 +81,7 @@ use function strtolower;
 use const CASE_UPPER;
 use const PHP_VERSION_ID;
 
-abstract class AbstractMappingDriverTest extends OrmTestCase
+abstract class MappingDriverTestCase extends OrmTestCase
 {
     abstract protected function loadDriver(): MappingDriver;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\ORM\Mapping;
 
 use const DIRECTORY_SEPARATOR;
 
-class PHPMappingDriverTest extends AbstractMappingDriverTest
+class PHPMappingDriverTest extends MappingDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\Models\DDC889\DDC889Class;
 
 use const DIRECTORY_SEPARATOR;
 
-class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
+class StaticPHPMappingDriverTest extends MappingDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/DriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/DriverTestCase.php
@@ -19,7 +19,7 @@ use function unlink;
 /**
  * @group DDC-1418
  */
-abstract class AbstractDriverTest extends TestCase
+abstract class DriverTestCase extends TestCase
 {
     /** @var string */
     private $dir;

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/XmlDriverTest.php
@@ -12,7 +12,7 @@ use function array_flip;
 /**
  * @group DDC-1418
  */
-class XmlDriverTest extends AbstractDriverTest
+class XmlDriverTest extends DriverTestCase
 {
     protected function getFileExtension(): string
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
@@ -12,7 +12,7 @@ use function array_flip;
 /**
  * @group DDC-1418
  */
-class YamlDriverTest extends AbstractDriverTest
+class YamlDriverTest extends DriverTestCase
 {
     protected function getFileExtension(): string
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -28,7 +28,7 @@ use function substr_count;
 
 use const DIRECTORY_SEPARATOR;
 
-class XmlMappingDriverTest extends AbstractMappingDriverTest
+class XmlMappingDriverTest extends MappingDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -18,7 +18,7 @@ use function class_exists;
 
 use const DIRECTORY_SEPARATOR;
 
-class YamlMappingDriverTest extends AbstractMappingDriverTest
+class YamlMappingDriverTest extends MappingDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
@@ -9,7 +9,7 @@ namespace Doctrine\Tests\ORM\Tools\Export;
  *
  * @link        http://www.phpdoctrine.org
  */
-class AnnotationClassMetadataExporterTest extends AbstractClassMetadataExporterTest
+class AnnotationClassMetadataExporterTest extends ClassMetadataExporterTestCase
 {
     protected function getType(): string
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
@@ -42,7 +42,7 @@ use function unlink;
  *
  * @link        http://www.phpdoctrine.org
  */
-abstract class AbstractClassMetadataExporterTest extends OrmTestCase
+abstract class ClassMetadataExporterTestCase extends OrmTestCase
 {
     /** @var string|null */
     protected $extension;

--- a/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
@@ -9,7 +9,7 @@ namespace Doctrine\Tests\ORM\Tools\Export;
  *
  * @link        http://www.phpdoctrine.org
  */
-class PhpClassMetadataExporterTest extends AbstractClassMetadataExporterTest
+class PhpClassMetadataExporterTest extends ClassMetadataExporterTestCase
 {
     protected function getType(): string
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Tools\Export\Driver\XmlExporter;
  *
  * @link        http://www.phpdoctrine.org
  */
-class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
+class XmlClassMetadataExporterTest extends ClassMetadataExporterTestCase
 {
     protected function getType(): string
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
@@ -11,7 +11,7 @@ use function class_exists;
  *
  * @link        http://www.phpdoctrine.org
  */
-class YamlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
+class YamlClassMetadataExporterTest extends ClassMetadataExporterTestCase
 {
     protected function getType(): string
     {


### PR DESCRIPTION
PHPUnit 10 will complain about abstract classes suffixed with `Test`. This is why I've renamed all of those classes to use the suffix `TestCase` instead. Since we use that suffix already for some of the abstract test case classes, our class naming should become a little more consistent this way.