### PR TITLE
Assert that serialization leaves PersistentCollection usable

### DIFF
--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -21,6 +21,8 @@ use stdClass;
 use function array_keys;
 use function assert;
 use function method_exists;
+use function serialize;
+use function unserialize;
 
 /**
  * Tests the lazy-loading capabilities of the PersistentCollection and the initialization of collections.
@@ -285,5 +287,14 @@ class PersistentCollectionTest extends OrmTestCase
         $this->_emMock->setUnitOfWork($unitOfWork);
 
         $this->collection->clear();
+    }
+
+    public function testItCanBeSerializedAndUnserializedBack(): void
+    {
+        $this->collection->add(new stdClass());
+        $collection = unserialize(serialize($this->collection));
+        $collection->add(new stdClass());
+        $collection[3] = new stdClass();
+        self::assertCount(3, $collection);
     }
 }


### PR DESCRIPTION
That feature is no longer covered since support for merging entities in the entity manager was removed.