### PR TITLE
Stop testing intermediary versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,15 +33,12 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
-          - "8.0"
           - "8.1"
         dbal-version:
           - "default"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             dbal-version: "2.13"
           - php-version: "8.1"
             dbal-version: "3@dev"
@@ -103,7 +100,7 @@ jobs:
           - "9.6"
           - "14"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             dbal-version: "2.13"
             postgres-version: "14"
           - php-version: "8.2"
@@ -171,7 +168,7 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             dbal-version: "2.13"
             mariadb-version: "10.6"
             extension: "pdo_mysql"
@@ -248,7 +245,7 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             dbal-version: "2.13"
             mysql-version: "8.0"
             extension: "pdo_mysql"


### PR DESCRIPTION
In my opinion, testing with the lowest-supported version, the latest version of each major version, and optionally the next minor version should be enough.