### PR TITLE
Optimize Object Hydration performance on large result sets

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -414,7 +414,7 @@ abstract class AbstractHydrator
      *                   data: array<array-key, array>,
      *                   newObjects?: array<array-key, array{
      *                       class: mixed,
-     *                       args?: array
+     *                       args: array
      *                   }>,
      *                   scalars?: array
      *               }
@@ -548,8 +548,10 @@ abstract class AbstractHydrator
      *
      * @psalm-return array<array-key, array{
      *                       class: mixed,
-     *                       args?: array
+     *                       args: array
      *                   }>
+     *
+     * @psalm-suppress MoreSpecificReturnType Psalm does not detect that args keys is always defined
      */
     protected function gatherRowDataFromNewObjectsMapping(array $data): array
     {
@@ -569,6 +571,7 @@ abstract class AbstractHydrator
             $newObjectsData[$objIndex]['args'][$argIndex] = $value;
         }
 
+        /** @psalm-suppress LessSpecificReturnStatement Psalm does not detect that args keys is always defined */
         return $newObjectsData;
     }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -22,6 +22,9 @@ use LogicException;
 use ReflectionClass;
 use TypeError;
 
+use function array_flip;
+use function array_key_exists;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function count;
@@ -94,6 +97,13 @@ abstract class AbstractHydrator
     protected $_hints = [];
 
     /**
+     * Precomputed information about how result's rows should be mapped to object or scalars.
+     *
+     * @var array<string, mixed>
+     */
+    protected $_rowMappingInfo = [];
+
+    /**
      * Initializes a new instance of a class derived from <tt>AbstractHydrator</tt>.
      *
      * @param EntityManagerInterface $em The EntityManager to use.
@@ -134,6 +144,7 @@ abstract class AbstractHydrator
         $evm->addEventListener([Events::onClear], $this);
 
         $this->prepare();
+        $this->prepareRowMappingInfo();
 
         return new IterableResult($this);
     }
@@ -181,6 +192,7 @@ abstract class AbstractHydrator
         $evm->addEventListener([Events::onClear], $this);
 
         $this->prepare();
+        $this->prepareRowMappingInfo();
 
         while (true) {
             $row = $this->statement()->fetchAssociative();
@@ -265,6 +277,7 @@ abstract class AbstractHydrator
 
         $this->_em->getEventManager()->addEventListener([Events::onClear], $this);
         $this->prepare();
+        $this->prepareRowMappingInfo();
 
         try {
             $result = $this->hydrateAllData();
@@ -339,10 +352,11 @@ abstract class AbstractHydrator
     {
         $this->statement()->free();
 
-        $this->_stmt          = null;
-        $this->_rsm           = null;
-        $this->_cache         = [];
-        $this->_metadataCache = [];
+        $this->_stmt           = null;
+        $this->_rsm            = null;
+        $this->_rowMappingInfo = [];
+        $this->_cache          = [];
+        $this->_metadataCache  = [];
 
         $this
             ->_em
@@ -396,6 +410,7 @@ abstract class AbstractHydrator
      *                                             row, grouped by their
      *                                             component alias.
      * @psalm-return array{
+     *                   ids: array<array-key, array<array-key, mixed>>,
      *                   data: array<array-key, array>,
      *                   newObjects?: array<array-key, array{
      *                       class: mixed,
@@ -406,82 +421,155 @@ abstract class AbstractHydrator
      */
     protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents)
     {
-        $rowData = ['data' => []];
+        $rowData = [
+            'ids'  => $this->gatherRowIDs($data, $id, $nonemptyComponents),
+            'data' => [],
+        ];
 
-        foreach ($data as $key => $value) {
-            $cacheKeyInfo = $this->hydrateColumnInfo($key);
-            if ($cacheKeyInfo === null) {
-                continue;
-            }
+        foreach (array_keys($this->_rowMappingInfo['dql']) as $alias) {
+            $rowData['data'][$alias] = $this->gatherRowDataFromDQLMapping($data, $alias);
+        }
 
-            $fieldName = $cacheKeyInfo['fieldName'];
+        if (isset($this->_rowMappingInfo['scalars'])) {
+            $rowData['scalars'] = $this->gatherRowDataFromScalarsMapping($data);
+        }
 
-            switch (true) {
-                case isset($cacheKeyInfo['isNewObjectParameter']):
-                    $argIndex = $cacheKeyInfo['argIndex'];
-                    $objIndex = $cacheKeyInfo['objIndex'];
-                    $type     = $cacheKeyInfo['type'];
-                    $value    = $type->convertToPHPValue($value, $this->_platform);
-
-                    if ($value !== null && isset($cacheKeyInfo['enumType'])) {
-                        $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
-                    }
-
-                    $rowData['newObjects'][$objIndex]['class']           = $cacheKeyInfo['class'];
-                    $rowData['newObjects'][$objIndex]['args'][$argIndex] = $value;
-                    break;
-
-                case isset($cacheKeyInfo['isScalar']):
-                    $type  = $cacheKeyInfo['type'];
-                    $value = $type->convertToPHPValue($value, $this->_platform);
-
-                    if ($value !== null && isset($cacheKeyInfo['enumType'])) {
-                        $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
-                    }
-
-                    $rowData['scalars'][$fieldName] = $value;
-
-                    break;
-
-                //case (isset($cacheKeyInfo['isMetaColumn'])):
-                default:
-                    $dqlAlias = $cacheKeyInfo['dqlAlias'];
-                    $type     = $cacheKeyInfo['type'];
-
-                    // If there are field name collisions in the child class, then we need
-                    // to only hydrate if we are looking at the correct discriminator value
-                    if (
-                        isset($cacheKeyInfo['discriminatorColumn'], $data[$cacheKeyInfo['discriminatorColumn']])
-                        && ! in_array((string) $data[$cacheKeyInfo['discriminatorColumn']], $cacheKeyInfo['discriminatorValues'], true)
-                    ) {
-                        break;
-                    }
-
-                    // in an inheritance hierarchy the same field could be defined several times.
-                    // We overwrite this value so long we don't have a non-null value, that value we keep.
-                    // Per definition it cannot be that a field is defined several times and has several values.
-                    if (isset($rowData['data'][$dqlAlias][$fieldName])) {
-                        break;
-                    }
-
-                    $rowData['data'][$dqlAlias][$fieldName] = $type
-                        ? $type->convertToPHPValue($value, $this->_platform)
-                        : $value;
-
-                    if ($rowData['data'][$dqlAlias][$fieldName] !== null && isset($cacheKeyInfo['enumType'])) {
-                        $rowData['data'][$dqlAlias][$fieldName] = $this->buildEnum($rowData['data'][$dqlAlias][$fieldName], $cacheKeyInfo['enumType']);
-                    }
-
-                    if ($cacheKeyInfo['isIdentifier'] && $value !== null) {
-                        $id[$dqlAlias]                .= '|' . $value;
-                        $nonemptyComponents[$dqlAlias] = true;
-                    }
-
-                    break;
-            }
+        if (isset($this->_rowMappingInfo['newObjects'])) {
+            $rowData['newObjects'] = $this->gatherRowDataFromNewObjectsMapping($data);
         }
 
         return $rowData;
+    }
+
+    /**
+     * @param mixed[]  $data               SQL Result Row.
+     * @param string[] $id                 Dql-Alias => ID-Hash.
+     * @param bool[]   $nonemptyComponents Does this DQL-Alias has at least one
+     *                                     non NULL value?
+     *
+     * @return mixed[][] An array with all the ids (name => value) of the row.
+     */
+    protected function gatherRowIDs(array $data, array &$id, array &$nonemptyComponents): array
+    {
+        $ids = [];
+
+        foreach ($this->_rowMappingInfo['ids'] as $column => $cacheKeyInfo) {
+            $dqlAlias  = $cacheKeyInfo['dqlAlias'];
+            $fieldName = $cacheKeyInfo['fieldName'];
+
+            $ids[$dqlAlias][$fieldName] = $data[$column];
+
+            if ($data[$column] !== null) {
+                $id[$dqlAlias]                .= '|' . $data[$column];
+                $nonemptyComponents[$dqlAlias] = true;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param mixed[] $data SQL Result Row.
+     *
+     * @return mixed[][] An array with all the fields (name => value) of the
+     *                   data row, grouped by their component alias.
+     */
+    protected function gatherRowDataFromDQLMapping(array $data, string $dqlAlias): array
+    {
+        $rowData = [];
+
+        foreach ($this->_rowMappingInfo['dql'][$dqlAlias] as $column => $cacheKeyInfo) {
+            $fieldName = $cacheKeyInfo['fieldName'];
+
+            // If there are field name collisions in the child class, then we need
+            // to only hydrate if we are looking at the correct discriminator value
+            if (
+                isset($cacheKeyInfo['discriminatorColumn'], $data[$cacheKeyInfo['discriminatorColumn']])
+                && ! isset($cacheKeyInfo['discriminatorValues'][$data[$cacheKeyInfo['discriminatorColumn']]])
+            ) {
+                continue;
+            }
+
+            // in an inheritance hierarchy the same field could be defined several times.
+            // We overwrite this value so long we don't have a non-null value, that value we keep.
+            // Per definition it cannot be that a field is defined several times and has several values.
+            if (isset($rowData[$fieldName])) {
+                continue;
+            }
+
+            // array_key_exists is more accurate as it accounts for null values
+            // but is slower so we first try a quicker version
+            if (! isset($data[$column]) && ! array_key_exists($column, $data)) {
+                continue;
+            }
+
+            $type = $cacheKeyInfo['type'];
+
+            $value = $type
+                ? $type->convertToPHPValue($data[$column], $this->_platform)
+                : $data[$column];
+
+            if ($value !== null && isset($cacheKeyInfo['enumType'])) {
+                $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
+            }
+
+            $rowData[$fieldName] = $value;
+        }
+
+        return $rowData;
+    }
+
+    /**
+     * @param mixed[] $data SQL Result Row.
+     *
+     * @return mixed[]
+     */
+    protected function gatherRowDataFromScalarsMapping(array $data): array
+    {
+        $scalarsData = [];
+
+        foreach ($this->_rowMappingInfo['scalars'] as $column => $cacheKeyInfo) {
+            $fieldName = $cacheKeyInfo['fieldName'];
+            $type      = $cacheKeyInfo['type'];
+            $value     = $type->convertToPHPValue($data[$column], $this->_platform);
+
+            if ($value !== null && isset($cacheKeyInfo['enumType'])) {
+                $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
+            }
+
+            $scalarsData[$fieldName] = $value;
+        }
+
+        return $scalarsData;
+    }
+
+    /**
+     * @param mixed[] $data SQL Result Row.
+     *
+     * @psalm-return array<array-key, array{
+     *                       class: mixed,
+     *                       args?: array
+     *                   }>
+     */
+    protected function gatherRowDataFromNewObjectsMapping(array $data): array
+    {
+        $newObjectsData = [];
+
+        foreach ($this->_rowMappingInfo['newObjects'] as $column => $cacheKeyInfo) {
+            $argIndex = $cacheKeyInfo['argIndex'];
+            $objIndex = $cacheKeyInfo['objIndex'];
+            $type     = $cacheKeyInfo['type'];
+            $value    = $type->convertToPHPValue($data[$column], $this->_platform);
+
+            if ($value !== null && isset($cacheKeyInfo['enumType'])) {
+                $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
+            }
+
+            $newObjectsData[$objIndex]['class']           = $cacheKeyInfo['class'];
+            $newObjectsData[$objIndex]['args'][$argIndex] = $value;
+        }
+
+        return $newObjectsData;
     }
 
     /**
@@ -525,6 +613,50 @@ abstract class AbstractHydrator
         return $rowData;
     }
 
+    private function prepareRowMappingInfo(): void
+    {
+        $resultSetMapping = $this->resultSetMapping();
+
+        $rowInfo = [
+            'dql' => [],
+            'ids' => [],
+        ];
+
+        foreach (array_keys($resultSetMapping->columnOwnerMap) as $column) {
+            $cacheKeyInfo = $this->hydrateColumnInfo($column);
+            if ($cacheKeyInfo === null) {
+                continue;
+            }
+
+            if (! isset($cacheKeyInfo['dqlAlias'])) {
+                continue;
+            }
+
+            $dqlAlias = $cacheKeyInfo['dqlAlias'];
+
+            $rowInfo['dql'][$dqlAlias][$column] = $cacheKeyInfo;
+
+            if ($cacheKeyInfo['isIdentifier']) {
+                $rowInfo['ids'][$column] = $cacheKeyInfo;
+            }
+        }
+
+        foreach ($resultSetMapping->scalarMappings as $column => $fieldName) {
+            $cacheKeyInfo = $this->hydrateColumnInfo($column);
+            if ($cacheKeyInfo === null) {
+                continue;
+            }
+
+            if (isset($this->_rsm->newObjectMappings[$column])) {
+                $rowInfo['newObjects'][$column] = $cacheKeyInfo;
+            } else {
+                $rowInfo['scalars'][$column] = $cacheKeyInfo;
+            }
+        }
+
+        $this->_rowMappingInfo = $rowInfo;
+    }
+
     /**
      * Retrieve column information from ResultSetMapping.
      *
@@ -562,7 +694,7 @@ abstract class AbstractHydrator
                         [
                             'discriminatorColumn' => $this->_rsm->discriminatorColumns[$ownerMap],
                             'discriminatorValue'  => $classMetadata->discriminatorValue,
-                            'discriminatorValues' => $this->getDiscriminatorValues($classMetadata),
+                            'discriminatorValues' => array_flip($this->getDiscriminatorValues($classMetadata)),
                         ]
                     );
                 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -30,9 +30,6 @@ class ObjectHydrator extends AbstractHydrator
     private $identifierMap = [];
 
     /** @var mixed[] */
-    private $resultPointers = [];
-
-    /** @var mixed[] */
     private $idTemplate = [];
 
     /** @var int */
@@ -118,8 +115,7 @@ class ObjectHydrator extends AbstractHydrator
         $this->identifierMap            =
         $this->initializedCollections   =
         $this->uninitializedCollections =
-        $this->existingCollections      =
-        $this->resultPointers           = [];
+        $this->existingCollections      = [];
 
         if ($eagerLoad) {
             $this->_uow->triggerEagerLoads();
@@ -133,8 +129,7 @@ class ObjectHydrator extends AbstractHydrator
         $this->identifierMap            =
         $this->initializedCollections   =
         $this->uninitializedCollections =
-        $this->existingCollections      =
-        $this->resultPointers           = [];
+        $this->existingCollections      = [];
     }
 
     /**
@@ -325,7 +320,7 @@ class ObjectHydrator extends AbstractHydrator
         $rowData = $this->gatherRowData($row, $id, $nonemptyComponents);
 
         // reset result pointers for each data row
-        $this->resultPointers = [];
+        $resultPointers = [];
 
         // Hydrate the data chunks
         foreach ($rowData['data'] as $dqlAlias => $data) {
@@ -352,16 +347,16 @@ class ObjectHydrator extends AbstractHydrator
 
                 // Get a reference to the parent object to which the joined element belongs.
                 if ($this->resultSetMapping()->isMixed && isset($this->rootAliases[$parentAlias])) {
-                    $objectClass  = $this->resultPointers[$parentAlias];
+                    $objectClass  = $resultPointers[$parentAlias];
                     $parentObject = $objectClass[key($objectClass)];
-                } elseif (isset($this->resultPointers[$parentAlias])) {
-                    $parentObject = $this->resultPointers[$parentAlias];
+                } elseif (isset($resultPointers[$parentAlias])) {
+                    $parentObject = $resultPointers[$parentAlias];
                 } else {
                     // Parent object of relation not found, mark as not-fetched again
                     $element = $this->getEntity($data, $dqlAlias);
 
                     // Update result pointer and provide initial fetch data for parent
-                    $this->resultPointers[$dqlAlias]               = $element;
+                    $resultPointers[$dqlAlias]                     = $element;
                     $rowData['data'][$parentAlias][$relationField] = $element;
 
                     // Mark as not-fetched again
@@ -393,9 +388,9 @@ class ObjectHydrator extends AbstractHydrator
                                 // Collection exists, only look for the element in the identity map.
                                 $element = $this->getEntityFromIdentityMap($entityName, $data);
                                 if ($element) {
-                                    $this->resultPointers[$dqlAlias] = $element;
+                                    $resultPointers[$dqlAlias] = $element;
                                 } else {
-                                    unset($this->resultPointers[$dqlAlias]);
+                                    unset($resultPointers[$dqlAlias]);
                                 }
                             } else {
                                 $element = $this->getEntity($data, $dqlAlias);
@@ -414,11 +409,11 @@ class ObjectHydrator extends AbstractHydrator
                                 }
 
                                 // Update result pointer
-                                $this->resultPointers[$dqlAlias] = $element;
+                                $resultPointers[$dqlAlias] = $element;
                             }
                         } else {
                             // Update result pointer
-                            $this->resultPointers[$dqlAlias] = $reflFieldValue[$index];
+                            $resultPointers[$dqlAlias] = $reflFieldValue[$index];
                         }
                     } elseif (! $reflFieldValue) {
                         $this->initRelatedCollection($parentObject, $parentClass, $relationField, $parentAlias);
@@ -458,7 +453,7 @@ class ObjectHydrator extends AbstractHydrator
                             }
 
                             // Update result pointer
-                            $this->resultPointers[$dqlAlias] = $element;
+                            $resultPointers[$dqlAlias] = $element;
                         } else {
                             $this->_uow->setOriginalEntityProperty($oid, $relationField, null);
                             $reflField->setValue($parentObject, null);
@@ -466,7 +461,7 @@ class ObjectHydrator extends AbstractHydrator
                         // else leave $reflFieldValue null for single-valued associations
                     } else {
                         // Update result pointer
-                        $this->resultPointers[$dqlAlias] = $reflFieldValue;
+                        $resultPointers[$dqlAlias] = $reflFieldValue;
                     }
                 }
             } else {
@@ -517,12 +512,12 @@ class ObjectHydrator extends AbstractHydrator
                     $this->identifierMap[$dqlAlias][$id[$dqlAlias]] = $resultKey;
 
                     // Update result pointer
-                    $this->resultPointers[$dqlAlias] = $element;
+                    $resultPointers[$dqlAlias] = $element;
                 } else {
                     // Update result pointer
-                    $index                           = $this->identifierMap[$dqlAlias][$id[$dqlAlias]];
-                    $this->resultPointers[$dqlAlias] = $result[$index];
-                    $resultKey                       = $index;
+                    $index                     = $this->identifierMap[$dqlAlias][$id[$dqlAlias]];
+                    $resultPointers[$dqlAlias] = $result[$index];
+                    $resultKey                 = $index;
                 }
             }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -13,7 +13,6 @@ use RuntimeException;
 use function array_keys;
 use function array_search;
 use function count;
-use function in_array;
 use function key;
 use function reset;
 use function sprintf;
@@ -127,7 +126,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             }
 
             // If we have inheritance in resultset, make sure the field belongs to the correct class
-            if (isset($cacheKeyInfo['discriminatorValues']) && ! in_array((string) $discrColumnValue, $cacheKeyInfo['discriminatorValues'], true)) {
+            if (isset($cacheKeyInfo['discriminatorValues']) && ! isset($cacheKeyInfo['discriminatorValues'][$discrColumnValue])) {
                 continue;
             }
 


### PR DESCRIPTION
Hi folks!

While assessing a client's project performance I found some optimizations regarding the ORM hydration process that improves speed when working with large result sets and collections.

<details>
 <summary>Expand to get some context on how we reached this.</summary>
The context is about online carts on a B2B e-commerce platform with a high number of items and complex personalization logic.
We reached the point in the optimization process where most of the time was spent in the ORM (after serialization) when fetching a cart.

This makes sense because of the volume and the logic at stake.
Denormalization or caching does not make sense for us because of the low read/write ratio and the business logic involved so we first went with the 2-step hydration technic.
</details>

While analyzing profiling results we more or less came to the same conclusion as #8390: the hydration process converts data over and over again even if the entity is already hydrated>

But after trying to work around performance for specific DBAL types that were costly to convert (namely Symfony's UUID and Dunglas's JSON document) and digging deeper into profiles I concluded something could be done directly in the Hydrator for the benefit of everyone instead of writing our specific optimized hydrator:
![Screenshot 2022-09-08 at 17 51 38](https://user-images.githubusercontent.com/870118/189378440-36c194aa-38d3-43c4-88b5-f40f67b70294.png)


This PR acts according to one consideration: most parts of the hydration process are not slow per se but are repeated for every row and column. By applying some small optimizations, moving some code before the first iteration, or some code at the very last moment, we can improve the overall process.
The more rows and columns, the more the process is accelerated.

For examples:
- type conversion can be costly but only identifiers are required to determine if the entity is already hydrated or not: the actual data can be converted later on in the process only if needed using only the columns required for the current entity (not the data for other entities in relations);
- we can prepare the mapping information in a way that prevents repeating some part of the process thousands of times;
- and we can avoid using the reflection to retrieve relations properties if they are available in another mapping.

With this patch, I manage to reach the following results:

| Metric | Before | After | Notes |
|-----------------------------|--------|-------|----------------|
|`->getQuery()->getResult()`| 726.39 ms | 358.67 ms | -51%, best of 20 iterations, query result cache enabled, 11 826 entities created
|`Doctrine\ORM\PersistentCollection::*`| 164 634 | 77 345
|`TypedNoDefaultReflectionProperty::getValue` | 162 770  | 125 669
|`Doctrine\ORM\Internal\Hydration\AbstractHydrator::resultSetMapping` | 441 742 | 19 745
|`Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateColumnInfo`| 946 970 | 337
|`Doctrine\DBAL\Types\IntegerType::convertToPHPValue`| 406 982 | 279 366
|`Doctrine\DBAL\Types\StringType::convertToPHPValue`| 181 207 | 63 473
|`Doctrine\DBAL\Types\BooleanType::convertToPHPValue`| 75 163 | 7 865
|`Doctrine\DBAL\Types\DateTimeImmutableType::convertToPHPValue`| 25 118 |  789
|`App\DBAL\Types\UuidType::convertToPHPValue`| 13 056 | 413

I hope we can manage to get this work so that everyone enjoys better performance 🤗
If you are willing to move in this direction, we can probably adapt ArrayHydrator the same way.