### PR TITLE
Test for array of enums

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Entity.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Entity.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+class GH10063Entity
+{
+    /**
+     * @Column
+     * @Id
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /**
+     * @Column(type="simple_array", length=255, nullable=true, enumType=GH10063Enum::class)
+     */
+    private array $colors = [];
+
+    /**
+     * @param array<int, GH10063Enum> $colors
+     */
+    public function setColors(array $colors): self
+    {
+        $this->colors = $colors;
+        return $this;
+    }
+    /**
+     * @return array<int, GH10063Enum>
+     */
+    public function getColors(): array
+    {
+        return $this->colors;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Entity.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Entity.php
@@ -19,9 +19,7 @@ class GH10063Entity
      */
     public int $id;
 
-    /**
-     * @Column(type="simple_array", length=255, nullable=true, enumType=GH10063Enum::class)
-     */
+    /** @Column(type="simple_array", length=255, nullable=true, enumType=GH10063Enum::class) */
     private array $colors = [];
 
     /**
@@ -30,8 +28,10 @@ class GH10063Entity
     public function setColors(array $colors): self
     {
         $this->colors = $colors;
+
         return $this;
     }
+
     /**
      * @return array<int, GH10063Enum>
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Enum.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Enum.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 enum GH10063Enum: string
 {
-    case Red = 'red';
+    case Red   = 'red';
     case Green = 'green';
-    case Blue = 'blue';
+    case Blue  = 'blue';
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Enum.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Enum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+enum GH10063Enum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH10063Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH10063Entity::class);
+    }
+
+    public function testArrayOfEnums(): void
+    {
+        $entity = (new GH10063Entity())->setColors([GH10063Enum::Red, GH10063Enum::Green]);
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(GH10063Entity::class, $entity->id);
+        assert($entity instanceof GH10063Entity);
+        self::assertEquals([GH10063Enum::Red, GH10063Enum::Green], $entity->getColors());
+    }
+}
+
+/** @Entity */
+class GH10063Entity
+{
+    /**
+     * @Column
+     * @Id
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /**
+     * @Column(type="simple_array", length=255, nullable=true, enumType=GH10063Enum::class)
+     */
+    private array $colors = [];
+
+    /**
+     * @param array<int, GH10063Enum> $colors
+     */
+    public function setColors(array $colors): self
+    {
+        $this->colors = $colors;
+        return $this;
+    }
+    /**
+     * @return array<int, GH10063Enum>
+     */
+    public function getColors(): array
+    {
+        return $this->colors;
+    }
+}
+
+enum GH10063Enum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
@@ -4,15 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-/**
- * @requires PHP 8.1
- */
 final class GH10063Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
@@ -22,6 +15,9 @@ final class GH10063Test extends OrmFunctionalTestCase
         $this->createSchemaForModels(GH10063Entity::class);
     }
 
+    /**
+     * @requires PHP 8.1
+     */
     public function testArrayOfEnums(): void
     {
         $entity = (new GH10063Entity())->setColors([GH10063Enum::Red, GH10063Enum::Green]);
@@ -34,49 +30,4 @@ final class GH10063Test extends OrmFunctionalTestCase
         assert($entity instanceof GH10063Entity);
         self::assertEquals([GH10063Enum::Red, GH10063Enum::Green], $entity->getColors());
     }
-}
-
-/**
- * @Entity
- * @requires PHP 8.1
- */
-class GH10063Entity
-{
-    /**
-     * @Column
-     * @Id
-     * @GeneratedValue
-     */
-    public int $id;
-
-    /**
-     * @Column(type="simple_array", length=255, nullable=true, enumType=GH10063Enum::class)
-     */
-    private array $colors = [];
-
-    /**
-     * @param array<int, GH10063Enum> $colors
-     */
-    public function setColors(array $colors): self
-    {
-        $this->colors = $colors;
-        return $this;
-    }
-    /**
-     * @return array<int, GH10063Enum>
-     */
-    public function getColors(): array
-    {
-        return $this->colors;
-    }
-}
-
-/**
- * @requires PHP 8.1
- */
-enum GH10063Enum: string
-{
-    case Red = 'red';
-    case Green = 'green';
-    case Blue = 'blue';
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @requires PHP 8.1
+ */
 final class GH10063Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
@@ -33,7 +36,10 @@ final class GH10063Test extends OrmFunctionalTestCase
     }
 }
 
-/** @Entity */
+/**
+ * @Entity
+ * @requires PHP 8.1
+ */
 class GH10063Entity
 {
     /**
@@ -65,6 +71,9 @@ class GH10063Entity
     }
 }
 
+/**
+ * @requires PHP 8.1
+ */
 enum GH10063Enum: string
 {
     case Red = 'red';

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10063Test.php
@@ -27,7 +27,7 @@ final class GH10063Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $entity = $this->_em->find(GH10063Entity::class, $entity->id);
-        assert($entity instanceof GH10063Entity);
+        self::assertInstanceOf(GH10063Entity::class, $entity);
         self::assertEquals([GH10063Enum::Red, GH10063Enum::Green], $entity->getColors());
     }
 }


### PR DESCRIPTION
As requested in https://github.com/doctrine/orm/issues/10063

I'm not sure if this is really testing anything, since (I think) it passes in 2.13.2 too. Could you please double-check?

Are PHP attributes (mapping information) not available in tests?