### PR TITLE
Infer types in `OneToManyPersister::deleteEntityCollection`

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -174,16 +174,18 @@ class OneToManyPersister extends AbstractCollectionPersister
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
         $columns     = [];
         $parameters  = [];
+        $types       = [];
 
         foreach ($targetClass->associationMappings[$mapping['mappedBy']]['joinColumns'] as $joinColumn) {
             $columns[]    = $this->quoteStrategy->getJoinColumnName($joinColumn, $targetClass, $this->platform);
             $parameters[] = $identifier[$sourceClass->getFieldForColumn($joinColumn['referencedColumnName'])];
+            $types[]      = PersisterHelper::getTypeOfField($sourceClass->getFieldForColumn($joinColumn['referencedColumnName']), $sourceClass, $this->em);
         }
 
         $statement = 'DELETE FROM ' . $this->quoteStrategy->getTableName($targetClass, $this->platform)
             . ' WHERE ' . implode(' = ? AND ', $columns) . ' = ?';
 
-        return $this->conn->executeStatement($statement, $parameters);
+        return $this->conn->executeStatement($statement, $parameters, array_merge(...$types));
     }
 
     /**

--- a/tests/Doctrine/Tests/Models/OneToManyPersister/ChildClass.php
+++ b/tests/Doctrine/Tests/Models/OneToManyPersister/ChildClass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToManyPersister;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="onetomanypersister_child")
+ */
+class ChildClass
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @Id
+     * @ManyToOne(targetEntity=ParentClass::class, inversedBy="children", cascade={"persist"})
+     * @JoinColumn(name="parent_id", referencedColumnName="id")
+     * @var ParentClass
+     */
+    public $parent;
+
+    public function __construct(int $id, ParentClass $otherParent)
+    {
+        $this->id     = $id;
+        $this->parent = $otherParent;
+    }
+}

--- a/tests/Doctrine/Tests/Models/OneToManyPersister/ParentClass.php
+++ b/tests/Doctrine/Tests/Models/OneToManyPersister/ParentClass.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToManyPersister;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+
+/**
+ * @Entity
+ * @Table(name="onetomanypersister_parent")
+ */
+class ParentClass
+{
+    /**
+     * @Id
+     * @Column(type="CustomIdObject", length=255)
+     * @var CustomIdObject
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity=ChildClass::class, mappedBy="parent", orphanRemoval=true, cascade={"persist"})
+     * @var Collection|ChildClass[]
+     * @psalm-var Collection<ChildClass>
+     */
+    public $children;
+
+    public function __construct(CustomIdObject $id)
+    {
+        $this->id       = $id;
+        $this->children = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/OneToManyPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/OneToManyPersisterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+use Doctrine\Tests\DbalTypes\CustomIdObjectType;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Models\OneToManyPersister\ChildClass;
+use Doctrine\Tests\Models\OneToManyPersister\ParentClass;
+use Doctrine\Tests\OrmTestCase;
+
+use function array_pop;
+use function assert;
+
+/** @covers \Doctrine\ORM\Persisters\Collection\OneToManyPersister */
+final class OneToManyPersisterTest extends OrmTestCase
+{
+    protected function setUp(): void
+    {
+        if (DBALType::hasType(CustomIdObjectType::NAME)) {
+            DBALType::overrideType(CustomIdObjectType::NAME, CustomIdObjectType::class);
+        } else {
+            DBALType::addType(CustomIdObjectType::NAME, CustomIdObjectType::class);
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * @group OneToManyPersister
+     */
+    public function testDeleteOneToManyCollection(): void
+    {
+        $parent = new ParentClass(new CustomIdObject('foo'));
+        $child1 = new ChildClass(1, $parent);
+        $child2 = new ChildClass(2, $parent);
+
+        $parent->children->add($child1);
+        $parent->children->add($child2);
+
+        $em = $this->getTestEntityManager();
+        $em->persist($parent);
+        $em->flush();
+
+        self::assertInstanceOf(PersistentCollection::class, $parent->children);
+
+        $persister = new OneToManyPersister($em);
+        $persister->delete($parent->children);
+
+        $conn = $em->getConnection();
+        assert($conn instanceof ConnectionMock);
+
+        $updates       = $conn->getExecuteStatements();
+        $lastStatement = array_pop($updates);
+
+        self::assertSame('DELETE FROM onetomanypersister_child WHERE parent_id = ?', $lastStatement['sql']);
+        self::assertSame([$parent->id], $lastStatement['params']);
+        self::assertSame([CustomIdObjectType::NAME], $lastStatement['types']);
+    }
+}


### PR DESCRIPTION
Similar to #8401

In our app we are using Symfony Uuid and when collection needs to be cleared the deletion query is executed without types therefore Uuid casts to string instead of to binary and no relations are deleted.