### PR TITLE
Allow different strategy of Property change detection

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -95,7 +95,8 @@ use const PHP_VERSION_ID;
  *      requireSQLConversion?: bool,
  *      declared?: class-string,
  *      declaredField?: string,
- *      options?: array<string, mixed>
+ *      options?: array<string, mixed>,
+ *      changeDetector?:string
  * }
  * @psalm-type JoinColumnData = array{
  *     name: string,

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -66,6 +66,9 @@ final class Column implements Annotation
      */
     public $generated;
 
+    /** @var string|null the name of a class implementing ChangeDetectorInterface */
+    public $changeDetector;
+
     /**
      * @param class-string<\BackedEnum>|null $enumType
      * @param array<string,mixed>            $options
@@ -84,7 +87,8 @@ final class Column implements Annotation
         ?string $enumType = null,
         array $options = [],
         ?string $columnDefinition = null,
-        ?string $generated = null
+        ?string $generated = null,
+        ?string $changeDetector = null,
     ) {
         $this->name             = $name;
         $this->type             = $type;
@@ -99,5 +103,6 @@ final class Column implements Annotation
         $this->options          = $options;
         $this->columnDefinition = $columnDefinition;
         $this->generated        = $generated;
+        $this->changeDetector   = $changeDetector;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -782,7 +782,8 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
      *                   enumType?: class-string,
      *                   options?: mixed[],
      *                   columnName?: string,
-     *                   columnDefinition?: string
+     *                   columnDefinition?: string,
+     *                   changeDetector?:string
      *               }
      */
     private function columnToArray(string $fieldName, Mapping\Column $column): array
@@ -796,6 +797,10 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
             'nullable'      => $column->nullable,
             'precision'     => $column->precision,
         ];
+
+        if ($column->changeDetector) {
+            $mapping['changeDetector'] = $column->changeDetector;
+        }
 
         if (! $column->insertable) {
             $mapping['notInsertable'] = true;

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/AbstractChangeDetectorByClone.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/AbstractChangeDetectorByClone.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use function is_object;
+
+abstract class AbstractChangeDetectorByClone implements ChangeDetector
+{
+    /** @inheritDoc */
+    public function copyOriginalValue(&$originalValue)
+    {
+        if (is_object($originalValue)) {
+            return clone $originalValue;
+        }
+
+        return null;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/ByReferenceChangeDetector.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/ByReferenceChangeDetector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+/**
+ * This is the original behavior of the Doctrine UnitOfWork value change computation
+ */
+class ByReferenceChangeDetector implements ChangeDetector
+{
+    /** @inheritDoc */
+    public function copyOriginalValue(&$originalValue)
+    {
+        return $originalValue;
+    }
+
+    public function isChanged($value, $originalValue): bool
+    {
+        return $value !== $originalValue;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/ChangeDetector.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/ChangeDetector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+interface ChangeDetector
+{
+    /**
+     * How the UnitOfWork should keep trace of the original value
+     *
+     * @param mixed $originalValue
+     *
+     * @return mixed
+     */
+    public function copyOriginalValue(&$originalValue);
+
+    /**
+     * Whether or not the two value must be considered as different and trigger an UPDATE query
+     *
+     * @param mixed $value
+     * @param mixed $originalValue
+     */
+    public function isChanged($value, $originalValue): bool;
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/ChangeDetectorRegistry.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/ChangeDetectorRegistry.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use InvalidArgumentException;
+
+use function class_exists;
+use function gettype;
+
+class ChangeDetectorRegistry
+{
+    /** @var ChangeDetector[] */
+    private $changeDetectors = [];
+
+    /**
+     * @param mixed $originalValue
+     *
+     * @return mixed
+     */
+    public function copyOriginalValue(ClassMetadata $class, string $propertyName, &$originalValue)
+    {
+        return $this->getChangeDetectorFromMetadata($class, $propertyName)->copyOriginalValue($originalValue);
+    }
+
+   /**
+    * Whether or not the two values must be considered as different and trigger an UPDATE query
+    *
+    * @param mixed $value
+    * @param mixed $originalValue
+    */
+    public function isChanged(ClassMetadata $class, string $propertyName, $value, $originalValue): bool
+    {
+        return $this->getChangeDetectorFromMetadata($class, $propertyName)->isChanged($value, $originalValue);
+    }
+
+    public function getChangeDetectorFromMetadata(ClassMetadata $class, string $propertyName): ChangeDetector
+    {
+        if (isset($class->fieldMappings[$propertyName]['changeDetector'])) {
+            return $this->getChangeDetector($class->fieldMappings[$propertyName]['changeDetector']);
+        }
+
+        return $this->getChangeDetector(ByReferenceChangeDetector::class);
+    }
+
+    public function getChangeDetector(string $key): ChangeDetector
+    {
+        if (! isset($this->changeDetectors[$key])) {
+            if (class_exists($key)) {
+                $this->changeDetectors[$key] = new $key();
+                if (! $this->changeDetectors[$key] instanceof ChangeDetector) {
+                    throw new InvalidArgumentException('Expected ChangeDetector, got ' . gettype($this->changeDetectors[$key]));
+                }
+            }
+        }
+
+        return $this->changeDetectors[$key];
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByDate.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByDate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use DateTimeInterface;
+
+class DateTimeObjectByDate extends AbstractChangeDetectorByClone
+{
+    public function isChanged($value, $originalValue): bool
+    {
+        if ($value instanceof DateTimeInterface && $originalValue instanceof DateTimeInterface) {
+            return $value->format('Y-m-d') !== $originalValue->format('Y-m-d');
+        }
+
+        return $value !== $originalValue;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByTime.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByTime.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use DateTimeInterface;
+
+class DateTimeObjectByTime extends AbstractChangeDetectorByClone
+{
+    public function isChanged($value, $originalValue): bool
+    {
+        if ($value instanceof DateTimeInterface && $originalValue instanceof DateTimeInterface) {
+            return $value->format('H:i:s') !== $originalValue->format('H:i:s');
+        }
+
+        return $value !== $originalValue;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByTimestamp.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/DateTimeObjectByTimestamp.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use DateTimeInterface;
+
+class DateTimeObjectByTimestamp extends AbstractChangeDetectorByClone
+{
+    public function isChanged($value, $originalValue): bool
+    {
+        if ($value instanceof DateTimeInterface && $originalValue instanceof DateTimeInterface) {
+            return $value->getTimestamp() !== $originalValue->getTimestamp();
+        }
+
+        return $value !== $originalValue;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/ValueByJson.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/ValueByJson.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+use function json_encode;
+
+class ValueByJson extends AbstractChangeDetectorByClone
+{
+    public function isChanged($value, $originalValue): bool
+    {
+        $value         = $value === null ? null : json_encode($value);
+        $originalValue = $originalValue === null ? null : json_encode($originalValue);
+
+        return $value !== $originalValue;
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ChangeDetector/ValueByString.php
+++ b/lib/Doctrine/ORM/Tools/ChangeDetector/ValueByString.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\ChangeDetector;
+
+class ValueByString extends AbstractChangeDetectorByClone
+{
+    public function isChanged($value, $originalValue): bool
+    {
+        return (string) $value !== (string) $originalValue;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5542Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5542Test.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTime;
+use DateTimeInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Tools\ChangeDetector\DateTimeObjectByDate;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class DDC5542Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(DDC5542Book::class);
+    }
+
+    public function testDateIsSavedByValue(): void
+    {
+        //entity création
+        $newBook              = new DDC5542Book();
+        $newBook->title       = 'Foobar';
+        $newBook->publishedAt = new DateTime('2020-01-01');
+
+        $this->_em->persist($newBook);
+        $this->_em->flush();
+        $bookId = $newBook->id;
+        $this->_em->clear();
+
+        //retrieve the entity and change values
+        $dbBook = $this->_em->find(DDC5542Book::class, $bookId);
+        $this->assertInstanceOf(DateTime::class, $dbBook->publishedAt);
+        $this->assertEquals('2020-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        $dbBook->title = 'Barfoo';
+        // the date is changed by value, not by reference
+        $dbBook->publishedAt->modify('+ 1 year');
+        $this->assertEquals('2021-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // chack that the date modification has been recorded
+        $dbBook2 = $this->_em->find(DDC5542Book::class, $bookId);
+
+        $this->assertEquals('Barfoo', $dbBook2->title);
+        $this->assertEquals('2021-01-01', $dbBook2->publishedAt->format('Y-m-d'));
+    }
+}
+
+/** @Entity */
+#[ORM\Entity]
+class DDC5542Book
+{
+    /**
+    * @Column(type="integer")
+    * @Id
+    * @GeneratedValue
+    */
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column(type: 'integer')]
+    public ?int $id;
+
+    /** @Column(length=50) */
+    #[ORM\Column(type: 'string')]
+    public ?string $title = null;
+
+     /** @Column(type="date", nullable="true", changeDetector="Doctrine\ORM\Tools\ChangeDetector\DateTimeObjectByDate") */
+    #[ORM\Column(type: 'date', nullable:true, changeDetector:DateTimeObjectByDate::class)]
+    public ?DatetImeInterface $publishedAt = null;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5542Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5542Test.php
@@ -6,21 +6,34 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 use DateTimeInterface;
+use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Tools\ChangeDetector\DateTimeObjectByDate;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function print_r;
+use function sprintf;
+
+use const PHP_EOL;
+
 class DDC5542Test extends OrmFunctionalTestCase
 {
+    private DDC5542DBALSQLLogger $sqlLogger;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->createSchemaForModels(DDC5542Book::class);
+
+        $this->sqlLogger = new DDC5542DBALSQLLogger();
+        $cfg             = $this->_em->getConnection()->getConfiguration();
+        $cfg->setSQLLogger($this->sqlLogger);
     }
 
     public function testDateIsSavedByValue(): void
@@ -54,9 +67,94 @@ class DDC5542Test extends OrmFunctionalTestCase
         $this->assertEquals('Barfoo', $dbBook2->title);
         $this->assertEquals('2021-01-01', $dbBook2->publishedAt->format('Y-m-d'));
     }
+
+    public function testDateCanBeUpdatedsTwiceOnALoadedEntity(): void
+    {
+        //entity création
+        $newBook              = new DDC5542Book();
+        $newBook->title       = 'Foobar';
+        $newBook->publishedAt = new DateTime('2020-01-01');
+
+        $this->_em->persist($newBook);
+        $this->_em->flush();
+        $bookId = $newBook->id;
+        $this->_em->clear();
+
+        //retrieve the entity
+        $dbBook = $this->_em->find(DDC5542Book::class, $bookId);
+        $this->assertInstanceOf(DateTime::class, $dbBook->publishedAt);
+        $this->assertEquals('2020-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        // the date is changed by value, not by reference
+        $dbBook->publishedAt->modify('+ 1 year');
+        $this->assertEquals('2021-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        $this->_em->flush();
+        $this->assertEquals('2021-01-01', $this->getValueInDatabase($bookId));
+
+        // the date is changed by reference
+        $dbBook->publishedAt = new DateTime('2022-01-01');
+
+        $this->_em->flush();
+        $this->assertEquals('2022-01-01', $this->getValueInDatabase($bookId));
+        $this->assertEquals('2022-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        // the rechanged by value
+        $dbBook->publishedAt->modify('+1year');
+        $this->assertEquals('2023-01-01', $dbBook->publishedAt->format('Y-m-d'));
+        $this->_em->flush();
+        $this->assertEquals('2023-01-01', $this->getValueInDatabase($bookId));
+    }
+
+    public function testDateByValueDoesNotTriggerUnexpectedSQLQueries(): void
+    {
+        //entity création
+        $newBook              = new DDC5542Book();
+        $newBook->title       = 'Foobar';
+        $newBook->publishedAt = new DateTime('2020-01-01');
+
+        $this->_em->persist($newBook);
+        $this->_em->flush();
+        $this->assertCountQueries(3);// START TRANSACTION + INSERT + COMMIT
+        $bookId = $newBook->id;
+        $this->_em->clear();
+
+        //retrieve the entity and change values
+        $dbBook = $this->_em->find(DDC5542Book::class, $bookId);
+        $this->assertCountQueries(4);
+        $this->assertInstanceOf(DateTime::class, $dbBook->publishedAt);
+        $this->assertEquals('2020-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        // the date is changed by reference
+        $dbBook->publishedAt = new DateTime('2020-01-01');
+        $this->assertEquals('2020-01-01', $dbBook->publishedAt->format('Y-m-d'));
+
+        $this->_em->flush();
+        $this->assertCountQueries(4);//as date did not change, no update queries expected
+
+        $this->assertEquals('2020-01-01', $this->getValueInDatabase($bookId));
+    }
+
+    private function assertCountQueries(int $expectedCount): void
+    {
+        $this->assertCount($expectedCount, $this->sqlLogger->queries, 'Unexpected queries count ' . PHP_EOL . print_r($this->sqlLogger->queries, true));
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getValueInDatabase($id, $column = 'publishedAt', $tableName = 'ddc_5542_book')
+    {
+        $sql = sprintf('SELECT %s FROM %s WHERE id=?', $column, $tableName);
+
+        return $this->_em->getConnection()->fetchOne($sql, [$id]);
+    }
 }
 
-/** @Entity */
+/**
+ * @Entity
+ * @Table(name="ddc_5542_book")
+*/
 #[ORM\Entity]
 class DDC5542Book
 {
@@ -75,4 +173,19 @@ class DDC5542Book
      /** @Column(type="date", nullable="true", changeDetector="Doctrine\ORM\Tools\ChangeDetector\DateTimeObjectByDate") */
     #[ORM\Column(type: 'date', nullable:true, changeDetector:DateTimeObjectByDate::class)]
     public ?DatetImeInterface $publishedAt = null;
+}
+
+
+class DDC5542DBALSQLLogger implements SQLLogger
+{
+    public array $queries = [];
+
+    public function startQuery($sql, ?array $params = null, ?array $types = null): void
+    {
+        $this->queries[] = $sql;
+    }
+
+    public function stopQuery(): void
+    {
+    }
 }


### PR DESCRIPTION
Proposal to implement different strategy concerning the property change computation.

https://github.com/doctrine/orm/issues/5542

todo:
- [  ] allow determining ChangeDetector from custom DBAL\type
- [  ] more functional test with differents type (json, etc..)
- [  ] unit test for the differents ChangeDetector
- [  ] allow using Yaml mapping
- [  ] allow using Xml mapping 