### PR TITLE
Stabilize the DBAL dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-ctype": "*",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.3",
-        "doctrine/dbal": "^3.4@dev",
+        "doctrine/dbal": "^3.4",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4 || ^2.0",


### PR DESCRIPTION
DBAL 3.4.0 has been released, so we can remove the `@dev` flag.