### PR TITLE
PHP CodeSniffer 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpstan/phpstan": "~1.4.10 || 1.7.9",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "psr/log": "^1 || ^2 || ^3",
-        "squizlabs/php_codesniffer": "3.6.2",
+        "squizlabs/php_codesniffer": "3.7.0",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "vimeo/psalm": "4.23.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -266,21 +266,4 @@
         <!-- https://github.com/doctrine/orm/issues/8537 -->
         <exclude-pattern>lib/Doctrine/ORM/QueryBuilder.php</exclude-pattern>
     </rule>
-
-    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
-        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/AccessLevel.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/City.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Unit.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/UserStatus.php</exclude-pattern>
-    </rule>
-    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
-        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/AccessLevel.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/City.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Suit.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/Unit.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/Models/Enums/UserStatus.php</exclude-pattern>
-    </rule>
 </ruleset>

--- a/tests/Doctrine/Tests/Models/Enums/AccessLevel.php
+++ b/tests/Doctrine/Tests/Models/Enums/AccessLevel.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\Enums;
 
 enum AccessLevel: int
 {
-    case Admin = 1;
-    case User = 2;
+    case Admin  = 1;
+    case User   = 2;
     case Guests = 3;
 }

--- a/tests/Doctrine/Tests/Models/Enums/City.php
+++ b/tests/Doctrine/Tests/Models/Enums/City.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\Enums;
 
 enum City: string
 {
-    case Paris = 'Paris';
-    case Cannes = 'Cannes';
+    case Paris    = 'Paris';
+    case Cannes   = 'Cannes';
     case StJulien = 'St Julien';
 }

--- a/tests/Doctrine/Tests/Models/Enums/Suit.php
+++ b/tests/Doctrine/Tests/Models/Enums/Suit.php
@@ -6,8 +6,8 @@ namespace Doctrine\Tests\Models\Enums;
 
 enum Suit: string
 {
-    case Hearts = 'H';
+    case Hearts   = 'H';
     case Diamonds = 'D';
-    case Clubs = 'C';
-    case Spades = 'S';
+    case Clubs    = 'C';
+    case Spades   = 'S';
 }

--- a/tests/Doctrine/Tests/Models/Enums/Unit.php
+++ b/tests/Doctrine/Tests/Models/Enums/Unit.php
@@ -6,6 +6,6 @@ namespace Doctrine\Tests\Models\Enums;
 
 enum Unit: string
 {
-    case Gram = 'g';
+    case Gram  = 'g';
     case Meter = 'm';
 }

--- a/tests/Doctrine/Tests/Models/Enums/UserStatus.php
+++ b/tests/Doctrine/Tests/Models/Enums/UserStatus.php
@@ -6,6 +6,6 @@ namespace Doctrine\Tests\Models\Enums;
 
 enum UserStatus: string
 {
-    case Active = 'active';
+    case Active   = 'active';
     case Inactive = 'inactive';
 }


### PR DESCRIPTION
PHP CodeSniffer finally understands enums. 🎉 This allows us to remove some hacks from phpcs.xml.