### PR TITLE
Require PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,17 +19,14 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
           - "8.1"
         dbal-version:
           - "default"
+          - "3@dev"
+          - "4@dev"
         include:
-          - php-version: "8.1"
-            dbal-version: "3@dev"
           - php-version: "8.2"
             dbal-version: "3@dev"
-          - php-version: "8.1"
-            dbal-version: "4@dev"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "ext-ctype": "*",
         "doctrine/collections": "^1.5",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
-    <config name="php_version" value="80000"/>
+    <config name="php_version" value="80100"/>
 
     <file>lib</file>
     <file>tests</file>


### PR DESCRIPTION
I'd like to propose to (once again) bump the minimum PHP version for the 3.0 branch to PHP 8.1.

[Symfony did the same thing](https://symfony.com/blog/symfony-6-1-will-require-php-8-1), mainly because of problems related to property types and preloading. I think, those problems will also apply to us, now that we add more and more native property types to the codebase. DBAL 4 will also require PHP 8.1 (doctrine/dbal#5543).

Among the installations that upgrade to our latest feature releases, PHP 8.1 has [already reached a share of nearly 50%](https://packagist.org/packages/doctrine/orm/php-stats#2.12). PHP 8.0 on the other hand will only receive bugfixes for a few months.

Regarding features, I believe that `readonly` properties will come in handy, especially for public properties on our attribute classes. Since making those properties `readonly` is technically a BC break, the 3.0 release would be a good opportunity for that change.