### PR TITLE
Add missing property declaration

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -51,6 +51,9 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
     /** @var CmsPhonenumber */
     private $phonenumber;
 
+    /** @var array<string, mixed> */
+    private $previousCacheConfig = [];
+
     protected function setUp(): void
     {
         $this->useModelSet('tweet');


### PR DESCRIPTION
In `ExtraLazyCollectionTest`, we use a property `previousCacheConfig` without declaring it. In PHP 8.2, this will triggger a deprecation notice. I'm sure that the declaration is missing my accident, so this PR adds it.