### PR TITLE
bug: getSingleColumnResult with indexBy

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\ORM\Exception\MultipleSelectorsFoundException;
 
 use function array_column;
+use function array_combine;
 use function count;
 
 /**
@@ -29,6 +30,12 @@ final class ScalarColumnHydrator extends AbstractHydrator
 
         $result = $this->statement()->fetchAllNumeric();
 
-        return array_column($result, 0);
+        $resultColumn = array_column($result, 0);
+
+        if (isset($this->resultSetMapping()->indexByMap['scalars'])) {
+            return array_combine($resultColumn, $resultColumn);
+        }
+
+        return $resultColumn;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarColumnHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarColumnHydratorTest.php
@@ -82,8 +82,8 @@ class ScalarColumnHydratorTest extends HydrationTestCase
         $this->assertIsArray($result);
         $this->assertCount(2, $result);
 
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[2]);
     }
 
     /**


### PR DESCRIPTION
This change make it possible to use `indexBy` with `getSingleColumnResult`.