### PR TITLE
Widen types for DiscriminatorMap

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -83,9 +83,8 @@ class HydrationException extends ORMException
     }
 
     /**
-     * @param string   $discrValue
-     * @param string[] $discrValues
-     * @psalm-param list<string> $discrValues
+     * @param string           $discrValue
+     * @param list<int|string> $discrValues
      *
      * @return HydrationException
      */

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -519,9 +519,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see discriminatorColumn
      *
-     * @var array<string, string>
+     * @var array<int|string, string>
      *
-     * @psalm-var array<string, class-string>
+     * @psalm-var array<int|string, class-string>
      */
     public $discriminatorMap = [];
 
@@ -3219,7 +3219,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the discriminator values used by this class.
      * Used for JOINED and SINGLE_TABLE inheritance mapping strategies.
      *
-     * @psalm-param array<string, class-string> $map
+     * @psalm-param array<int|string, class-string> $map
      *
      * @return void
      */
@@ -3233,9 +3233,8 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds one entry of the discriminator map with a new class and corresponding name.
      *
-     * @param string $name
-     * @param string $className
-     * @psalm-param class-string $className
+     * @param int|string   $name
+     * @param class-string $className
      *
      * @return void
      *

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3219,7 +3219,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the discriminator values used by this class.
      * Used for JOINED and SINGLE_TABLE inheritance mapping strategies.
      *
-     * @psalm-param array<int|string, class-string> $map
+     * @param array<int|string, string> $map
      *
      * @return void
      */
@@ -3233,8 +3233,8 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds one entry of the discriminator map with a new class and corresponding name.
      *
-     * @param int|string   $name
-     * @param class-string $className
+     * @param int|string $name
+     * @param string     $className
      *
      * @return void
      *
@@ -3708,7 +3708,6 @@ class ClassMetadataInfo implements ClassMetadata
 
     /**
      * @param string|null $className
-     * @psalm-param string|class-string|null $className
      *
      * @return string|null null if the input value is null
      * @psalm-return class-string|null

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
@@ -11,20 +11,15 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Annotation
  * @NamedArgumentConstructor()
  * @Target("CLASS")
- * @template TKey of int|string
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DiscriminatorMap implements Annotation
 {
-    /**
-     * @var array<int|string, string>
-     * @psalm-var array<TKey, class-string>
-     */
+    /** @var array<int|string, string> */
     public $value;
 
     /**
      * @param array<int|string, string> $value
-     * @psalm-param array<TKey, class-string> $value
      */
     public function __construct(array $value)
     {

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
@@ -11,19 +11,20 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Annotation
  * @NamedArgumentConstructor()
  * @Target("CLASS")
+ * @template TKey of int|string
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DiscriminatorMap implements Annotation
 {
     /**
-     * @var array<string, string>
-     * @psalm-var array<string, class-string>
+     * @var array<int|string, string>
+     * @psalm-var array<TKey, class-string>
      */
     public $value;
 
     /**
-     * @param array<string, string> $value
-     * @psalm-param array<string, class-string> $value
+     * @param array<int|string, string> $value
+     * @psalm-param array<TKey, class-string> $value
      */
     public function __construct(array $value)
     {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -82,7 +82,7 @@ class XmlExporter extends AbstractExporter
 
             foreach ($metadata->discriminatorMap as $value => $className) {
                 $discriminatorMappingXml = $discriminatorMapXml->addChild('discriminator-mapping');
-                $discriminatorMappingXml->addAttribute('value', $value);
+                $discriminatorMappingXml->addAttribute('value', (string) $value);
                 $discriminatorMappingXml->addAttribute('class', $className);
             }
         }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -459,8 +459,7 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$class</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$repositoryClassName</code>
     </ArgumentTypeCoercion>
     <DeprecatedMethod occurrences="1">
@@ -829,8 +828,7 @@
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>$map</code>
+    <ArgumentTypeCoercion occurrences="2">
       <code>(string) $xmlRoot['repository-class']</code>
       <code>isset($xmlRoot['repository-class']) ? (string) $xmlRoot['repository-class'] : null</code>
     </ArgumentTypeCoercion>


### PR DESCRIPTION
Fixes #9921

* Discriminator values may be integers
* The annotation does not require the entity classes to be valid FQCNs. If both entities are in the same namespace, the short name suffices.