### PR TITLE
made sure that target entity is cacheable

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -134,8 +134,8 @@ class DefaultQueryCache implements QueryCache
                     throw NonCacheableEntity::fromEntity($assoc['targetEntity']);
                 }
 
-                $assocRegion   = $assocPersister->getCacheRegion();
-                $assocMetadata = $this->em->getClassMetadata($assoc['targetEntity']);
+                $assocRegion    = $assocPersister->getCacheRegion();
+                $assocMetadata  = $this->em->getClassMetadata($assoc['targetEntity']);
 
                 if ($assoc['type'] & ClassMetadata::TO_ONE) {
                     $assocKey   = new EntityCacheKey($assocMetadata->rootEntityName, $assoc['identifier']);

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -130,7 +130,9 @@ class DefaultQueryCache implements QueryCache
 
             foreach ($entry['associations'] as $name => $assoc) {
                 $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
-                assert($assocPersister instanceof CachedEntityPersister);
+                if (! $assocPersister instanceof CachedEntityPersister) {
+                    throw NonCacheableEntity::fromEntity($assoc['targetEntity']);
+                }
 
                 $assocRegion   = $assocPersister->getCacheRegion();
                 $assocMetadata = $this->em->getClassMetadata($assoc['targetEntity']);
@@ -335,6 +337,10 @@ class DefaultQueryCache implements QueryCache
     private function storeAssociationCache(QueryCacheKey $key, array $assoc, $assocValue): ?array
     {
         $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
+        if (! $assocPersister instanceof CachedEntityPersister) {
+            throw NonCacheableEntity::fromEntity($assoc['targetEntity']);
+        }
+        
         $assocMetadata  = $assocPersister->getClassMetadata();
         $assocRegion    = $assocPersister->getCacheRegion();
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -340,7 +340,7 @@ class DefaultQueryCache implements QueryCache
         if (! $assocPersister instanceof CachedEntityPersister) {
             throw NonCacheableEntity::fromEntity($assoc['targetEntity']);
         }
-        
+
         $assocMetadata  = $assocPersister->getClassMetadata();
         $assocRegion    = $assocPersister->getCacheRegion();
 


### PR DESCRIPTION
Target entity is not always related to a CachedEntityPersister. 
e.g Two Entities inheriting from each other and only **child class** is cached.