### PR TITLE
Add tests for SQL output feature

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\AbstractCommand;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+abstract class AbstractCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @param class-string<AbstractCommand> $commandClass
+     */
+    protected function getCommandTester(string $commandClass): CommandTester
+    {
+        $entityManager = $this->getEntityManager(null, ORMSetup::createDefaultAnnotationDriver([
+            __DIR__ . '/Models',
+        ]));
+
+        if (! $entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+            self::markTestSkipped('We are testing the symfony/console integration');
+        }
+
+        return new CommandTester(new $commandClass(
+            new SingleManagerProvider($entityManager)
+        ));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
+
+class CreateCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $tester = $this->getCommandTester(CreateCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
+use Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models\Keyboard;
+
+final class DropCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $this->createSchemaForModels(Keyboard::class);
+        $tester = $this->getCommandTester(DropCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('DROP TABLE keyboard', $tester->getDisplay());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/Models/Keyboard.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/Models/Keyboard.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="keyboard")
+ */
+final class Keyboard
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255);
+     */
+    private $name;
+
+    public function __construct(int $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+
+class UpdateCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $tester = $this->getCommandTester(UpdateCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
It is not covered yet, and that makes contributions to these commands
hard. This only covers the `--dump-sql` part of the commands.