### PR TITLE
Fix FieldMapping for generated key

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -82,7 +82,7 @@ use const PHP_VERSION_ID;
  *      nullable?: bool,
  *      notInsertable?: bool,
  *      notUpdatable?: bool,
- *      generated?: string,
+ *      generated?: int,
  *      enumType?: class-string<BackedEnum>,
  *      columnDefinition?: string,
  *      precision?: int,


### PR DESCRIPTION
All of the `GENERATED_*` constants are integers.