### PR TITLE
Disable doctrine/dbal dev job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,8 +29,6 @@ jobs:
         include:
           - php-version: "8.0"
             dbal-version: "2.13"
-          - php-version: "8.1"
-            dbal-version: "3@dev"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Porting [prep work](https://github.com/doctrine/orm/pull/9799) to 2.12.x would mean porting fixes for something that
is not actually impacting the end user.

