### PR TITLE
Flip conditional extension of legacy AnnotationDriver class

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php
@@ -9,18 +9,18 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 use function class_exists;
 
-if (class_exists(PersistenceAnnotationDriver::class)) {
+if (! class_exists(PersistenceAnnotationDriver::class)) {
     /**
      * @internal This class will be removed in ORM 3.0.
      */
-    abstract class CompatibilityAnnotationDriver extends PersistenceAnnotationDriver
+    abstract class CompatibilityAnnotationDriver implements MappingDriver
     {
     }
 } else {
     /**
      * @internal This class will be removed in ORM 3.0.
      */
-    abstract class CompatibilityAnnotationDriver implements MappingDriver
+    abstract class CompatibilityAnnotationDriver extends PersistenceAnnotationDriver
     {
     }
 }

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -56,9 +56,6 @@ parameters:
             message: '#^Call to method injectObjectManager\(\) on an unknown class Doctrine\\Persistence\\ObjectManagerAware\.$#'
             path: lib/Doctrine/ORM/UnitOfWork.php
 
-        # https://github.com/phpstan/phpstan/issues/7290
-        - '#expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\(Annotation|Attribute)Driver given#'
-
         # https://github.com/phpstan/phpstan/issues/7292
         -
             message: '#^Offset class\-string on array\<class\-string, array\<string, mixed\>\> in isset\(\) always exists and is not nullable\.$#'

--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -42,17 +42,6 @@ parameters:
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
 
-        # Compatibility layer for AttributeDriver
-        -
-            message: "#^PHPDoc type Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeReader of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$reader is not covariant with PHPDoc type Doctrine\\\\Common\\\\Annotations\\\\Reader of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$reader\\.$#"
-            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-        -
-            message: "#^PHPDoc type array\\<string, int\\> of property Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:\\$entityAnnotationClasses is not covariant with PHPDoc type array\\<class\\-string, bool\\|int\\> of overridden property Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:\\$entityAnnotationClasses\\.$#"
-            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-        -
-            message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeReader\\) of method Doctrine\\\\ORM\\\\Mapping\\\\Driver\\\\AttributeDriver\\:\\:getReader\\(\\) should be compatible with return type \\(Doctrine\\\\Common\\\\Annotations\\\\Reader\\) of method Doctrine\\\\Persistence\\\\Mapping\\\\Driver\\\\AnnotationDriver\\:\\:getReader\\(\\)$#"
-            path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-
         # https://github.com/phpstan/phpstan/issues/7292
         -
             message: '#^Offset class\-string on array\<class\-string, array\<string, mixed\>\> in isset\(\) always exists and is not nullable\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,9 +53,6 @@ parameters:
             message: '#^Call to method injectObjectManager\(\) on an unknown class Doctrine\\Persistence\\ObjectManagerAware\.$#'
             path: lib/Doctrine/ORM/UnitOfWork.php
 
-        # https://github.com/phpstan/phpstan/issues/7290
-        - '#expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\(Annotation|Attribute)Driver given#'
-
         # https://github.com/phpstan/phpstan/issues/7292
         -
             message: '#^Offset class\-string on array\<class\-string, array\<string, mixed\>\> in isset\(\) always exists and is not nullable\.$#'


### PR DESCRIPTION
This PR flips the if/else block of the conditional `CompatibilityAnnotationDriver` class declaration. I do this to work around a PHPStan bug (see phpstan/phpstan#7290).

PHPStan 1.7 basically ignores the `if` block and picks the first of the two declarations. For projects that have upgraded to Persistence 3 already, PHPStan will complain about code like this:

```php
$config->setMetadataDriverImpl(new AnnotationDriver());
```

My idea is that the implementation that implements the interface directly is the more correct one. Worst-case scenario with my patch is that PHPStan does not know about the inheritance of the two annotation classes when Persistance 2 is still installed. From my PoV, that's the lesser evil.

cc @VincentLanglet