### PR TITLE
Fix DBAL 4 compatibility

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\QueryCacheKey;
@@ -327,15 +328,15 @@ abstract class AbstractQuery
     /**
      * Sets a query parameter.
      *
-     * @param string|int      $key   The parameter position or name.
-     * @param mixed           $value The parameter value.
-     * @param string|int|null $type  The parameter type. If specified, the given value will be run through
-     *                               the type conversion of this type. This is usually not needed for
-     *                               strings and numeric types.
+     * @param string|int                    $key   The parameter position or name.
+     * @param mixed                         $value The parameter value.
+     * @param ParameterType|string|int|null $type  The parameter type. If specified, the given value will be run through
+     *                                             the type conversion of this type. This is usually not needed for
+     *                                             strings and numeric types.
      *
      * @return $this
      */
-    public function setParameter(string|int $key, mixed $value, string|int|null $type = null): static
+    public function setParameter(string|int $key, mixed $value, ParameterType|string|int|null $type = null): static
     {
         $existingParameter = $this->getParameter($key);
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\EntityCacheKey;
@@ -83,8 +84,14 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         return $this->persister->getInserts();
     }
 
-    public function getSelectSQL(array|Criteria $criteria, ?array $assoc = null, ?int $lockMode = null, ?int $limit = null, ?int $offset = null, ?array $orderBy = null): string
-    {
+    public function getSelectSQL(
+        array|Criteria $criteria,
+        ?array $assoc = null,
+        LockMode|int|null $lockMode = null,
+        ?int $limit = null,
+        ?int $offset = null,
+        ?array $orderBy = null
+    ): string {
         return $this->persister->getSelectSQL($criteria, $assoc, $lockMode, $limit, $offset, $orderBy);
     }
 
@@ -103,8 +110,12 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         return $this->persister->getResultSetMapping();
     }
 
-    public function getSelectConditionStatementSQL(string $field, mixed $value, ?array $assoc = null, ?string $comparison = null): string
-    {
+    public function getSelectConditionStatementSQL(
+        string $field,
+        mixed $value,
+        ?array $assoc = null,
+        ?string $comparison = null
+    ): string {
         return $this->persister->getSelectConditionStatementSQL($field, $value, $assoc, $comparison);
     }
 
@@ -191,8 +202,13 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      * @param string[]|Criteria $criteria
      * @param string[]          $orderBy
      */
-    protected function getHash(string $query, array|Criteria $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): string
-    {
+    protected function getHash(
+        string $query,
+        array|Criteria $criteria,
+        ?array $orderBy = null,
+        ?int $limit = null,
+        ?int $offset = null
+    ): string {
         [$params] = $criteria instanceof Criteria
             ? $this->persister->expandCriteriaParameters($criteria)
             : $this->persister->expandParameters($criteria);
@@ -224,16 +240,24 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function getManyToManyCollection(array $assoc, object $sourceEntity, ?int $offset = null, ?int $limit = null): array
-    {
+    public function getManyToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        ?int $offset = null,
+        ?int $limit = null
+    ): array {
         return $this->persister->getManyToManyCollection($assoc, $sourceEntity, $offset, $limit);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getOneToManyCollection(array $assoc, object $sourceEntity, ?int $offset = null, ?int $limit = null): array
-    {
+    public function getOneToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        ?int $offset = null,
+        ?int $limit = null
+    ): array {
         return $this->persister->getOneToManyCollection($assoc, $sourceEntity, $offset, $limit);
     }
 
@@ -255,8 +279,15 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function load(array $criteria, ?object $entity = null, ?array $assoc = null, array $hints = [], ?int $lockMode = null, ?int $limit = null, ?array $orderBy = null): ?object
-    {
+    public function load(
+        array $criteria,
+        ?object $entity = null,
+        ?array $assoc = null,
+        array $hints = [],
+        LockMode|int|null $lockMode = null,
+        ?int $limit = null,
+        ?array $orderBy = null
+    ): ?object {
         if ($entity !== null || $assoc !== null || $hints !== [] || $lockMode !== null) {
             return $this->persister->load($criteria, $entity, $assoc, $hints, $lockMode, $limit, $orderBy);
         }
@@ -295,8 +326,12 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadAll(array $criteria = [], ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
-    {
+    public function loadAll(
+        array $criteria = [],
+        ?array $orderBy = null,
+        ?int $limit = null,
+        ?int $offset = null
+    ): array {
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
         $hash       = $this->getHash($query, $criteria);
         $rsm        = $this->getResultSetMapping();
@@ -419,8 +454,11 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadManyToManyCollection(array $assoc, object $sourceEntity, PersistentCollection $collection): array
-    {
+    public function loadManyToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        PersistentCollection $collection
+    ): array {
         $persister = $this->uow->getCollectionPersister($assoc);
         $hasCache  = ($persister instanceof CachedPersister);
 
@@ -450,8 +488,11 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToManyCollection(array $assoc, object $sourceEntity, PersistentCollection $collection): mixed
-    {
+    public function loadOneToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        PersistentCollection $collection
+    ): mixed {
         $persister = $this->uow->getCollectionPersister($assoc);
         $hasCache  = ($persister instanceof CachedPersister);
 
@@ -489,7 +530,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function lock(array $criteria, int $lockMode): void
+    public function lock(array $criteria, LockMode|int $lockMode): void
     {
         $this->persister->lock($criteria, $lockMode);
     }
@@ -497,7 +538,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function refresh(array $id, object $entity, ?int $lockMode = null): void
+    public function refresh(array $id, object $entity, LockMode|int|null $lockMode = null): void
     {
         $this->persister->refresh($id, $entity, $lockMode);
     }

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Decorator;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
@@ -119,12 +120,12 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritdoc}
      */
-    public function lock(object $entity, int $lockMode, $lockVersion = null): void
+    public function lock(object $entity, LockMode|int $lockMode, $lockVersion = null): void
     {
         $this->wrapped->lock($entity, $lockMode, $lockVersion);
     }
 
-    public function find(string $className, mixed $id, ?int $lockMode = null, ?int $lockVersion = null): ?object
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?object
     {
         return $this->wrapped->find($className, $id, $lockMode, $lockVersion);
     }

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -270,7 +270,7 @@ use function ltrim;
     /**
      * {@inheritdoc}
      */
-    public function find($className, mixed $id, ?int $lockMode = null, ?int $lockVersion = null): ?object
+    public function find($className, mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?object
     {
         $class = $this->metadataFactory->getMetadataFor(ltrim($className, '\\'));
 
@@ -520,7 +520,7 @@ use function ltrim;
     /**
      * {@inheritDoc}
      */
-    public function lock(object $entity, int $lockMode, $lockVersion = null): void
+    public function lock(object $entity, LockMode|int $lockMode, $lockVersion = null): void
     {
         $this->unitOfWork->lock($entity, $lockMode, $lockVersion);
     }
@@ -689,7 +689,7 @@ use function ltrim;
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */
-    private function checkLockRequirements(int $lockMode, ClassMetadata $class): void
+    private function checkLockRequirements(LockMode|int $lockMode, ClassMetadata $class): void
     {
         switch ($lockMode) {
             case LockMode::OPTIMISTIC:

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -110,13 +110,13 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string   $className   The class name of the entity to find.
-     * @param mixed    $id          The identity of the entity to find.
-     * @param int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
-     *                              or NULL if no specific lock mode should be used
-     *                              during the search.
-     * @param int|null $lockVersion The version of the entity to find when using
-     *                              optimistic locking.
+     * @param string            $className   The class name of the entity to find.
+     * @param mixed             $id          The identity of the entity to find.
+     * @param LockMode|int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
+     *                                       or NULL if no specific lock mode should be used
+     *                                       during the search.
+     * @param int|null          $lockVersion The version of the entity to find when using
+     *                                       optimistic locking.
      * @psalm-param class-string<T> $className
      * @psalm-param LockMode::*|null $lockMode
      *
@@ -130,7 +130,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @template T of object
      */
-    public function find(string $className, mixed $id, ?int $lockMode = null, ?int $lockVersion = null): ?object;
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?object;
 
     /**
      * Gets a reference to the entity identified by the given type and identifier
@@ -189,7 +189,7 @@ interface EntityManagerInterface extends ObjectManager
      * @throws OptimisticLockException
      * @throws PessimisticLockException
      */
-    public function lock(object $entity, int $lockMode, $lockVersion = null): void;
+    public function lock(object $entity, LockMode|int $lockMode, $lockVersion = null): void;
 
     /**
      * Gets the EventManager used by the EntityManager.

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -75,15 +75,15 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Finds an entity by its primary key / identifier.
      *
-     * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                           or NULL if no specific lock mode should be used
-     *                           during the search.
+     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                                    or NULL if no specific lock mode should be used
+     *                                    during the search.
      * @psalm-param LockMode::*|null $lockMode
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @psalm-return ?T
      */
-    public function find(mixed $id, ?int $lockMode = null, ?int $lockVersion = null): ?object
+    public function find(mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?object
     {
         return $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
     }

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Collection;
 use BadMethodCallException;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
@@ -86,7 +87,14 @@ class ManyToManyPersister extends AbstractCollectionPersister
             ? $mapping['inversedBy']
             : $mapping['mappedBy'];
 
-        return $persister->load([$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index], null, $mapping, [], 0, 1);
+        return $persister->load(
+            [$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index],
+            null,
+            $mapping,
+            [],
+            LockMode::NONE,
+            1
+        );
     }
 
     public function count(PersistentCollection $collection): int

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\PersistentCollection;
@@ -47,7 +48,14 @@ interface EntityPersister
      * @param mixed[]|null     $orderBy
      * @psalm-param LockMode::*|null $lockMode
      */
-    public function getSelectSQL(array|Criteria $criteria, ?array $assoc = null, ?int $lockMode = null, ?int $limit = null, ?int $offset = null, ?array $orderBy = null): string;
+    public function getSelectSQL(
+        array|Criteria $criteria,
+        ?array $assoc = null,
+        LockMode|int|null $lockMode = null,
+        ?int $limit = null,
+        ?int $offset = null,
+        ?array $orderBy = null
+    ): string;
 
     /**
      * Get the COUNT SQL to count entities (optionally based on a criteria)
@@ -61,14 +69,14 @@ interface EntityPersister
      *
      * @param string[] $criteria
      *
-     * @psalm-return array{list<mixed>, list<int|string|null>}
+     * @psalm-return array{list<mixed>, list<ParameterType::*|int|string>}
      */
     public function expandParameters(array $criteria): array;
 
     /**
      * Expands Criteria Parameters by walking the expressions and grabbing all parameters and types from it.
      *
-     * @psalm-return array{list<mixed>, list<int|string|null>}
+     * @psalm-return array{list<mixed>, list<ParameterType::*|int|string>}
      */
     public function expandCriteriaParameters(Criteria $criteria): array;
 
@@ -77,7 +85,12 @@ interface EntityPersister
      *
      * @psalm-param array<string, mixed>|null  $assoc
      */
-    public function getSelectConditionStatementSQL(string $field, mixed $value, ?array $assoc = null, ?string $comparison = null): string;
+    public function getSelectConditionStatementSQL(
+        string $field,
+        mixed $value,
+        ?array $assoc = null,
+        ?string $comparison = null
+    ): string;
 
     /**
      * Adds an entity to the queued insertions.
@@ -137,17 +150,17 @@ interface EntityPersister
     /**
      * Loads an entity by a list of field criteria.
      *
-     * @param mixed[]       $criteria The criteria by which to load the entity.
-     * @param object|null   $entity   The entity to load the data into. If not specified,
-     *                                a new entity is created.
-     * @param mixed[]|null  $assoc    The association that connects the entity
-     *                                to load to another entity, if any.
-     * @param mixed[]       $hints    Hints for entity creation.
-     * @param int|null      $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                                or NULL if no specific lock mode should be used
-     *                                for loading the entity.
-     * @param int|null      $limit    Limit number of results.
-     * @param string[]|null $orderBy  Criteria to order by.
+     * @param mixed[]           $criteria The criteria by which to load the entity.
+     * @param object|null       $entity   The entity to load the data into. If not specified,
+     *                                    a new entity is created.
+     * @param mixed[]|null      $assoc    The association that connects the entity
+     *                                    to load to another entity, if any.
+     * @param mixed[]           $hints    Hints for entity creation.
+     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                                    or NULL if no specific lock mode should be used
+     *                                    for loading the entity.
+     * @param int|null          $limit    Limit number of results.
+     * @param string[]|null     $orderBy  Criteria to order by.
      * @psalm-param array<string, mixed>       $criteria
      * @psalm-param array<string, mixed>|null  $assoc
      * @psalm-param array<string, mixed>       $hints
@@ -163,7 +176,7 @@ interface EntityPersister
         ?object $entity = null,
         ?array $assoc = null,
         array $hints = [],
-        ?int $lockMode = null,
+        LockMode|int|null $lockMode = null,
         ?int $limit = null,
         ?array $orderBy = null
     ): ?object;
@@ -199,15 +212,15 @@ interface EntityPersister
     /**
      * Refreshes a managed entity.
      *
-     * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                           or NULL if no specific lock mode should be used
-     *                           for refreshing the managed entity.
+     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                                    or NULL if no specific lock mode should be used
+     *                                    for refreshing the managed entity.
      * @psalm-param array<string, mixed> $id The identifier of the entity as an
      *                                       associative array from column or
      *                                       field names to values.
      * @psalm-param LockMode::*|null $lockMode
      */
-    public function refresh(array $id, object $entity, ?int $lockMode = null): void;
+    public function refresh(array $id, object $entity, LockMode|int|null $lockMode = null): void;
 
     /**
      * Loads Entities matching the given Criteria object.
@@ -224,7 +237,12 @@ interface EntityPersister
      *
      * @return mixed[]
      */
-    public function loadAll(array $criteria = [], ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array;
+    public function loadAll(
+        array $criteria = [],
+        ?array $orderBy = null,
+        ?int $limit = null,
+        ?int $offset = null
+    ): array;
 
     /**
      * Gets (sliced or full) elements of the given collection.
@@ -233,7 +251,12 @@ interface EntityPersister
      *
      * @return mixed[]
      */
-    public function getManyToManyCollection(array $assoc, object $sourceEntity, ?int $offset = null, ?int $limit = null): array;
+    public function getManyToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        ?int $offset = null,
+        ?int $limit = null
+    ): array;
 
     /**
      * Loads a collection of entities of a many-to-many association.
@@ -244,7 +267,11 @@ interface EntityPersister
      *
      * @return mixed[]
      */
-    public function loadManyToManyCollection(array $assoc, object $sourceEntity, PersistentCollection $collection): array;
+    public function loadManyToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        PersistentCollection $collection
+    ): array;
 
     /**
      * Loads a collection of entities in a one-to-many association.
@@ -252,7 +279,11 @@ interface EntityPersister
      * @param PersistentCollection $collection The collection to load/fill.
      * @psalm-param array<string, mixed> $assoc
      */
-    public function loadOneToManyCollection(array $assoc, object $sourceEntity, PersistentCollection $collection): mixed;
+    public function loadOneToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        PersistentCollection $collection
+    ): mixed;
 
     /**
      * Locks all rows of this entity matching the given criteria with the specified pessimistic lock mode.
@@ -260,7 +291,7 @@ interface EntityPersister
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param LockMode::* $lockMode
      */
-    public function lock(array $criteria, int $lockMode): void;
+    public function lock(array $criteria, LockMode|int $lockMode): void;
 
     /**
      * Returns an array with (sliced or full list) of elements in the specified collection.
@@ -269,7 +300,12 @@ interface EntityPersister
      *
      * @return mixed[]
      */
-    public function getOneToManyCollection(array $assoc, object $sourceEntity, ?int $offset = null, ?int $limit = null): array;
+    public function getOneToManyCollection(
+        array $assoc,
+        object $sourceEntity,
+        ?int $offset = null,
+        ?int $limit = null
+    ): array;
 
     /**
      * Checks whether the given managed entity exists in the database.

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -236,7 +236,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         return (bool) $this->conn->delete($rootTable, $id, $rootTypes);
     }
 
-    public function getSelectSQL(array|Criteria $criteria, ?array $assoc = null, ?int $lockMode = null, ?int $limit = null, ?int $offset = null, ?array $orderBy = null): string
+    public function getSelectSQL(array|Criteria $criteria, ?array $assoc = null, LockMode|int|null $lockMode = null, ?int $limit = null, ?int $offset = null, ?array $orderBy = null): string
     {
         $this->switchPersisterContext($offset, $limit);
 
@@ -324,7 +324,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             . (empty($conditionSql) ? '' : ' WHERE ' . $conditionSql);
     }
 
-    protected function getLockTablesSql(int $lockMode): string
+    protected function getLockTablesSql(LockMode|int $lockMode): string
     {
         $joinSql           = '';
         $identifierColumns = $this->class->getIdentifierColumnNames();

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -648,7 +648,7 @@ final class Query extends AbstractQuery
      *
      * @throws TransactionRequiredException
      */
-    public function setLockMode(int $lockMode): self
+    public function setLockMode(LockMode|int $lockMode): self
     {
         if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if (! $this->em->getConnection()->isTransactionActive()) {

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -84,7 +84,7 @@ class TrimFunction extends FunctionNode
     /**
      * @psalm-return TrimMode::*
      */
-    private function getTrimMode(): int
+    private function getTrimMode(): TrimMode|int
     {
         if ($this->leading) {
             return TrimMode::LEADING;

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -29,7 +29,7 @@ final class ParameterTypeInferer
      * - Type (\Doctrine\DBAL\Types\Type::*)
      * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
      */
-    public static function inferType(mixed $value): int|string
+    public static function inferType(mixed $value): ParameterType|int|string
     {
         if (is_int($value)) {
             return Types::INTEGER;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2013,7 +2013,7 @@ class UnitOfWork implements PropertyChangedListener
      * @throws TransactionRequiredException
      * @throws OptimisticLockException
      */
-    public function lock(object $entity, int $lockMode, $lockVersion = null): void
+    public function lock(object $entity, LockMode|int $lockMode, $lockVersion = null): void
     {
         if ($this->getEntityState($entity, self::STATE_DETACHED) !== self::STATE_MANAGED) {
             throw ORMInvalidArgumentException::entityNotManaged($entity);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,13 @@ parameters:
 
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
+
+        # We can be certain that those values are not matched.
+        -
+            message: '~^Match expression does not handle remaining values:~'
+            path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+
+        # DBAL 4 compatibility
+        -
+            message: '~^Method Doctrine\\ORM\\Query\\AST\\Functions\\TrimFunction::getTrimMode\(\) never returns .* so it can be removed from the return type\.$~'
+            path: lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1030,10 +1030,9 @@
       <code>array</code>
       <code>array</code>
     </MoreSpecificReturnType>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="2">
       <code>$assoc['mappedBy']</code>
       <code>$association</code>
-      <code>$type</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="1">
       <code>$assoc['isOwningSide']</code>
@@ -2244,16 +2243,10 @@
       <code>$collectionToUpdate</code>
       <code>$commitOrder[$i]</code>
     </ArgumentTypeCoercion>
-    <InvalidNullableReturnType occurrences="1">
-      <code>object</code>
-    </InvalidNullableReturnType>
     <InvalidPropertyAssignmentValue occurrences="2">
       <code>$this-&gt;entityChangeSets</code>
       <code>$this-&gt;entityChangeSets</code>
     </InvalidPropertyAssignmentValue>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
-    </NullableReturnStatement>
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$this-&gt;identityMap[$rootClassName]</code>
     </PossiblyInvalidArrayOffset>

--- a/psalm.xml
+++ b/psalm.xml
@@ -148,6 +148,12 @@
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
             </errorLevel>
         </UndefinedClass>
+        <UnhandledMatchCondition>
+            <errorLevel type="suppress">
+                <!-- We can be certain that those values are not matched. -->
+                <file name="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php"/>
+            </errorLevel>
+        </UnhandledMatchCondition>
         <ArgumentTypeCoercion>
             <errorLevel type="suppress">
                 <!-- See https://github.com/JetBrains/phpstorm-stubs/pull/1383 -->

--- a/tests/Doctrine/Performance/Mock/NonLoadingPersister.php
+++ b/tests/Doctrine/Performance/Mock/NonLoadingPersister.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Performance\Mock;
 
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 
 /**
@@ -23,7 +24,7 @@ class NonLoadingPersister extends BasicEntityPersister
         ?object $entity = null,
         ?array $assoc = null,
         array $hints = [],
-        ?int $lockMode = null,
+        LockMode|int|null $lockMode = null,
         ?int $limit = null,
         ?array $orderBy = null
     ): ?object {

--- a/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -6,6 +6,7 @@ namespace Doctrine\Performance\Mock;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
@@ -132,7 +133,7 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function lock(object $entity, int $lockMode, $lockVersion = null): void
+    public function lock(object $entity, LockMode|int $lockMode, $lockVersion = null): void
     {
         $this->realEntityManager->lock($entity, $lockMode, $lockVersion);
     }
@@ -175,7 +176,7 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
         return $this->realEntityManager->hasFilters();
     }
 
-    public function find(string $className, mixed $id, ?int $lockMode = null, ?int $lockVersion = null): ?object
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null): ?object
     {
         return $this->realEntityManager->find($className, $id, $lockMode, $lockVersion);
     }

--- a/tests/Doctrine/Tests/Mocks/CompatibilityType.php
+++ b/tests/Doctrine/Tests/Mocks/CompatibilityType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks;
+
+use Doctrine\DBAL\ParameterType;
+
+use function enum_exists;
+
+use const PHP_VERSION_ID;
+
+if (PHP_VERSION_ID < 80100 || ! enum_exists(ParameterType::class)) {
+    trait CompatibilityType
+    {
+        public function getBindingType(): int
+        {
+            return $this->doGetBindingType();
+        }
+
+        private function doGetBindingType(): int|ParameterType
+        {
+            return parent::getBindingType();
+        }
+    }
+} else {
+    trait CompatibilityType
+    {
+        public function getBindingType(): ParameterType
+        {
+            return $this->doGetBindingType();
+        }
+
+        private function doGetBindingType(): int|ParameterType
+        {
+            return parent::getBindingType();
+        }
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9335Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\Tests\Mocks\CompatibilityType;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -54,6 +55,8 @@ final class GH9335Test extends OrmFunctionalTestCase
 
 class GH9335IntObjectType extends Type
 {
+    use CompatibilityType;
+
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getIntegerTypeDeclarationSQL($column);
@@ -74,7 +77,7 @@ class GH9335IntObjectType extends Type
         return new GH9335IntObject((int) $value);
     }
 
-    public function getBindingType(): int
+    private function doGetBindingType(): ParameterType|int
     {
         return ParameterType::INTEGER;
     }

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -46,7 +46,7 @@ class ParameterTypeInfererTest extends OrmTestCase
     /**
      * @dataProvider providerParameterTypeInferer
      */
-    public function testParameterTypeInferer(mixed $value, int|string $expected): void
+    public function testParameterTypeInferer(mixed $value, ParameterType|int|string $expected): void
     {
         self::assertEquals($expected, ParameterTypeInferer::inferType($value));
     }


### PR DESCRIPTION
DBAL 4's switch to enums made some changes necessary. Maybe it would be wise at this point to introduce our own enums for `LockMode` and `ParameterType`, to be more resilient to this kind of changes?