### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -8,8 +8,13 @@ on:
     branches:
       - "*.x"
 
+permissions:
+  contents: read
+
 jobs:
   coding-standards:
+    permissions:
+      contents: none
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:
       php-version: "8.1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,6 +11,9 @@ on:
 env:
   fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -12,6 +12,9 @@ on:
 env:
   fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
   phpbench:
     name: "PHPBench"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -5,8 +5,13 @@ on:
     types:
       - "closed"
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: none
     uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.4.1"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "*.x"
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
