### PR TITLE
Stop passing event manager to constructor

### DIFF
--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -64,10 +64,6 @@ class EntityManagerMock extends EntityManager
             $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
         }
 
-        if ($eventManager === null) {
-            $eventManager = $conn->getEventManager();
-        }
-
-        return new EntityManagerMock($conn, $config, $eventManager);
+        return new EntityManagerMock($conn, $config);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -324,7 +324,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $config->setMetadataDriverImpl($metadataDriver);
 
-        return EntityManagerMock::create($conn, $config, $eventManager);
+        return EntityManagerMock::create($conn, $config);
     }
 
     protected function createTestFactory(): ClassMetadataFactoryTestSubject

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -851,7 +851,7 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_connectionMock = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['commit'])
             ->setConstructorArgs([[], $driver])
             ->getMock();
-        $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null);
+        $this->_emMock         = EntityManagerMock::create($this->_connectionMock);
         $this->_unitOfWork     = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
 

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -851,7 +851,7 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_connectionMock = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['commit'])
             ->setConstructorArgs([[], $driver])
             ->getMock();
-        $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null, $this->eventManager);
+        $this->_emMock         = EntityManagerMock::create($this->_connectionMock, null);
         $this->_unitOfWork     = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
 


### PR DESCRIPTION
That argument has been removed in #9915

Stumbled upon this while trying to merge up… IMO we should reconsider not statically analyzing the tests directory.