### PR TITLE
DDC-1680

### DIFF
--- a/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class PostRemoveEventArgs extends LifecycleEventArgs
+{
+    /** @param object $entity */
+    public function __construct($entity, EntityManagerInterface $objectManager, private mixed $identifier)
+    {
+        parent::__construct($entity, $objectManager);
+    }
+
+    public function getIdentifier(): mixed
+    {
+        return $this->identifier;
+    }
+}

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Exception\ORMException;
@@ -1252,12 +1253,13 @@ class UnitOfWork implements PropertyChangedListener
             // Entity with this $oid after deletion treated as NEW, even if the $oid
             // is obtained by a new entity because the old one went out of scope.
             //$this->entityStates[$oid] = self::STATE_NEW;
+            $identifier = $class->reflFields[$class->identifier[0]]->getValue($entity);
             if (! $class->isIdentifierNatural()) {
                 $class->reflFields[$class->identifier[0]]->setValue($entity, null);
             }
 
             if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new PostRemoveEventArgs($entity, $this->em, $identifier), $invoke);
             }
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
@@ -172,6 +173,6 @@ class EntityListenersTest extends OrmFunctionalTestCase
         self::assertCount(1, $this->listener->postRemoveCalls);
         self::assertSame($fix, $this->listener->postRemoveCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->postRemoveCalls[0][0]);
-        self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->postRemoveCalls[0][1]);
+        self::assertInstanceOf(PostRemoveEventArgs::class, $this->listener->postRemoveCalls[0][1]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\Column;
@@ -408,7 +409,7 @@ DQL;
         self::assertInstanceOf(PreUpdateEventArgs::class, $e->calls['preUpdateHandler']);
         self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postUpdateHandler']);
         self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['preRemoveHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postRemoveHandler']);
+        self::assertInstanceOf(PostRemoveEventArgs::class, $e->calls['postRemoveHandler']);
     }
 }
 
@@ -686,7 +687,7 @@ class LifecycleCallbackEventArgEntity
     }
 
     /** @PostRemove */
-    public function postRemoveHandler(LifecycleEventArgs $event): void
+    public function postRemoveHandler(PostRemoveEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }


### PR DESCRIPTION
Create PostRemoveEventArgs to be able to get entity identifier in postRemove listeners.

Fixes #2326

- [ ] update documentation
- [ ] implement real test case checking if id is available
  - [ ] What happens with multiple identifier fields? I'm not sure because only the first identifer seems to be set to null anyway.