### PR TITLE
Make code blocks consistent in Embeddable documentation

### DIFF
--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -151,6 +151,12 @@ directly, set ``columnPrefix=false`` (``use-column-prefix="false"`` for XML):
             private $address;
         }
 
+    .. code-block:: xml
+
+        <entity name="User">
+            <embedded name="address" class="Address" use-column-prefix="false" />
+        </entity>
+
     .. code-block:: yaml
 
         User:
@@ -159,12 +165,6 @@ directly, set ``columnPrefix=false`` (``use-column-prefix="false"`` for XML):
             address:
               class: Address
               columnPrefix: false
-
-    .. code-block:: xml
-
-        <entity name="User">
-            <embedded name="address" class="Address" use-column-prefix="false" />
-        </entity>
 
 
 DQL


### PR DESCRIPTION
All other tabs for code blocks in this page is `PHP | XML | Yaml`, except for the last one. This change is just to make the tabs consistent for all the code blocks