### PR TITLE
Fix change set computation with enums

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use BackedEnum;
 use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -742,6 +743,10 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 $orgValue = $originalData[$propName];
+
+                if ($orgValue instanceof BackedEnum) {
+                    $orgValue = $orgValue->value;
+                }
 
                 // skip if value haven't changed
                 if ($orgValue === $actualValue) {

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -260,6 +260,46 @@ class EnumTest extends OrmFunctionalTestCase
         self::assertEqualsCanonicalizing([Unit::Gram, Unit::Meter], $result[0]->supportedUnits);
     }
 
+    public function testEnumChangeSetsSimpleObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card       = new Card();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->find(Card::class, $card->id);
+
+        $this->_em->getUnitOfWork()->computeChangeSets();
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($result));
+    }
+
+    public function testEnumChangeSetsObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card       = new Card();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->createQueryBuilder()
+            ->from(Card::class, 'c')
+            ->select('c')
+            ->getQuery()
+            ->getResult();
+
+        $this->_em->getUnitOfWork()->computeChangeSets();
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($result[0]));
+    }
+
     public function testFindByEnum(): void
     {
         $this->setUpEntitySchema([Card::class]);


### PR DESCRIPTION
Fixes #10071 , uses test cases from #10073 by @mzk

My attempt at solving the issue. The `ReflectionEnumProperty::getValue()` method returns the value of the enum, while some hydrators pass an enum object in the data set to the `UnitOfWork::$originalEntityData` array.

The `SimpleObjectHydrator` doesn't convert strings into enums, while the `ObjectHydrator` (or to be more precise the `AbstractHydrator::gatherRowData()` method) does. Even though this doesn't seem to be causing any issues, the inconsistency seems unintentional to me, so if you think it should be fixed please let me know and I'll open a PR.