### PR TITLE
Adjust casing of `SQLitePlatform` for DBAL 4

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\Tests\Models\Company\CompanyManager;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -317,7 +317,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         if (
             $unit === 'month'
             && $inOneUnit->format('m') === $now->modify('+2 month')->format('m')
-            && ! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform
+            && ! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform
         ) {
             $inOneUnit = new DateTimeImmutable('last day of next month');
         }
@@ -355,7 +355,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         if (
             $unit === 'month'
             && $oneUnitAgo->format('m') === $now->format('m')
-            && ! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform
+            && ! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform
         ) {
             $oneUnitAgo = new DateTimeImmutable('last day of previous month');
         }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\Tests\Models;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -25,7 +25,7 @@ class DDC214Test extends OrmFunctionalTestCase
 
         $conn = $this->_em->getConnection();
 
-        if ($conn->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($conn->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('SQLite does not support ALTER TABLE statements.');
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTimeZone;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -20,7 +20,7 @@ class DDC1695Test extends OrmFunctionalTestCase
 {
     public function testIssue(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('Only with sqlite');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\LockMode;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\TransactionRequiredException;
@@ -30,7 +30,7 @@ class DDC933Test extends OrmFunctionalTestCase
      */
     public function testLockCTIClass(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('It should not run on in-memory databases');
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
@@ -30,7 +30,11 @@ use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\OrmTestCase;
 use Exception;
 
+use function class_exists;
 use function sprintf;
+
+// DBAL 3 compatibility
+class_exists('Doctrine\\DBAL\\Platforms\\SqlitePlatform');
 
 class SelectSqlGenerationTest extends OrmTestCase
 {
@@ -929,7 +933,7 @@ class SelectSqlGenerationTest extends OrmTestCase
 
     public function testBooleanLiteralInWhereOnSqlite(): void
     {
-        $this->entityManager = $this->createTestEntityManagerWithPlatform(new SqlitePlatform());
+        $this->entityManager = $this->createTestEntityManagerWithPlatform(new SQLitePlatform());
         $this->assertSqlGeneration(
             'SELECT b FROM Doctrine\Tests\Models\Generic\BooleanModel b WHERE b.booleanField = true',
             'SELECT b0_.id AS id_0, b0_.booleanField AS booleanField_1 FROM boolean_model b0_ WHERE b0_.booleanField = 1'
@@ -1064,7 +1068,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function testPessimisticWriteLockQueryHint(): void
     {
-        if ($this->entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($this->entityManager->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('SqLite does not support Row locking at all.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/AbstractCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\AbstractCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
@@ -22,7 +22,7 @@ abstract class AbstractCommandTest extends OrmFunctionalTestCase
             __DIR__ . '/Models',
         ]));
 
-        if (! $entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+        if (! $entityManager->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('We are testing the symfony/console integration');
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -27,7 +27,7 @@ class ValidateSchemaCommandTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
             self::markTestSkipped('Only with sqlite');
         }
 

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use UnexpectedValueException;
 
 use function assert;
@@ -89,7 +89,7 @@ class TestUtil
 
         $platform = $privConn->getDatabasePlatform();
 
-        if ($platform instanceof SqlitePlatform) {
+        if ($platform instanceof SQLitePlatform) {
             $schema = $testConn->createSchemaManager()->createSchema();
             $stmts  = $schema->toDropSql($testConn->getDatabasePlatform());
 


### PR DESCRIPTION
Follows doctrine/dbal#5521

On DBAL 4, `SqlitePlatform` has been renamed to `SQLitePlatform`. This causes trouble with autoloading when attempting to create a new instance of that class.

This PR changes all references to how DBAL 4 defines the class and adds `class_exists()` calls for the old casing where we need it.