### PR TITLE
Deprecate passing null to Query::setFirstResult()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.13
 
+## Deprecated passing `null` to `Doctrine\ORM\Query::setFirstResult()`
+
+`$query->setFirstResult(null);` is equivalent to `$query->setFirstResult(0)`.
+
 ## Deprecated calling setters without arguments
 
 The following methods will require an argument in 3.0. Pass `null` instead of

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -33,6 +33,7 @@ use function assert;
 use function count;
 use function get_debug_type;
 use function in_array;
+use function is_int;
 use function ksort;
 use function md5;
 use function method_exists;
@@ -656,7 +657,19 @@ final class Query extends AbstractQuery
      */
     public function setFirstResult($firstResult): self
     {
-        $this->firstResult = (int) $firstResult;
+        if (! is_int($firstResult)) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9809',
+                'Calling %s with %s is deprecated and will result in a TypeError in Doctrine 3.0. Pass an integer.',
+                __METHOD__,
+                get_debug_type($firstResult)
+            );
+
+            $firstResult = (int) $firstResult;
+        }
+
+        $this->firstResult = $firstResult;
         $this->_state      = self::STATE_DIRTY;
 
         return $this;

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -139,6 +139,13 @@ class QueryTest extends OrmTestCase
         $q->setDQL(null);
     }
 
+    public function testSettingNullFirstResultIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9809');
+        $q = $this->entityManager->createQuery();
+        $q->setFirstResult(null);
+    }
+
     /**
      * @group DDC-968
      */


### PR DESCRIPTION
The argument is cast to an integer, so the user might as well pass 0
instead, and we can require an integer.