### PR TITLE
Fix type doc blocks in annotation classes

### DIFF
--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -17,41 +17,48 @@ final class AssociationOverride implements Annotation
      * The name of the relationship property whose mapping is being overridden.
      *
      * @var string
+     * @readonly
      */
     public $name;
 
     /**
      * The join column that is being mapped to the persistent attribute.
      *
-     * @var array<\Doctrine\ORM\Mapping\JoinColumn>|null
+     * @var array<JoinColumn>|null
+     * @readonly
      */
     public $joinColumns;
 
     /**
      * The join column that is being mapped to the persistent attribute.
      *
-     * @var array<\Doctrine\ORM\Mapping\JoinColumn>|null
+     * @var array<JoinColumn>|null
+     * @readonly
      */
     public $inverseJoinColumns;
 
     /**
      * The join table that maps the relationship.
      *
-     * @var \Doctrine\ORM\Mapping\JoinTable|null
+     * @var JoinTable|null
+     * @readonly
      */
     public $joinTable;
 
     /**
      * The name of the association-field on the inverse-side.
      *
-     * @var ?string
+     * @var string|null
+     * @readonly
      */
     public $inversedBy;
 
     /**
      * The fetching strategy to use for the association.
      *
-     * @var ?string
+     * @var string|null
+     * @psalm-var 'LAZY'|'EAGER'|'EXTRA_LAZY'|null
+     * @readonly
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      */
     public $fetch;
@@ -59,6 +66,7 @@ final class AssociationOverride implements Annotation
     /**
      * @param JoinColumn|array<JoinColumn> $joinColumns
      * @param JoinColumn|array<JoinColumn> $inverseJoinColumns
+     * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY'|null $fetch
      */
     public function __construct(
         string $name,

--- a/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 
+use function array_values;
 use function is_array;
 
 /**
@@ -21,7 +22,8 @@ final class AssociationOverrides implements Annotation
     /**
      * Mapping overrides of relationship properties.
      *
-     * @var array<AssociationOverride>
+     * @var list<AssociationOverride>
+     * @readonly
      */
     public $overrides = [];
 
@@ -36,8 +38,8 @@ final class AssociationOverrides implements Annotation
             if (! ($override instanceof AssociationOverride)) {
                 throw MappingException::invalidOverrideType('AssociationOverride', $override);
             }
-
-            $this->overrides[] = $override;
         }
+
+        $this->overrides = array_values($overrides);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/AttributeOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverride.php
@@ -17,13 +17,15 @@ final class AttributeOverride implements Annotation
      * The name of the property whose mapping is being overridden.
      *
      * @var string
+     * @readonly
      */
     public $name;
 
     /**
      * The column definition.
      *
-     * @var \Doctrine\ORM\Mapping\Column
+     * @var Column
+     * @readonly
      */
     public $column;
 

--- a/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 
+use function array_values;
 use function is_array;
 
 /**
@@ -21,7 +22,8 @@ final class AttributeOverrides implements Annotation
     /**
      * One or more field or property mapping overrides.
      *
-     * @var array<AttributeOverride>
+     * @var list<AttributeOverride>
+     * @readonly
      */
     public $overrides = [];
 
@@ -36,8 +38,8 @@ final class AttributeOverrides implements Annotation
             if (! ($override instanceof AttributeOverride)) {
                 throw MappingException::invalidOverrideType('AttributeOverride', $override);
             }
-
-            $this->overrides[] = $override;
         }
+
+        $this->overrides = array_values($overrides);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Cache.php
+++ b/lib/Doctrine/ORM/Mapping/Cache.php
@@ -18,14 +18,18 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 final class Cache implements Annotation
 {
     /**
+     * The concurrency strategy.
+     *
      * @Enum({"READ_ONLY", "NONSTRICT_READ_WRITE", "READ_WRITE"})
-     * @var string The concurrency strategy.
+     * @var string
+     * @psalm-var 'READ_ONLY'|'NONSTRICT_READ_WRITE'|'READ_WRITE'
      */
     public $usage = 'READ_ONLY';
 
     /** @var string|null Cache region name. */
     public $region;
 
+    /** @psalm-param 'READ_ONLY'|'NONSTRICT_READ_WRITE'|'READ_WRITE' $usage */
     public function __construct(string $usage = 'READ_ONLY', ?string $region = null)
     {
         $this->usage  = $usage;

--- a/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
@@ -19,10 +19,13 @@ final class ChangeTrackingPolicy implements Annotation
      * The change tracking policy.
      *
      * @var string
+     * @psalm-var 'DEFERRED_IMPLICIT'|'DEFERRED_EXPLICIT'|'NOTIFY'
+     * @readonly
      * @Enum({"DEFERRED_IMPLICIT", "DEFERRED_EXPLICIT", "NOTIFY"})
      */
     public $value;
 
+    /** @psalm-param 'DEFERRED_IMPLICIT'|'DEFERRED_EXPLICIT'|'NOTIFY' $value */
     public function __construct(string $value)
     {
         $this->value = $value;

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -5,29 +5,40 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;
+use BackedEnum;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
- * @NamedArgumentConstructor()
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY","ANNOTATION"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Column implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var mixed */
+    /**
+     * @var mixed
+     * @readonly
+     */
     public $type;
 
-    /** @var int|null */
+    /**
+     * @var int|null
+     * @readonly
+     */
     public $length;
 
     /**
      * The precision for a decimal (exact numeric) column (Applies only for decimal column).
      *
      * @var int|null
+     * @readonly
      */
     public $precision = 0;
 
@@ -35,40 +46,63 @@ final class Column implements Annotation
      * The scale for a decimal (exact numeric) column (Applies only for decimal column).
      *
      * @var int|null
+     * @readonly
      */
     public $scale = 0;
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $unique = false;
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $nullable = false;
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $insertable = true;
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $updatable = true;
 
-    /** @var class-string<\BackedEnum>|null */
+    /**
+     * @var class-string<BackedEnum>|null
+     * @readonly
+     */
     public $enumType = null;
 
-    /** @var array<string,mixed> */
+    /**
+     * @var array<string,mixed>
+     * @readonly
+     */
     public $options = [];
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $columnDefinition;
 
     /**
      * @var string|null
+     * @readonly
      * @psalm-var 'NEVER'|'INSERT'|'ALWAYS'|null
      * @Enum({"NEVER", "INSERT", "ALWAYS"})
      */
     public $generated;
 
     /**
-     * @param class-string<\BackedEnum>|null $enumType
-     * @param array<string,mixed>            $options
+     * @param class-string<BackedEnum>|null $enumType
+     * @param array<string,mixed>           $options
      * @psalm-param 'NEVER'|'INSERT'|'ALWAYS'|null $generated
      */
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
@@ -15,7 +15,10 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class CustomIdGenerator implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $class;
 
     public function __construct(?string $class = null)

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -15,23 +15,28 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DiscriminatorColumn implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $type;
 
-    /** @var int|null */
+    /**
+     * @var int|null
+     * @readonly
+     */
     public $length;
 
     /**
-     * Field name used in non-object hydration (array/scalar).
-     *
-     * @var mixed
+     * @var string|null
+     * @readonly
      */
-    public $fieldName;
-
-    /** @var string */
     public $columnDefinition;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
@@ -15,7 +15,10 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DiscriminatorMap implements Annotation
 {
-    /** @var array<int|string, string> */
+    /**
+     * @var array<int|string, string>
+     * @readonly
+     */
     public $value;
 
     /** @param array<int|string, string> $value */

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -15,10 +15,16 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Embedded implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $class;
 
-    /** @var string|bool|null */
+    /**
+     * @var string|bool|null
+     * @readonly
+     */
     public $columnPrefix;
 
     public function __construct(?string $class = null, $columnPrefix = null)

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -20,10 +20,14 @@ final class Entity implements Annotation
     /**
      * @var string|null
      * @psalm-var class-string<EntityRepository<T>>|null
+     * @readonly
      */
     public $repositoryClass;
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $readOnly = false;
 
     /** @psalm-param class-string<EntityRepository<T>>|null $repositoryClass */

--- a/lib/Doctrine/ORM/Mapping/EntityListeners.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListeners.php
@@ -22,6 +22,7 @@ final class EntityListeners implements Annotation
      * Specifies the names of the entity listeners.
      *
      * @var array<string>
+     * @readonly
      */
     public $value = [];
 

--- a/lib/Doctrine/ORM/Mapping/GeneratedValue.php
+++ b/lib/Doctrine/ORM/Mapping/GeneratedValue.php
@@ -16,13 +16,16 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 final class GeneratedValue implements Annotation
 {
     /**
-     * The type of Id generator.
+     * The type of ID generator.
      *
      * @var string
+     * @psalm-var 'AUTO'|'SEQUENCE'|'IDENTITY'|'NONE'|'CUSTOM'
+     * @readonly
      * @Enum({"AUTO", "SEQUENCE", "TABLE", "IDENTITY", "NONE", "UUID", "CUSTOM"})
      */
     public $strategy = 'AUTO';
 
+    /** @psalm-param 'AUTO'|'SEQUENCE'|'IDENTITY'|'NONE'|'CUSTOM' $strategy */
     public function __construct(string $strategy = 'AUTO')
     {
         $this->strategy = $strategy;

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -15,19 +15,34 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class Index implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $columns;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $fields;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $flags;
 
-    /** @var array<string,mixed>|null */
+    /**
+     * @var array<string,mixed>|null
+     * @readonly
+     */
     public $options;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -19,10 +19,13 @@ final class InheritanceType implements Annotation
      * The inheritance type used by the class and its subclasses.
      *
      * @var string
+     * @psalm-var 'NONE'|'JOINED'|'SINGLE_TABLE'|'TABLE_PER_CLASS'
+     * @readonly
      * @Enum({"NONE", "JOINED", "SINGLE_TABLE", "TABLE_PER_CLASS"})
      */
     public $value;
 
+    /** @psalm-param 'NONE'|'JOINED'|'SINGLE_TABLE'|'TABLE_PER_CLASS' $value */
     public function __construct(string $value)
     {
         $this->value = $value;

--- a/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
@@ -10,54 +10,5 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class InverseJoinColumn implements Annotation
 {
-    /** @var string|null */
-    public $name;
-
-    /** @var string */
-    public $referencedColumnName = 'id';
-
-    /** @var bool */
-    public $unique = false;
-
-    /** @var bool */
-    public $nullable = true;
-
-    /** @var mixed */
-    public $onDelete;
-
-    /** @var string|null */
-    public $columnDefinition;
-
-    /**
-     * Field name used in non-object hydration (array/scalar).
-     *
-     * @var string|null
-     */
-    public $fieldName;
-
-    /** @var array<string, mixed> */
-    public $options = [];
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function __construct(
-        ?string $name = null,
-        string $referencedColumnName = 'id',
-        bool $unique = false,
-        bool $nullable = true,
-        $onDelete = null,
-        ?string $columnDefinition = null,
-        ?string $fieldName = null,
-        array $options = []
-    ) {
-        $this->name                 = $name;
-        $this->referencedColumnName = $referencedColumnName;
-        $this->unique               = $unique;
-        $this->nullable             = $nullable;
-        $this->onDelete             = $onDelete;
-        $this->columnDefinition     = $columnDefinition;
-        $this->fieldName            = $fieldName;
-        $this->options              = $options;
-    }
+    use JoinColumnProperties;
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -15,52 +15,5 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class JoinColumn implements Annotation
 {
-    /** @var string|null */
-    public $name;
-
-    /** @var string */
-    public $referencedColumnName = 'id';
-
-    /** @var bool */
-    public $unique = false;
-
-    /** @var bool */
-    public $nullable = true;
-
-    /** @var mixed */
-    public $onDelete;
-
-    /** @var string|null */
-    public $columnDefinition;
-
-    /**
-     * Field name used in non-object hydration (array/scalar).
-     *
-     * @var string|null
-     */
-    public $fieldName;
-
-    /** @var array<string, mixed> */
-    public $options = [];
-
-    /** @param array<string, mixed> $options */
-    public function __construct(
-        ?string $name = null,
-        string $referencedColumnName = 'id',
-        bool $unique = false,
-        bool $nullable = true,
-        $onDelete = null,
-        ?string $columnDefinition = null,
-        ?string $fieldName = null,
-        array $options = []
-    ) {
-        $this->name                 = $name;
-        $this->referencedColumnName = $referencedColumnName;
-        $this->unique               = $unique;
-        $this->nullable             = $nullable;
-        $this->onDelete             = $onDelete;
-        $this->columnDefinition     = $columnDefinition;
-        $this->fieldName            = $fieldName;
-        $this->options              = $options;
-    }
+    use JoinColumnProperties;
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumnProperties.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnProperties.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+trait JoinColumnProperties
+{
+    /**
+     * @var string|null
+     * @readonly
+     */
+    public $name;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    public $referencedColumnName = 'id';
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    public $unique = false;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    public $nullable = true;
+
+    /**
+     * @var mixed
+     * @readonly
+     */
+    public $onDelete;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    public $columnDefinition;
+
+    /**
+     * Field name used in non-object hydration (array/scalar).
+     *
+     * @var string|null
+     * @readonly
+     */
+    public $fieldName;
+
+    /**
+     * @var array<string, mixed>
+     * @readonly
+     */
+    public $options = [];
+
+    /**
+     * @param mixed                $onDelete
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        ?string $name = null,
+        string $referencedColumnName = 'id',
+        bool $unique = false,
+        bool $nullable = true,
+        $onDelete = null,
+        ?string $columnDefinition = null,
+        ?string $fieldName = null,
+        array $options = []
+    ) {
+        $this->name                 = $name;
+        $this->referencedColumnName = $referencedColumnName;
+        $this->unique               = $unique;
+        $this->nullable             = $nullable;
+        $this->onDelete             = $onDelete;
+        $this->columnDefinition     = $columnDefinition;
+        $this->fieldName            = $fieldName;
+        $this->options              = $options;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -15,19 +15,34 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class JoinTable implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $schema;
 
-    /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
+    /**
+     * @var array<JoinColumn>
+     * @readonly
+     */
     public $joinColumns = [];
 
-    /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
+    /**
+     * @var array<JoinColumn>
+     * @readonly
+     */
     public $inverseJoinColumns = [];
 
-    /** @var array<string, mixed> */
+    /**
+     * @var array<string, mixed>
+     * @readonly
+     */
     public $options = [];
 
     /** @param array<string, mixed> $options */

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -16,35 +16,56 @@ use Doctrine\Deprecations\Deprecation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class ManyToMany implements Annotation
 {
-    /** @var class-string|null */
+    /**
+     * @var class-string|null
+     * @readonly
+     */
     public $targetEntity;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $mappedBy;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $inversedBy;
 
-    /** @var string[]|null */
+    /**
+     * @var string[]|null
+     * @readonly
+     */
     public $cascade;
 
     /**
      * The fetching strategy to use for the association.
      *
      * @var string
+     * @psalm-var 'LAZY'|'EAGER'|'EXTRA_LAZY'
+     * @readonly
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      */
     public $fetch = 'LAZY';
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $orphanRemoval = false;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $indexBy;
 
     /**
      * @param class-string|null $targetEntity
      * @param string[]|null     $cascade
+     * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY' $fetch
      */
     public function __construct(
         ?string $targetEntity = null,

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -15,26 +15,38 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class ManyToOne implements Annotation
 {
-    /** @var class-string|null */
+    /**
+     * @var class-string|null
+     * @readonly
+     */
     public $targetEntity;
 
-    /** @var string[]|null */
+    /**
+     * @var string[]|null
+     * @readonly
+     */
     public $cascade;
 
     /**
      * The fetching strategy to use for the association.
      *
      * @var string
+     * @psalm-var 'LAZY'|'EAGER'|'EXTRA_LAZY'
+     * @readonly
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      */
     public $fetch = 'LAZY';
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $inversedBy;
 
     /**
      * @param class-string|null $targetEntity
      * @param string[]|null     $cascade
+     * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY' $fetch
      */
     public function __construct(
         ?string $targetEntity = null,

--- a/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
+++ b/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
@@ -19,6 +19,7 @@ final class MappedSuperclass implements Annotation
     /**
      * @var string|null
      * @psalm-var class-string<EntityRepository>|null
+     * @readonly
      */
     public $repositoryClass;
 

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -15,32 +15,50 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class OneToMany implements Annotation
 {
-    /** @var string */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $mappedBy;
 
-    /** @var class-string|null */
+    /**
+     * @var class-string|null
+     * @readonly
+     */
     public $targetEntity;
 
-    /** @var array<string> */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $cascade;
 
     /**
      * The fetching strategy to use for the association.
      *
      * @var string
+     * @psalm-var 'LAZY'|'EAGER'|'EXTRA_LAZY'
+     * @readonly
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      */
     public $fetch = 'LAZY';
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $orphanRemoval = false;
 
-    /** @var string */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $indexBy;
 
     /**
      * @param class-string|null $targetEntity
      * @param string[]|null     $cascade
+     * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY' $fetch
      */
     public function __construct(
         ?string $mappedBy = null,

--- a/lib/Doctrine/ORM/Mapping/OneToOne.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOne.php
@@ -15,32 +15,50 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class OneToOne implements Annotation
 {
-    /** @var class-string|null */
+    /**
+     * @var class-string|null
+     * @readonly
+     */
     public $targetEntity;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $mappedBy;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $inversedBy;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $cascade;
 
     /**
      * The fetching strategy to use for the association.
      *
      * @var string
+     * @psalm-var 'LAZY'|'EAGER'|'EXTRA_LAZY'
+     * @readonly
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      */
     public $fetch = 'LAZY';
 
-    /** @var bool */
+    /**
+     * @var bool
+     * @readonly
+     */
     public $orphanRemoval = false;
 
     /**
      * @param class-string|null  $targetEntity
      * @param array<string>|null $cascade
+     * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY' $fetch
      */
     public function __construct(
         ?string $mappedBy = null,

--- a/lib/Doctrine/ORM/Mapping/OrderBy.php
+++ b/lib/Doctrine/ORM/Mapping/OrderBy.php
@@ -15,7 +15,10 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class OrderBy implements Annotation
 {
-    /** @var array<string> */
+    /**
+     * @var array<string>
+     * @readonly
+     */
     public $value;
 
     /** @param array<string> $value */

--- a/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
@@ -15,13 +15,22 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class SequenceGenerator implements Annotation
 {
-    /** @var string */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $sequenceName;
 
-    /** @var int */
+    /**
+     * @var int
+     * @readonly
+     */
     public $allocationSize = 1;
 
-    /** @var int */
+    /**
+     * @var int
+     * @readonly
+     */
     public $initialValue = 1;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -15,25 +15,40 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Table implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $schema;
 
-    /** @var array<\Doctrine\ORM\Mapping\Index>|null */
+    /**
+     * @var array<Index>|null
+     * @readonly
+     */
     public $indexes;
 
-    /** @var array<\Doctrine\ORM\Mapping\UniqueConstraint>|null */
+    /**
+     * @var array<UniqueConstraint>|null
+     * @readonly
+     */
     public $uniqueConstraints;
 
-    /** @var array<string,mixed> */
+    /**
+     * @var array<string,mixed>
+     * @readonly
+     */
     public $options = [];
 
     /**
-     * @param array<\Doctrine\ORM\Mapping\Index>            $indexes
-     * @param array<\Doctrine\ORM\Mapping\UniqueConstraint> $uniqueConstraints
-     * @param array<string,mixed>                           $options
+     * @param array<Index>            $indexes
+     * @param array<UniqueConstraint> $uniqueConstraints
+     * @param array<string,mixed>     $options
      */
     public function __construct(
         ?string $name = null,

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -15,16 +15,28 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class UniqueConstraint implements Annotation
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     * @readonly
+     */
     public $name;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $columns;
 
-    /** @var array<string>|null */
+    /**
+     * @var array<string>|null
+     * @readonly
+     */
     public $fields;
 
-    /** @var array<string,mixed>|null */
+    /**
+     * @var array<string,mixed>|null
+     * @readonly
+     */
     public $options;
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -505,7 +505,6 @@
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
-      <code>ClassMetadata</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
@@ -719,11 +718,6 @@
       <code>$class-&gt;associationMappings[$fieldName]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$columnDefinition</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php">
     <DeprecatedMethod occurrences="2">
       <code>addNamedNativeQuery</code>
@@ -732,6 +726,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>new ReflectionClass($metadata-&gt;name)</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1"/>
     <LessSpecificReturnStatement occurrences="1">
       <code>$mapping</code>
     </LessSpecificReturnStatement>
@@ -761,6 +756,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>new ReflectionClass($metadata-&gt;name)</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1"/>
     <InvalidArrayAccess occurrences="4">
       <code>$value[0]</code>
       <code>$value[0]</code>
@@ -805,8 +801,7 @@
       <code>$this-&gt;tables[$tableName]</code>
       <code>$this-&gt;tables[$tableName]</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullReference occurrences="4">
-      <code>getColumns</code>
+    <PossiblyNullReference occurrences="3">
       <code>getColumns</code>
       <code>getColumns</code>
       <code>getIndexes</code>
@@ -964,16 +959,6 @@
       <code>$name</code>
     </MissingConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Mapping/InverseJoinColumn.php">
-    <MissingParamType occurrences="1">
-      <code>$onDelete</code>
-    </MissingParamType>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/JoinColumn.php">
-    <MissingParamType occurrences="1">
-      <code>$onDelete</code>
-    </MissingParamType>
-  </file>
   <file src="lib/Doctrine/ORM/Mapping/JoinColumns.php">
     <MissingConstructor occurrences="1">
       <code>$value</code>
@@ -1016,13 +1001,6 @@
       <code>$query</code>
     </MissingConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Mapping/OneToMany.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="3">
-      <code>$cascade</code>
-      <code>$indexBy</code>
-      <code>$mappedBy</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
   <file src="lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;embeddedClass</code>
@@ -1035,11 +1013,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $embeddedClass</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/SequenceGenerator.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$sequenceName</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php">
     <MissingConstructor occurrences="1">
@@ -2926,9 +2899,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$referencedFieldName</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>getColumns</code>
-    </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset occurrences="7">
       <code>$assoc['joinColumns']</code>
       <code>$class-&gt;getAssociationMapping($fieldName)['joinColumns']</code>


### PR DESCRIPTION
In 3.0, I'd like to flag all public properties of our annotation classes as `readonly`. Since we always use them as is they were immutable, this is  the reasonable thing to do imho.

This PR prepares this change by adding a `@readonly` annotation to all dock blocks. I've also fixed a few other inconsistencies.