### PR TITLE
Add parentheses to `EntityManager::contains()`

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -836,8 +836,10 @@ use function strpos;
     public function contains($entity)
     {
         return $this->unitOfWork->isScheduledForInsert($entity)
-            || $this->unitOfWork->isInIdentityMap($entity)
-            && ! $this->unitOfWork->isScheduledForDelete($entity);
+            || (
+                $this->unitOfWork->isInIdentityMap($entity)
+                && ! $this->unitOfWork->isScheduledForDelete($entity)
+            );
     }
 
     /**


### PR DESCRIPTION
Make order of operations more explicit.