### PR TITLE
Run foreign key tests on all platforms

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -35,10 +35,6 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
      */
     public function testIssue2059(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $user = new Table('ddc2059_user');
         $user->addColumn('id', 'integer');
         $user->setPrimaryKey(['id']);
@@ -57,10 +53,6 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
     public function testLoadMetadataFromDatabase(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $table = new Table('dbdriver_foo');
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
@@ -88,10 +80,6 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
     public function testLoadMetadataWithForeignKeyFromDatabase(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $tableB = new Table('dbdriver_bar');
         $tableB->addColumn('id', 'integer');
         $tableB->setPrimaryKey(['id']);
@@ -122,10 +110,6 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
     public function testDetectManyToManyTables(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $metadatas = $this->extractClassMetadata(['CmsUsers', 'CmsGroups', 'CmsTags']);
 
         self::assertArrayHasKey('CmsUsers', $metadatas, 'CmsUsers entity was not detected.');
@@ -162,10 +146,6 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
     public function testLoadMetadataFromDatabaseDetail(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $table = new Table('dbdriver_foo');
 
         $table->addColumn('id', 'integer', ['unsigned' => true]);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7684Test.php
@@ -16,10 +16,6 @@ class GH7684Test extends DatabaseDriverTestCase
 {
     public function testIssue(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $table1 = new Table('GH7684_identity_test_table');
         $table1->addColumn('id', 'integer');
         $table1->setPrimaryKey(['id']);


### PR DESCRIPTION
SQLite now supports foreign keys.

2.13.x requires DBAL 3.4, so this should be fine.

https://github.com/doctrine/dbal/pull/5427