### PR TITLE
fix: disabling versioning

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3509,9 +3509,8 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->isVersioned = $bool;
 
-        if ($bool) {
-            $this->requiresFetchAfterChange = true;
-        }
+        $this->requiresFetchAfterChange = $bool 
+                                          || count(array_column($this->fieldMappings, 'generated')) > 0;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -28,6 +28,7 @@ use ReflectionNamedType;
 use ReflectionProperty;
 use RuntimeException;
 
+use function array_column;
 use function array_diff;
 use function array_flip;
 use function array_intersect;
@@ -3509,7 +3510,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->isVersioned = $bool;
 
-        $this->requiresFetchAfterChange = $bool 
+        $this->requiresFetchAfterChange = $bool
                                           || count(array_column($this->fieldMappings, 'generated')) > 0;
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -288,10 +288,11 @@ class ClassMetadataTest extends OrmTestCase
 
     public function testDisablingVersioningRestoresOriginalState(): void
     {
-        $field = ['fieldName' => 'version', 'type' => 'integer'];
+        $versionedField = ['fieldName' => 'version', 'type' => 'integer'];
+        
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->setVersionMapping($field);
+        $cm->setVersionMapping($versionedField);
 
         self::assertTrue($cm->isVersioned);
         self::assertEquals('version', $cm->versionField);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -309,7 +309,7 @@ class ClassMetadataTest extends OrmTestCase
     public function testDisablingVersioningWithGeneratedFieldsRestoresOriginalState(): void
     {
         $versionedField = ['fieldName' => 'version', 'type' => 'integer'];
-        $generatedField = ['fieldName' => 'id', 'type' => 'integer', 'generated'=> ClassMetadata::GENERATED_ALWAYS];
+        $generatedField = ['fieldName' => 'id', 'type' => 'integer', 'generated' => ClassMetadata::GENERATED_ALWAYS];
 
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -286,6 +286,25 @@ class ClassMetadataTest extends OrmTestCase
         $cm->setVersionMapping($field);
     }
 
+    public function testDisablingVersioningRestoresOriginalState(): void
+    {
+        $field = ['fieldName' => 'version', 'type' => 'integer'];
+        $cm = new ClassMetadata(CMS\CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->setVersionMapping($field);
+
+        self::assertTrue($cm->isVersioned);
+        self::assertEquals('version', $cm->versionField);
+        self::assertTrue($cm->requiresFetchAfterChange);
+
+        $cm->setVersioned(false);
+        $cm->setVersionField(null);
+
+        self::assertFalse($cm->isVersioned);
+        self::assertNull($cm->versionField);
+        self::assertFalse($cm->requiresFetchAfterChange);
+    }
+
     public function testGetSingleIdentifierFieldNameMultipleIdentifierEntityThrowsException(): void
     {
         $cm = new ClassMetadata(CMS\CmsUser::class);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -289,7 +289,7 @@ class ClassMetadataTest extends OrmTestCase
     public function testDisablingVersioningRestoresOriginalState(): void
     {
         $versionedField = ['fieldName' => 'version', 'type' => 'integer'];
-        
+
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setVersionMapping($versionedField);
@@ -304,6 +304,28 @@ class ClassMetadataTest extends OrmTestCase
         self::assertFalse($cm->isVersioned);
         self::assertNull($cm->versionField);
         self::assertFalse($cm->requiresFetchAfterChange);
+    }
+
+    public function testDisablingVersioningWithGeneratedFieldsRestoresOriginalState(): void
+    {
+        $versionedField = ['fieldName' => 'version', 'type' => 'integer'];
+        $generatedField = ['fieldName' => 'id', 'type' => 'integer', 'generated'=> ClassMetadata::GENERATED_ALWAYS];
+
+        $cm = new ClassMetadata(CMS\CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->setVersionMapping($versionedField);
+        $cm->mapField($generatedField);
+
+        self::assertTrue($cm->isVersioned);
+        self::assertEquals('version', $cm->versionField);
+        self::assertTrue($cm->requiresFetchAfterChange);
+
+        $cm->setVersioned(false);
+        $cm->setVersionField(null);
+
+        self::assertFalse($cm->isVersioned);
+        self::assertNull($cm->versionField);
+        self::assertTrue($cm->requiresFetchAfterChange);
     }
 
     public function testGetSingleIdentifierFieldNameMultipleIdentifierEntityThrowsException(): void


### PR DESCRIPTION
When ClassMetadataInfo has the version field information (versioning), `->setVersioned(false)` will set the `requiresFetchAfterChange` flag to invalid if "generated" fields are not mapped. This PR fixes setting the flag state.

The consequence of the invalid state of `requiresFetchAfterChange` is the generation of invalid queries by the BasicEntityPersister::fetchVersionAndNotUpsertableValues method during the INSERT and UPDATE operations.

In this PR, I added two tests that verify the state after the `setVersioned(false)` operation is performed.

**Why**
`setVersioned(...)` is public and not restricted (by comments or doc) method. It is possible to call `setVersioned(false)` after `setVersionMapping(...)` which will produce invalid state. In some cases we need to overwrite state to achieve business feature f.e. to disable version verification during flush() in app with annotated entities with @Version. 





