### PR TITLE
Fix using enums with the QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -464,13 +464,13 @@ abstract class AbstractHydrator
                         break;
                     }
 
-                    if ($value !== null && isset($cacheKeyInfo['enumType'])) {
-                        $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
-                    }
-
                     $rowData['data'][$dqlAlias][$fieldName] = $type
                         ? $type->convertToPHPValue($value, $this->_platform)
                         : $value;
+
+                    if ($rowData['data'][$dqlAlias][$fieldName] !== null && isset($cacheKeyInfo['enumType'])) {
+                        $rowData['data'][$dqlAlias][$fieldName] = $this->buildEnum($rowData['data'][$dqlAlias][$fieldName], $cacheKeyInfo['enumType']);
+                    }
 
                     if ($cacheKeyInfo['isIdentifier'] && $value !== null) {
                         $id[$dqlAlias]                .= '|' . $value;

--- a/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
@@ -63,8 +63,8 @@ class ReflectionEnumProperty extends ReflectionProperty
     }
 
     /**
-     * @param object                         $object
-     * @param int|string|int[]|string[]|null $value
+     * @param object                                                 $object
+     * @param int|string|int[]|string[]|BackedEnum|BackedEnum[]|null $value
      */
     public function setValue($object, $value = null): void
     {
@@ -82,11 +82,15 @@ class ReflectionEnumProperty extends ReflectionProperty
     }
 
     /**
-     * @param object     $object
-     * @param int|string $value
+     * @param object                $object
+     * @param int|string|BackedEnum $value
      */
     private function initializeEnumValue($object, $value): BackedEnum
     {
+        if ($value instanceof BackedEnum) {
+            return $value;
+        }
+
         $enumType = $this->enumType;
 
         try {

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -66,6 +66,58 @@ class EnumTest extends OrmFunctionalTestCase
         $this->assertEquals(Suit::Clubs, $fetchedCard->suit);
     }
 
+    public function testEnumHydrationObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card1       = new Card();
+        $card1->suit = Suit::Clubs;
+        $card2       = new Card();
+        $card2->suit = Suit::Hearts;
+
+        $this->_em->persist($card1);
+        $this->_em->persist($card2);
+        $this->_em->flush();
+
+        unset($card1, $card2);
+        $this->_em->clear();
+
+        /** @var list<Card> $foundCards */
+        $foundCards = $this->_em->createQueryBuilder()
+            ->select('c')
+            ->from(Card::class, 'c')
+            ->where('c.suit = :suit')
+            ->setParameter('suit', Suit::Clubs)
+            ->getQuery()
+            ->getResult();
+
+        self::assertNotEmpty($foundCards);
+        foreach ($foundCards as $card) {
+            self::assertSame(Suit::Clubs, $card->suit);
+        }
+    }
+
+    public function testEnumArrayHydrationObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Scale::class]);
+
+        $scale                 = new Scale();
+        $scale->supportedUnits = [Unit::Gram, Unit::Meter];
+
+        $this->_em->persist($scale);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->createQueryBuilder()
+            ->from(Scale::class, 's')
+            ->select('s')
+            ->getQuery()
+            ->getResult();
+
+        self::assertInstanceOf(Scale::class, $result[0]);
+        self::assertEqualsCanonicalizing([Unit::Gram, Unit::Meter], $result[0]->supportedUnits);
+    }
+
     public function testEnumHydration(): void
     {
         $this->setUpEntitySchema([Card::class, CardWithNullable::class]);


### PR DESCRIPTION
Fixes #10057.

After upgrading to version `2.13.2` I started getting the following error:

```
App\Enum\TestEnum::from(): Argument #1 ($value) must be of type string, App\Enum\TestEnum given
```

It happens when an enum is used with the `QueryBuilder`, eg:

```php
$testRepository
    ->createQueryBuilder('t')
    ->where('t.enum = :type')
    ->setParameter('type', TestEnum::Foo)
    ->getQuery()->getResult()
;
```

Caused by #10041.

Since my knowledge of the ORM code base is limited I'm not sure if this is the best place to fix the bug, so any suggestions are appreciated.