### PR TITLE
Use NullCacheItemPool when using a Paginator.

### DIFF
--- a/lib/Doctrine/ORM/Cache/NullCacheItem.php
+++ b/lib/Doctrine/ORM/Cache/NullCacheItem.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Cache;
+
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * @internal this class is used as a workaround for a cache issue.
+ *
+ * @see https://github.com/doctrine/orm/pull/10095
+ */
+final class NullCacheItem implements CacheItemInterface
+{
+    public function getKey(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return null;
+    }
+
+    public function isHit(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($value)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAt($expiration)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAfter($time)
+    {
+        return $this;
+    }
+}

--- a/lib/Doctrine/ORM/Cache/NullCacheItemPool.php
+++ b/lib/Doctrine/ORM/Cache/NullCacheItemPool.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Cache;
+
+use Closure;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Traversable;
+
+/**
+ * @internal this class is used as a workaround for a cache issue.
+ *
+ * @see https://github.com/doctrine/orm/pull/10095
+ */
+final class NullCacheItemPool implements CacheItemPoolInterface
+{
+    /** @var Closure|null */
+    private static $createCacheItem;
+
+    public function __construct()
+    {
+        self::$createCacheItem ?? self::$createCacheItem = Closure::bind(
+            static function (string $key) {
+                return new NullCacheItem();
+            },
+            null,
+            NullCacheItem::class
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key): CacheItemInterface
+    {
+        return (self::$createCacheItem)($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = []): Traversable
+    {
+        return $this->generateItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key): bool
+    {
+        return false;
+    }
+
+    public function clear(string $prefix = ''): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys): bool
+    {
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string> $keys
+     *
+     * @return Traversable<NullCacheItem>
+     */
+    private function generateItems(array $keys): Traversable
+    {
+        $f = self::$createCacheItem;
+
+        foreach ($keys as $key) {
+            yield $key => $f($key);
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Tools\Pagination;
 use ArrayIterator;
 use Countable;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Cache\NullCacheItemPool;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
@@ -160,7 +161,7 @@ class Paginator implements Countable, IteratorAggregate
             $whereInQuery->setFirstResult(0)->setMaxResults(null);
             $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
             $whereInQuery->setCacheable($this->query->isCacheable());
-            $whereInQuery->expireQueryCache();
+            $whereInQuery->setQueryCache(new NullCacheItemPool());
 
             $result = $whereInQuery->getResult($this->query->getHydrationMode());
         } else {


### PR DESCRIPTION
This fixes a bug where Doctrine would recreate the DQL to SQL parsing
cache on every request which would fill up OPCache with duplicates.
We now use a "Null" cache implementation instead of calling
Query::expireQueryCache().
@see https://github.com/doctrine/orm/issues/9917