### PR TITLE
Remove calls to deprecated `MockBuilder::setMethods()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -26,6 +26,7 @@ use Doctrine\Tests\Models\Cache\AttractionLocationInfo;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -36,6 +37,8 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class DefaultCacheFactoryTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
+
     /** @var CacheFactory&MockObject */
     private $factory;
 
@@ -53,8 +56,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->em            = $this->getTestEntityManager();
         $this->regionsConfig = new RegionsConfiguration();
         $arguments           = [$this->regionsConfig, $this->getSharedSecondLevelCache()];
-        $this->factory       = $this->getMockBuilder(DefaultCacheFactory::class)
-                                    ->setMethods(['getRegion'])
+        $this->factory       = $this->getMockBuilderWithOnlyMethods(DefaultCacheFactory::class, ['getRegion'])
                                     ->setConstructorArgs($arguments)
                                     ->getMock();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -128,19 +128,14 @@ class QueryCacheTest extends OrmFunctionalTestCase
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
         $sqlExecMock = $this->getMockBuilder(AbstractSqlExecutor::class)
-                            ->setMethods(['execute'])
-                            ->getMock();
+                            ->getMockForAbstractClass();
 
         $sqlExecMock->expects(self::once())
                     ->method('execute')
                     ->willReturn(10);
 
-        $parserResultMock = $this->getMockBuilder(ParserResult::class)
-                                 ->setMethods(['getSqlExecutor'])
-                                 ->getMock();
-        $parserResultMock->expects(self::once())
-                         ->method('getSqlExecutor')
-                         ->willReturn($sqlExecMock);
+        $parserResultMock = new ParserResult();
+        $parserResultMock->setSqlExecutor($sqlExecMock);
 
         $cache = $this->createMock(CacheItemPoolInterface::class);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -15,16 +15,16 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
-use PHPUnit\Framework\MockObject\MockObject;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\TestCase;
-
-use function assert;
 
 /**
  * @group DDC-2359
  */
 class DDC2359Test extends TestCase
 {
+    use MockBuilderCompatibilityTools;
+
     /**
      * Verifies that {@see \Doctrine\ORM\Mapping\ClassMetadataFactory::wakeupReflection} is
      * not called twice when loading metadata from a driver
@@ -35,14 +35,13 @@ class DDC2359Test extends TestCase
         $mockMetadata  = $this->createMock(ClassMetadata::class);
         $entityManager = $this->createMock(EntityManager::class);
 
-        $metadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)
-                                ->setMethods(['newClassMetadataInstance', 'wakeupReflection'])
-                                ->getMock();
-        assert($metadataFactory instanceof ClassMetadataFactory || $metadataFactory instanceof MockObject);
+        $metadataFactory = $this
+            ->getMockBuilderWithOnlyMethods(ClassMetadataFactory::class, ['newClassMetadataInstance', 'wakeupReflection'])
+            ->getMock();
 
-        $configuration = $this->getMockBuilder(Configuration::class)
-                              ->setMethods(['getMetadataDriverImpl'])
-                              ->getMock();
+        $configuration = $this
+            ->getMockBuilderWithOnlyMethods(Configuration::class, ['getMetadataDriverImpl'])
+            ->getMock();
 
         $connection = $this->createMock(Connection::class);
 

--- a/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -60,8 +60,7 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
         $this->hydrator = $this
             ->getMockBuilder(AbstractHydrator::class)
             ->setConstructorArgs([$mockEntityManagerInterface])
-            ->setMethods(['hydrateAllData'])
-            ->getMock();
+            ->getMockForAbstractClass();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -26,11 +26,14 @@ use Doctrine\Tests\Models\Forum\ForumBoard;
 use Doctrine\Tests\Models\Forum\ForumCategory;
 use Doctrine\Tests\Models\Hydration\EntityWithArrayDefaultArrayValueM2M;
 use Doctrine\Tests\Models\Hydration\SimpleEntity;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 
 use function count;
 
 class ObjectHydratorTest extends HydrationTestCase
 {
+    use MockBuilderCompatibilityTools;
+
     /**
      * @psalm-return list<array{mixed}>
      */
@@ -1032,8 +1035,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyInstance = new ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMockBuilder(ProxyFactory::class)
-                             ->setMethods(['getProxy'])
+        $proxyFactory = $this->getMockBuilderWithOnlyMethods(ProxyFactory::class, ['getProxy'])
                              ->disableOriginalConstructor()
                              ->getMock();
 
@@ -1081,8 +1083,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyInstance = new ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMockBuilder(ProxyFactory::class)
-                             ->setMethods(['getProxy'])
+        $proxyFactory = $this->getMockBuilderWithOnlyMethods(ProxyFactory::class, ['getProxy'])
                              ->disableOriginalConstructor()
                              ->getMock();
 

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -9,9 +9,12 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Id\SequenceGenerator;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 
 class SequenceGeneratorTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
+
     public function testGeneration(): void
     {
         $sequenceGenerator = new SequenceGenerator('seq', 10);
@@ -20,9 +23,8 @@ class SequenceGeneratorTest extends OrmTestCase
         $platform->method('getSequenceNextValSQL')
             ->willReturn('');
 
-        $connection = $this->getMockBuilder(Connection::class)
+        $connection = $this->getMockBuilderWithOnlyMethods(Connection::class, ['fetchOne', 'getDatabasePlatform'])
             ->setConstructorArgs([[], $this->createMock(Driver::class)])
-            ->setMethods(['fetchOne', 'getDatabasePlatform'])
             ->getMock();
         $connection->method('getDatabasePlatform')
             ->willReturn($platform);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -39,11 +39,12 @@ use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use DoctrineGlobalArticle;
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
-use stdClass;
 
 use function array_search;
 use function assert;
@@ -53,6 +54,7 @@ use function sprintf;
 
 class ClassMetadataFactoryTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
     use VerifyDeprecations;
 
     public function testGetMetadataForSingleClass(): void
@@ -259,15 +261,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         self::assertEquals($childDiscriminatorMap, $rootDiscriminatorMap);
         self::assertEquals($anotherChildDiscriminatorMap, $rootDiscriminatorMap);
-
-        // ClassMetadataFactory::addDefaultDiscriminatorMap shouldn't be called again, because the
-        // discriminator map is already cached
-        $cmf = $this->getMockBuilder(ClassMetadataFactory::class)->setMethods(['addDefaultDiscriminatorMap'])->getMock();
-        $cmf->setEntityManager($em);
-        $cmf->expects(self::never())
-            ->method('addDefaultDiscriminatorMap');
-
-        $rootMetadata = $cmf->getMetadataFor(RootClass::class);
     }
 
     public function testGetAllMetadataWorksWithBadConnection(): void
@@ -432,23 +425,31 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cmf          = new ClassMetadataFactory();
         $mockDriver   = new MetadataDriverMock();
         $em           = $this->createEntityManager($mockDriver);
-        $listener     = $this->getMockBuilder(stdClass::class)->setMethods(['onClassMetadataNotFound'])->getMock();
         $eventManager = $em->getEventManager();
 
         $cmf->setEntityManager($em);
 
-        $listener
-            ->expects(self::any())
-            ->method('onClassMetadataNotFound')
-            ->will(self::returnCallback(static function (OnClassMetadataNotFoundEventArgs $args) use ($metadata, $em): void {
-                self::assertNull($args->getFoundMetadata());
-                self::assertSame('Foo', $args->getClassName());
-                self::assertSame($em, $args->getObjectManager());
+        $eventManager->addEventListener([Events::onClassMetadataNotFound], new class ($metadata, $em) {
+            /** @var ClassMetadata */
+            private $metadata;
+            /** @var EntityManagerInterface */
+            private $em;
 
-                $args->setFoundMetadata($metadata);
-            }));
+            public function __construct(ClassMetadata $metadata, EntityManagerInterface $em)
+            {
+                $this->metadata = $metadata;
+                $this->em       = $em;
+            }
 
-        $eventManager->addEventListener([Events::onClassMetadataNotFound], $listener);
+            public function onClassMetadataNotFound(OnClassMetadataNotFoundEventArgs $args): void
+            {
+                Assert::assertNull($args->getFoundMetadata());
+                Assert::assertSame('Foo', $args->getClassName());
+                Assert::assertSame($this->em, $args->getObjectManager());
+
+                $args->setFoundMetadata($this->metadata);
+            }
+        });
 
         self::assertSame($metadata, $cmf->getMetadataFor('Foo'));
     }

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Stringable;
 
 use function spl_object_id;
 use function uniqid;
@@ -59,7 +60,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
         $stringEntity3 = uniqid('entity3', true);
         $entity1       = new stdClass();
         $entity2       = new stdClass();
-        $entity3       = $this->getMockBuilder(stdClass::class)->setMethods(['__toString'])->getMock();
+        $entity3       = $this->createMock(Stringable::class);
         $association1  = [
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
@@ -76,7 +77,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
             'targetEntity' => 'baz3',
         ];
 
-        $entity3->expects(self::any())->method('__toString')->willReturn($stringEntity3);
+        $entity3->method('__toString')->willReturn($stringEntity3);
 
         return [
             'one entity found' => [

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -20,6 +20,7 @@ use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use ReflectionProperty;
 use stdClass;
 
@@ -31,6 +32,8 @@ use function sys_get_temp_dir;
  */
 class ProxyFactoryTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
+
     /** @var UnitOfWorkMock */
     private $uowMock;
 
@@ -60,7 +63,9 @@ class ProxyFactoryTest extends OrmTestCase
     {
         $identifier = ['id' => 42];
         $proxyClass = 'Proxies\__CG__\Doctrine\Tests\Models\ECommerce\ECommerceFeature';
-        $persister  = $this->getMockBuilder(BasicEntityPersister::class)->setMethods(['load'])->disableOriginalConstructor()->getMock();
+        $persister  = $this->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['load'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->uowMock->setEntityPersister(ECommerceFeature::class, $persister);
 
@@ -122,8 +127,7 @@ class ProxyFactoryTest extends OrmTestCase
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized(): void
     {
         $persister = $this
-            ->getMockBuilder(BasicEntityPersister::class)
-            ->setMethods(['load', 'getClassMetadata'])
+            ->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['load', 'getClassMetadata'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->uowMock->setEntityPersister(ECommerceFeature::class, $persister);
@@ -153,8 +157,7 @@ class ProxyFactoryTest extends OrmTestCase
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized(): void
     {
         $persister = $this
-            ->getMockBuilder(BasicEntityPersister::class)
-            ->setMethods(['load', 'getClassMetadata'])
+            ->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['load', 'getClassMetadata'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->uowMock->setEntityPersister(ECommerceFeature::class, $persister);
@@ -193,8 +196,7 @@ class ProxyFactoryTest extends OrmTestCase
         $classMetaData = $this->emMock->getClassMetadata(CompanyEmployee::class);
 
         $persister = $this
-            ->getMockBuilder(BasicEntityPersister::class)
-            ->setMethods(['load', 'getClassMetadata'])
+            ->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['load', 'getClassMetadata'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->uowMock->setEntityPersister(CompanyEmployee::class, $persister);

--- a/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
@@ -28,7 +28,7 @@ class ParserResultTest extends TestCase
     {
         self::assertNull($this->parserResult->getSqlExecutor());
 
-        $executor = $this->getMockBuilder(AbstractSqlExecutor::class)->setMethods(['execute'])->getMock();
+        $executor = $this->getMockForAbstractClass(AbstractSqlExecutor::class);
         $this->parserResult->setSqlExecutor($executor);
         self::assertSame($executor, $this->parserResult->getSqlExecutor());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -13,10 +13,13 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class PaginatorTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
+
     /** @var Connection&MockObject */
     private $connection;
     /** @var EntityManagerInterface&MockObject */
@@ -26,14 +29,12 @@ class PaginatorTest extends OrmTestCase
 
     protected function setUp(): void
     {
-        $this->connection = $this->getMockBuilder(ConnectionMock::class)
+        $this->connection = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['executeQuery'])
             ->setConstructorArgs([[], $this->createMock(Driver::class)])
-            ->setMethods(['executeQuery'])
             ->getMock();
 
-        $this->em = $this->getMockBuilder(EntityManagerDecorator::class)
+        $this->em = $this->getMockBuilderWithOnlyMethods(EntityManagerDecorator::class, ['newHydrator'])
             ->setConstructorArgs([$this->getTestEntityManager($this->connection)])
-            ->setMethods(['newHydrator'])
             ->getMock();
 
         $this->hydrator = $this->createMock(AbstractHydrator::class);

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -38,6 +38,7 @@ use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\GeoNames\City;
 use Doctrine\Tests\Models\GeoNames\Country;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
@@ -54,6 +55,7 @@ use function uniqid;
  */
 class UnitOfWorkTest extends OrmTestCase
 {
+    use MockBuilderCompatibilityTools;
     use VerifyDeprecations;
 
     /**
@@ -848,9 +850,8 @@ class UnitOfWorkTest extends OrmTestCase
             ->willReturn($this->createMock(Driver\Connection::class));
 
         // Set another connection mock that fail on commit
-        $this->_connectionMock = $this->getMockBuilder(ConnectionMock::class)
+        $this->_connectionMock = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['commit'])
             ->setConstructorArgs([[], $driver])
-            ->setMethods(['commit'])
             ->getMock();
         $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null, $this->eventManager);
         $this->_unitOfWork     = new UnitOfWorkMock($this->_emMock);

--- a/tests/Doctrine/Tests/PHPUnitCompatibility/MockBuilderCompatibilityTools.php
+++ b/tests/Doctrine/Tests/PHPUnitCompatibility/MockBuilderCompatibilityTools.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\PHPUnitCompatibility;
+
+use PHPUnit\Framework\MockObject\MockBuilder;
+
+use function method_exists;
+
+trait MockBuilderCompatibilityTools
+{
+    /**
+     * @param list<string> $onlyMethods
+     * @psalm-param class-string<TMockedType> $className
+     *
+     * @psalm-return MockBuilder<TMockedType>
+     *
+     * @template TMockedType of object
+     */
+    private function getMockBuilderWithOnlyMethods(string $className, array $onlyMethods): MockBuilder
+    {
+        $builder = $this->getMockBuilder($className);
+
+        return method_exists($builder, 'onlyMethods')
+            ? $builder->onlyMethods($onlyMethods) // PHPUnit 8+
+            : $builder->setMethods($onlyMethods); // PHPUnit 7
+    }
+}


### PR DESCRIPTION
`MockBuilder::setMethods()` is gone in PHPUnit 10.