### PR TITLE
Introduce assertQueryLogTail() for better tests

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -153,16 +153,14 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $train = $this->_em->find(get_class($train), $train->id);
-        $this->assertSQLEquals(
-            'SELECT t0.id AS id_1, t0.driver_id AS driver_id_2, t3.id AS id_4, t3.name AS name_5, t0.owner_id AS owner_id_6, t7.id AS id_8, t7.name AS name_9 FROM Train t0 LEFT JOIN TrainDriver t3 ON t0.driver_id = t3.id INNER JOIN TrainOwner t7 ON t0.owner_id = t7.id WHERE t0.id = ?',
-            $this->getLastLoggedQuery()['sql']
+        $this->assertQueryLogTail(
+            'SELECT t0.id AS id_1, t0.driver_id AS driver_id_2, t3.id AS id_4, t3.name AS name_5, t0.owner_id AS owner_id_6, t7.id AS id_8, t7.name AS name_9 FROM Train t0 LEFT JOIN TrainDriver t3 ON t0.driver_id = t3.id INNER JOIN TrainOwner t7 ON t0.owner_id = t7.id WHERE t0.id = ?'
         );
 
         $this->_em->clear();
         $driver = $this->_em->find(get_class($driver), $driver->id);
-        $this->assertSQLEquals(
-            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id IN (?)',
-            $this->getLastLoggedQuery()['sql']
+        $this->assertQueryLogTail(
+            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id IN (?)'
         );
     }
 
@@ -183,16 +181,11 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
 
         $waggon = $this->_em->find(get_class($waggon), $waggon->id);
 
-        // The last query is the eager loading of the owner of the train
-        $this->assertSQLEquals(
-            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id IN (?)',
-            $this->getLastLoggedQuery()['sql']
-        );
-
-        // The one before is the fetching of the waggon and train
-        $this->assertSQLEquals(
+        $this->assertQueryLogTail(
+            // The one before is the fetching of the waggon and train
             'SELECT t0.id AS id_1, t0.train_id AS train_id_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM Waggon t0 INNER JOIN Train t3 ON t0.train_id = t3.id WHERE t0.id = ?',
-            $this->getLastLoggedQuery(1)['sql']
+            // The last query is the eager loading of the owner of the train
+            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id IN (?)'
         );
     }
 
@@ -208,9 +201,8 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $waggon = $this->_em->find(get_class($owner), $owner->id);
-        $this->assertSQLEquals(
-            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id = ?',
-            $this->getLastLoggedQuery()['sql']
+        $this->assertQueryLogTail(
+            'SELECT t0.id AS id_1, t0.name AS name_2, t3.id AS id_4, t3.driver_id AS driver_id_5, t3.owner_id AS owner_id_6 FROM TrainOwner t0 LEFT JOIN Train t3 ON t3.owner_id = t0.id WHERE t0.id = ?'
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
@@ -51,14 +51,9 @@ class OneToOneInverseSideLoadAfterDqlQueryTest extends OrmFunctionalTestCase
         self::assertInstanceOf(InverseSide::class, $fetchedInverse);
         self::assertInstanceOf(OwningSide::class, $fetchedInverse->owning);
 
-        $this->assertSQLEquals(
+        $this->assertQueryLogTail(
             'select o0_.id as id_0 from one_to_one_inverse_side_load_inverse o0_ where o0_.id = ?',
-            $this->getLastLoggedQuery(1)['sql']
-        );
-
-        $this->assertSQLEquals(
-            'select t0.id as id_1, t0.inverse as inverse_2 from one_to_one_inverse_side_load_owning t0 WHERE t0.inverse = ?',
-            $this->getLastLoggedQuery()['sql']
+            'select t0.id as id_1, t0.inverse as inverse_2 from one_to_one_inverse_side_load_owning t0 WHERE t0.inverse = ?'
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
@@ -49,16 +49,14 @@ class DDC1595Test extends OrmFunctionalTestCase
         $entity1 = $repository->find($e1->id);
 
         // DDC-1596
-        $this->assertSQLEquals(
-            "SELECT t0.id AS id_1, t0.type FROM base t0 WHERE t0.id = ? AND t0.type IN ('Entity1')",
-            $this->getLastLoggedQuery()['sql']
+        $this->assertQueryLogTail(
+            "SELECT t0.id AS id_1, t0.type FROM base t0 WHERE t0.id = ? AND t0.type IN ('Entity1')"
         );
 
         $entities = $entity1->getEntities()->getValues();
 
-        self::assertEquals(
-            "SELECT t0.id AS id_1, t0.type FROM base t0 INNER JOIN entity1_entity2 ON t0.id = entity1_entity2.item WHERE entity1_entity2.parent = ? AND t0.type IN ('Entity2')",
-            $this->getLastLoggedQuery()['sql']
+        self::assertQueryLogTail(
+            "SELECT t0.id AS id_1, t0.type FROM base t0 INNER JOIN entity1_entity2 ON t0.id = entity1_entity2.item WHERE entity1_entity2.parent = ? AND t0.type IN ('Entity2')"
         );
 
         $this->_em->clear();
@@ -66,9 +64,8 @@ class DDC1595Test extends OrmFunctionalTestCase
         $entity1  = $repository->find($e1->id);
         $entities = $entity1->getEntities()->count();
 
-        $this->assertSQLEquals(
-            'SELECT COUNT(*) FROM entity1_entity2 t WHERE t.parent = ?',
-            $this->getLastLoggedQuery()['sql']
+        $this->assertQueryLogTail(
+            'SELECT COUNT(*) FROM entity1_entity2 t WHERE t.parent = ?'
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6823Test.php
@@ -37,13 +37,15 @@ class GH6823Test extends OrmFunctionalTestCase
             GH6823Status::class
         );
 
-        self::assertEquals('CREATE TABLE gh6823_user (id VARCHAR(255) NOT NULL, group_id VARCHAR(255) CHARACTER SET ascii DEFAULT NULL COLLATE `ascii_general_ci`, status_id VARCHAR(255) CHARACTER SET latin1 DEFAULT NULL COLLATE `latin1_bin`, INDEX IDX_70DD1774FE54D947 (group_id), INDEX IDX_70DD17746BF700BD (status_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(6)['sql']);
-        self::assertEquals('CREATE TABLE gh6823_user_tags (user_id VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_bin`, tag_id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, INDEX IDX_596B1281A76ED395 (user_id), INDEX IDX_596B1281BAD26311 (tag_id), PRIMARY KEY(user_id, tag_id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(5)['sql']);
-        self::assertEquals('CREATE TABLE gh6823_group (id VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB', $this->getLastLoggedQuery(4)['sql']);
-        self::assertEquals('CREATE TABLE gh6823_status (id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, PRIMARY KEY(id)) DEFAULT CHARACTER SET koi8r COLLATE `koi8r_bin` ENGINE = InnoDB', $this->getLastLoggedQuery(3)['sql']);
-        self::assertEquals('ALTER TABLE gh6823_user ADD CONSTRAINT FK_70DD1774FE54D947 FOREIGN KEY (group_id) REFERENCES gh6823_group (id)', $this->getLastLoggedQuery(2)['sql']);
-        self::assertEquals('ALTER TABLE gh6823_user ADD CONSTRAINT FK_70DD17746BF700BD FOREIGN KEY (status_id) REFERENCES gh6823_status (id)', $this->getLastLoggedQuery(1)['sql']);
-        self::assertEquals('ALTER TABLE gh6823_user_tags ADD CONSTRAINT FK_596B1281A76ED395 FOREIGN KEY (user_id) REFERENCES gh6823_user (id)', $this->getLastLoggedQuery(0)['sql']);
+        self::assertQueryLogTail(
+            'CREATE TABLE gh6823_user (id VARCHAR(255) NOT NULL, group_id VARCHAR(255) CHARACTER SET ascii DEFAULT NULL COLLATE `ascii_general_ci`, status_id VARCHAR(255) CHARACTER SET latin1 DEFAULT NULL COLLATE `latin1_bin`, INDEX IDX_70DD1774FE54D947 (group_id), INDEX IDX_70DD17746BF700BD (status_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_bin` ENGINE = InnoDB',
+            'CREATE TABLE gh6823_user_tags (user_id VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_bin`, tag_id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, INDEX IDX_596B1281A76ED395 (user_id), INDEX IDX_596B1281BAD26311 (tag_id), PRIMARY KEY(user_id, tag_id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB',
+            'CREATE TABLE gh6823_group (id VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET ascii COLLATE `ascii_general_ci` ENGINE = InnoDB',
+            'CREATE TABLE gh6823_status (id VARCHAR(255) CHARACTER SET latin1 NOT NULL COLLATE `latin1_bin`, PRIMARY KEY(id)) DEFAULT CHARACTER SET koi8r COLLATE `koi8r_bin` ENGINE = InnoDB',
+            'ALTER TABLE gh6823_user ADD CONSTRAINT FK_70DD1774FE54D947 FOREIGN KEY (group_id) REFERENCES gh6823_group (id)',
+            'ALTER TABLE gh6823_user ADD CONSTRAINT FK_70DD17746BF700BD FOREIGN KEY (status_id) REFERENCES gh6823_status (id)',
+            'ALTER TABLE gh6823_user_tags ADD CONSTRAINT FK_596B1281A76ED395 FOREIGN KEY (user_id) REFERENCES gh6823_user (id)'
+        );
     }
 }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -38,11 +38,13 @@ use RuntimeException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Throwable;
 
+use function array_column;
 use function array_map;
 use function array_pop;
 use function array_reverse;
 use function array_slice;
 use function assert;
+use function count;
 use function explode;
 use function get_debug_type;
 use function getenv;
@@ -947,6 +949,20 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         return $lastQuery;
+    }
+
+    /**
+     * Asserts that the query log finishes with the given SQL queries, modulo case.
+     */
+    final protected function assertQueryLogTail(string ...$expectedQueries): void
+    {
+        self::assertSame(
+            array_map('mb_strtolower', $expectedQueries),
+            array_map('mb_strtolower', array_column(array_slice(
+                $this->getQueryLog()->queries,
+                -1 * count($expectedQueries)
+            ), 'sql'))
+        );
     }
 
     /**


### PR DESCRIPTION
Right now, you get an exception when trying to get a log line that is
out of bounds. It is hard to tell what the query log looks like when
that happens.

I decided to work on this after facing that issue on #9885