### PR TITLE
Ensure consistent original data with enums

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -697,7 +697,7 @@ abstract class AbstractHydrator
      *
      * @return BackedEnum|array<BackedEnum>
      */
-    private function buildEnum($value, string $enumType)
+    final protected function buildEnum($value, string $enumType)
     {
         if (is_array($value)) {
             return array_map(static function ($value) use ($enumType): BackedEnum {

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -6,9 +6,11 @@ namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Query;
 use Exception;
 use RuntimeException;
+use ValueError;
 
 use function array_keys;
 use function array_search;
@@ -138,6 +140,21 @@ class SimpleObjectHydrator extends AbstractHydrator
             if (isset($cacheKeyInfo['type'])) {
                 $type  = $cacheKeyInfo['type'];
                 $value = $type->convertToPHPValue($value, $this->_platform);
+            }
+
+            if ($value !== null && isset($cacheKeyInfo['enumType'])) {
+                $originalValue = $value;
+                try {
+                    $value = $this->buildEnum($originalValue, $cacheKeyInfo['enumType']);
+                } catch (ValueError $e) {
+                    throw MappingException::invalidEnumValue(
+                        $entityName,
+                        $cacheKeyInfo['fieldName'],
+                        (string) $originalValue,
+                        $cacheKeyInfo['enumType'],
+                        $e
+                    );
+                }
             }
 
             $fieldName = $cacheKeyInfo['fieldName'];

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1506,6 +1506,9 @@ class BasicEntityPersister implements EntityPersister
         $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
 
         $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field);
+        if (! empty($fieldMapping['enumType'])) {
+            $this->currentPersisterContext->rsm->addEnumResult($columnAlias, $fieldMapping['enumType']);
+        }
 
         if (isset($fieldMapping['requireSQLConversion'])) {
             $type = Type::getType($fieldMapping['type']);


### PR DESCRIPTION
As mentioned in #10074, the `SimpleObjectHydrator` doesn't convert strings into enums, while the `ObjectHydrator` does, causing inconsistent values in the `UnitOfWork::$originalEntityData` array. This PR aims to fix that.