### PR TITLE
Use error style for notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/lexer": "^1.2.3",
         "doctrine/persistence": "^2.4 || ^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/console": "^3.3 || ^4.0 || ^5.0 || ^6.0",
         "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.16"
     },

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -67,7 +67,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em         = $this->getEntityManager($input);
         $ownerClass = $input->getArgument('owner-class');

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -66,7 +66,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em          = $this->getEntityManager($input);
         $entityClass = $input->getArgument('entity-class');

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -40,7 +40,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em          = $this->getEntityManager($input);
         $cacheDriver = $em->getConfiguration()->getMetadataCache();

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -63,7 +63,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em          = $this->getEntityManager($input);
         $cache       = $em->getConfiguration()->getQueryCache();

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -65,7 +65,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em    = $this->getEntityManager($input);
         $name  = $input->getArgument('region-name');

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -65,7 +65,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em          = $this->getEntityManager($input);
         $cache       = $em->getConfiguration()->getResultCache();

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -97,7 +97,7 @@ class ConvertDoctrine1SchemaCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
-        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
+        $ui->getErrorStyle()->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
 
         // Process source directories
         $fromPaths = array_merge([$input->getArgument('from-path')], $input->getOption('from'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -88,7 +88,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
-        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
+        $ui->getErrorStyle()->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
 
         $em = $this->getEntityManager($input);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -38,7 +38,7 @@ class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('This console command has been deprecated and will be removed in a future version of Doctrine ORM.');
 
         $em = $this->getEntityManager($input);

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -76,7 +76,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
 
         $em = $this->getEntityManager($input);

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -47,7 +47,7 @@ class GenerateProxiesCommand extends AbstractEntityManagerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em = $this->getEntityManager($input);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -48,7 +48,7 @@ class GenerateRepositoriesCommand extends AbstractEntityManagerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');
 
         $em = $this->getEntityManager($input);

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -43,7 +43,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $entityManager = $this->getEntityManager($input);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -62,7 +62,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $entityManager = $this->getEntityManager($input);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -38,7 +38,7 @@ abstract class AbstractCommand extends AbstractEntityManagerCommand
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
 
         if (empty($metadatas)) {
-            $ui->success('No Metadata Classes to process.');
+            $ui->getErrorStyle()->success('No Metadata Classes to process.');
 
             return 0;
         }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -57,14 +57,16 @@ EOT
             return 0;
         }
 
-        $ui->caution('This operation should not be executed in a production environment!');
+        $notificationUi = $ui->getErrorStyle();
 
-        $ui->text('Creating database schema...');
-        $ui->newLine();
+        $notificationUi->caution('This operation should not be executed in a production environment!');
+
+        $notificationUi->text('Creating database schema...');
+        $notificationUi->newLine();
 
         $schemaTool->createSchema($metadatas);
 
-        $ui->success('Database schema created successfully!');
+        $notificationUi->success('Database schema created successfully!');
 
         return 0;
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -67,9 +67,11 @@ EOT
             return 0;
         }
 
+        $notificationUi = $ui->getErrorStyle();
+
         if ($force) {
-            $ui->text('Dropping database schema...');
-            $ui->newLine();
+            $notificationUi->text('Dropping database schema...');
+            $notificationUi->newLine();
 
             if ($isFullDatabaseDrop) {
                 $schemaTool->dropDatabase();
@@ -77,12 +79,12 @@ EOT
                 $schemaTool->dropSchema($metadatas);
             }
 
-            $ui->success('Database schema dropped successfully!');
+            $notificationUi->success('Database schema dropped successfully!');
 
             return 0;
         }
 
-        $ui->caution('This operation should not be executed in a production environment!');
+        $notificationUi->caution('This operation should not be executed in a production environment!');
 
         if ($isFullDatabaseDrop) {
             $sqls = $schemaTool->getDropDatabaseSQL();
@@ -91,12 +93,12 @@ EOT
         }
 
         if (empty($sqls)) {
-            $ui->success('Nothing to drop. The database is empty!');
+            $notificationUi->success('Nothing to drop. The database is empty!');
 
             return 0;
         }
 
-        $ui->text(
+        $notificationUi->text(
             [
                 sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)),
                 '',

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -78,8 +78,10 @@ EOT
 
         $sqls = $schemaTool->getUpdateSchemaSql($metadatas, $saveMode);
 
+        $notificationUi = $ui->getErrorStyle();
+
         if (empty($sqls)) {
-            $ui->success('Nothing to update - your database is already in sync with the current entity metadata.');
+            $notificationUi->success('Nothing to update - your database is already in sync with the current entity metadata.');
 
             return 0;
         }
@@ -95,25 +97,25 @@ EOT
 
         if ($force) {
             if ($dumpSql) {
-                $ui->newLine();
+                $notificationUi->newLine();
             }
 
-            $ui->text('Updating database schema...');
-            $ui->newLine();
+            $notificationUi->text('Updating database schema...');
+            $notificationUi->newLine();
 
             $schemaTool->updateSchema($metadatas, $saveMode);
 
             $pluralization = count($sqls) === 1 ? 'query was' : 'queries were';
 
-            $ui->text(sprintf('    <info>%s</info> %s executed', count($sqls), $pluralization));
-            $ui->success('Database schema updated successfully!');
+            $notificationUi->text(sprintf('    <info>%s</info> %s executed', count($sqls), $pluralization));
+            $notificationUi->success('Database schema updated successfully!');
         }
 
         if ($dumpSql || $force) {
             return 0;
         }
 
-        $ui->caution(
+        $notificationUi->caution(
             [
                 'This operation should not be executed in a production environment!',
                 '',
@@ -122,7 +124,7 @@ EOT
             ]
         );
 
-        $ui->text(
+        $notificationUi->text(
             [
                 sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)),
                 '',

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -40,7 +40,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $ui = new SymfonyStyle($input, $output);
+        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em        = $this->getEntityManager($input);
         $validator = new SchemaValidator($em);


### PR DESCRIPTION
`stderr` is not a great name for something that is not meant to be processed (piped into) a program, but to be read by humans. Most commands should use stderr, and some of them should partially use `stdout`, typically when dumping SQL requests.