### PR TITLE
Support native enum hydration when using `NEW` operator

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1617,6 +1617,11 @@ class SqlWalker implements TreeWalker
                     }
 
                     $sqlSelectExpressions[] = $col . ' AS ' . $columnAlias;
+
+                    if (! empty($fieldMapping['enumType'])) {
+                        $this->rsm->addEnumResult($columnAlias, $fieldMapping['enumType']);
+                    }
+
                     break;
 
                 case $e instanceof AST\Literal:

--- a/tests/Doctrine/Tests/Models/DataTransferObjects/DtoWithArrayOfEnums.php
+++ b/tests/Doctrine/Tests/Models/DataTransferObjects/DtoWithArrayOfEnums.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\DataTransferObjects;
+
+use Doctrine\Tests\Models\Enums\Unit;
+
+final class DtoWithArrayOfEnums
+{
+    /** @var Unit[] */
+    public $supportedUnits;
+
+    /**
+     * @param Unit[] $supportedUnits
+     */
+    public function __construct(array $supportedUnits)
+    {
+        $this->supportedUnits = $supportedUnits;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DataTransferObjects/DtoWithEnum.php
+++ b/tests/Doctrine/Tests/Models/DataTransferObjects/DtoWithEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\DataTransferObjects;
+
+use Doctrine\Tests\Models\Enums\Suit;
+
+final class DtoWithEnum
+{
+    /** @var Suit|null */
+    public $suit;
+
+    public function __construct(?Suit $suit)
+    {
+        $this->suit = $suit;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -7,7 +7,10 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Query\Expr\Func;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\Models\DataTransferObjects\DtoWithArrayOfEnums;
+use Doctrine\Tests\Models\DataTransferObjects\DtoWithEnum;
 use Doctrine\Tests\Models\Enums\Card;
 use Doctrine\Tests\Models\Enums\CardWithDefault;
 use Doctrine\Tests\Models\Enums\CardWithNullable;
@@ -69,11 +72,7 @@ class EnumTest extends OrmFunctionalTestCase
         $card       = new Card();
         $card->suit = Suit::Clubs;
 
-        $cardWithNullable       = new CardWithNullable();
-        $cardWithNullable->suit = null;
-
         $this->_em->persist($card);
-        $this->_em->persist($cardWithNullable);
         $this->_em->flush();
         $this->_em->clear();
 
@@ -85,6 +84,18 @@ class EnumTest extends OrmFunctionalTestCase
 
         $this->assertInstanceOf(Suit::class, $result[0]['suit']);
         $this->assertEquals(Suit::Clubs, $result[0]['suit']);
+    }
+
+    public function testNullableEnumHydration(): void
+    {
+        $this->setUpEntitySchema([Card::class, CardWithNullable::class]);
+
+        $cardWithNullable       = new CardWithNullable();
+        $cardWithNullable->suit = null;
+
+        $this->_em->persist($cardWithNullable);
+        $this->_em->flush();
+        $this->_em->clear();
 
         $result = $this->_em->createQueryBuilder()
             ->from(CardWithNullable::class, 'c')
@@ -113,6 +124,66 @@ class EnumTest extends OrmFunctionalTestCase
             ->getResult();
 
         self::assertEqualsCanonicalizing([Unit::Gram, Unit::Meter], $result[0]['supportedUnits']);
+    }
+
+    public function testEnumInDtoHydration(): void
+    {
+        $this->setUpEntitySchema([Card::class, CardWithNullable::class]);
+
+        $card       = new Card();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->createQueryBuilder()
+            ->from(CardWithNullable::class, 'c')
+            ->select('NEW ' . DtoWithEnum::class . '(c.suit)')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertNull($result[0]->suit);
+    }
+
+    public function testNullableEnumInDtoHydration(): void
+    {
+        $this->setUpEntitySchema([Card::class, CardWithNullable::class]);
+
+        $cardWithNullable       = new CardWithNullable();
+        $cardWithNullable->suit = null;
+
+        $this->_em->persist($cardWithNullable);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->createQueryBuilder()
+            ->from(CardWithNullable::class, 'c')
+            ->select('NEW ' . DtoWithEnum::class . '(c.suit)')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertNull($result[0]->suit);
+    }
+
+    public function testEnumArrayInDtoHydration(): void
+    {
+        $this->setUpEntitySchema([Scale::class]);
+
+        $scale                 = new Scale();
+        $scale->supportedUnits = [Unit::Gram, Unit::Meter];
+
+        $this->_em->persist($scale);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->createQueryBuilder()
+            ->from(Scale::class, 's')
+            ->select(new Func('NEW ' . DtoWithArrayOfEnums::class, ['s.supportedUnits']))
+            ->getQuery()
+            ->getResult();
+
+        self::assertEqualsCanonicalizing([Unit::Gram, Unit::Meter], $result[0]->supportedUnits);
     }
 
     public function testFindByEnum(): void


### PR DESCRIPTION
Using the `NEW` operator with the query builder now properly converts
scalar values to native enums inside data transfer objects.