### PR TITLE
Deprecate getEntityManager and getEntity from PreUpdateEventArgs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,6 +48,11 @@ Calling `AbstractQuery::setFetchMode()` with anything else than
 `Doctrine\ORM\Mapping::FETCH_LAZY` being used. Relying on that behavior is
 deprecated and will result in an exception in 3.0.
 
+## Deprecated `Doctrine\ORM\Event\PreUpdateEventArgs::getEntityManager()` and `Doctrine\ORM\Event\PreUpdateEventArgs::getEntity()`
+
+In 3.0, `Doctrine\ORM\Event\PreUpdateEventArgs` will extend `Doctrine\Persistence\Event\PreUpdateEventArgs` instead of
+`Doctrine\ORM\Event\LifecycleEventArgs` and those methods won't be available. Use `getObjectManager()` and `getObject()` instead.
+
 ## Prepare split of output walkers and tree walkers
 
 In 3.0, `SqlWalker` and its child classes won't implement the `TreeWalker`

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use InvalidArgumentException;
@@ -98,6 +99,40 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
+     * @deprecated 2.13. Use {@see getObject} instead.
+     *
+     * @return object
+     */
+    public function getEntity()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return parent::getEntity();
+    }
+
+    /**
+     * @deprecated 2.13. Use {@see getObjectManager} instead.
+     *
+     * @return EntityManagerInterface
+     */
+    public function getEntityManager()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/9875',
+            'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getObjectManager() instead.',
+            __METHOD__
+        );
+
+        return parent::getEntityManager();
+    }
+
+    /**
      * Asserts the field exists in changeset.
      *
      * @throws InvalidArgumentException
@@ -108,7 +143,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
             throw new InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the entity "%s" in PreUpdateEventArgs.',
                 $field,
-                get_debug_type($this->getEntity())
+                get_debug_type($this->getObject())
             ));
         }
     }


### PR DESCRIPTION
Ref: https://github.com/doctrine/orm/issues/9875

In 3.0, PreUpdateEventArgs will extend PreUpdateEventArgs from `doctrine/persistence` instead of `Doctrine\ORM\Event\LifecycleEventArgs` and those methods won't be available anymore.

This will ease the upgrade to 3.0