### PR TITLE
schema tool: remove useless text from --dump-sql output

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -49,11 +49,9 @@ EOT
 
         if ($dumpSql) {
             $sqls = $schemaTool->getCreateSchemaSql($metadatas);
-            $ui->text('The following SQL statements will be executed:');
-            $ui->newLine();
 
             foreach ($sqls as $sql) {
-                $ui->text(sprintf('    %s;', $sql));
+                $ui->writeln(sprintf('%s;', $sql));
             }
 
             return 0;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -60,11 +60,8 @@ EOT
                 $sqls = $schemaTool->getDropSchemaSQL($metadatas);
             }
 
-            $ui->text('The following SQL statements will be executed:');
-            $ui->newLine();
-
             foreach ($sqls as $sql) {
-                $ui->text(sprintf('    %s;', $sql));
+                $ui->writeln(sprintf('%s;', $sql));
             }
 
             return 0;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -88,10 +88,8 @@ EOT
         $force   = $input->getOption('force') === true;
 
         if ($dumpSql) {
-            $ui->text('The following SQL statements will be executed:');
-            $ui->newLine();
             foreach ($sqls as $sql) {
-                $ui->text(sprintf('    %s;', $sql));
+                $ui->writeln(sprintf('%s;', $sql));
             }
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
@@ -8,10 +8,14 @@ use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
 
 class CreateCommandTest extends AbstractCommandTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testItPrintsTheSql(): void
     {
         $tester = $this->getCommandTester(CreateCommand::class);
         $tester->execute(['--dump-sql' => true]);
-        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+
+        self::$sharedConn->executeStatement($tester->getDisplay());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
@@ -9,11 +9,15 @@ use Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models\Keyboard;
 
 final class DropCommandTest extends AbstractCommandTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testItPrintsTheSql(): void
     {
         $this->createSchemaForModels(Keyboard::class);
         $tester = $this->getCommandTester(DropCommand::class);
         $tester->execute(['--dump-sql' => true]);
-        self::assertStringContainsString('DROP TABLE keyboard', $tester->getDisplay());
+
+        self::$sharedConn->executeStatement($tester->getDisplay());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -8,10 +8,14 @@ use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 
 class UpdateCommandTest extends AbstractCommandTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testItPrintsTheSql(): void
     {
         $tester = $this->getCommandTester(UpdateCommand::class);
         $tester->execute(['--dump-sql' => true]);
-        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+
+        self::$sharedConn->executeStatement($tester->getDisplay());
     }
 }


### PR DESCRIPTION
the description and semantics of the `--dump-sql` switch
indicate an sql dump. without that useless line

    The following SQL statements will be executed:

the output can actually be used to generate a plain
dump.sql file that can be fed into sql command-
consuming programs.

resolves #8263.
resolves #7186.