### PR TITLE
Deprecate passing ArrayCollection instances

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.13
 
+## Deprecated passing `Traversable` to several methods
+
+You should now pass associative arrays or lists of `Parameter` objects to the
+following methods:
+
+- `Doctrine\ORM\AbstractQuery::execute()`
+- `Doctrine\ORM\AbstractQuery::setParameters()`
+- `Doctrine\ORM\AbstractQuery::toIterable()`
+- `Doctrine\ORM\QueryBuilder::setParameters()`
+
 ## Deprecated `QueryBuilder` methods and constants.
 
 1. The `QueryBuilder::getState()` method has been deprecated as the builder state is an internal concern.
@@ -394,7 +404,7 @@ function foo(EntityManagerInterface $entityManager, callable $func) {
     if (method_exists($entityManager, 'wrapInTransaction')) {
         return $entityManager->wrapInTransaction($func);
     }
-    
+
     return $entityManager->transactional($func);
 }
 ```
@@ -460,7 +470,7 @@ implementation. To work around this:
 * As a quick workaround, you can lock the doctrine/cache dependency to work around this: `composer require doctrine/cache ^1.11`.
   Note that this is only recommended as a bandaid fix, as future versions of ORM will no longer work with doctrine/cache
   1.11.
-  
+
 ## Deprecated: doctrine/cache for metadata caching
 
 The `Doctrine\ORM\Configuration#setMetadataCacheImpl()` method is deprecated and should no longer be used. Please use
@@ -485,12 +495,12 @@ Note that `toIterable()` yields results of the query, unlike `iterate()` which y
 
 # Upgrade to 2.7
 
-## Added `Doctrine\ORM\AbstractQuery#enableResultCache()` and `Doctrine\ORM\AbstractQuery#disableResultCache()` methods	
+## Added `Doctrine\ORM\AbstractQuery#enableResultCache()` and `Doctrine\ORM\AbstractQuery#disableResultCache()` methods
 
 Method `Doctrine\ORM\AbstractQuery#useResultCache()` which could be used for both enabling and disabling the cache
-(depending on passed flag) was split into two.	
+(depending on passed flag) was split into two.
 
-## Minor BC BREAK: paginator output walkers aren't be called anymore on sub-queries for queries without max results  
+## Minor BC BREAK: paginator output walkers aren't be called anymore on sub-queries for queries without max results
 
 To optimize DB interaction, `Doctrine\ORM\Tools\Pagination\Paginator` no longer fetches identifiers to be able to
 perform the pagination with join collections when max results isn't set in the query.
@@ -509,7 +519,7 @@ In the last patch of the `v2.6.x` series, we fixed a bug that was not converting
 In order to not break BC we've introduced a way to enable the fixed behavior using a boolean constructor argument. This
 argument will be removed in 3.0 and the default behavior will be the fixed one.
 
-## Deprecated: `Doctrine\ORM\AbstractQuery#useResultCache()`	
+## Deprecated: `Doctrine\ORM\AbstractQuery#useResultCache()`
 
 Method `Doctrine\ORM\AbstractQuery#useResultCache()` is deprecated because it is split into `enableResultCache()`
 and `disableResultCache()`. It will be removed in 3.0.
@@ -539,7 +549,7 @@ These related classes have been deprecated:
 
  * `Doctrine\ORM\Proxy\ProxyFactory`
  * `Doctrine\ORM\Proxy\Autoloader` - we suggest using the composer autoloader instead
- 
+
 These methods have been deprecated:
 
  * `Doctrine\ORM\Configuration#getAutoGenerateProxyClasses()`
@@ -588,7 +598,7 @@ If your code relies on single entity flushing optimisations via
 
 Said API was affected by multiple data integrity bugs due to the fact
 that change tracking was being restricted upon a subset of the managed
-entities. The ORM cannot support committing subsets of the managed 
+entities. The ORM cannot support committing subsets of the managed
 entities while also guaranteeing data integrity, therefore this
 utility was removed.
 
@@ -689,8 +699,8 @@ either:
  - map those classes as `MappedSuperclass`
 
 ## Minor BC BREAK: ``EntityManagerInterface`` instead of ``EntityManager`` in type-hints
- 
-As of 2.5, classes requiring the ``EntityManager`` in any method signature will now require 
+
+As of 2.5, classes requiring the ``EntityManager`` in any method signature will now require
 an ``EntityManagerInterface`` instead.
 If you are extending any of the following classes, then you need to check following
 signatures:
@@ -783,7 +793,7 @@ the `Doctrine\ORM\Repository\DefaultRepositoryFactory`.
 When executing DQL queries with new object expressions, instead of returning DTOs numerically indexes, it will now respect user provided aliases. Consider the following query:
 
     SELECT new UserDTO(u.id,u.name) as user,new AddressDTO(a.street,a.postalCode) as address, a.id as addressId FROM User u INNER JOIN u.addresses a WITH a.isPrimary = true
-    
+
 Previously, your result would be similar to this:
 
     array(

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
 use Psr\Cache\CacheItemPoolInterface;
+use Traversable;
 
 use function array_keys;
 use function array_values;
@@ -34,6 +35,7 @@ use function count;
 use function get_debug_type;
 use function in_array;
 use function is_int;
+use function iterator_to_array;
 use function ksort;
 use function md5;
 use function method_exists;
@@ -737,6 +739,16 @@ final class Query extends AbstractQuery
     /** {@inheritDoc} */
     public function toIterable(iterable $parameters = [], $hydrationMode = self::HYDRATE_OBJECT): iterable
     {
+        if ($parameters instanceof Traversable) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/9816',
+                'Passing a Traversable to %s is deprecated.',
+                __METHOD__
+            );
+            $parameters = iterator_to_array($parameters);
+        }
+
         $this->setHint(self::HINT_INTERNAL_ITERATION, true);
 
         return parent::toIterable($parameters, $hydrationMode);

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -6,11 +6,9 @@ namespace Doctrine\ORM\Tools\Pagination;
 
 use ArrayIterator;
 use Countable;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;
@@ -178,7 +176,7 @@ class Paginator implements Countable, IteratorAggregate
     {
         $cloneQuery = clone $query;
 
-        $cloneQuery->setParameters(clone $query->getParameters());
+        $cloneQuery->setParameters($query->getParameters()->toArray());
         $cloneQuery->setCacheable(false);
 
         foreach ($query->getHints() as $name => $value) {
@@ -250,8 +248,7 @@ class Paginator implements Countable, IteratorAggregate
     {
         $parser            = new Parser($query);
         $parameterMappings = $parser->parse()->getParameterMappings();
-        /** @var Collection|Parameter[] $parameters */
-        $parameters = $query->getParameters();
+        $parameters        = $query->getParameters();
 
         foreach ($parameters as $key => $parameter) {
             $parameterName = $parameter->getName();
@@ -261,6 +258,6 @@ class Paginator implements Countable, IteratorAggregate
             }
         }
 
-        $query->setParameters($parameters);
+        $query->setParameters($parameters->toArray());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Tests\DbalTypes\UpperCaseStringType;
@@ -203,10 +201,6 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
     public function testFluentInterface(): void
     {
-        $parameters = new ArrayCollection();
-        $parameters->add(new Parameter(1, 'foo'));
-        $parameters->add(new Parameter(2, 'bar'));
-
         $rsm = new ResultSetMapping();
 
         $q  = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
@@ -215,7 +209,7 @@ class NativeQueryTest extends OrmFunctionalTestCase
           ->expireResultCache(true)
           ->setHint('foo', 'bar')
           ->setParameter(1, 'foo')
-          ->setParameters($parameters)
+          ->setParameters([1 => 'foo', 2 => 'bar'])
           ->setResultCacheDriver(null)
           ->setResultCacheLifetime(3500);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2090Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2090Test.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Query\Parameter;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -49,11 +47,11 @@ class DDC2090Test extends OrmFunctionalTestCase
             ->set('e.startDate', ':date')
             ->set('e.salary', ':salary')
             ->where('e = :e')
-            ->setParameters(new ArrayCollection([
-                new Parameter('e', $employee1),
-                new Parameter('date', $date1),
-                new Parameter('salary', 101),
-            ]))
+            ->setParameters([
+                'e' => $employee1,
+                'date' => $date1,
+                'salary' => 101,
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -63,11 +61,11 @@ class DDC2090Test extends OrmFunctionalTestCase
             ->set('e.startDate', ':date')
             ->set('e.salary', ':salary')
             ->where('e = :e')
-            ->setParameters(new ArrayCollection([
-                new Parameter('e', $employee2),
-                new Parameter('date', $date2),
-                new Parameter('salary', 102),
-            ]))
+            ->setParameters([
+                'e' => $employee2,
+                'date' => $date2,
+                'salary' => 102,
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -87,11 +85,11 @@ class DDC2090Test extends OrmFunctionalTestCase
             ->set('e.startDate', '?1')
             ->set('e.salary', '?2')
             ->where('e = ?0')
-            ->setParameters(new ArrayCollection([
-                new Parameter('0', $employee1),
-                new Parameter('1', $date1),
-                new Parameter('2', 101),
-            ]))
+            ->setParameters([
+                '0' => $employee1,
+                '1' => $date1,
+                '2' => 101,
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -101,11 +99,11 @@ class DDC2090Test extends OrmFunctionalTestCase
             ->set('e.startDate', '?1')
             ->set('e.salary', '?2')
             ->where('e = ?0')
-            ->setParameters(new ArrayCollection([
-                new Parameter('0', $employee2),
-                new Parameter('1', $date2),
-                new Parameter('2', 102),
-            ]))
+            ->setParameters([
+                '0' => $employee2,
+                '1' => $date2,
+                '2' => 102,
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -80,7 +80,10 @@ class QueryTest extends OrmTestCase
         $parameters->add(new Parameter(1, 'foo'));
         $parameters->add(new Parameter(2, 'bar'));
 
-        $query->setParameters($parameters);
+        $query->setParameters([
+            1 => 'foo',
+            2 => 'bar',
+        ]);
 
         self::assertEquals($parameters, $query->getParameters());
     }
@@ -121,7 +124,7 @@ class QueryTest extends OrmTestCase
           ->setHint('foo', 'bar')
           ->setHint('bar', 'baz')
           ->setParameter(1, 'bar')
-          ->setParameters(new ArrayCollection([new Parameter(2, 'baz')]))
+          ->setParameters([2 => 'baz'])
           ->setResultCacheDriver(null)
           ->setResultCache(null)
           ->setResultCacheId('foo')
@@ -229,6 +232,13 @@ class QueryTest extends OrmTestCase
         }
 
         self::assertTrue(true);
+    }
+
+    public function testToIterableWithArrayCollectionParametersIsDeprecated(): void
+    {
+        $q = $this->entityManager->createQuery('SELECT u from Doctrine\Tests\Models\CMS\CmsUser u');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9816');
+        $q->toIterable(new ArrayCollection());
     }
 
     /** @group DDC-1697 */

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -642,35 +642,27 @@ class QueryBuilderTest extends OrmTestCase
         self::assertFalse($inferred->typeWasSpecified());
     }
 
-    public function testSetParameters(): void
+    public function testParametersAreConvertedToArrayCollection(): void
     {
         $qb = $this->entityManager->createQueryBuilder();
-        $qb->select('u')
-           ->from(CmsUser::class, 'u')
-           ->where($qb->expr()->orX('u.username = :username', 'u.username = :username2'));
 
         $parameters = new ArrayCollection();
         $parameters->add(new Parameter('username', 'jwage'));
         $parameters->add(new Parameter('username2', 'jonwage'));
 
-        $qb->setParameters($parameters);
+        $qb->setParameters([
+            'username' => 'jwage',
+            'username2' => 'jonwage',
+        ]);
 
         self::assertEquals($parameters, $qb->getQuery()->getParameters());
     }
 
-    public function testGetParameters(): void
+    public function testSetArrayCollectionParametersIsDeprecated(): void
     {
         $qb = $this->entityManager->createQueryBuilder();
-        $qb->select('u')
-           ->from(CmsUser::class, 'u')
-           ->where('u.id = :id');
-
-        $parameters = new ArrayCollection();
-        $parameters->add(new Parameter('id', 1));
-
-        $qb->setParameters($parameters);
-
-        self::assertEquals($parameters, $qb->getParameters());
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9816');
+        $qb->setParameters(new ArrayCollection());
     }
 
     public function testGetParameter(): void
@@ -683,7 +675,7 @@ class QueryBuilderTest extends OrmTestCase
         $parameters = new ArrayCollection();
         $parameters->add(new Parameter('id', 1));
 
-        $qb->setParameters($parameters);
+        $qb->setParameters(['id' => 1]);
 
         self::assertEquals($parameters->first(), $qb->getParameter('id'));
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -60,7 +60,10 @@ class PaginatorTest extends OrmTestCase
             FROM Doctrine\\Tests\\Models\\CMS\\CmsUser u
             WHERE u.id = :paramInWhere'
         );
-        $query->setParameters(['paramInWhere' => $paramInWhere, 'paramInSubSelect' => $paramInSubSelect]);
+        $query->setParameters([
+            'paramInWhere' => $paramInWhere,
+            'paramInSubSelect' => $paramInSubSelect,
+        ]);
         $query->setMaxResults(1);
         $paginator = (new Paginator($query, true))->setUseOutputWalkers(false);
 


### PR DESCRIPTION
There does not seem to be a point to it, and it is very verbose.