### PR TITLE
Change parent classes in some events

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,6 +48,17 @@ Calling `AbstractQuery::setFetchMode()` with anything else than
 `Doctrine\ORM\Mapping::FETCH_LAZY` being used. Relying on that behavior is
 deprecated and will result in an exception in 3.0.
 
+## Deprecated `getEntityManager()` in `Doctrine\ORM\Event\OnClearEventArgs` and `Doctrine\ORM\Event\*FlushEventArgs`
+
+This method has been deprecated in:
+
+* `Doctrine\ORM\Event\OnClearEventArgs`
+* `Doctrine\ORM\Event\OnFlushEventArgs`
+* `Doctrine\ORM\Event\PostFlushEventArgs`
+* `Doctrine\ORM\Event\PreFlushEventArgs`
+
+It will be removed in 3.0. Use `getObjectManager()` instead.
+
 ## Prepare split of output walkers and tree walkers
 
 In 3.0, `SqlWalker` and its child classes won't implement the `TreeWalker`

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
 
 /**
  * Provides event arguments for the onClear event.
  *
  * @link        www.doctrine-project.org
+ *
+ * @extends BaseOnClearEventArgs<EntityManagerInterface>
  */
-class OnClearEventArgs extends EventArgs
+class OnClearEventArgs extends BaseOnClearEventArgs
 {
-    /** @var EntityManagerInterface */
-    private $em;
-
     /** @var string|null */
     private $entityClass;
 
@@ -25,18 +25,28 @@ class OnClearEventArgs extends EventArgs
      */
     public function __construct(EntityManagerInterface $em, $entityClass = null)
     {
-        $this->em          = $em;
+        parent::__construct($em);
+
         $this->entityClass = $entityClass;
     }
 
     /**
      * Retrieves associated EntityManager.
      *
+     * @deprecated 2.13. Use {@see getObjectManager} instead.
+     *
      * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
-        return $this->em;
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return $this->getObjectManager();
     }
 
     /**

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -4,31 +4,35 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the preFlush event.
  *
  * @link        www.doctrine-project.org
+ *
+ * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class OnFlushEventArgs extends EventArgs
+class OnFlushEventArgs extends ManagerEventArgs
 {
-    /** @var EntityManagerInterface */
-    private $em;
-
-    public function __construct(EntityManagerInterface $em)
-    {
-        $this->em = $em;
-    }
-
     /**
      * Retrieve associated EntityManager.
+     *
+     * @deprecated 2.13. Use {@see getObjectManager} instead.
      *
      * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
-        return $this->em;
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return $this->getObjectManager();
     }
 }

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -4,31 +4,35 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the postFlush event.
  *
  * @link        www.doctrine-project.org
+ *
+ * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class PostFlushEventArgs extends EventArgs
+class PostFlushEventArgs extends ManagerEventArgs
 {
-    /** @var EntityManagerInterface */
-    private $em;
-
-    public function __construct(EntityManagerInterface $em)
-    {
-        $this->em = $em;
-    }
-
     /**
      * Retrieves associated EntityManager.
+     *
+     * @deprecated 2.13. Use {@see getObjectManager} instead.
      *
      * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
-        return $this->em;
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return $this->getObjectManager();
     }
 }

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -4,29 +4,33 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the preFlush event.
  *
  * @link        www.doctrine-project.com
+ *
+ * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class PreFlushEventArgs extends EventArgs
+class PreFlushEventArgs extends ManagerEventArgs
 {
-    /** @var EntityManagerInterface */
-    private $em;
-
-    public function __construct(EntityManagerInterface $em)
-    {
-        $this->em = $em;
-    }
-
     /**
+     * @deprecated 2.13. Use {@see getObjectManager} instead.
+     *
      * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
-        return $this->em;
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return $this->getObjectManager();
     }
 }

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -51,7 +51,7 @@ class DebugUnitOfWorkListener
      */
     public function onFlush(OnFlushEventArgs $args)
     {
-        $this->dumpIdentityMap($args->getEntityManager());
+        $this->dumpIdentityMap($args->getObjectManager());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -78,7 +78,7 @@ class OnFlushListener
     {
         //echo "---preFlush".PHP_EOL;
 
-        $em  = $args->getEntityManager();
+        $em  = $args->getObjectManager();
         $uow = $em->getUnitOfWork();
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {

--- a/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
@@ -55,7 +55,7 @@ class PostFlushEventTest extends OrmFunctionalTestCase
     {
         $this->_em->persist($this->createNewValidUser());
         $this->_em->flush();
-        $receivedEm = $this->listener->receivedArgs->getEntityManager();
+        $receivedEm = $this->listener->receivedArgs->getObjectManager();
         self::assertSame($this->_em, $receivedEm);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
@@ -67,7 +67,7 @@ class OnFlushListener
      */
     public function onFlush(OnFlushEventArgs $args): void
     {
-        $em        = $args->getEntityManager();
+        $em        = $args->getObjectManager();
         $uow       = $em->getUnitOfWork();
         $deletions = $uow->getScheduledEntityDeletions();
         $updates   = $uow->getScheduledEntityUpdates();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
@@ -56,7 +56,7 @@ class DDC3160OnFlushListener
 
     public function onFlush(OnFlushEventArgs $args): void
     {
-        $em  = $args->getEntityManager();
+        $em  = $args->getObjectManager();
         $uow = $em->getUnitOfWork();
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {


### PR DESCRIPTION
Ref: https://github.com/doctrine/orm/issues/9875

*FlushEventArgs classes should extend ManagerEventArgs from `doctrine/persistence` to be able to use `ManagerEventArgs` for any persistance implementation.

`OnClearEventArgs` should extend from `OnClearEventArgs` from `doctrine/persistence`.