### PR TITLE
Create dedicated event argument classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,18 @@
 
 Use `Doctrine\Persistence\Proxy` instead to check whether proxies are initialized.
 
+## Deprecated `Doctrine\ORM\Event\LifecycleEventArgs` class.
+
+It will be removed in 3.0. Use one of the dedicated event classes instead:
+
+* `Doctrine\ORM\Event\PrePersistEventArgs`
+* `Doctrine\ORM\Event\PreUpdateEventArgs`
+* `Doctrine\ORM\Event\PreRemoveEventArgs`
+* `Doctrine\ORM\Event\PostPersistEventArgs`
+* `Doctrine\ORM\Event\PostUpdateEventArgs`
+* `Doctrine\ORM\Event\PostRemoveEventArgs`
+* `Doctrine\ORM\Event\PostLoadEventArgs`
+
 # Upgrade to 2.13
 
 ## Deprecated `QueryBuilder` methods and constants.

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -144,20 +144,20 @@ Events Overview
 | Event                                                           | Dispatched by         | Lifecycle | Passed                              |
 |                                                                 |                       | Callback  | Argument                            |
 +=================================================================+=======================+===========+=====================================+
-| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       | `LifecycleEventArgs`_               |
+| :ref:`preRemove<reference-events-pre-remove>`                   | ``$em->remove()``     | Yes       | `PreRemoveEventArgs`_               |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
-| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `LifecycleEventArgs`_               |
+| :ref:`postRemove<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `PostRemoveEventArgs`_              |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
-| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       | `LifecycleEventArgs`_               |
+| :ref:`prePersist<reference-events-pre-persist>`                 | ``$em->persist()``    | Yes       | `PrePersistEventArgs`_              |
 |                                                                 | on *initial* persist  |           |                                     |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
-| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       | `LifecycleEventArgs`_               |
+| :ref:`postPersist<reference-events-post-update-remove-persist>` | ``$em->flush()``      | Yes       | `PostPersistEventArgs`_             |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
 | :ref:`preUpdate<reference-events-pre-update>`                   | ``$em->flush()``      | Yes       | `PreUpdateEventArgs`_               |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
-| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `LifecycleEventArgs`_               |
+| :ref:`postUpdate<reference-events-post-update-remove-persist>`  | ``$em->flush()``      | Yes       | `PostUpdateEventArgs`_              |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
-| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       | `LifecycleEventArgs`_               |
+| :ref:`postLoad<reference-events-post-load>`                     | Loading from database | Yes       | `PostLoadEventArgs`_                |
 +-----------------------------------------------------------------+-----------------------+-----------+-------------------------------------+
 | :ref:`loadClassMetadata<reference-events-load-class-metadata>`  | Loading of mapping    | No        | `LoadClassMetadataEventArgs`_       |
 |                                                                 | metadata              |           |                                     |
@@ -214,7 +214,7 @@ specific to a particular entity class's lifecycle.
 
         <?php
         use Doctrine\DBAL\Types\Types;
-        use Doctrine\ORM\Event\LifecycleEventArgs;
+        use Doctrine\ORM\Event\PrePersistEventArgs;
 
         #[Entity]
         #[HasLifecycleCallbacks]
@@ -226,7 +226,7 @@ specific to a particular entity class's lifecycle.
             public $value;
 
             #[PrePersist]
-            public function doStuffOnPrePersist(LifecycleEventArgs $eventArgs)
+            public function doStuffOnPrePersist(PrePersistEventArgs $eventArgs)
             {
                 $this->createdAt = date('Y-m-d H:i:s');
             }
@@ -246,7 +246,7 @@ specific to a particular entity class's lifecycle.
     .. code-block:: annotation
 
         <?php
-        use Doctrine\Persistence\Event\LifecycleEventArgs;
+        use Doctrine\ORM\Event\PrePersistEventArgs;
 
         /**
          * @Entity
@@ -260,7 +260,7 @@ specific to a particular entity class's lifecycle.
             public $value;
 
             /** @PrePersist */
-            public function doStuffOnPrePersist(LifecycleEventArgs $eventArgs)
+            public function doStuffOnPrePersist(PrePersistEventArgs $eventArgs)
             {
                 $this->createdAt = date('Y-m-d H:i:s');
             }
@@ -353,11 +353,11 @@ A lifecycle event listener looks like the following:
 .. code-block:: php
 
     <?php
-    use Doctrine\Persistence\Event\LifecycleEventArgs;
+    use Doctrine\ORM\Event\PreUpdateEventArgs;
 
     class MyEventListener
     {
-        public function preUpdate(LifecycleEventArgs $args)
+        public function preUpdate(PreUpdateEventArgs $args)
         {
             $entity = $args->getObject();
             $entityManager = $args->getObjectManager();
@@ -374,9 +374,9 @@ A lifecycle event subscriber may look like this:
 .. code-block:: php
 
     <?php
+    use Doctrine\ORM\Event\PostUpdateEventArgs;
     use Doctrine\ORM\Events;
     use Doctrine\EventSubscriber;
-    use Doctrine\Persistence\Event\LifecycleEventArgs;
 
     class MyEventSubscriber implements EventSubscriber
     {
@@ -387,7 +387,7 @@ A lifecycle event subscriber may look like this:
             );
         }
 
-        public function postUpdate(LifecycleEventArgs $args)
+        public function postUpdate(PostUpdateEventArgs $args)
         {
             $entity = $args->getObject();
             $entityManager = $args->getObjectManager();
@@ -461,7 +461,7 @@ this association is marked as :ref:`cascade: persist<transitive-persistence>`. A
 during this operation is also persisted and ``prePersist`` called
 on it. This is called :ref:`persistence by reachability<persistence-by-reachability>`.
 
-In both cases you get passed a ``LifecycleEventArgs`` instance
+In both cases you get passed a ``PrePersistEventArgs`` instance
 which has access to the entity and the entity manager.
 
 This event is only triggered on *initial* persist of an entity
@@ -830,35 +830,40 @@ you need to map the listener method using the event type mapping:
     .. code-block:: php
 
         <?php
-        use Doctrine\ORM\Event\PreUpdateEventArgs;
+        use Doctrine\ORM\Event\PostLoadEventArgs;
+        use Doctrine\ORM\Event\PostPersistEventArgs;
+        use Doctrine\ORM\Event\PostRemoveEventArgs;
+        use Doctrine\ORM\Event\PostUpdateEventArgs;
         use Doctrine\ORM\Event\PreFlushEventArgs;
-        use Doctrine\Persistence\Event\LifecycleEventArgs;
+        use Doctrine\ORM\Event\PrePersistEventArgs;
+        use Doctrine\ORM\Event\PreRemoveEventArgs;
+        use Doctrine\ORM\Event\PreUpdateEventArgs;
 
         class UserListener
         {
             /** @PrePersist */
-            public function prePersistHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function prePersistHandler(User $user, PrePersistEventArgs $event) { // ... }
 
             /** @PostPersist */
-            public function postPersistHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function postPersistHandler(User $user, PostPersistEventArgs $event) { // ... }
 
             /** @PreUpdate */
             public function preUpdateHandler(User $user, PreUpdateEventArgs $event) { // ... }
 
             /** @PostUpdate */
-            public function postUpdateHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function postUpdateHandler(User $user, PostUpdateEventArgs $event) { // ... }
 
             /** @PostRemove */
-            public function postRemoveHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function postRemoveHandler(User $user, PostRemoveEventArgs $event) { // ... }
 
             /** @PreRemove */
-            public function preRemoveHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function preRemoveHandler(User $user, PreRemoveEventArgs $event) { // ... }
 
             /** @PreFlush */
             public function preFlushHandler(User $user, PreFlushEventArgs $event) { // ... }
 
             /** @PostLoad */
-            public function postLoadHandler(User $user, LifecycleEventArgs $event) { // ... }
+            public function postLoadHandler(User $user, PostLoadEventArgs $event) { // ... }
         }
     .. code-block:: xml
 
@@ -1071,8 +1076,13 @@ and the EntityManager.
         }
     }
 
-.. _LifecycleEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+.. _PrePersistEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PrePersistEventArgs.php
+.. _PreRemoveEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PreRemoveEventArgs.php
 .. _PreUpdateEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+.. _PostPersistEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostPersistEventArgs.php
+.. _PostRemoveEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+.. _PostUpdateEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostUpdateEventArgs.php
+.. _PostLoadEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostLoadEventArgs.php
 .. _PreFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
 .. _PostFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
 .. _OnFlushEventArgs: https://github.com/doctrine/orm/blob/HEAD/lib/Doctrine/ORM/Event/OnFlushEventArgs.php

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -12,6 +12,8 @@ use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
  * of entities.
  *
+ * @deprecated This class will be removed in ORM 3.0. Use one of the dedicated classes instead.
+ *
  * @extends BaseLifecycleEventArgs<EntityManagerInterface>
  */
 class LifecycleEventArgs extends BaseLifecycleEventArgs

--- a/lib/Doctrine/ORM/Event/PostLoadEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostLoadEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PostLoadEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PostPersistEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostPersistEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PostPersistEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PostRemoveEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PostUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostUpdateEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PostUpdateEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PrePersistEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PrePersistEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PrePersistEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PreRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreRemoveEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+final class PreRemoveEventArgs extends LifecycleEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -12,7 +12,7 @@ use function get_debug_type;
 use function sprintf;
 
 /**
- * Class that holds event arguments for a preInsert/preUpdate event.
+ * Class that holds event arguments for a preUpdate event.
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Internal;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\ListenersInvoker;
+use Doctrine\ORM\Event\PostLoadEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
@@ -67,7 +67,7 @@ final class HydrationCompleteHandler
                 $class,
                 Events::postLoad,
                 $entity,
-                new LifecycleEventArgs($entity, $this->em),
+                new PostLoadEventArgs($entity, $this->em),
                 $invoke
             );
         }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -13,11 +13,15 @@ use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreRemoveEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnexpectedAssociationValue;
@@ -984,7 +988,7 @@ class UnitOfWork implements PropertyChangedListener
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::prePersist);
 
         if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-            $this->listenersInvoker->invoke($class, Events::prePersist, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+            $this->listenersInvoker->invoke($class, Events::prePersist, $entity, new PrePersistEventArgs($entity, $this->em), $invoke);
         }
 
         $idGen = $class->idGenerator;
@@ -1157,7 +1161,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         foreach ($entities as $entity) {
-            $this->listenersInvoker->invoke($class, Events::postPersist, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+            $this->listenersInvoker->invoke($class, Events::postPersist, $entity, new PostPersistEventArgs($entity, $this->em), $invoke);
         }
     }
 
@@ -1222,7 +1226,7 @@ class UnitOfWork implements PropertyChangedListener
             unset($this->entityUpdates[$oid]);
 
             if ($postUpdateInvoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postUpdate, $entity, new LifecycleEventArgs($entity, $this->em), $postUpdateInvoke);
+                $this->listenersInvoker->invoke($class, Events::postUpdate, $entity, new PostUpdateEventArgs($entity, $this->em), $postUpdateInvoke);
             }
         }
     }
@@ -1258,7 +1262,7 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new PostRemoveEventArgs($entity, $this->em), $invoke);
             }
         }
     }
@@ -1900,7 +1904,7 @@ class UnitOfWork implements PropertyChangedListener
                 $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::preRemove);
 
                 if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                    $this->listenersInvoker->invoke($class, Events::preRemove, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+                    $this->listenersInvoker->invoke($class, Events::preRemove, $entity, new PreRemoveEventArgs($entity, $this->em), $invoke);
                 }
 
                 $this->scheduleForDelete($entity);

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,6 +29,7 @@
                 <!-- Remove on 3.0.x -->
                 <referencedClass name="Doctrine\Common\Persistence\PersistentObject"/>
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
+                <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs"/>
                 <referencedClass name="Doctrine\ORM\Exception\UnknownEntityNamespace"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContractListener.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContractListener.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\Company;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\PrePersist;
 
@@ -17,14 +17,14 @@ class CompanyFlexUltraContractListener
 
     /** @PrePersist */
     #[ORM\PrePersist]
-    public function prePersistHandler1(CompanyContract $contract, LifecycleEventArgs $args): void
+    public function prePersistHandler1(CompanyContract $contract, PrePersistEventArgs $args): void
     {
         $this->prePersistCalls[] = func_get_args();
     }
 
     /** @PrePersist */
     #[ORM\PrePersist]
-    public function prePersistHandler2(CompanyContract $contract, LifecycleEventArgs $args): void
+    public function prePersistHandler2(CompanyContract $contract, PrePersistEventArgs $args): void
     {
         $this->prePersistCalls[] = func_get_args();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -6,8 +6,13 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreRemoveEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -402,13 +407,13 @@ DQL;
         self::assertArrayHasKey('postRemoveHandler', $e->calls);
 
         self::assertInstanceOf(PreFlushEventArgs::class, $e->calls['preFlushHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postLoadHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['prePersistHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postPersistHandler']);
+        self::assertInstanceOf(PostLoadEventArgs::class, $e->calls['postLoadHandler']);
+        self::assertInstanceOf(PrePersistEventArgs::class, $e->calls['prePersistHandler']);
+        self::assertInstanceOf(PostPersistEventArgs::class, $e->calls['postPersistHandler']);
         self::assertInstanceOf(PreUpdateEventArgs::class, $e->calls['preUpdateHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postUpdateHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['preRemoveHandler']);
-        self::assertInstanceOf(LifecycleEventArgs::class, $e->calls['postRemoveHandler']);
+        self::assertInstanceOf(PostUpdateEventArgs::class, $e->calls['postUpdateHandler']);
+        self::assertInstanceOf(PreRemoveEventArgs::class, $e->calls['preRemoveHandler']);
+        self::assertInstanceOf(PostRemoveEventArgs::class, $e->calls['postRemoveHandler']);
     }
 }
 
@@ -662,19 +667,19 @@ class LifecycleCallbackEventArgEntity
     public $calls = [];
 
     /** @PostPersist */
-    public function postPersistHandler(LifecycleEventArgs $event): void
+    public function postPersistHandler(PostPersistEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }
 
     /** @PrePersist */
-    public function prePersistHandler(LifecycleEventArgs $event): void
+    public function prePersistHandler(PrePersistEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }
 
     /** @PostUpdate */
-    public function postUpdateHandler(LifecycleEventArgs $event): void
+    public function postUpdateHandler(PostUpdateEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }
@@ -686,13 +691,13 @@ class LifecycleCallbackEventArgEntity
     }
 
     /** @PostRemove */
-    public function postRemoveHandler(LifecycleEventArgs $event): void
+    public function postRemoveHandler(PostRemoveEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }
 
     /** @PreRemove */
-    public function preRemoveHandler(LifecycleEventArgs $event): void
+    public function preRemoveHandler(PreRemoveEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }
@@ -704,7 +709,7 @@ class LifecycleCallbackEventArgEntity
     }
 
     /** @PostLoad */
-    public function postLoadHandler(LifecycleEventArgs $event): void
+    public function postLoadHandler(PostLoadEventArgs $event): void
     {
         $this->calls[__FUNCTION__] = $event;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Util\ClassUtils;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsEmail;
@@ -265,7 +265,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
 class PostLoadListener
 {
-    public function postLoad(LifecycleEventArgs $event): void
+    public function postLoad(PostLoadEventArgs $event): void
     {
         // Expected to be mocked out
         echo 'Should never be called!';
@@ -280,7 +280,7 @@ class PostLoadListenerCheckAssociationsArePopulated
     /** @var bool */
     public $populated = false;
 
-    public function postLoad(LifecycleEventArgs $event): void
+    public function postLoad(PostLoadEventArgs $event): void
     {
         $object = $event->getObject();
         if ($object instanceof CmsUser) {
@@ -299,7 +299,7 @@ class PostLoadListenerLoadEntityInEventHandler
     /** @psalm-var array<class-string, int> */
     private $firedByClasses = [];
 
-    public function postLoad(LifecycleEventArgs $event): void
+    public function postLoad(PostLoadEventArgs $event): void
     {
         $object = $event->getObject();
         $class  = ClassUtils::getClass($object);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
@@ -358,12 +359,12 @@ class ListenerSecondLevelCacheTest
         $this->dispatch(__FUNCTION__, $args);
     }
 
-    public function postUpdate(LifecycleEventArgs $args): void
+    public function postUpdate(PostUpdateEventArgs $args): void
     {
         $this->dispatch(__FUNCTION__, $args);
     }
 
-    public function postRemove(LifecycleEventArgs $args): void
+    public function postRemove(PostRemoveEventArgs $args): void
     {
         $this->dispatch(__FUNCTION__, $args);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -121,7 +121,7 @@ class DDC2602Test extends OrmFunctionalTestCase
 
 class DDC2602PostLoadListener
 {
-    public function postLoad(LifecycleEventArgs $event): void
+    public function postLoad(PostLoadEventArgs $event): void
     {
         $entity = $event->getObject();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
@@ -6,7 +6,8 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -108,12 +109,12 @@ class DDC3033Product
     }
 
     /** @PreUpdate */
-    public function preUpdate(LifecycleEventArgs $eventArgs): void
+    public function preUpdate(PreUpdateEventArgs $eventArgs): void
     {
     }
 
     /** @PostUpdate */
-    public function postUpdate(LifecycleEventArgs $eventArgs): void
+    public function postUpdate(PostUpdateEventArgs $eventArgs): void
     {
         $em            = $eventArgs->getObjectManager();
         $uow           = $em->getUnitOfWork();


### PR DESCRIPTION
Following https://github.com/doctrine/orm/pull/9906#issuecomment-1207773042 and https://github.com/doctrine/orm/pull/9906#issuecomment-1207781277

This PR creates dedicated event argument classes instead of using the generic `LifecycleEventArgs` class (and deprecates it).

Eventually this would allow to implement PSR-14 eventually (as pointed out https://github.com/doctrine/orm/pull/9906#issuecomment-1207781277).