### PR TITLE
Store PersistentCollection changes in entity change set as array

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -141,6 +141,12 @@ Use one of the dedicated event classes instead:
 * `Doctrine\ORM\Event\PostRemoveEventArgs`
 * `Doctrine\ORM\Event\PostLoadEventArgs`
 
+## BC BREAK: Changed entity changeset when a `Collection` is modified
+
+When working with an entity with a `Collection` property, when that property
+is changed, the changeset stored in `UnitOfWork` includes the old and the new
+value of this property as an array of two items.
+
 ## BC BREAK: Removed `AttributeDriver::$entityAnnotationClasses` and `AttributeDriver::getReader()`
 
 * If you need to change the behavior of `AttributeDriver::isTransient()`,

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\PersistentCollection;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use InvalidArgumentException;
 
@@ -19,12 +18,12 @@ use function sprintf;
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {
-    /** @var array<string, array{mixed, mixed}|PersistentCollection> */
+    /** @var array<string, array{mixed, mixed}> */
     private array $entityChangeSet;
 
     /**
      * @param mixed[][] $changeSet
-     * @psalm-param array<string, array{mixed, mixed}|PersistentCollection> $changeSet
+     * @psalm-param array<string, array{mixed, mixed}> $changeSet
      */
     public function __construct(object $entity, EntityManagerInterface $em, array &$changeSet)
     {
@@ -37,7 +36,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      * Retrieves entity changeset.
      *
      * @return mixed[][]
-     * @psalm-return array<string, array{mixed, mixed}|PersistentCollection>
+     * @psalm-return array<string, array{mixed, mixed}>
      */
     public function getEntityChangeSet(): array
     {

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -5,95 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
-use InvalidArgumentException;
-
-use function get_debug_type;
-use function sprintf;
+use Doctrine\Persistence\Event\PreUpdateEventArgs as BasePreUpdateEventArgs;
 
 /**
  * Class that holds event arguments for a preUpdate event.
  *
- * @extends LifecycleEventArgs<EntityManagerInterface>
+ * @extends BasePreUpdateEventArgs<EntityManagerInterface>
  */
-class PreUpdateEventArgs extends LifecycleEventArgs
+class PreUpdateEventArgs extends BasePreUpdateEventArgs
 {
-    /** @var array<string, array{mixed, mixed}> */
-    private array $entityChangeSet;
-
-    /**
-     * @param mixed[][] $changeSet
-     * @psalm-param array<string, array{mixed, mixed}> $changeSet
-     */
-    public function __construct(object $entity, EntityManagerInterface $em, array &$changeSet)
-    {
-        parent::__construct($entity, $em);
-
-        $this->entityChangeSet = &$changeSet;
-    }
-
-    /**
-     * Retrieves entity changeset.
-     *
-     * @return mixed[][]
-     * @psalm-return array<string, array{mixed, mixed}>
-     */
-    public function getEntityChangeSet(): array
-    {
-        return $this->entityChangeSet;
-    }
-
-    /**
-     * Checks if field has a changeset.
-     */
-    public function hasChangedField(string $field): bool
-    {
-        return isset($this->entityChangeSet[$field]);
-    }
-
-    /**
-     * Gets the old value of the changeset of the changed field.
-     */
-    public function getOldValue(string $field): mixed
-    {
-        $this->assertValidField($field);
-
-        return $this->entityChangeSet[$field][0];
-    }
-
-    /**
-     * Gets the new value of the changeset of the changed field.
-     */
-    public function getNewValue(string $field): mixed
-    {
-        $this->assertValidField($field);
-
-        return $this->entityChangeSet[$field][1];
-    }
-
-    /**
-     * Sets the new value of this field.
-     */
-    public function setNewValue(string $field, mixed $value): void
-    {
-        $this->assertValidField($field);
-
-        $this->entityChangeSet[$field][1] = $value;
-    }
-
-    /**
-     * Asserts the field exists in changeset.
-     *
-     * @throws InvalidArgumentException
-     */
-    private function assertValidField(string $field): void
-    {
-        if (! isset($this->entityChangeSet[$field])) {
-            throw new InvalidArgumentException(sprintf(
-                'Field "%s" is not a valid field of the entity "%s" in PreUpdateEventArgs.',
-                $field,
-                get_debug_type($this->getObject()),
-            ));
-        }
-    }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -514,7 +514,7 @@ class UnitOfWork implements PropertyChangedListener
      * Gets the changeset for an entity.
      *
      * @return mixed[][]
-     * @psalm-return array<string, array{mixed, mixed}|PersistentCollection>
+     * @psalm-return array<string, array{mixed, mixed}>
      */
     public function & getEntityChangeSet(object $entity): array
     {
@@ -715,7 +715,7 @@ class UnitOfWork implements PropertyChangedListener
                     }
 
                     $this->collectionDeletions[$coid] = $orgValue;
-                    $changeSet[$propName]             = $orgValue; // Signal changeset, to-many assocs will be ignored.
+                    $changeSet[$propName]             = [$orgValue, $actualValue];
 
                     continue;
                 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1214,11 +1214,7 @@
       <code>$collectionToDelete</code>
       <code>$collectionToUpdate</code>
     </InvalidArgument>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->entityChangeSets]]></code>
-      <code><![CDATA[$this->entityChangeSets]]></code>
-    </InvalidPropertyAssignmentValue>
-    <NoValue>
+    <NoValue occurrences="2">
       <code>$entityState</code>
       <code>$entityState</code>
     </NoValue>


### PR DESCRIPTION
The property `$entityChangeSets` of UnitOfWork stores entity changes as an array of two items for each property changed. 

https://github.com/doctrine/orm/blob/a3a8caae516d8b88c025692159ce44f7ee7f1844/lib/Doctrine/ORM/UnitOfWork.php#L143-L149

But for `Collection` it has another behaviour as pointed out in https://github.com/doctrine/orm/discussions/8955 and changed the phpdoc in https://github.com/doctrine/orm/pull/8959.

That was added in https://github.com/doctrine/orm/commit/65bbdc30de891340b685c483046b535be4282718.

This PR modifies that case storing an `array` instead of the `PersistentCollection`, this will allow `PreUpdateEventArgs` to extend from `PreUpdateEventArgs` of `doctrine/persistence`.

I'm not sure if this is the right fix, but apparently the test added in the original commit passes with this change.