### PR TITLE
fix: readonly property's Entity deletion

### DIFF
--- a/tests/Doctrine/Tests/Models/GH10097/EntityWithReadonlyIdentifier.php
+++ b/tests/Doctrine/Tests/Models/GH10097/EntityWithReadonlyIdentifier.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10097;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Entity;
+
+/** @Entity */
+class EntityWithReadonlyIdentifier
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     * @ORM\GeneratedValue
+     */
+    public readonly int $id;
+}


### PR DESCRIPTION
fixes #10032

- What ultimately happens if an entity has its identifier [not nulled](https://github.com/doctrine/orm/blob/2.13.x/lib/Doctrine/ORM/UnitOfWork.php#L1252)? What happens in a world where every Entities in a project have readonly identifiers and therefore aren't nulled? What about non nullable but writable identifiers?
- On a more general design, should we treat an Entity with a readonly identifier [as we do for a readonly Entity](https://github.com/Nayte91/orm/blob/cc6c38b8b0f084a6fff49396ef96ec1c03b57c5e/lib/Doctrine/ORM/UnitOfWork.php#L853)?
- What is the minimal PHP version for orm? 7.4? How will behave the [isReadOnly()](https://github.com/Nayte91/orm/blob/cc6c38b8b0f084a6fff49396ef96ec1c03b57c5e/lib/Doctrine/ORM/UnitOfWork.php#L3423) method on PHP < 8.1?