### PR TITLE
Switch to setUpEntitySchema

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -32,21 +31,6 @@ class DDC832Test extends OrmFunctionalTestCase
             DDC832JoinedTreeIndex::class,
             DDC832Like::class
         );
-    }
-
-    public function tearDown(): void
-    {
-        $platform = $this->_em->getConnection()->getDatabasePlatform();
-
-        $sm = $this->createSchemaManager();
-        $sm->dropTable($platform->quoteIdentifier('TREE_INDEX'));
-        $sm->dropTable($platform->quoteIdentifier('INDEX'));
-        $sm->dropTable($platform->quoteIdentifier('LIKE'));
-
-        if ($platform instanceof PostgreSQLPlatform) {
-            $sm->dropSequence($platform->quoteIdentifier('INDEX_id_seq'));
-            $sm->dropSequence($platform->quoteIdentifier('LIKE_id_seq'));
-        }
     }
 
     /**

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -344,7 +344,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     final protected function createSchemaForModels(string ...$models): void
     {
         try {
-            $this->_schemaTool->createSchema($this->getMetadataForModels($models));
+            $this->setUpEntitySchema($models);
         } catch (ToolsException $e) {
         }
     }


### PR DESCRIPTION
It might be more performant since we are keeping track of tables that
were already created.

This can also result in the metadata for some classes not being loaded,
which makes a test fail, and I think it reveals the bug covered by this
test was not actually fixed.