### PR TITLE
Automap events in AttachEntityListenersListener

### DIFF
--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 
 use function ltrim;
 
@@ -17,11 +18,11 @@ class AttachEntityListenersListener
     private $entityListeners = [];
 
     /**
-     * Adds a entity listener for a specific entity.
+     * Adds an entity listener for a specific entity.
      *
      * @param string      $entityClass      The entity to attach the listener.
      * @param string      $listenerClass    The listener class.
-     * @param string      $eventName        The entity lifecycle event.
+     * @param string|null $eventName        The entity lifecycle event.
      * @param string|null $listenerCallback The listener callback method or NULL to use $eventName.
      *
      * @return void
@@ -49,7 +50,11 @@ class AttachEntityListenersListener
         }
 
         foreach ($this->entityListeners[$metadata->name] as $listener) {
-            $metadata->addEntityListener($listener['event'], $listener['class'], $listener['method']);
+            if ($listener['event'] === null) {
+                EntityListenerBuilder::bindEntityListener($metadata, $listener['class']);
+            } else {
+                $metadata->addEntityListener($listener['event'], $listener['class'], $listener['method']);
+            }
         }
 
         unset($this->entityListeners[$metadata->name]);

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -112,6 +112,31 @@ class AttachEntityListenersListenerTest extends OrmTestCase
 
         $this->factory->getMetadataFor(AttachEntityListenersListenerTestFooEntity::class);
     }
+
+    public function testAttachWithoutSpecifyingAnEventName(): void
+    {
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestFooEntity::class,
+            AttachEntityListenersListenerTestListener::class,
+            null
+        );
+
+        $metadata = $this->factory->getMetadataFor(AttachEntityListenersListenerTestFooEntity::class);
+
+        self::assertCount(2, $metadata->entityListeners);
+
+        self::assertArrayHasKey('prePersist', $metadata->entityListeners);
+        self::assertArrayHasKey('postPersist', $metadata->entityListeners);
+
+        self::assertCount(1, $metadata->entityListeners['prePersist']);
+        self::assertCount(1, $metadata->entityListeners['postPersist']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['prePersist'][0]['class']);
+
+        self::assertEquals('postPersist', $metadata->entityListeners['postPersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postPersist'][0]['class']);
+    }
 }
 
 /** @Entity */


### PR DESCRIPTION
Required for https://github.com/doctrine/DoctrineBundle/issues/1560

Currently, the `AttachEntityListenersListener::addEntityListener()` method requires an `eventName` to be specified when registering a listener. With this change `null` can be passed allowing the event names to be read from the listener class by iterating over the method names.