### PR TITLE
Do not instantiate interface

### DIFF
--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -605,7 +605,7 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_emMock->setUnitOfWork($this->_unitOfWork);
 
         $this->connection->method('commit')
-            ->willThrowException(new Exception());
+            ->willThrowException($this->createStub(Exception::class));
 
         // Setup fake persister and id generator
         $userPersister = new EntityPersisterMock($this->_emMock, $this->_emMock->getClassMetadata(ForumUser::class));


### PR DESCRIPTION
In DBAL 4.0, `Doctrine\DBAL\Exception` becomes an interface.

Note: the code I'm fixing is only the way it is on branch 3.0.x, this fix cannot be backported for that reason.