### PR TITLE
Show Expr::countDistinct() and Expr::concat() use variable-length argument lists

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -262,7 +262,7 @@ class Expr
      */
     public function countDistinct(...$x)
     {
-        return 'COUNT(DISTINCT ' . implode(', ', func_get_args()) . ')';
+        return 'COUNT(DISTINCT ' . implode(', ', $x) . ')';
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -260,7 +260,7 @@ class Expr
      *
      * @return string
      */
-    public function countDistinct(...$x)
+    public function countDistinct(mixed ...$x)
     {
         return 'COUNT(DISTINCT ' . implode(', ', $x) . ')';
     }

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -544,7 +544,7 @@ class Expr
      *
      * @return Expr\Func
      */
-    public function concat(...$x)
+    public function concat(mixed ...$x)
     {
         return new Expr\Func('CONCAT', $x);
     }

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Query;
 
 use Traversable;
 
-use function func_get_args;
 use function implode;
 use function is_bool;
 use function is_iterable;

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -546,7 +546,7 @@ class Expr
      */
     public function concat(...$x)
     {
-        return new Expr\Func('CONCAT', func_get_args());
+        return new Expr\Func('CONCAT', $x);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -256,11 +256,11 @@ class Expr
     /**
      * Creates an instance of COUNT(DISTINCT) function, with the given argument.
      *
-     * @param mixed $x Argument to be used in COUNT(DISTINCT) function.
+     * @param mixed ...$x Argument to be used in COUNT(DISTINCT) function.
      *
      * @return string
      */
-    public function countDistinct($x)
+    public function countDistinct(...$x)
     {
         return 'COUNT(DISTINCT ' . implode(', ', func_get_args()) . ')';
     }
@@ -540,12 +540,11 @@ class Expr
     /**
      * Creates a CONCAT() function expression with the given arguments.
      *
-     * @param mixed $x     First argument to be used in CONCAT() function.
-     * @param mixed $y,... Other arguments to be used in CONCAT() function.
+     * @param mixed ...$x Arguments to be used in CONCAT() function.
      *
      * @return Expr\Func
      */
-    public function concat($x, $y)
+    public function concat(...$x)
     {
         return new Expr\Func('CONCAT', func_get_args());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\AbstractCommand;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+abstract class AbstractCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @param class-string<AbstractCommand> $commandClass
+     */
+    protected function getCommandTester(string $commandClass): CommandTester
+    {
+        $entityManager = $this->getEntityManager(null, ORMSetup::createDefaultAnnotationDriver([
+            __DIR__ . '/Models',
+        ]));
+
+        if (! $entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+            self::markTestSkipped('We are testing the symfony/console integration');
+        }
+
+        return new CommandTester(new $commandClass(
+            new SingleManagerProvider($entityManager)
+        ));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
+
+class CreateCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $tester = $this->getCommandTester(CreateCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
+use Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models\Keyboard;
+
+final class DropCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $this->createSchemaForModels(Keyboard::class);
+        $tester = $this->getCommandTester(DropCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('DROP TABLE keyboard', $tester->getDisplay());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/Models/Keyboard.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/Models/Keyboard.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="keyboard")
+ */
+final class Keyboard
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255);
+     */
+    private $name;
+
+    public function __construct(int $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
+
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+
+class UpdateCommandTest extends AbstractCommandTest
+{
+    public function testItPrintsTheSql(): void
+    {
+        $tester = $this->getCommandTester(UpdateCommand::class);
+        $tester->execute(['--dump-sql' => true]);
+        self::assertStringContainsString('CREATE TABLE keyboard', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
The functions `Expr::countDistinct()` and `Expr::concat()` both use `func_get_args()` to accept a variable number of arguments.

They should explicitly show this via the "`...`" operator, which has been supported since PHP 5.6.