### PR TITLE
fix: class normalisation test

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -151,7 +151,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $actual = $cmf->getMetadataFor($cm1->name);
     }
 
-    public function testHasGetMetadataNamespaceSeparatorIsNotNormalized(): void
+    public function testHasGetMetadataClassIsNormalized(): void
     {
         require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 
@@ -165,9 +165,9 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $h2 = $mf->hasMetadataFor('\\' . DoctrineGlobalArticle::class);
         $m2 = $mf->getMetadataFor('\\' . DoctrineGlobalArticle::class);
 
-        self::assertNotSame($m1, $m2);
-        self::assertFalse($h2);
+        self::assertSame($m1, $m2);
         self::assertTrue($h1);
+        self::assertTrue($h2);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -151,25 +151,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $actual = $cmf->getMetadataFor($cm1->name);
     }
 
-    public function testHasGetMetadataClassIsNormalized(): void
-    {
-        require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
-
-        $metadataDriver = $this->createAnnotationDriver([__DIR__ . '/../../Models/Global/']);
-
-        $entityManager = $this->createEntityManager($metadataDriver);
-
-        $mf = $entityManager->getMetadataFactory();
-        $m1 = $mf->getMetadataFor(DoctrineGlobalArticle::class);
-        $h1 = $mf->hasMetadataFor(DoctrineGlobalArticle::class);
-        $h2 = $mf->hasMetadataFor('\\' . DoctrineGlobalArticle::class);
-        $m2 = $mf->getMetadataFor('\\' . DoctrineGlobalArticle::class);
-
-        self::assertSame($m1, $m2);
-        self::assertTrue($h1);
-        self::assertTrue($h2);
-    }
-
     /**
      * @group DDC-1512
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -39,7 +39,6 @@ use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\OrmTestCase;
-use DoctrineGlobalArticle;
 use Exception;
 use InvalidArgumentException;
 use ReflectionClass;


### PR DESCRIPTION
As per https://github.com/doctrine/persistence/pull/301

This test was not added to fix a bug, but to make sure that classes are not normalized at the time for "[performance reasons](https://github.com/doctrine/orm/issues/1750#issuecomment-162355601)" this check makes no sense now and in fact causes bugs without the normalization, this was solved in the linked PR and now causes this test to fail

I changed the test to check for the exact opposite as per when it was first introduced https://github.com/doctrine/orm/blame/705a477067e7a68c834ed65605d8d230677b5eaf/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php#L62