### PR TITLE
Add types to `Node::dispatch()`

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 class AggregateExpression extends Node
 {
     /** @var string */
@@ -31,10 +33,7 @@ class AggregateExpression extends Node
         $this->isDistinct     = $isDistinct;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkAggregateExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ArithmeticExpression ::= SimpleArithmeticExpression | "(" Subselect ")"
  *
@@ -33,10 +35,7 @@ class ArithmeticExpression extends Node
         return (bool) $this->subselect;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkArithmeticExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ArithmeticFactor ::= [("+" | "-")] ArithmeticPrimary
  *
@@ -47,11 +49,8 @@ class ArithmeticFactor extends Node
         return $this->sign === false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkArithmeticFactor($this);
+        return $walker->walkArithmeticFactor($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ArithmeticTerm ::= ArithmeticFactor {("*" | "/") ArithmeticFactor}*
  *
@@ -22,11 +24,8 @@ class ArithmeticTerm extends Node
         $this->arithmeticFactors = $arithmeticFactors;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkArithmeticTerm($this);
+        return $walker->walkArithmeticTerm($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 class BetweenExpression extends Node
 {
     /** @var ArithmeticExpression */
@@ -30,11 +32,8 @@ class BetweenExpression extends Node
         $this->rightBetweenExpression = $rightExpr;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkBetweenExpression($this);
+        return $walker->walkBetweenExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * CoalesceExpression ::= "COALESCE" "(" ScalarExpression {"," ScalarExpression}* ")"
  *
@@ -22,11 +24,8 @@ class CoalesceExpression extends Node
         $this->scalarExpressions = $scalarExpressions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkCoalesceExpression($this);
+        return $walker->walkCoalesceExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * CollectionMemberExpression ::= EntityExpression ["NOT"] "MEMBER" ["OF"] CollectionValuedPathExpression
  *
@@ -30,10 +32,7 @@ class CollectionMemberExpression extends Node
         $this->collectionValuedPathExpression = $collValuedPathExpr;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkCollectionMemberExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ComparisonExpression ::= ArithmeticExpression ComparisonOperator ( QuantifiedExpression | ArithmeticExpression ) |
  *                          StringExpression ComparisonOperator (StringExpression | QuantifiedExpression) |
@@ -37,11 +39,8 @@ class ComparisonExpression extends Node
         $this->operator        = $operator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkComparisonExpression($this);
+        return $walker->walkComparisonExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ConditionalExpression ::= ConditionalTerm {"OR" ConditionalTerm}*
  *
@@ -22,11 +24,8 @@ class ConditionalExpression extends Node
         $this->conditionalTerms = $conditionalTerms;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkConditionalExpression($this);
+        return $walker->walkConditionalExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ConditionalFactor ::= ["NOT"] ConditionalPrimary
  *
@@ -25,11 +27,8 @@ class ConditionalFactor extends Node
         $this->conditionalPrimary = $conditionalPrimary;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkConditionalFactor($this);
+        return $walker->walkConditionalFactor($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ConditionalPrimary ::= SimpleConditionalExpression | "(" ConditionalExpression ")"
  *
@@ -33,11 +35,8 @@ class ConditionalPrimary extends Node
         return (bool) $this->conditionalExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkConditionalPrimary($this);
+        return $walker->walkConditionalPrimary($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ConditionalTerm ::= ConditionalFactor {"AND" ConditionalFactor}*
  *
@@ -22,11 +24,8 @@ class ConditionalTerm extends Node
         $this->conditionalFactors = $conditionalFactors;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkConditionalTerm($this);
+        return $walker->walkConditionalTerm($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/DeleteClause.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * DeleteClause ::= "DELETE" ["FROM"] AbstractSchemaName [["AS"] AliasIdentificationVariable]
  *
@@ -25,11 +27,8 @@ class DeleteClause extends Node
         $this->abstractSchemaName = $abstractSchemaName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkDeleteClause($this);
+        return $walker->walkDeleteClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * DeleteStatement = DeleteClause [WhereClause]
  *
@@ -25,11 +27,8 @@ class DeleteStatement extends Node
         $this->deleteClause = $deleteClause;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkDeleteStatement($this);
+        return $walker->walkDeleteStatement($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * EmptyCollectionComparisonExpression ::= CollectionValuedPathExpression "IS" ["NOT"] "EMPTY"
  *
@@ -25,11 +27,8 @@ class EmptyCollectionComparisonExpression extends Node
         $this->expression = $expression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkEmptyCollectionComparisonExpression($this);
+        return $walker->walkEmptyCollectionComparisonExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ExistsExpression ::= ["NOT"] "EXISTS" "(" Subselect ")"
  *
@@ -25,11 +27,8 @@ class ExistsExpression extends Node
         $this->subselect = $subselect;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkExistsExpression($this);
+        return $walker->walkExistsExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/FromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/FromClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * FromClause ::= "FROM" IdentificationVariableDeclaration {"," IdentificationVariableDeclaration}
  *
@@ -22,11 +24,8 @@ class FromClause extends Node
         $this->identificationVariableDeclarations = $identificationVariableDeclarations;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkFromClause($this);
+        return $walker->walkFromClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
@@ -33,12 +33,7 @@ abstract class FunctionNode extends Node
      */
     abstract public function getSql(SqlWalker $sqlWalker);
 
-    /**
-     * @param SqlWalker $sqlWalker
-     *
-     * @return string
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $sqlWalker): string
     {
         return $sqlWalker->walkFunction($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * GeneralCaseExpression ::= "CASE" WhenClause {WhenClause}* "ELSE" ScalarExpression "END"
  *
@@ -27,11 +29,8 @@ class GeneralCaseExpression extends Node
         $this->elseScalarExpression = $elseScalarExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkGeneralCaseExpression($this);
+        return $walker->walkGeneralCaseExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/GroupByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/GroupByClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 class GroupByClause extends Node
 {
     /** @var mixed[] */
@@ -17,11 +19,8 @@ class GroupByClause extends Node
         $this->groupByItems = $groupByItems;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkGroupByClause($this);
+        return $walker->walkGroupByClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/HavingClause.php
+++ b/lib/Doctrine/ORM/Query/AST/HavingClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 class HavingClause extends Node
 {
     /** @var ConditionalExpression */
@@ -17,11 +19,8 @@ class HavingClause extends Node
         $this->conditionalExpression = $conditionalExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkHavingClause($this);
+        return $walker->walkHavingClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * IdentificationVariableDeclaration ::= RangeVariableDeclaration [IndexBy] {JoinVariableDeclaration}*
  *
@@ -32,11 +34,8 @@ class IdentificationVariableDeclaration extends Node
         $this->joins                    = $joins;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkIdentificationVariableDeclaration($this);
+        return $walker->walkIdentificationVariableDeclaration($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * InExpression ::= ArithmeticExpression ["NOT"] "IN" "(" (Literal {"," Literal}* | Subselect) ")"
  *
@@ -31,11 +33,8 @@ class InExpression extends Node
         $this->expression = $expression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkInExpression($this);
+        return $walker->walkInExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * IndexBy ::= "INDEX" "BY" SingleValuedPathExpression
  *
@@ -19,11 +21,10 @@ class IndexBy extends Node
         $this->singleValuedPathExpression = $singleValuedPathExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkIndexBy($this);
+        $walker->walkIndexBy($this);
+
+        return '';
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Query\SqlWalker;
 
 use function is_numeric;
 use function strlen;
@@ -34,10 +35,7 @@ class InputParameter extends Node
         $this->name    = $param;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkInputParameter($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * InstanceOfExpression ::= IdentificationVariable ["NOT"] "INSTANCE" ["OF"] (InstanceOfParameter | "(" InstanceOfParameter {"," InstanceOfParameter}* ")")
  * InstanceOfParameter  ::= AbstractSchemaName | InputParameter
@@ -29,11 +31,8 @@ class InstanceOfExpression extends Node
         $this->identificationVariable = $identVariable;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkInstanceOfExpression($this);
+        return $walker->walkInstanceOfExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Join.php
+++ b/lib/Doctrine/ORM/Query/AST/Join.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * Join ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" JoinAssociationPathExpression
  *          ["AS"] AliasIdentificationVariable [("ON" | "WITH") ConditionalExpression]
@@ -39,11 +41,8 @@ class Join extends Node
         $this->joinAssociationDeclaration = $joinAssociationDeclaration;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkJoin($this);
+        return $walker->walkJoin($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * JoinAssociationDeclaration ::= JoinAssociationPathExpression ["AS"] AliasIdentificationVariable
  *
@@ -32,11 +34,8 @@ class JoinAssociationDeclaration extends Node
         $this->indexBy                       = $indexBy;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkJoinAssociationDeclaration($this);
+        return $walker->walkJoinAssociationDeclaration($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * JoinClassPathExpression ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
  *
@@ -27,10 +29,7 @@ class JoinClassPathExpression extends Node
         $this->aliasIdentificationVariable = $aliasIdentificationVar;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkJoinPathExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * JoinVariableDeclaration ::= Join [IndexBy]
  *
@@ -27,10 +29,7 @@ class JoinVariableDeclaration extends Node
         $this->indexBy = $indexBy;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkJoinVariableDeclaration($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/LikeExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/LikeExpression.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * LikeExpression ::= StringExpression ["NOT"] "LIKE" string ["ESCAPE" char]
@@ -37,11 +38,8 @@ class LikeExpression extends Node
         $this->escapeChar       = $escapeChar;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkLikeExpression($this);
+        return $walker->walkLikeExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Literal.php
+++ b/lib/Doctrine/ORM/Query/AST/Literal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 class Literal extends Node
 {
     public const STRING  = 1;
@@ -30,10 +32,7 @@ class Literal extends Node
         $this->value = $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkLiteral($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * NewObjectExpression ::= "NEW" IdentificationVariable "(" NewObjectArg {"," NewObjectArg}* ")"
  *
@@ -27,11 +29,8 @@ class NewObjectExpression extends Node
         $this->args      = $args;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkNewObject($this);
+        return $walker->walkNewObject($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -27,13 +27,9 @@ abstract class Node
      *
      * Implementation is not mandatory for all nodes.
      *
-     * @param SqlWalker $walker
-     *
-     * @return string
-     *
      * @throws ASTException
      */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         throw ASTException::noDispatchForNode($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * NullComparisonExpression ::= (SingleValuedPathExpression | InputParameter) "IS" ["NOT"] "NULL"
  *
@@ -25,11 +27,8 @@ class NullComparisonExpression extends Node
         $this->expression = $expression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkNullComparisonExpression($this);
+        return $walker->walkNullComparisonExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * NullIfExpression ::= "NULLIF" "(" ScalarExpression "," ScalarExpression ")"
  *
@@ -27,11 +29,8 @@ class NullIfExpression extends Node
         $this->secondExpression = $secondExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkNullIfExpression($this);
+        return $walker->walkNullIfExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/OrderByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * OrderByClause ::= "ORDER" "BY" OrderByItem {"," OrderByItem}*
  *
@@ -22,11 +24,8 @@ class OrderByClause extends Node
         $this->orderByItems = $orderByItems;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkOrderByClause($this);
+        return $walker->walkOrderByClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/OrderByItem.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByItem.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 use function strtoupper;
 
 /**
@@ -43,11 +45,8 @@ class OrderByItem extends Node
         return strtoupper($this->type) === 'DESC';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkOrderByItem($this);
+        return $walker->walkOrderByItem($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * ParenthesisExpression ::= "(" ArithmeticPrimary ")"
  */
@@ -17,10 +19,7 @@ class ParenthesisExpression extends Node
         $this->expression = $expression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkParenthesisExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/PathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PathExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * AssociationPathExpression ::= CollectionValuedPathExpression | SingleValuedAssociationPathExpression
  * SingleValuedPathExpression ::= StateFieldPathExpression | SingleValuedAssociationPathExpression
@@ -50,10 +52,7 @@ class PathExpression extends Node
         $this->field                  = $field;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkPathExpression($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 use function strtoupper;
 
 /**
@@ -51,11 +53,8 @@ class QuantifiedExpression extends Node
         return strtoupper($this->type) === 'SOME';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkQuantifiedExpression($this);
+        return $walker->walkQuantifiedExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * RangeVariableDeclaration ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
  *
@@ -32,10 +34,7 @@ class RangeVariableDeclaration extends Node
         $this->isRoot                      = $isRoot;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($walker)
+    public function dispatch(SqlWalker $walker): string
     {
         return $walker->walkRangeVariableDeclaration($this);
     }

--- a/lib/Doctrine/ORM/Query/AST/SelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SelectClause = "SELECT" ["DISTINCT"] SelectExpression {"," SelectExpression}
  *
@@ -27,11 +29,8 @@ class SelectClause extends Node
         $this->selectExpressions = $selectExpressions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSelectClause($this);
+        return $walker->walkSelectClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SelectExpression ::= IdentificationVariable ["." "*"] | StateFieldPathExpression |
  *                      (AggregateExpression | "(" Subselect ")") [["AS"] ["HIDDEN"] FieldAliasIdentificationVariable]
@@ -33,11 +35,8 @@ class SelectExpression extends Node
         $this->hiddenAliasResultVariable   = $hiddenAliasResultVariable;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSelectExpression($this);
+        return $walker->walkSelectExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SelectStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectStatement.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SelectStatement = SelectClause FromClause [WhereClause] [GroupByClause] [HavingClause] [OrderByClause]
  *
@@ -39,11 +41,8 @@ class SelectStatement extends Node
         $this->fromClause   = $fromClause;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSelectStatement($this);
+        return $walker->walkSelectStatement($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SimpleArithmeticExpression ::= ArithmeticTerm {("+" | "-") ArithmeticTerm}*
  *
@@ -22,11 +24,8 @@ class SimpleArithmeticExpression extends Node
         $this->arithmeticTerms = $arithmeticTerms;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSimpleArithmeticExpression($this);
+        return $walker->walkSimpleArithmeticExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SimpleCaseExpression ::= "CASE" CaseOperand SimpleWhenClause {SimpleWhenClause}* "ELSE" ScalarExpression "END"
  *
@@ -32,11 +34,8 @@ class SimpleCaseExpression extends Node
         $this->elseScalarExpression = $elseScalarExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSimpleCaseExpression($this);
+        return $walker->walkSimpleCaseExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SimpleSelectClause  ::= "SELECT" ["DISTINCT"] SimpleSelectExpression
  *
@@ -27,11 +29,8 @@ class SimpleSelectClause extends Node
         $this->isDistinct             = $isDistinct;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSimpleSelectClause($this);
+        return $walker->walkSimpleSelectClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SimpleSelectExpression ::= StateFieldPathExpression | IdentificationVariable
  *                          | (AggregateExpression [["AS"] FieldAliasIdentificationVariable])
@@ -26,11 +28,8 @@ class SimpleSelectExpression extends Node
         $this->expression = $expression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSimpleSelectExpression($this);
+        return $walker->walkSimpleSelectExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SimpleWhenClause ::= "WHEN" ScalarExpression "THEN" ScalarExpression
  *
@@ -27,11 +29,8 @@ class SimpleWhenClause extends Node
         $this->thenScalarExpression = $thenScalarExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkWhenClauseExpression($this);
+        return $walker->walkWhenClauseExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Subselect.php
+++ b/lib/Doctrine/ORM/Query/AST/Subselect.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * Subselect ::= SimpleSelectClause SubselectFromClause [WhereClause] [GroupByClause] [HavingClause] [OrderByClause]
  *
@@ -39,11 +41,8 @@ class Subselect extends Node
         $this->subselectFromClause = $subselectFromClause;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSubselect($this);
+        return $walker->walkSubselect($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * SubselectFromClause ::= "FROM" SubselectIdentificationVariableDeclaration {"," SubselectIdentificationVariableDeclaration}*
  *
@@ -22,11 +24,8 @@ class SubselectFromClause extends Node
         $this->identificationVariableDeclarations = $identificationVariableDeclarations;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkSubselectFromClause($this);
+        return $walker->walkSubselectFromClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/UpdateClause.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * UpdateClause ::= "UPDATE" AbstractSchemaName [["AS"] AliasIdentificationVariable] "SET" UpdateItem {"," UpdateItem}*
  *
@@ -30,11 +32,8 @@ class UpdateClause extends Node
         $this->updateItems        = $updateItems;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkUpdateClause($this);
+        return $walker->walkUpdateClause($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/UpdateItem.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateItem.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * UpdateItem ::= [IdentificationVariable "."] {StateField | SingleValuedAssociationField} "=" NewValue
  * NewValue ::= SimpleArithmeticExpression | StringPrimary | DatetimePrimary | BooleanPrimary |
@@ -29,11 +31,8 @@ class UpdateItem extends Node
         $this->newValue       = $newValue;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkUpdateItem($this);
+        return $walker->walkUpdateItem($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * UpdateStatement = UpdateClause [WhereClause]
  *
@@ -25,11 +27,8 @@ class UpdateStatement extends Node
         $this->updateClause = $updateClause;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkUpdateStatement($this);
+        return $walker->walkUpdateStatement($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/WhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhenClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * WhenClause ::= "WHEN" ConditionalExpression "THEN" ScalarExpression
  *
@@ -27,11 +29,8 @@ class WhenClause extends Node
         $this->thenScalarExpression    = $thenScalarExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkWhenClauseExpression($this);
+        return $walker->walkWhenClauseExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/WhereClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhereClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * WhereClause ::= "WHERE" ConditionalExpression
  *
@@ -22,11 +24,8 @@ class WhereClause extends Node
         $this->conditionalExpression = $conditionalExpression;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatch($sqlWalker)
+    public function dispatch(SqlWalker $walker): string
     {
-        return $sqlWalker->walkWhereClause($this);
+        return $walker->walkWhereClause($this);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,16 +271,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\AST\\\\IndexBy\\:\\:dispatch\\(\\) should return string but returns void\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/AST/IndexBy.php
-
-		-
-			message: "#^Result of method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkIndexBy\\(\\) \\(void\\) is used\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/AST/IndexBy.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkJoinPathExpression\\(\\)\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1118,92 +1118,30 @@
       <code>$parserResult</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/BetweenExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/CoalesceExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ComparisonExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ConditionalExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ConditionalFactor.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/ConditionalTerm.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/DeleteClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$aliasIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/DeleteStatement.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/ExistsExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/FromClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
     <PossiblyInvalidPropertyAssignmentValue occurrences="1">
@@ -1400,66 +1338,21 @@
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/GroupByClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/HavingClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/InExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/IndexBy.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>dispatch</code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement occurrences="1">
-      <code>$sqlWalker-&gt;walkIndexBy($this)</code>
-    </NullableReturnStatement>
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$not</code>
       <code>$value</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Join.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod occurrences="1">
@@ -1471,16 +1364,6 @@
       <code>walkJoinVariableDeclaration</code>
     </UndefinedMethod>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/LikeExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/NewObjectExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/Node.php">
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($obj)</code>
@@ -1490,131 +1373,47 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/NullIfExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/OrderByClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/OrderByItem.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SelectClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SelectExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SelectStatement.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$fieldIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Subselect.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/SubselectFromClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/UpdateClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$aliasIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/UpdateItem.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/UpdateStatement.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/WhenClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/WhereClause.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$sqlWalker</code>
-    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">


### PR DESCRIPTION
Part of #9772

This PR adds native types to all implementations of `Node::dispatch()` and makes sure the only parameter of that method is consistently named `$walker`.