### PR TITLE
Removed orderBy clause in walk select statement

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -71,9 +71,7 @@ class CountOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform instanceof SQLServerPlatform) {
-            $AST->orderByClause = null;
-        }
+        $AST->orderByClause = null;
 
         $sql = parent::walkSelectStatement($AST);
 


### PR DESCRIPTION
I've encountered an issue with an IBM Informix database
system would suffer heavily from having an order by in the
count select statement. Currently, this file contains a condition
where it will remove the order by statement for Sql Server.
Why are we keeping for other database systems? Even if it should
only make a minor difference, i can't see a reason to keep this
in the query since we are simply doing a count.