### PR TITLE
Deprecate `EntityManager::create()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,13 @@ It will be removed in 3.0. Use one of the dedicated event classes instead:
 
 # Upgrade to 2.13
 
+## Deprecated `EntityManager::create()`
+
+The constructor of `EntityManager` is now public and should be used instead of the `create()` method.
+However, the constructor expects a `Connection` while `create()` accepted an array with connection parameters.
+You can pass that array to DBAL's `Doctrine\DBAL\DriverManager::getConnection()` method to bootstrap the
+connection.
+
 ## Deprecated `QueryBuilder` methods and constants.
 
 1. The `QueryBuilder::getState()` method has been deprecated as the builder state is an internal concern.

--- a/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
+++ b/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
@@ -196,7 +196,7 @@ Example usage
     <?php
 
     // Bootstrapping stuff...
-    // $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config);
+    // $em = new \Doctrine\ORM\EntityManager($connection, $config);
 
     // Setup custom mapping type
     use Doctrine\DBAL\Types\Type;

--- a/docs/en/cookbook/dql-user-defined-functions.rst
+++ b/docs/en/cookbook/dql-user-defined-functions.rst
@@ -46,7 +46,7 @@ configuration:
     $config->addCustomNumericFunction($name, $class);
     $config->addCustomDatetimeFunction($name, $class);
 
-    $em = EntityManager::create($dbParams, $config);
+    $em = new EntityManager($connection, $config);
 
 The ``$name`` is the name the function will be referred to in the
 DQL query. ``$class`` is a string of a class-name which has to
@@ -247,5 +247,3 @@ vendor sql functions and extend the DQL languages scope.
 Code for this Extension to DQL and other Doctrine Extensions can be
 found
 `in the GitHub DoctrineExtensions repository <https://github.com/beberlei/DoctrineExtensions>`_.
-
-

--- a/docs/en/cookbook/resolve-target-entity-listener.rst
+++ b/docs/en/cookbook/resolve-target-entity-listener.rst
@@ -127,7 +127,8 @@ the targetEntity resolution will occur reliably:
     // Add the ResolveTargetEntityListener
     $evm->addEventListener(Doctrine\ORM\Events::loadClassMetadata, $rtel);
 
-    $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config, $evm);
+    $connection = \Doctrine\DBAL\DriverManager::createConnection($connectionOptions, $config, $evm);
+    $em = new \Doctrine\ORM\EntityManager($connection, $config, $evm);
 
 Final Thoughts
 --------------
@@ -136,5 +137,3 @@ With the ``ResolveTargetEntityListener``, we are able to decouple our
 bundles, keeping them usable by themselves, but still being able to
 define relationships between different objects. By using this method,
 I've found my bundles end up being easier to maintain independently.
-
-

--- a/docs/en/cookbook/sql-table-prefixes.rst
+++ b/docs/en/cookbook/sql-table-prefixes.rst
@@ -81,6 +81,4 @@ before the prefix has been set.
     $tablePrefix = new \DoctrineExtensions\TablePrefix('prefix_');
     $evm->addEventListener(\Doctrine\ORM\Events::loadClassMetadata, $tablePrefix);
     
-    $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config, $evm);
-
-
+    $em = new \Doctrine\ORM\EntityManager($connection, $config, $evm);

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -41,12 +41,12 @@ steps of configuration.
         $config->setAutoGenerateProxyClasses(false);
     }
 
-    $connectionOptions = array(
+    $connection = DriverManager::getConnection([
         'driver' => 'pdo_sqlite',
-        'path' => 'database.sqlite'
-    );
+        'path' => 'database.sqlite',
+    ], $config);
 
-    $em = EntityManager::create($connectionOptions, $config);
+    $em = new EntityManager($connection, $config);
 
 Doctrine and Caching
 --------------------
@@ -276,15 +276,13 @@ proxy sets an exclusive file lock which can cause serious
 performance bottlenecks in systems with regular concurrent
 requests.
 
-Connection Options
-------------------
+Connection
+----------
 
-The ``$connectionOptions`` passed as the first argument to
-``EntityManager::create()`` has to be either an array or an
-instance of ``Doctrine\DBAL\Connection``. If an array is passed it
-is directly passed along to the DBAL Factory
-``Doctrine\DBAL\DriverManager::getConnection()``. The DBAL
-configuration is explained in the
+The ``$connection`` passed as the first argument to he constructor of
+``EntityManager`` has to be an instance of ``Doctrine\DBAL\Connection``.
+You can use the factory ``Doctrine\DBAL\DriverManager::getConnection()``
+to create such a connection. The DBAL configuration is explained in the
 `DBAL section <https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html>`_.
 
 Proxy Objects

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -41,22 +41,24 @@ access point to ORM functionality provided by Doctrine.
     // bootstrap.php
     require_once "vendor/autoload.php";
 
+    use Doctrine\DBAL\DriverManager;
     use Doctrine\ORM\EntityManager;
     use Doctrine\ORM\ORMSetup;
 
-    $paths = array("/path/to/entity-files");
+    $paths = ['/path/to/entity-files'];
     $isDevMode = false;
 
     // the connection configuration
-    $dbParams = array(
+    $dbParams = [
         'driver'   => 'pdo_mysql',
         'user'     => 'root',
         'password' => '',
         'dbname'   => 'foo',
-    );
+    ];
 
     $config = ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create($dbParams, $config);
+    $connection = DriverManager::getConnection($dbParams, $config);
+    $entityManager = new EntityManager($connection, $config);
 
 .. note::
 
@@ -68,18 +70,20 @@ Or if you prefer XML:
 .. code-block:: php
 
     <?php
-    $paths = array("/path/to/xml-mappings");
+    $paths = ['/path/to/xml-mappings'];
     $config = ORMSetup::createXMLMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create($dbParams, $config);
+    $connection = DriverManager::getConnection($dbParams, $config);
+    $entityManager = new EntityManager($connection, $config);
 
 Or if you prefer YAML:
 
 .. code-block:: php
 
     <?php
-    $paths = array("/path/to/yml-mappings");
+    $paths = ['/path/to/yml-mappings'];
     $config = ORMSetup::createYAMLMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create($dbParams, $config);
+    $connection = DriverManager::getConnection($dbParams, $config);
+    $entityManager = new EntityManager($connection, $config);
 
 .. note::
     If you want to use yml mapping you should add yaml dependency to your `composer.json`:

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -319,11 +319,11 @@ With Nested Conditions in WHERE Clause:
 
     <?php
     $query = $em->createQuery('SELECT u FROM ForumUser u WHERE (u.username = :name OR u.username = :name2) AND u.id = :id');
-    $query->setParameters(array(
+    $query->setParameters([
         'name' => 'Bob',
         'name2' => 'Alice',
         'id' => 321,
-    ));
+    ]);
     $users = $query->getResult(); // array of ForumUser objects
 
 With COUNT DISTINCT:
@@ -794,7 +794,7 @@ You can register custom DQL functions in your ORM Configuration:
     $config->addCustomNumericFunction($name, $class);
     $config->addCustomDatetimeFunction($name, $class);
 
-    $em = EntityManager::create($dbParams, $config);
+    $em = new EntityManager($connection, $config);
 
 The functions have to return either a string, numeric or datetime
 value depending on the registered function type. As an example we
@@ -806,8 +806,8 @@ classes have to implement the base class :
     <?php
     namespace MyProject\Query\AST;
 
-    use \Doctrine\ORM\Query\AST\Functions\FunctionNode;
-    use \Doctrine\ORM\Query\Lexer;
+    use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+    use Doctrine\ORM\Query\Lexer;
 
     class MysqlFloor extends FunctionNode
     {
@@ -1057,7 +1057,7 @@ the Query class. Here they are:
 
 Instead of using these methods, you can alternatively use the
 general-purpose method
-``Query#execute(array $params = array(), $hydrationMode = Query::HYDRATE_OBJECT)``.
+``Query#execute(array $params = [], $hydrationMode = Query::HYDRATE_OBJECT)``.
 Using this method you can directly supply the hydration mode as the
 second parameter via one of the Query constants. In fact, the
 methods mentioned earlier are just convenient shortcuts for the

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -416,7 +416,7 @@ EventManager that is passed to the EntityManager factory:
     $eventManager->addEventListener([Events::preUpdate], new MyEventListener());
     $eventManager->addEventSubscriber(new MyEventSubscriber());
 
-    $entityManager = EntityManager::create($dbOpts, $config, $eventManager);
+    $entityManager = new EntityManager($connection, $config, $eventManager);
 
 You can also retrieve the event manager instance after the
 EntityManager was created:
@@ -1016,7 +1016,7 @@ Implementing your own resolver:
 
     // Configure the listener resolver only before instantiating the EntityManager
     $configurations->setEntityListenerResolver(new MyEntityListenerResolver);
-    EntityManager::create(.., $configurations, ..);
+    $entityManager = new EntityManager(.., $configurations, ..);
 
 .. _reference-events-load-class-metadata:
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -136,6 +136,7 @@ step:
 
     <?php
     // bootstrap.php
+    use Doctrine\DBAL\DriverManager;
     use Doctrine\ORM\EntityManager;
     use Doctrine\ORM\ORMSetup;
 
@@ -160,14 +161,14 @@ step:
     //    isDevMode: true,
     // );
 
-    // database configuration parameters
-    $conn = array(
+    // configuring the database connection
+    $connection = DriverManager::getConnection([
         'driver' => 'pdo_sqlite',
         'path' => __DIR__ . '/db.sqlite',
-    );
+    ], $config)
 
     // obtaining the entity manager
-    $entityManager = EntityManager::create($conn, $config);
+    $entityManager = new EntityManager($connection, $config);
 
 .. note::
     The YAML driver is deprecated and will be removed in version 3.0.

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -60,8 +60,8 @@ use function strpos;
  *     $paths = ['/path/to/entity/mapping/files'];
  *
  *     $config = ORMSetup::createAttributeMetadataConfiguration($paths);
- *     $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
- *     $entityManager = EntityManager::create($dbParams, $config);
+ *     $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+ *     $entityManager = new EntityManager($connection, $config);
  *
  * For more information see
  * {@link http://docs.doctrine-project.org/projects/doctrine-orm/en/stable/reference/configuration.html}
@@ -156,7 +156,7 @@ class EntityManager implements EntityManagerInterface
      * Creates a new EntityManager that operates on the given database connection
      * and uses the given Configuration and EventManager implementations.
      */
-    public function __construct(Connection $conn, Configuration $config)
+    public function __construct(Connection $conn, Configuration $config, ?EventManager $eventManager = null)
     {
         if (! $config->getMetadataDriverImpl()) {
             throw MissingMappingDriverImplementation::create();
@@ -164,7 +164,7 @@ class EntityManager implements EntityManagerInterface
 
         $this->conn         = $conn;
         $this->config       = $config;
-        $this->eventManager = $conn->getEventManager();
+        $this->eventManager = $eventManager ?? $conn->getEventManager();
 
         $metadataFactoryClassName = $config->getClassMetadataFactoryName();
 
@@ -952,6 +952,8 @@ class EntityManager implements EntityManagerInterface
     /**
      * Factory method to create EntityManager instances.
      *
+     * @deprecated Use {@see DriverManager::getConnection()} to bootstrap the connection and call the constructor.
+     *
      * @param mixed[]|Connection $connection   An array with the connection parameters or an existing Connection instance.
      * @param Configuration      $config       The Configuration instance to use.
      * @param EventManager|null  $eventManager The EventManager instance to use.
@@ -964,6 +966,15 @@ class EntityManager implements EntityManagerInterface
      */
     public static function create($connection, Configuration $config, ?EventManager $eventManager = null)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9961',
+            '%s() is deprecated. To boostrap a DBAL connection, call %s::getConnection() instead. Use the constructor to create an instance of %s.',
+            __METHOD__,
+            DriverManager::class,
+            self::class
+        );
+
         $connection = static::createConnection($connection, $config, $eventManager);
 
         return new EntityManager($connection, $config);
@@ -971,6 +982,8 @@ class EntityManager implements EntityManagerInterface
 
     /**
      * Factory method to create Connection instances.
+     *
+     * @deprecated Use {@see DriverManager::getConnection()} to bootstrap the connection.
      *
      * @param mixed[]|Connection $connection   An array with the connection parameters or an existing Connection instance.
      * @param Configuration      $config       The Configuration instance to use.
@@ -984,6 +997,14 @@ class EntityManager implements EntityManagerInterface
      */
     protected static function createConnection($connection, Configuration $config, ?EventManager $eventManager = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/9961',
+            '%s() is deprecated, call %s::getConnection() instead.',
+            __METHOD__,
+            DriverManager::class
+        );
+
         if (is_array($connection)) {
             return DriverManager::getConnection($connection, $config, $eventManager ?: new EventManager());
         }

--- a/psalm.xml
+++ b/psalm.xml
@@ -77,6 +77,7 @@
                 <referencedMethod name="Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateRow"/>
                 <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
                 <referencedMethod name="Doctrine\ORM\Configuration::newDefaultAnnotationDriver"/>
+                <referencedMethod name="Doctrine\ORM\EntityManager::createConnection"/>
                 <referencedMethod name="Doctrine\ORM\Id\AbstractIdGenerator::generate"/>
                 <referencedMethod name="Doctrine\ORM\ORMInvalidArgumentException::invalidEntityName"/>
                 <referencedMethod name="Doctrine\ORM\ORMSetup::createDefaultAnnotationDriver"/>

--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -34,11 +35,11 @@ final class EntityManagerFactory
             realpath(__DIR__ . '/Models/GeoNames'),
         ]));
 
-        $entityManager = EntityManager::create(
-            [
+        $entityManager = new EntityManager(
+            DriverManager::getConnection([
                 'driverClass' => Driver::class,
                 'memory'      => true,
-            ],
+            ], $config),
             $config
         );
 
@@ -71,6 +72,6 @@ final class EntityManagerFactory
             }
         };
 
-        return EntityManager::create($connection, $config, $connection->getEventManager());
+        return new EntityManager($connection, $config);
     }
 }

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
+use BadMethodCallException;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\UnitOfWork;
+
+use function sprintf;
 
 /**
  * Special EntityManager mock used for testing purposes.
@@ -22,10 +26,19 @@ class EntityManagerMock extends EntityManager
     /** @var ProxyFactory|null */
     private $_proxyFactoryMock;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getUnitOfWork()
+    public function __construct(Connection $conn, ?Configuration $config = null, ?EventManager $eventManager = null)
+    {
+        if ($config === null) {
+            $config = new Configuration();
+            $config->setProxyDir(__DIR__ . '/../Proxies');
+            $config->setProxyNamespace('Doctrine\Tests\Proxies');
+            $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
+        }
+
+        parent::__construct($conn, $config, $eventManager);
+    }
+
+    public function getUnitOfWork(): UnitOfWork
     {
         return $this->_uowMock ?? parent::getUnitOfWork();
     }
@@ -51,19 +64,10 @@ class EntityManagerMock extends EntityManager
     }
 
     /**
-     * Mock factory method to create an EntityManager.
-     *
      * {@inheritdoc}
      */
-    public static function create($conn, ?Configuration $config = null, ?EventManager $eventManager = null)
+    public static function create($connection, Configuration $config, ?EventManager $eventManager = null): self
     {
-        if ($config === null) {
-            $config = new Configuration();
-            $config->setProxyDir(__DIR__ . '/../Proxies');
-            $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
-        }
-
-        return new EntityManagerMock($conn, $config);
+        throw new BadMethodCallException(sprintf('Call to deprecated method %s().', __METHOD__));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -123,7 +123,7 @@ class LockAgentWorker
 
         $config->setQueryCache(new ArrayAdapter());
 
-        return EntityManager::create($conn, $config);
+        return new EntityManager($conn, $config);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -257,7 +257,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
             $config
         );
 
-        $entityManager = EntityManager::create($connection, $config);
+        $entityManager = new EntityManager($connection, $config);
 
         (new SchemaTool($entityManager))->createSchema([$entityManager->getClassMetadata(DateTimeModel::class)]);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -47,7 +47,7 @@ class DDC3634Test extends OrmFunctionalTestCase
     {
         $veryLargeId = PHP_INT_MAX . PHP_INT_MAX;
 
-        $entityManager = EntityManager::create(
+        $entityManager = new EntityManager(
             new DDC3634LastInsertIdMockingConnection($veryLargeId, $this->_em->getConnection()),
             $this->_em->getConfiguration()
         );

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
@@ -33,7 +33,7 @@ class GH7869Test extends OrmTestCase
         $connection->method('getEventManager')
             ->willReturn(new EventManager());
 
-        $em = new class (EntityManagerMock::create($connection)) extends EntityManagerDecorator {
+        $em = new class (new EntityManagerMock($connection)) extends EntityManagerDecorator {
             /** @var int */
             public $getClassMetadataCalls = 0;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -300,7 +300,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $config->setMetadataDriverImpl($metadataDriver);
 
-        return EntityManagerMock::create($conn, $config);
+        return new EntityManagerMock($conn, $config);
     }
 
     protected function createTestFactory(): ClassMetadataFactoryTestSubject

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -56,7 +56,7 @@ class PersistentCollectionTest extends OrmTestCase
         $connection->method('executeQuery')
             ->willReturn($this->createMock(Result::class));
 
-        $this->_emMock = EntityManagerMock::create($connection);
+        $this->_emMock = new EntityManagerMock($connection);
 
         $this->setUpPersistentCollection();
     }

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -55,7 +55,7 @@ class ProxyFactoryTest extends OrmTestCase
         $connection->method('getEventManager')
             ->willReturn(new EventManager());
 
-        $this->emMock  = EntityManagerMock::create($connection);
+        $this->emMock  = new EntityManagerMock($connection);
         $this->uowMock = new UnitOfWorkMock($this->emMock);
         $this->emMock->setUnitOfWork($this->uowMock);
         $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', ProxyFactory::AUTOGENERATE_ALWAYS);

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -46,7 +46,7 @@ class ConvertDoctrine1SchemaTest extends OrmTestCase
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl($metadataDriver);
 
-        return EntityManagerMock::create($connection, $config);
+        return new EntityManagerMock($connection, $config);
     }
 
     public function testTest(): void

--- a/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
@@ -66,7 +66,7 @@ abstract class ClassMetadataExporterTestCase extends OrmTestCase
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl($metadataDriver);
 
-        return EntityManagerMock::create($connection, $config);
+        return new EntityManagerMock($connection, $config);
     }
 
     protected function createMetadataDriver(string $type, string $path): MappingDriver

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -116,7 +116,7 @@ class UnitOfWorkTest extends OrmTestCase
 
         $this->eventManager    = $this->getMockBuilder(EventManager::class)->getMock();
         $this->_connectionMock = new Connection([], $driver, null, $this->eventManager);
-        $this->_emMock         = EntityManagerMock::create($this->_connectionMock);
+        $this->_emMock         = new EntityManagerMock($this->_connectionMock);
         // SUT
         $this->_unitOfWork = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
@@ -841,7 +841,7 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_connectionMock = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['commit'])
             ->setConstructorArgs([[], $driver])
             ->getMock();
-        $this->_emMock         = EntityManagerMock::create($this->_connectionMock);
+        $this->_emMock         = new EntityManagerMock($this->_connectionMock);
         $this->_unitOfWork     = new UnitOfWorkMock($this->_emMock);
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -830,7 +830,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $evm->addEventListener(['onFlush'], new DebugUnitOfWorkListener());
         }
 
-        return EntityManager::create($conn, $config);
+        return new EntityManager($conn, $config);
     }
 
     final protected function createSchemaManager(): AbstractSchemaManager

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -107,7 +107,7 @@ abstract class OrmTestCase extends DoctrineTestCase
             ], $config);
         }
 
-        return EntityManagerMock::create($connection, $config);
+        return new EntityManagerMock($connection, $config);
     }
 
     protected function enableSecondLevelCache(bool $log = true): void


### PR DESCRIPTION
Now that the entity manager's constructor is public, why not make it the only way to construct an EM?

The only additional feature that `create()` has is that you can pass the connection parameters instead of a real DBAL connection. However, I believe that bootstrapping the DBAL connection is a concern that belongs into the DBAL library and the DBAL's `DriverManager` class already does a fine job in that regard.

This is why I believe that we shouldn't need the `create()` method anymore.