### PR TITLE
Simplify `LanguageRecognitionTest`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -16,8 +16,6 @@ use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\Mocks\MockTreeWalker;
 use Doctrine\Tests\OrmTestCase;
 
-use const PHP_EOL;
-
 class LanguageRecognitionTest extends OrmTestCase
 {
     /** @var EntityManagerInterface */
@@ -28,34 +26,16 @@ class LanguageRecognitionTest extends OrmTestCase
         $this->entityManager = $this->getTestEntityManager();
     }
 
-    public function assertValidDQL($dql, $debug = false): void
+    public function assertValidDQL(string $dql): void
     {
-        try {
-            $parserResult = $this->parseDql($dql);
-            $this->addToAssertionCount(1);
-        } catch (QueryException $e) {
-            if ($debug) {
-                echo $e->getTraceAsString() . PHP_EOL;
-            }
-
-            self::fail($e->getMessage());
-        }
+        $this->parseDql($dql);
+        $this->addToAssertionCount(1);
     }
 
-    public function assertInvalidDQL($dql, $debug = false): void
+    public function assertInvalidDQL(string $dql): void
     {
-        try {
-            $parserResult = $this->parseDql($dql);
-
-            self::fail('No syntax errors were detected, when syntax errors were expected');
-        } catch (QueryException $e) {
-            if ($debug) {
-                echo $e->getMessage() . PHP_EOL;
-                echo $e->getTraceAsString() . PHP_EOL;
-            }
-
-            $this->addToAssertionCount(1);
-        }
+        $this->expectException(QueryException::class);
+        $this->parseDql($dql);
     }
 
     /**
@@ -370,7 +350,7 @@ class LanguageRecognitionTest extends OrmTestCase
      */
     public function testConstantValueInSelect(): void
     {
-        $this->assertValidDQL("SELECT u.name, 'foo' AS bar FROM Doctrine\Tests\Models\CMS\CmsUser u", true);
+        $this->assertValidDQL("SELECT u.name, 'foo' AS bar FROM Doctrine\Tests\Models\CMS\CmsUser u");
     }
 
     public function testDuplicateAliasInSubselectPart(): void
@@ -594,7 +574,7 @@ class LanguageRecognitionTest extends OrmTestCase
     {
         $this->entityManager->getConfiguration()->addCustomStringFunction('CC', Query\AST\Functions\ConcatFunction::class);
 
-        $this->assertValidDQL("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CC('%', u.name) LIKE '%foo%'", true);
+        $this->assertValidDQL("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CC('%', u.name) LIKE '%foo%'");
     }
 
     /**


### PR DESCRIPTION
PHPUnit is pretty good at catching exceptions and printing stack traces, so we don't have to do that.