### PR TITLE
Make paginator covariant

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;
 use IteratorAggregate;
 use ReturnTypeWillChange;
+use Traversable;
 
 use function array_key_exists;
 use function array_map;
@@ -25,7 +26,7 @@ use function count;
 /**
  * The paginator can handle various complex scenarios with DQL.
  *
- * @template T
+ * @template-covariant T
  */
 class Paginator implements Countable, IteratorAggregate
 {
@@ -124,8 +125,8 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      *
-     * @return ArrayIterator
-     * @psalm-return ArrayIterator<array-key, T>
+     * @return Traversable
+     * @psalm-return Traversable<array-key, T>
      */
     #[ReturnTypeWillChange]
     public function getIterator()

--- a/tests/Doctrine/StaticAnalysis/Tools/Pagination/paginator-covariant.php
+++ b/tests/Doctrine/StaticAnalysis/Tools/Pagination/paginator-covariant.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\StaticAnalysis\Tools\Pagination;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+/**
+ * @template-covariant T of object
+ */
+abstract class PaginatorFactory
+{
+    /** @var class-string<T> */
+    private $class;
+
+    /**
+     * @param class-string<T> $class
+     */
+    final public function __construct(string $class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * @return class-string<T>
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @psalm-return Paginator<T>
+     */
+    abstract public function createPaginator(): Paginator;
+}
+
+interface Animal
+{
+}
+
+class Cat implements Animal
+{
+}
+
+/**
+ * @param Paginator<Animal> $paginator
+ */
+function getFirstAnimal(Paginator $paginator): ?Animal
+{
+    foreach ($paginator as $result) {
+        return $result;
+    }
+
+    return null;
+}
+
+/**
+ * @param PaginatorFactory<Cat> $catPaginatorFactory
+ */
+function test(PaginatorFactory $catPaginatorFactory): ?Animal
+{
+    return getFirstAnimal($catPaginatorFactory->createPaginator());
+}


### PR DESCRIPTION
see https://phpstan.org/blog/whats-up-with-template-covariant
see https://psalm.dev/docs/annotating_code/templated_annotations/

A method which accepts `Paginator<Animal>` should be able to accept `Paginator<Cat>`.

I received the error
```
Template type T is declared as covariant, but occurs in invariant position in return type of method Doctrine\ORM\Tools\Pagination\Paginator::getIterator().
```

It's because the template of ArrayIterator is not covariant.
But the template for Traversable is covariant.

It makes sens to use Traversable instead of ArrayIterator as return type because
- IteratorAggregate::getIterator() use Traversable as return type
- it doesn't make sens to allow adding elements to this Iterator

ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Countable
the issue is the ArrayAccess.

If you preferred I can use somethink like
```
@psalm-return Traversable<array-key, T>&Countable
@psalm-return Traversable<array-key, T>&Serializable&Countable
@psalm-return SeekableIterator<array-key, T>&Serializable&Countable
...
```

Any suggestion @greg0ire ?