### PR TITLE
Address deprecation of Table::changeColumn()

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -518,8 +518,9 @@ class SchemaTool
         }
 
         if ($table->hasColumn($columnName)) {
+            $method = method_exists($table, 'modifyColumn') ? 'modifyColumn' : 'changeColumn';
             // required in some inheritance scenarios
-            $table->changeColumn($columnName, $options);
+            $table->$method($columnName, $options);
         } else {
             $table->addColumn($columnName, $columnType, $options);
         }


### PR DESCRIPTION
It is deprecated in favor of `Table::modifyColumn()`.

See https://github.com/doctrine/dbal/pull/5747