### PR TITLE
Add custom highly optimized metadata cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "phpstan/phpstan": "~1.4.10 || 1.8.8",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "psr/log": "^1 || ^2 || ^3",
-        "psr/cache": "^1 || ^2",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "phpstan/phpstan": "~1.4.10 || 1.8.8",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "psr/log": "^1 || ^2 || ^3",
+        "psr/cache": "^1 || ^2",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",

--- a/lib/Doctrine/ORM/Mapping/Cache/PhpMetadataCache.php
+++ b/lib/Doctrine/ORM/Mapping/Cache/PhpMetadataCache.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping\Cache;
+
+use Composer\InstalledVersions;
+use Doctrine\Common\Cache\Psr6\CacheItem;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+use function array_map;
+use function dirname;
+use function file_exists;
+use function file_put_contents;
+use function filemtime;
+use function get_class;
+use function gettype;
+use function in_array;
+use function is_dir;
+use function is_object;
+use function mkdir;
+use function opcache_invalidate;
+use function serialize;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use function var_export;
+
+class PhpMetadataCache implements CacheItemPoolInterface
+{
+    /** @var string */
+    private $cacheDir;
+
+    /** @var bool */
+    private $debug;
+
+    public function __construct(string $cacheDir, bool $debug = false)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->debug    = $debug;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        $fileName = $this->wiggle($item->getKey());
+
+        $this->assertValidFilePath($fileName);
+
+        if (! is_dir($this->cacheDir) && is_dir(dirname($this->cacheDir))) {
+            @mkdir($this->cacheDir, 0755);
+        }
+
+        $metadata = $item->get();
+
+        if (! ($metadata instanceof ClassMetadataInfo)) {
+            throw new \InvalidArgumentException(sprintf(
+                'PhpMetadataCache only works for Doctrine\ORM\Mapping\ClassMetadataInfo instances, %s given.',
+                is_object($metadata) ? get_class($metadata) : gettype($metadata)
+            ));
+        }
+
+        $class = new \ReflectionClass(ClassMetadataInfo::class);
+
+        $namingStrategy = serialize($metadata->getNamingStrategy());
+
+        $content = "<?php\n\n\$classMetadata = new \Doctrine\ORM\Mapping\ClassMetadata('" . $metadata->name . "', unserialize('" . $namingStrategy . "'));\n";
+
+        $skipProperties      = ['reflClass', 'reflFields', 'namingStrategy'];
+        $serializeProperties = ['idGenerator', 'instantiator'];
+
+        foreach ($class->getProperties() as $property) {
+            $key = $property->getName();
+            $property->setAccessible(true);
+            $value = $property->getValue($metadata);
+
+            if (in_array($key, $serializeProperties)) {
+                $content .= "\$classMetadata->$key = unserialize('" . serialize($value) . "');\n";
+            } elseif (in_array($key, $skipProperties)) {
+                continue;
+            } else {
+                $content .= "\$classMetadata->$key = " . var_export($value, true) . ";\n";
+            }
+        }
+
+        $content .= "return array(\$classMetadata, '" . InstalledVersions::getVersion('doctrine/orm') . "');";
+
+        file_put_contents($this->cacheDir . '/' . $fileName . '.php', $content);
+        if (extension_loaded('opcache')) {
+            opcache_invalidate($this->cacheDir . '/' . $fileName . '.php');
+        }
+
+        return true;
+    }
+
+    /** @return ?ClassMetadataInfo */
+    private function fetch(string $key)
+    {
+        $fileName = $this->wiggle($key);
+
+        $this->assertValidFilePath($fileName);
+
+        $file = $this->cacheDir . '/' . $fileName . '.php';
+
+        if (! file_exists($file)) {
+            return null;
+        }
+
+        [$data, $version] = require $file;
+
+        if ($version !== InstalledVersions::getVersion('doctrine/orm')) {
+            return null;
+        }
+
+        if ($this->debug) {
+            $reflClass = new \ReflectionClass($data->name);
+
+            if (filemtime($file) < filemtime($reflClass->getFilename())) {
+                return null;
+            }
+        }
+
+        return $data;
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        $value = $this->fetch($key);
+
+        if ($value instanceof ClassMetadataInfo) {
+            return new CacheItem($key, $value, true);
+        }
+
+        return new CacheItem($key, null, false);
+    }
+
+    /** @param string[] $keys */
+    public function getItems(array $keys = []): iterable
+    {
+        return array_map(function (string $key) {
+            return $this->getItem($key);
+        }, $keys);
+    }
+
+    public function hasItem(string $key): bool
+    {
+        $data = $this->fetch($key);
+
+        return $data !== null;
+    }
+
+    public function clear(): bool
+    {
+        return true;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return true;
+    }
+
+    /** @param string[] $keys */
+    public function deleteItems(array $keys): bool
+    {
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+
+    private function wiggle(string $id): string
+    {
+        return str_replace(['\\', '$'], ['.', ''], $id);
+    }
+
+    private function assertValidFilePath(string $id): void
+    {
+        if (str_contains($id, '..')) {
+            throw new \RuntimeException('Invalid file path given, contains double dots.');
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3913,4 +3913,9 @@ class ClassMetadataInfo implements ClassMetadata
 
         return $reflectionProperty;
     }
+
+    public function getNamingStrategy() : NamingStrategy
+    {
+        return $this->namingStrategy;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/Cache/PhpMetadataCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Cache/PhpMetadataCacheTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Mapping\Cache;
+
+use Doctrine\Common\Cache\Psr6\CacheItem;
+use Doctrine\ORM\Mapping\Cache\PhpMetadataCache;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class PhpMetadataCacheTest extends OrmFunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function testLoadedMetadataEqualUncached()
+    {
+        $cache = new PhpMetadataCache(sys_get_temp_dir() . '/dcmetatest');
+
+        foreach (self::$modelSets as $classes) {
+            foreach ($classes as $class) {
+                $metadata = $this->_em->getMetadataFactory()->getMetadataFor($class);
+
+                $key = str_replace("\\", ".", $metadata->name);
+                $cache->save(new CacheItem($key, $metadata, false));
+
+                $cached = $cache->getItem($key)->get();
+                $cached->reflClass = $metadata->reflClass;
+                $cached->reflFields = $metadata->reflFields;
+
+                $this->assertEquals($metadata, $cached);
+            }
+        }
+    }
+
+    /**
+     * @after
+     */
+    public function removeMetadataTestDirectory()
+    {
+        $dir = sys_get_temp_dir() . '/dcmetatest';
+
+        if (is_dir($dir)) {
+            $files = scandir($dir);
+            foreach ($files as $file) {
+                if ($file === "." || $file === "..") {
+                    continue;
+                }
+
+                unlink($dir . "/" . $file);
+            }
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/Cache/PhpMetadataCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Cache/PhpMetadataCacheTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping\Cache;
 
 use Doctrine\Common\Cache\Psr6\CacheItem;
+use Doctrine\Common\Cache\Psr6\TypedCacheItem;
 use Doctrine\ORM\Mapping\Cache\PhpMetadataCache;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -14,13 +15,16 @@ class PhpMetadataCacheTest extends OrmFunctionalTestCase
     public function testLoadedMetadataEqualUncached()
     {
         $cache = new PhpMetadataCache(sys_get_temp_dir() . '/dcmetatest');
+        $itemClass = (PHP_VERSION_ID >= 80000)
+            ? TypedCacheItem::class
+            : CacheItem::class;
 
         foreach (self::$modelSets as $classes) {
             foreach ($classes as $class) {
                 $metadata = $this->_em->getMetadataFactory()->getMetadataFor($class);
 
                 $key = str_replace("\\", ".", $metadata->name);
-                $cache->save(new CacheItem($key, $metadata, false));
+                $cache->save(new $itemClass($key, $metadata, false));
 
                 $cached = $cache->getItem($key)->get();
                 $cached->reflClass = $metadata->reflClass;


### PR DESCRIPTION
There have been a few performance features in PHP engine since we originally built the Metadata cache layer for PHP 5.3 and ORM 2.0 in 2010. Mainly, Opcache, Interned Strings, Packed Arrays and other optimizations of parsing literal code vs unserializing an object.

This custom metadata driver has been in production at Tideways for roughly 5 years now and we haven't gotten around to open-source it.

It creates a PHP file that is assigning properties on `ClassMetadata`, the complex ones using `var_export`. See an example generated cache file for the widely used `CmsUser` model in the testsuite: https://gist.github.com/beberlei/a10fea49b2140b029fe13d97b66f159e

These cache files can be stored in Opcache and are quicker to load than any other metadata cache mechanism.

Using the debug flag, an invalidation of the metadata when compared to the filemtime of the actual entity is implemented.

Loading the metadata with the wrong version of doctrine is guarded against with Composer Runtime API serializing the version of orm into the cache.

For Doctrine 3.0 it might be sensible to completly switch to this driver only and make sure metadata are generated at the same time as proxys for production.

Added this as a first solution proposal for https://twitter.com/benjamincremer/status/1481571522259083266 - also need to do some benchmarks and profiling, as well as fixing all the CI issues before undrafting.

One potentially problematic thing will be the PSR Cache version differences, maybe using two classes.