### PR TITLE
Fix heading levels for the embeddable tutorial

### DIFF
--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -1,5 +1,5 @@
 Separating Concerns using Embeddables
--------------------------------------
+=====================================
 
 Embeddables are classes which are not entities themselves, but are embedded
 in entities and can also be queried in DQL. You'll mostly want to use them


### PR DESCRIPTION
Currently, subsections of that tutorial are creating top-level entries in the sidebar table of contents: 
![image](https://user-images.githubusercontent.com/439401/193816587-d88e1d3b-f4ef-4d86-94c4-89fe0861d583.png)
