### PR TITLE
fix: attribute association override default values not set for joinColumns and inverseJoinColumns if joinTable is set for a many-to-many association

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -484,8 +484,8 @@ class AttributeDriver extends CompatibilityAnnotationDriver
                     $joinTable      = [
                         'name'      => $joinTableAnnot->name,
                         'schema'    => $joinTableAnnot->schema,
-                        'joinColumns' => $override['joinColumns'] ?? [],
-                        'inverseJoinColumns' => $override['inverseJoinColumns'] ?? [],
+                        'joinColumns' => $override['joinColumns'] ?? null,
+                        'inverseJoinColumns' => $override['inverseJoinColumns'] ?? null,
                     ];
 
                     unset($override['joinColumns'], $override['inverseJoinColumns']);

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
@@ -21,6 +21,11 @@ use Doctrine\ORM\Mapping\JoinTable;
  *              inverseJoinColumns=@JoinColumn(name="admingroup_id")
  *          )
  *      ),
+ *      @AssociationOverride(name="organizations",
+ *          joinTable=@JoinTable(
+ *              name="ddc964_users_adminorganizations"
+ *          )
+ *      ),
  *      @AssociationOverride(name="address",
  *          joinColumns=@JoinColumn(
  *              name="adminaddress_id", referencedColumnName="id"
@@ -29,7 +34,7 @@ use Doctrine\ORM\Mapping\JoinTable;
  * })
  */
 #[Entity]
-#[AssociationOverrides([new AssociationOverride(name: 'groups', joinTable: new JoinTable(name: 'ddc964_users_admingroups'), joinColumns: [new JoinColumn(name: 'adminuser_id')], inverseJoinColumns: [new JoinColumn(name: 'admingroup_id')]), new AssociationOverride(name: 'address', joinColumns: [new JoinColumn(name: 'adminaddress_id', referencedColumnName: 'id')])])]
+#[AssociationOverrides([new AssociationOverride(name: 'groups', joinTable: new JoinTable(name: 'ddc964_users_admingroups'), joinColumns: [new JoinColumn(name: 'adminuser_id')], inverseJoinColumns: [new JoinColumn(name: 'admingroup_id')]), new AssociationOverride(name: 'organizations', joinTable: new JoinTable(name: 'ddc964_users_adminorganizations')), new AssociationOverride(name: 'address', joinColumns: [new JoinColumn(name: 'adminaddress_id', referencedColumnName: 'id')])])]
 class DDC964Admin extends DDC964User
 {
     public static function loadMetadata(ClassMetadata $metadata): void
@@ -58,6 +63,13 @@ class DDC964Admin extends DDC964User
                         ['name' => 'admingroup_id'],
                     ],
                 ],
+            ]
+        );
+
+        $metadata->setAssociationOverride(
+            'organizations',
+            [
+                'joinTable' => ['name' => 'ddc964_users_adminorganizations'],
             ]
         );
     }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Organization.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Organization.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\DDC964;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\ManyToMany;
 
 /**
  * @Entity
  */
-class DDC964Group
+class DDC964Organization
 {
     /**
      * @var int
@@ -31,16 +28,9 @@ class DDC964Group
      */
     private $name;
 
-    /**
-     * @psalm-var Collection<int, DDC964User>
-     * @ManyToMany(targetEntity="DDC964User", mappedBy="groups")
-     */
-    private $users;
-
     public function __construct(?string $name = null)
     {
-        $this->name  = $name;
-        $this->users = new ArrayCollection();
+        $this->name = $name;
     }
 
     public function setName(string $name): void
@@ -51,18 +41,5 @@ class DDC964Group
     public function getName(): ?string
     {
         return $this->name;
-    }
-
-    public function addUser(DDC964User $user): void
-    {
-        $this->users[] = $user;
-    }
-
-    /**
-     * @psalm-return Collection<int, DDC964User>
-     */
-    public function getUsers(): Collection
-    {
-        return $this->users;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -54,6 +54,20 @@ class DDC964User
     protected $groups;
 
     /**
+     * @psalm-var Collection<int, DDC964Organization>
+     * @ManyToMany(targetEntity="DDC964Organization")
+     * @JoinTable(name="ddc964_users_organizations",
+     *  joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
+     *  inverseJoinColumns={@JoinColumn(name="organization_id", referencedColumnName="id")}
+     * )
+     */
+    #[ManyToMany(targetEntity: DDC964Organization::class)]
+    #[JoinTable(name: 'ddc964_users_organizations')]
+    #[JoinColumn(name: 'user_id', referencedColumnName: 'id')]
+    #[InverseJoinColumn(name: 'organization_id', referencedColumnName: 'id')]
+    protected $organizations;
+
+    /**
      * @var DDC964Address
      * @ManyToOne(targetEntity="DDC964Address", cascade={"persist", "merge"})
      * @JoinColumn(name="address_id", referencedColumnName="id")
@@ -64,8 +78,9 @@ class DDC964User
 
     public function __construct(?string $name = null)
     {
-        $this->name   = $name;
-        $this->groups = new ArrayCollection();
+        $this->name          = $name;
+        $this->groups        = new ArrayCollection();
+        $this->organizations = new ArrayCollection();
     }
 
     public function getId(): int
@@ -92,9 +107,22 @@ class DDC964User
     /**
      * @psalm-return Collection<int, DDC964Group>
      */
-    public function getGroups(): ArrayCollection
+    public function getGroups(): Collection
     {
         return $this->groups;
+    }
+
+    public function addOrganization(DDC964Organization $organization): void
+    {
+        $this->organizations->add($organization);
+    }
+
+    /**
+     * @psalm-return Collection<int, DDC964Organization>
+     */
+    public function getOrganizations(): Collection
+    {
+        return $this->organizations;
     }
 
     public function getAddress(): DDC964Address
@@ -157,6 +185,28 @@ class DDC964User
                     'inverseJoinColumns' => [
                         [
                             'name' => 'group_id',
+                            'referencedColumnName' => 'id',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $metadata->mapManyToMany(
+            [
+                'fieldName'      => 'organizations',
+                'targetEntity'   => 'DDC964Organization',
+                'joinTable'      => [
+                    'name'          => 'ddc964_users_organizations',
+                    'joinColumns'   => [
+                        [
+                            'name' => 'user_id',
+                            'referencedColumnName' => 'id',
+                        ],
+                    ],
+                    'inverseJoinColumns' => [
+                        [
+                            'name' => 'organization_id',
                             'referencedColumnName' => 'id',
                         ],
                     ],

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -776,9 +776,11 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         // assert groups association mappings
         self::assertArrayHasKey('groups', $guestMetadata->associationMappings);
         self::assertArrayHasKey('groups', $adminMetadata->associationMappings);
+        self::assertArrayHasKey('organizations', $adminMetadata->associationMappings);
 
-        $guestGroups = $guestMetadata->associationMappings['groups'];
-        $adminGroups = $adminMetadata->associationMappings['groups'];
+        $guestGroups        = $guestMetadata->associationMappings['groups'];
+        $adminGroups        = $adminMetadata->associationMappings['groups'];
+        $adminOrganizations = $adminMetadata->associationMappings['organizations'];
 
         // assert not override attributes
         self::assertEquals($guestGroups['fieldName'], $adminGroups['fieldName']);
@@ -809,6 +811,14 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals(['adminuser_id' => 'id'], $adminGroups['relationToSourceKeyColumns']);
         self::assertEquals(['admingroup_id' => 'id'], $adminGroups['relationToTargetKeyColumns']);
         self::assertEquals(['adminuser_id', 'admingroup_id'], $adminGroups['joinTableColumns']);
+
+        self::assertEquals('ddc964_users_adminorganizations', $adminOrganizations['joinTable']['name']);
+        self::assertEquals('ddc964admin_id', $adminOrganizations['joinTable']['joinColumns'][0]['name']);
+        self::assertEquals('ddc964organization_id', $adminOrganizations['joinTable']['inverseJoinColumns'][0]['name']);
+
+        self::assertEquals(['ddc964admin_id' => 'id'], $adminOrganizations['relationToSourceKeyColumns']);
+        self::assertEquals(['ddc964organization_id' => 'id'], $adminOrganizations['relationToTargetKeyColumns']);
+        self::assertEquals(['ddc964admin_id', 'ddc964organization_id'], $adminOrganizations['joinTableColumns']);
 
         // assert address association mappings
         self::assertArrayHasKey('address', $guestMetadata->associationMappings);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Admin.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Admin.php
@@ -29,3 +29,10 @@ $metadata->setAssociationOverride(
         ],
     ]
 );
+
+$metadata->setAssociationOverride(
+    'organizations',
+    [
+        'joinTable' => ['name' => 'ddc964_users_adminorganizations'],
+    ]
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
@@ -59,4 +59,26 @@ $metadata->mapManyToMany(
     ]
 );
 
+$metadata->mapManyToMany(
+    [
+        'fieldName'      => 'organizations',
+        'targetEntity'   => 'DDC964Organization',
+        'joinTable'      => [
+            'name'          => 'ddc964_users_organizations',
+            'joinColumns'   => [
+                [
+                    'name' => 'user_id',
+                    'referencedColumnName' => 'id',
+                ],
+            ],
+            'inverseJoinColumns' => [
+                [
+                    'name' => 'organization_id',
+                    'referencedColumnName' => 'id',
+                ],
+            ],
+        ],
+    ]
+);
+
 $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Admin.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Admin.dcm.xml
@@ -16,6 +16,9 @@
                     </inverse-join-columns>
                 </join-table>
             </association-override>
+            <association-override name="organizations">
+                <join-table name="ddc964_users_adminorganizations"/>
+            </association-override>
             <association-override name="address">
                 <join-columns>
                     <join-column name="adminaddress_id" referenced-column-name="id"/>
@@ -23,5 +26,5 @@
             </association-override>
         </association-overrides>
     </entity>
-        
+
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964User.dcm.xml
@@ -8,7 +8,7 @@
         <id name="id" type="integer" column="user_id" length="150">
             <generator strategy="AUTO"/>
         </id>
-        
+
         <field name="name" column="user_name" type="string" length="250" nullable="true" unique="false" />
 
         <many-to-one field="address" target-entity="DDC964Address">
@@ -34,6 +34,17 @@
                 </inverse-join-columns>
             </join-table>
         </many-to-many>
+
+        <many-to-many field="organizations" target-entity="DDC964Organization">
+            <join-table name="ddc964_users_organizations">
+                <join-columns>
+                    <join-column name="user_id" referenced-column-name="id" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="organization_id" referenced-column-name="id" />
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
     </mapped-superclass>
-        
+
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Admin.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Admin.dcm.yml
@@ -15,3 +15,8 @@ Doctrine\Tests\Models\DDC964\DDC964Admin:
         inverseJoinColumns:
           admingroup_id:
             referencedColumnName: id
+    organizations:
+      joinTable:
+        name: ddc964_users_adminorganizations
+        joinColumns: []
+        inverseJoinColumns: []

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964User.dcm.yml
@@ -1,7 +1,7 @@
 Doctrine\Tests\Models\DDC964\DDC964User:
   type: mappedSuperclass
   id:
-    id: 
+    id:
       type: integer
       column: user_id
       length: 150
@@ -33,3 +33,13 @@ Doctrine\Tests\Models\DDC964\DDC964User:
           group_id:
             referencedColumnName: id
       cascade: [ persist, merge, detach ]
+    organizations:
+      targetEntity: DDC964Organization
+      joinTable:
+        name: ddc964_users_organizations
+        joinColumns:
+          user_id:
+            referencedColumnName: id
+        inverseJoinColumns:
+          organization_id:
+            referencedColumnName: id


### PR DESCRIPTION
This PR fixes a bug when an attribute association override is used for a many-to-many association with only a join table set.
In this case, `joinColumns` and `inverseJoinColumns` will be set to an empty array:
https://github.com/doctrine/orm/blob/f79ec43e70eff026af23adb0bcfdf4df13d54036/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php#L487-L488
Later on, in the method `_validateAndCompleteManyToManyMapping`, default values will not be set and the empty arrays will be kept because of `isset`:
https://github.com/doctrine/orm/blob/f79ec43e70eff026af23adb0bcfdf4df13d54036/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2056-L2064

The first commit adds a failing test. You can see that the configuration works for all the mappings (PHP, XML, annotations...) excepted the attribute mapping.
The second commit fixes it by using `null` instead of empty arrays.

Related PR (introducing the bug): https://github.com/doctrine/orm/pull/9241
@beberlei if you can have a look at this PR since you wrote the code :slightly_smiling_face: 