### PR TITLE
Update documentation to not use deprecated method

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -541,7 +541,7 @@ mentioned sets. See this example:
     {
         public function onFlush(OnFlushEventArgs $eventArgs)
         {
-            $em = $eventArgs->getEntityManager();
+            $em = $eventArgs->getObjectManager();
             $uow = $em->getUnitOfWork();
 
             foreach ($uow->getScheduledEntityInsertions() as $entity) {


### PR DESCRIPTION
I forgot to change this in https://github.com/doctrine/orm/pull/9876 as pointed out in https://github.com/doctrine/orm/pull/9876#issuecomment-1207765070