### PR TITLE
Fix setting readonly properties in different scopes

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -76,10 +76,12 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
             $this->parentProperty->setValue($object, $embeddedObject);
         }
 
-        if ($this->childProperty->isReadOnly()) {
+        $declaringClass =  $this->childProperty->getDeclaringClass();
+
+        if ($this->childProperty->isReadOnly() && $declaringClass->getName() !== $this->embeddedClass) {
             // changing a read-only property is not allowed to do so we are changing the scope to the declaring class
-            $class = $this->childProperty->getDeclaringClass();
-            $class->getProperty($this->childProperty->getName())->setValue($embeddedObject, $value);
+            $scopedChildProperty = $declaringClass->getProperty($this->childProperty->getName());
+            $scopedChildProperty->setValue($embeddedObject, $value);
         } else {
             $this->childProperty->setValue($embeddedObject, $value);
         }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -9,7 +9,6 @@ use ReflectionProperty;
 use ReturnTypeWillChange;
 
 use function method_exists;
-use function var_dump;
 
 /**
  * Acts as a proxy to a nested Property structure, making it look like

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -79,13 +79,15 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
         }
 
         if (PHP_VERSION_ID >= 80100) {
-            $declaringClass =  $this->childProperty->getDeclaringClass();
+            if ($this->childProperty->isReadOnly()) {
+                $declaringClass = $this->childProperty->getDeclaringClass();
 
-            if ($this->childProperty->isReadOnly() && $declaringClass->getName() !== $this->embeddedClass) {
-                $scopedChildProperty = $declaringClass->getProperty($this->childProperty->getName());
-                $scopedChildProperty->setValue($embeddedObject, $value);
+                if ($declaringClass->getName() !== $this->embeddedClass) {
+                    $scopedChildProperty = $declaringClass->getProperty($this->childProperty->getName());
+                    $scopedChildProperty->setValue($embeddedObject, $value);
 
-                return;
+                    return;
+                }
             }
         }
 

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -8,8 +8,6 @@ use Doctrine\Instantiator\Instantiator;
 use ReflectionProperty;
 use ReturnTypeWillChange;
 
-use function method_exists;
-
 use const PHP_VERSION_ID;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -84,7 +84,10 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
 
                 if ($declaringClass->getName() !== $this->embeddedClass) {
                     $scopedChildProperty = $declaringClass->getProperty($this->childProperty->getName());
-                    $scopedChildProperty->setValue($embeddedObject, $value);
+
+                    if (! $scopedChildProperty->isInitialized($embeddedObject)) {
+                        $scopedChildProperty->setValue($embeddedObject, $value);
+                    }
 
                     return;
                 }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -76,6 +76,12 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
             $this->parentProperty->setValue($object, $embeddedObject);
         }
 
-        $this->childProperty->setValue($embeddedObject, $value);
+        if ($this->childProperty->isReadOnly()) {
+            // changing a read-only property is not allowed to do so we are changing the scope to the declaring class
+            $class = $this->childProperty->getDeclaringClass();
+            $class->getProperty($this->childProperty->getName())->setValue($embeddedObject, $value);
+        } else {
+            $this->childProperty->setValue($embeddedObject, $value);
+        }
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -10,6 +10,8 @@ use ReturnTypeWillChange;
 
 use function method_exists;
 
+use const PHP_VERSION_ID;
+
 /**
  * Acts as a proxy to a nested Property structure, making it look like
  * just a single scalar property.
@@ -78,7 +80,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
             $this->parentProperty->setValue($object, $embeddedObject);
         }
 
-        if (method_exists($this->childProperty, 'isReadOnly')) {
+        if (PHP_VERSION_ID >= 80100) {
             $declaringClass =  $this->childProperty->getDeclaringClass();
 
             if ($this->childProperty->isReadOnly() && $declaringClass->getName() !== $this->embeddedClass) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 
 /**
- * This file is required to be in a separate file to allow using PHP 8.1 features which will otherwise break tests against PHP 8.0 or lower
+ * This is required to be in a separate file to allow using PHP 8.1 features which will otherwise break tests against PHP 8.0 or lower
  */
 
 abstract class GH10049AggregatedRootId

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * This file is required to be in a separate file to allow using PHP 8.1 features which will otherwise break tests against PHP 8.0 or lower
+ */
+
+abstract class GH10049AggregatedRootId
+{
+    /**
+     * @Id
+     * @Column(name="id", type="string")
+     */
+    public readonly string $value;
+
+    public function __construct(?string $value = null)
+    {
+        $this->value = $value ?? 'a';
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}
+
+/**
+ * @Embeddable
+ */
+final class GH10049BookId extends GH10049AggregatedRootId
+{
+}
+
+/**
+ * @Entity
+ */
+class GH10049Book
+{
+    /** @Embedded(columnPrefix=false) */
+    public readonly GH10049BookId $id;
+
+    public function __construct(?GH10049BookId $id = null)
+    {
+        $this->id = $id ?? new GH10049BookId();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php
@@ -26,11 +26,6 @@ abstract class GH10049AggregatedRootId
     {
         $this->value = $value ?? 'a';
     }
-
-    public function __toString()
-    {
-        return $this->value;
-    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
@@ -40,7 +40,7 @@ class GH10049Test extends OrmFunctionalTestCase
 
     public function testIssue(): void
     {
-        $id = "b";
+        $id = 'b';
 
         $book = new GH10049Book(new GH10049BookId($id));
 
@@ -69,7 +69,7 @@ abstract class GH10049AggregatedRootId
 
     public function __construct(?string $value = null)
     {
-        $this->value = $value ?? "a";
+        $this->value = $value ?? 'a';
     }
 
     public function __toString()
@@ -90,9 +90,7 @@ final class GH10049BookId extends GH10049AggregatedRootId
  */
 class GH10049Book
 {
-    /**
-     * @Embedded(columnPrefix=false)
-     */
+    /** @Embedded(columnPrefix=false) */
     public readonly GH10049BookId $id;
 
     public function __construct(?GH10049BookId $id = null)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
+ * @requires PHP 8.1
  * @group GH-10049
  */
 class GH10049Test extends OrmFunctionalTestCase

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Embeddable;
-use Doctrine\ORM\Mapping\Embedded;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -19,6 +14,8 @@ class GH10049Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
+        require_once __DIR__ . '/GH10049Mocks.php';
+
         parent::setUp();
 
         $this->_schemaTool->createSchema(
@@ -56,46 +53,7 @@ class GH10049Test extends OrmFunctionalTestCase
 
         // assert Book was persisted and could be hydrated
         self::assertInstanceOf(GH10049Book::class, $persistedBook);
+        self::assertInstanceOf(GH10049BookId::class, $persistedBook->id);
         self::assertEquals($id, $persistedBook->id->value);
-    }
-}
-
-abstract class GH10049AggregatedRootId
-{
-    /**
-     * @Id
-     * @Column(name="id", type="string")
-     */
-    public readonly string $value;
-
-    public function __construct(?string $value = null)
-    {
-        $this->value = $value ?? 'a';
-    }
-
-    public function __toString()
-    {
-        return $this->value;
-    }
-}
-
-/**
- * @Embeddable
- */
-final class GH10049BookId extends GH10049AggregatedRootId
-{
-}
-
-/**
- * @Entity
- */
-class GH10049Book
-{
-    /** @Embedded(columnPrefix=false) */
-    public readonly GH10049BookId $id;
-
-    public function __construct(?GH10049BookId $id = null)
-    {
-        $this->id = $id ?? new GH10049BookId();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Test.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-10049
+ */
+class GH10049Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(GH10049Book::class),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->_schemaTool->dropSchema(
+            [
+                $this->_em->getClassMetadata(GH10049Book::class),
+            ]
+        );
+
+        parent::tearDown();
+    }
+
+    public function testIssue(): void
+    {
+        $id = "b";
+
+        $book = new GH10049Book(new GH10049BookId($id));
+
+        $this->_em->persist($book);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(GH10049Book::class);
+
+        $persistedBook = $repository->find($id);
+
+        // assert Book was persisted and could be hydrated
+        self::assertInstanceOf(GH10049Book::class, $persistedBook);
+        self::assertEquals($id, $persistedBook->id->value);
+    }
+}
+
+abstract class GH10049AggregatedRootId
+{
+    /**
+     * @Id
+     * @Column(name="id", type="string")
+     */
+    public readonly string $value;
+
+    public function __construct(?string $value = null)
+    {
+        $this->value = $value ?? "a";
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}
+
+/**
+ * @Embeddable
+ */
+final class GH10049BookId extends GH10049AggregatedRootId
+{
+}
+
+/**
+ * @Entity
+ */
+class GH10049Book
+{
+    /**
+     * @Embedded(columnPrefix=false)
+     */
+    public readonly GH10049BookId $id;
+
+    public function __construct(?GH10049BookId $id = null)
+    {
+        $this->id = $id ?? new GH10049BookId();
+    }
+}


### PR DESCRIPTION
Looks like #10049 can be fixed like this, it simply uses the described method from the RFC by changing the scope to the declaring class.

It will only be executed if the `isReadOnly`-method is present, this will also check if PHP is 8.1 or higher, I am not sure if there is any performance impact on this.

As I described in the `tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049Mocks.php` file, it is required to have them outside, otherwise, the file will be fully parsed by PHP 7.4 and will throw an error because the keyword `readonly` is new and not backwards compatible.

Fixes: #10049