### PR TITLE
Document properties as possibly null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -251,11 +251,6 @@ parameters:
 			path: lib/Doctrine/ORM/PersistentCollection.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
-			count: 2
-			path: lib/Doctrine/ORM/PersistentCollection.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Persisters\\\\Collection\\\\OneToManyPersister\\:\\:delete\\(\\) should return int\\|null but empty return statement found\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1100,12 +1100,6 @@
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="4">
-      <code>$this-&gt;em</code>
-      <code>$this-&gt;em</code>
-      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
-      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
-    </RedundantConditionGivenDocblockType>
     <TooManyArguments occurrences="1">
       <code>andX</code>
     </TooManyArguments>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1100,9 +1100,6 @@
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
-    <TooManyArguments occurrences="1">
-      <code>andX</code>
-    </TooManyArguments>
     <UndefinedInterfaceMethod occurrences="1">
       <code>matching</code>
     </UndefinedInterfaceMethod>


### PR DESCRIPTION
`__sleep()` does not list these properties as suposed to be serialized.

This means we have to assert that it is not in the many scenarios where
we resort to these properties. Introducing a private method allows us to
centralize the assertions.