### PR TITLE
Use a more precise phpdoc for ClassMetadataInfo::versionField than mixed

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 
 use function array_merge;
+use function assert;
 use function is_array;
 use function is_object;
 use function reset;
@@ -57,6 +58,7 @@ class DefaultEntityHydrator implements EntityHydrator
 
         if ($metadata->requiresFetchAfterChange) {
             if ($metadata->isVersioned) {
+                assert($metadata->versionField !== null);
                 $data[$metadata->versionField] = $metadata->getFieldValue($entity, $metadata->versionField);
             }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3518,7 +3518,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the name of the field that is to be used for versioning if this class is
      * versioned for optimistic locking.
      *
-     * @param string $versionField
+     * @param string|null $versionField
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -713,7 +713,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
      *
-     * @var mixed
+     * @var string
      */
     public $versionField;
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -713,7 +713,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
      *
-     * @var string
+     * @var string|null
      */
     public $versionField;
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -494,7 +494,8 @@ class BasicEntityPersister implements EntityPersister
         }
 
         if ($versioned) {
-            $versionField     = $this->class->versionField;
+            $versionField = $this->class->versionField;
+            assert($versionField !== null);
             $versionFieldType = $this->class->fieldMappings[$versionField]['type'];
             $versionColumn    = $this->quoteStrategy->getColumnName($versionField, $this->class, $this->platform);
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -54,6 +54,7 @@ use function array_merge;
 use function array_pop;
 use function array_sum;
 use function array_values;
+use function assert;
 use function count;
 use function current;
 use function get_class;
@@ -1612,6 +1613,8 @@ class UnitOfWork implements PropertyChangedListener
             case $class->isIdentifierNatural():
                 // Check for a version field, if available, to avoid a db lookup.
                 if ($class->isVersioned) {
+                    assert($class->versionField !== null);
+
                     return $class->getFieldValue($entity, $class->versionField)
                         ? self::STATE_DETACHED
                         : self::STATE_NEW;
@@ -2061,6 +2064,7 @@ class UnitOfWork implements PropertyChangedListener
             return;
         }
 
+        assert($class->versionField !== null);
         $reflField          = $class->reflFields[$class->versionField];
         $managedCopyVersion = $reflField->getValue($managedCopy);
         $entityVersion      = $reflField->getValue($entity);
@@ -2495,6 +2499,7 @@ class UnitOfWork implements PropertyChangedListener
                     $entity->__load();
                 }
 
+                assert($class->versionField !== null);
                 $entityVersion = $class->reflFields[$class->versionField]->getValue($entity);
 
                 // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator


### PR DESCRIPTION
The phpdoc for $versionField is mixed but this should be `string|null` instead
- Everytime it's not null, it's used as an array key.
- `public function setVersionField($versionField)` were only accepting string.