### PR TITLE
Flag QueryType as internal

### DIFF
--- a/lib/Doctrine/ORM/Internal/QueryType.php
+++ b/lib/Doctrine/ORM/Internal/QueryType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal;
 
+/**
+ * @internal To be used inside the QueryBuilder only.
+ */
 enum QueryType
 {
     case Select;


### PR DESCRIPTION
Follow-up to #9953. The new `QueryType` enum should be regarded as internal to the query builder.