### PR TITLE
Run only relevant workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,27 @@
+name: "Coding Standards"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+    paths:
+      - .github/workflows/coding-standards.yml
+      - bin/**
+      - composer.*
+      - lib/**
+      - phpcs.xml.dist
+      - tests/**
+  push:
+    branches:
+      - "*.x"
+    paths:
+      - .github/workflows/coding-standards.yml
+      - bin/**
+      - composer.*
+      - lib/**
+      - phpcs.xml.dist
+      - tests/**
+
+jobs:
+  coding-standards:
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@2.1.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,9 +4,23 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - ci/**
+      - composer.*
+      - lib/**
+      - phpunit.xml.dist
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - ci/**
+      - composer.*
+      - lib/**
+      - phpunit.xml.dist
+      - tests/**
 
 env:
   fail-fast: true

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -5,9 +5,21 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/phpbench.yml
+      - composer.*
+      - lib/**
+      - phpbench.json
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/phpbench.yml
+      - composer.*
+      - lib/**
+      - phpbench.json
+      - tests/**
 
 env:
   fail-fast: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,9 +5,23 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/static-analysis.yml
+      - composer.*
+      - lib/**
+      - phpstan*
+      - psalm*
+      - tests/**
   push:
     branches:
       - "*.x"
+    paths:
+      - .github/workflows/static-analysis.yml
+      - composer.*
+      - lib/**
+      - phpstan*
+      - psalm*
+      - tests/**
 
 jobs:
   static-analysis-phpstan:


### PR DESCRIPTION
The downside of this is that we will have to tweak the settings so that no job is required anymore.
The upside is that builds should be faster, and less resource-intensive. Note that this particular pull request is going to run all the workflows, as I'm touching the workflow files.

Inspired by #4919, prompted by https://afup.org/talks/4016-papa-et-maman-nettoient-l-internet