### PR TITLE
Enrich types

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\ArithmeticTerm;
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
@@ -16,7 +18,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class AbsFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
+    /** @var SimpleArithmeticExpression|ArithmeticTerm|PathExpression */
     public $simpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
@@ -23,7 +24,7 @@ class LocateFunction extends FunctionNode
     /** @var Node */
     public $secondStringPrimary;
 
-    /** @var SimpleArithmeticExpression|bool */
+    /** @var SimpleArithmeticExpression|Literal|bool */
     public $simpleArithmeticExpression = false;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\Literal;
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
@@ -16,10 +18,10 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class ModFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
+    /** @var SimpleArithmeticExpression|PathExpression */
     public $firstSimpleArithmeticExpression;
 
-    /** @var SimpleArithmeticExpression */
+    /** @var SimpleArithmeticExpression|Literal */
     public $secondSimpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
@@ -18,7 +19,7 @@ use function sprintf;
  */
 class SqrtFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
+    /** @var SimpleArithmeticExpression|PathExpression|FunctionNode */
     public $simpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
@@ -20,10 +22,10 @@ class SubstringFunction extends FunctionNode
     /** @var Node */
     public $stringPrimary;
 
-    /** @var SimpleArithmeticExpression */
+    /** @var SimpleArithmeticExpression|Literal */
     public $firstSimpleArithmeticExpression;
 
-    /** @var SimpleArithmeticExpression|null */
+    /** @var SimpleArithmeticExpression|Literal|InputParameter|null */
     public $secondSimpleArithmeticExpression = null;
 
     /**


### PR DESCRIPTION
Yesterday, I tried to migrate a new namespace to PHP8 syntax, and it turns out it has wrong PHPDoc. I suspect the same holds true for numerous types under the AST namespace. Here are types widenings I applied based on the unit tests, but I think it would be better to use a common ancestor in many cases.