### PR TITLE
Make `ReflectionEnumProperty::getValue()` return the enum

### DIFF
--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
+use BackedEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\EntityMissingAssignedId;
 
@@ -37,6 +38,10 @@ class AssignedGenerator extends AbstractIdGenerator
             if (isset($class->associationMappings[$idField])) {
                 // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
                 $value = $em->getUnitOfWork()->getSingleIdentifierValue($value);
+            }
+
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
             }
 
             $identifier[$idField] = $value;

--- a/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
@@ -38,7 +38,7 @@ class ReflectionEnumProperty extends ReflectionProperty
      *
      * @param object|null $object
      *
-     * @return int|string|int[]|string[]|null
+     * @return BackedEnum|null
      */
     #[ReturnTypeWillChange]
     public function getValue($object = null)
@@ -53,13 +53,7 @@ class ReflectionEnumProperty extends ReflectionProperty
             return null;
         }
 
-        if (is_array($enum)) {
-            return array_map(static function (BackedEnum $item): mixed {
-                return $item->value;
-            }, $enum);
-        }
-
-        return $enum->value;
+        return $enum;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -647,6 +647,9 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $newVal = $change[1];
+            if ($newVal instanceof BackedEnum) {
+                $newVal = $newVal->value;
+            }
 
             if (! isset($this->class->associationMappings[$field])) {
                 $fieldMapping = $this->class->fieldMappings[$field];


### PR DESCRIPTION
UoW compares orig and actual value. Orig value is the enum. But without this change, actual value is the inner value of the BackedEnum. Therefore, Entities with enum field are always considered a change.

So I though about it like this:

1. the orig and actual values MUST be enums so they're comparable – implies that property must return enum as a value and not the backed value.
2. I've found out the enumType is not filled when hydrating entity.

Resolves #10124, #10125.