### PR TITLE
Address array object type deprecation

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -74,6 +74,8 @@ class TypeTest extends OrmFunctionalTestCase
         $serialize->array['foo'] = 'bar';
         $serialize->array['bar'] = 'baz';
 
+        $this->createSchemaForModels(SerializationModel::class);
+        static::$sharedConn->executeStatement('DELETE FROM serialize_model');
         $this->_em->persist($serialize);
         $this->_em->flush();
         $this->_em->clear();
@@ -89,6 +91,8 @@ class TypeTest extends OrmFunctionalTestCase
         $serialize         = new SerializationModel();
         $serialize->object = new stdClass();
 
+        $this->createSchemaForModels(SerializationModel::class);
+        static::$sharedConn->executeStatement('DELETE FROM serialize_model');
         $this->_em->persist($serialize);
         $this->_em->flush();
         $this->_em->clear();

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -15,7 +15,7 @@ use Doctrine\Tests\Models\DDC117\DDC117Translation;
 use Doctrine\Tests\Models\DDC3293\DDC3293User;
 use Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed;
 use Doctrine\Tests\Models\DDC889\DDC889Class;
-use Doctrine\Tests\Models\Generic\SerializationModel;
+use Doctrine\Tests\Models\Generic\BooleanModel;
 use Doctrine\Tests\Models\GH7141\GH7141Article;
 use Doctrine\Tests\Models\GH7316\GH7316Article;
 use Doctrine\Tests\Models\ValueObjects\Name;
@@ -155,8 +155,8 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     public function testInvalidMappingFileException(): void
     {
         $this->expectException('Doctrine\Persistence\Mapping\MappingException');
-        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.SerializationModel.dcm.xml\' for class \'Doctrine\Tests\Models\Generic\SerializationModel\'.');
-        $this->createClassMetadata(SerializationModel::class);
+        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.xml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');
+        $this->createClassMetadata(BooleanModel::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -153,7 +153,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-1468
      */
-    public function testInvalidMappingFileException(): void
+    public function testItMentionsFilenameAndEntityNameOnInvalidMapping(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.xml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\DDC117\DDC117Translation;
 use Doctrine\Tests\Models\DDC3293\DDC3293User;
@@ -154,7 +155,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
      */
     public function testInvalidMappingFileException(): void
     {
-        $this->expectException('Doctrine\Persistence\Mapping\MappingException');
+        $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.xml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');
         $this->createClassMetadata(BooleanModel::class);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -11,7 +11,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Models\DDC3711\DDC3711EntityA;
 use Doctrine\Tests\Models\DirectoryTree\Directory;
 use Doctrine\Tests\Models\DirectoryTree\File;
-use Doctrine\Tests\Models\Generic\SerializationModel;
+use Doctrine\Tests\Models\Generic\BooleanModel;
 use Symfony\Component\Yaml\Yaml;
 
 use function class_exists;
@@ -59,8 +59,8 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
     public function testInvalidMappingFileException(): void
     {
         $this->expectException('Doctrine\Persistence\Mapping\MappingException');
-        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.SerializationModel.dcm.yml\' for class \'Doctrine\Tests\Models\Generic\SerializationModel\'.');
-        $this->createClassMetadata(SerializationModel::class);
+        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.yml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');
+        $this->createClassMetadata(BooleanModel::class);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -57,7 +57,7 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-1468
      */
-    public function testInvalidMappingFileException(): void
+    public function testItMentionsFilenameAndEntityNameOnInvalidMapping(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.yml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Tests\Models\DDC3711\DDC3711EntityA;
 use Doctrine\Tests\Models\DirectoryTree\Directory;
 use Doctrine\Tests\Models\DirectoryTree\File;
@@ -58,7 +59,7 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
      */
     public function testInvalidMappingFileException(): void
     {
-        $this->expectException('Doctrine\Persistence\Mapping\MappingException');
+        $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.BooleanModel.dcm.yml\' for class \'Doctrine\Tests\Models\Generic\BooleanModel\'.');
         $this->createClassMetadata(BooleanModel::class);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Generic.BooleanModel.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Generic.BooleanModel.dcm.xml
@@ -9,9 +9,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="array" column="array" type="array"/>
-        
-        <field name="object" column="object" type="object"/>
+        <field name="booleanField" column="boolean_field" type="boolean"/>
     </entity>
 
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Generic.BooleanModel.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Generic.BooleanModel.dcm.yml
@@ -7,7 +7,5 @@
       generator:
         strategy: AUTO
   fields:
-    array:
-      type: array
-    object:
-      type: object
+    booleanField:
+      type: boolean

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -154,7 +154,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Generic\BooleanModel::class,
             Models\Generic\DateTimeModel::class,
             Models\Generic\DecimalModel::class,
-            Models\Generic\SerializationModel::class,
         ],
         'routing' => [
             Models\Routing\RoutingLeg::class,
@@ -452,7 +451,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM boolean_model');
             $conn->executeStatement('DELETE FROM date_time_model');
             $conn->executeStatement('DELETE FROM decimal_model');
-            $conn->executeStatement('DELETE FROM serialize_model');
         }
 
         if (isset($this->_usedModelSets['routing'])) {


### PR DESCRIPTION
These types have been deprecated in https://github.com/doctrine/dbal/pull/5470

This PR should help making #9885 smaller.