### PR TITLE
Lazy and eager collection refresh inconsistency

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2473,13 +2473,13 @@ EXCEPTION
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 
+        $this->cascadeRefresh($entity, $visited, $lockMode);
+
         $this->getEntityPersister($class->name)->refresh(
             array_combine($class->getIdentifierFieldNames(), $this->entityIdentifiers[$oid]),
             $entity,
             $lockMode
         );
-
-        $this->cascadeRefresh($entity, $visited, $lockMode);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/LazyEagerCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/LazyEagerCollectionTest.php
@@ -17,6 +17,7 @@ class LazyEagerCollectionTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->createSchemaForModels(
             LazyEagerCollectionUser::class,
             LazyEagerCollectionAddress::class,

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/LazyEagerCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/LazyEagerCollectionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class LazyEagerCollectionTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createSchemaForModels(
+            LazyEagerCollectionUser::class,
+            LazyEagerCollectionAddress::class,
+            LazyEagerCollectionPhone::class
+        );
+    }
+
+    public function testRefreshRefreshesBothLazyAndEagerCollections(): void
+    {
+        $user       = new LazyEagerCollectionUser();
+        $user->data = 'Guilherme';
+
+        $ph       = new LazyEagerCollectionPhone();
+        $ph->data = '12345';
+        $user->addPhone($ph);
+
+        $ad       = new LazyEagerCollectionAddress();
+        $ad->data = '6789';
+        $user->addAddress($ad);
+
+        $this->_em->persist($user);
+        $this->_em->persist($ad);
+        $this->_em->persist($ph);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find(LazyEagerCollectionUser::class, $user->id);
+        $ph   = $user->phones[0];
+        $ad   = $user->addresses[0];
+
+        $ph->data = 'abc';
+        $ad->data = 'def';
+
+        $this->_em->refresh($user);
+
+        self::assertSame('12345', $ph->data);
+        self::assertSame('6789', $ad->data);
+    }
+}
+
+/**
+ * @Entity
+ */
+class LazyEagerCollectionUser
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255)
+     */
+    public $data;
+
+    /**
+     * @ORM\OneToMany(targetEntity="LazyEagerCollectionPhone", cascade={"refresh"}, fetch="EAGER", mappedBy="user")
+     *
+     * @var LazyEagerCollectionPhone[]
+     */
+    public $phones;
+
+    /**
+     * @ORM\OneToMany(targetEntity="LazyEagerCollectionAddress", cascade={"refresh"}, mappedBy="user")
+     *
+     * @var LazyEagerCollectionAddress[]
+     */
+    public $addresses;
+
+    public function __construct()
+    {
+        $this->addresses = new ArrayCollection();
+        $this->phones    = new ArrayCollection();
+    }
+
+    public function addPhone(LazyEagerCollectionPhone $phone): void
+    {
+        $phone->user    = $this;
+        $this->phones[] = $phone;
+    }
+
+    public function addAddress(LazyEagerCollectionAddress $address): void
+    {
+        $address->user     = $this;
+        $this->addresses[] = $address;
+    }
+}
+
+/** @Entity */
+class LazyEagerCollectionPhone
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255)
+     */
+    public $data;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="LazyEagerCollectionUser", inversedBy="phones")
+     *
+     * @var LazyEagerCollectionUser
+     */
+    public $user;
+}
+
+/** @Entity */
+class LazyEagerCollectionAddress
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255)
+     */
+    public $data;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="LazyEagerCollectionUser", inversedBy="addresses")
+     *
+     * @var LazyEagerCollectionUser
+     */
+    public $user;
+}


### PR DESCRIPTION
When there is a `cascade={"refresh"}`,  `EAGER` collections are refreshed, `LAZY` one are not refreshed, even if initialized...


The issue lies in the fact that `\Doctrine\ORM\UnitOfWork::cascadeRefresh` is called after the entity holding that collection has been refreshed, thus the lazy collections in there that have been edited are not refreshed (because the initial entity refresh has marked them as not initialized). 

Moving the `cascadeRefresh` before the entity is refreshed.. but that might break other things... i'm waiting for github actions to tell.

I fear that the same should be done for `\Doctrine\ORM\UnitOfWork::cascadeDetach`