### PR TITLE
Add helper function `TreeWalkerAdapter::getMetadataForDqlAlias()`

### DIFF
--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -6,11 +6,14 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use LogicException;
 
 use function array_diff;
 use function array_keys;
 use function debug_backtrace;
 use function is_a;
+use function sprintf;
 
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 
@@ -799,5 +802,16 @@ abstract class TreeWalkerAdapter implements TreeWalker
         );
 
         return null;
+    }
+
+    final protected function getMetadataForDqlAlias(string $dqlAlias): ClassMetadata
+    {
+        $metadata = $this->_getQueryComponents()[$dqlAlias]['metadata'] ?? null;
+
+        if ($metadata === null) {
+            throw new LogicException(sprintf('No metadata for DQL alias: %s', $dqlAlias));
+        }
+
+        return $metadata;
     }
 }

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 use RuntimeException;
 
-use function assert;
 use function count;
 use function reset;
 
@@ -31,7 +30,6 @@ class CountWalker extends TreeWalkerAdapter
             throw new RuntimeException('Cannot count query that uses a HAVING clause. Use the output walkers for pagination');
         }
 
-        $queryComponents = $this->_getQueryComponents();
         // Get the root entity and alias from the AST fromClause
         $from = $AST->fromClause->identificationVariableDeclarations;
 
@@ -39,10 +37,9 @@ class CountWalker extends TreeWalkerAdapter
             throw new RuntimeException('Cannot count query which selects two FROM components, cannot make distinction');
         }
 
-        $fromRoot  = reset($from);
-        $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-        assert(isset($queryComponents[$rootAlias]['metadata']));
-        $rootClass           = $queryComponents[$rootAlias]['metadata'];
+        $fromRoot            = reset($from);
+        $rootAlias           = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass           = $this->getMetadataForDqlAlias($rootAlias);
         $identifierFieldName = $rootClass->getSingleIdentifierFieldName();
 
         $pathType = PathExpression::TYPE_STATE_FIELD;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 use RuntimeException;
 
-use function assert;
 use function count;
 use function is_string;
 use function reset;
@@ -38,13 +37,11 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
 
     public function walkSelectStatement(SelectStatement $AST)
     {
-        $queryComponents = $this->_getQueryComponents();
         // Get the root entity and alias from the AST fromClause
         $from      = $AST->fromClause->identificationVariableDeclarations;
         $fromRoot  = reset($from);
         $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-        assert(isset($queryComponents[$rootAlias]['metadata']));
-        $rootClass = $queryComponents[$rootAlias]['metadata'];
+        $rootClass = $this->getMetadataForDqlAlias($rootAlias);
 
         $this->validate($AST);
         $identifier = $rootClass->getSingleIdentifierFieldName();
@@ -75,6 +72,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
             return;
         }
 
+        $queryComponents = $this->_getQueryComponents();
         foreach ($AST->orderByClause->orderByItems as $item) {
             if ($item->expression instanceof PathExpression) {
                 $AST->selectClause->selectExpressions[] = new SelectExpression(

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -49,7 +49,6 @@ class WhereInWalker extends TreeWalkerAdapter
 
     public function walkSelectStatement(SelectStatement $AST)
     {
-        $queryComponents = $this->_getQueryComponents();
         // Get the root entity and alias from the AST fromClause
         $from = $AST->fromClause->identificationVariableDeclarations;
 
@@ -57,10 +56,9 @@ class WhereInWalker extends TreeWalkerAdapter
             throw new RuntimeException('Cannot count query which selects two FROM components, cannot make distinction');
         }
 
-        $fromRoot  = reset($from);
-        $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-        assert(isset($queryComponents[$rootAlias]['metadata']));
-        $rootClass           = $queryComponents[$rootAlias]['metadata'];
+        $fromRoot            = reset($from);
+        $rootAlias           = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClass           = $this->getMetadataForDqlAlias($rootAlias);
         $identifierFieldName = $rootClass->getSingleIdentifierFieldName();
 
         $pathType = PathExpression::TYPE_STATE_FIELD;


### PR DESCRIPTION
Backport from #9551. This little helper makes the code of our tree walker as bit more accessible for static analysis and rids us off some `assert()`s.