### PR TITLE
Drop unmaintained Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/lexer": "^1.2.3",
         "doctrine/persistence": "^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/console": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13",


### PR DESCRIPTION
Symfony 3 is EOL and does not fully support PHP 8.1 anyway. I think we can safely drop it from our build matrix.