### PR TITLE
Fail gracefully if EM could not be constructed in tests

### DIFF
--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -907,7 +907,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
 
     final protected function isQueryLogAvailable(): bool
     {
-        return $this->_em->getConnection() instanceof DbalExtensions\Connection;
+        return $this->_em && $this->_em->getConnection() instanceof DbalExtensions\Connection;
     }
 
     final protected function getQueryLog(): QueryLog


### PR DESCRIPTION
Our functional test hooks into test failures. Here, the method `isQueryLogAvailable()` is called which assumes that the entity manager had been constructed by the setUp method. However, if constructing the EM fails (for whatever reason) or the test fails even earlier, we will run into a null pointer here and we won't see the actual test failure. This PR fixes that problem.