### PR TITLE
Fix calls to `AbstractSchemaManager::createSchema()`

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -878,7 +878,7 @@ class SchemaTool
     {
         $schema = $this->getSchemaFromMetadata($classes);
 
-        $deployedSchema = $this->schemaManager->createSchema();
+        $deployedSchema = $this->introspectSchema();
 
         foreach ($schema->getTables() as $table) {
             if (! $deployedSchema->hasTable($table->getName())) {
@@ -974,7 +974,7 @@ class SchemaTool
         $previousFilter = $config->getSchemaAssetsFilter();
 
         if ($previousFilter === null) {
-            return $this->schemaManager->createSchema();
+            return $this->introspectSchema();
         }
 
         // whitelist assets we already know about in $toSchema, use the existing filter otherwise
@@ -985,10 +985,19 @@ class SchemaTool
         });
 
         try {
-            return $this->schemaManager->createSchema();
+            return $this->introspectSchema();
         } finally {
             // restore schema assets filter
             $config->setSchemaAssetsFilter($previousFilter);
         }
+    }
+
+    private function introspectSchema(): Schema
+    {
+        $method = method_exists($this->schemaManager, 'introspectSchema')
+            ? 'introspectSchema'
+            : 'createSchema';
+
+        return $this->schemaManager->$method();
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -69,11 +69,6 @@
                 <referencedMethod name="Doctrine\DBAL\Connection::getSchemaManager"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsForeignKeyConstraints"/>
-                <!-- Remove on 2.14.x -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::createSchema"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Index::isFullfilledBy"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::changeColumn"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>
                 <!-- Remove on 3.0.x -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getEventManager"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Schema::visit"/>


### PR DESCRIPTION
`AbstractSchemaManager::createSchema()` has been deprecated in DBAL 3.5.