### PR TITLE
Stop triggering static analysis workflows on tests

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ on:
       - lib/**
       - phpstan*
       - psalm*
-      - tests/**
+      - tests/Doctrine/StaticAnalysis/**
   push:
     branches:
       - "*.x"
@@ -21,7 +21,7 @@ on:
       - lib/**
       - phpstan*
       - psalm*
-      - tests/**
+      - tests/Doctrine/StaticAnalysis/**
 
 jobs:
   static-analysis-phpstan:


### PR DESCRIPTION
In my opinion it is not great that we do not run static analysis tools on tests, but since we do not, let us stop triggering extra jobs for no reason.