### PR TITLE
Undeprecate LifecycleEventArgs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -73,10 +73,6 @@ This method has been deprecated in:
 
 It will be removed in 3.0. Use `getObjectManager()` instead.
 
-## Deprecated `Doctrine\ORM\Event\LifecycleEventArgs` class
-
-It will be removed in 3.0. Use `Doctrine\Persistence\Event\LifecycleEventArgs` instead.
-
 ## Prepare split of output walkers and tree walkers
 
 In 3.0, `SqlWalker` and its child classes won't implement the `TreeWalker`

--- a/docs/en/cookbook/strategy-cookbook-introduction.rst
+++ b/docs/en/cookbook/strategy-cookbook-introduction.rst
@@ -214,8 +214,8 @@ This might look like this:
 
     <?php
     use Doctrine\Common\EventSubscriber;
+    use Doctrine\ORM\Event\LifecycleEventArgs;
     use Doctrine\ORM\Events;
-    use Doctrine\Persistence\Event\LifecycleEventArgs;
 
     /**
      * The BlockStrategyEventListener will initialize a strategy after the

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -214,7 +214,7 @@ specific to a particular entity class's lifecycle.
 
         <?php
         use Doctrine\DBAL\Types\Types;
-        use Doctrine\Persistence\Event\LifecycleEventArgs;
+        use Doctrine\ORM\Event\LifecycleEventArgs;
 
         #[Entity]
         #[HasLifecycleCallbacks]

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -12,8 +12,6 @@ use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
  * of entities.
  *
- * @deprecated This class will be removed in ORM 3.0. Use "\Doctrine\Persistence\Event\LifecycleEventArgs" instead.
- *
  * @extends BaseLifecycleEventArgs<EntityManagerInterface>
  */
 class LifecycleEventArgs extends BaseLifecycleEventArgs

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,7 +29,6 @@
                 <!-- Remove on 3.0.x -->
                 <referencedClass name="Doctrine\Common\Persistence\PersistentObject"/>
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
-                <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs"/>
                 <referencedClass name="Doctrine\ORM\Exception\UnknownEntityNamespace"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContractListener.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContractListener.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\Company;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\PrePersist;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 use function func_get_args;
 

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\Column;
@@ -27,7 +28,6 @@ use Doctrine\ORM\Mapping\PreRemove;
 use Doctrine\ORM\Mapping\PreUpdate;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Query;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function count;

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
 use Exception;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -14,7 +15,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function in_array;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -17,7 +18,6 @@ use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\PostUpdate;
 use Doctrine\ORM\Mapping\PreUpdate;
 use Doctrine\ORM\Mapping\Table;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;


### PR DESCRIPTION
In https://github.com/doctrine/orm/pull/9906 I didn't think about what that meant when using event subscribers.

Deprecating this class means that users using SA tools have to update their code specifying the ObjectManager implementation.

From

```php
use use Doctrine\ORM\Event\LifecycleEventArgs;

public function postLoad(LifecycleEventArgs $args) {
    $blockItem = $args->getObject();
    // ...
}
```

to:

```php
use Doctrine\Persistence\Event\LifecycleEventArgs;

/**
 * @param LifecycleEventArgs<EntityManagerInterface> $args
 */
public function postLoad(LifecycleEventArgs $args) {
    $blockItem = $args->getObject();
    // ...
}
```

That's a bad DX, instead of this, we can create specific classes for each event and deprecate this class again when doing so and we don't make users to change their code twice (if they want to use the dedicate classes).
