### PR TITLE
Discriminator column generated value

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3243,6 +3243,13 @@ class ClassMetadataInfo implements ClassMetadata
             if (in_array($columnDef['type'], ['boolean', 'array', 'object', 'datetime', 'time', 'date'], true)) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
             }
+            if (! isset($columnDef['generated'])) {
+                $columnDef['generated'] = null;
+            }
+
+            if (!in_array($columnDef['generated'], ['NEVER', 'INSERT', 'ALWAYS', null], true)) {
+                throw MappingException::invalidGeneratedMode($columnDef['generated']);
+            }
 
             $this->discriminatorColumn = $columnDef;
         }
@@ -3256,6 +3263,10 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         return $this->discriminatorColumn;
+    }
+
+    final public function isDiscriminatorColumnGenerated(): bool {
+        return null !== $this->discriminatorColumn['generated'];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -34,15 +34,24 @@ final class DiscriminatorColumn implements Annotation
     /** @var string */
     public $columnDefinition;
 
+    /**
+     * @var string|null
+     * @psalm-var 'NEVER'|'INSERT'|'ALWAYS'|null
+     * @Enum({"NEVER", "INSERT", "ALWAYS"})
+     */
+    public $generated;
+
     public function __construct(
         ?string $name = null,
         ?string $type = null,
         ?int $length = null,
-        ?string $columnDefinition = null
+        ?string $columnDefinition = null,
+        ?string $generated = null
     ) {
         $this->name             = $name;
         $this->type             = $type;
         $this->length           = $length;
         $this->columnDefinition = $columnDefinition;
+        $this->generated        = $generated;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -314,6 +314,7 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
                             'type'             => $discrColumnAnnot->type ?: 'string',
                             'length'           => $discrColumnAnnot->length ?? 255,
                             'columnDefinition' => $discrColumnAnnot->columnDefinition,
+                            'generated'        => $discrColumnAnnot->generated ?? null,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -256,6 +256,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
                             'type'             => isset($discrColumnAttribute->type) ? (string) $discrColumnAttribute->type : 'string',
                             'length'           => isset($discrColumnAttribute->length) ? (int) $discrColumnAttribute->length : 255,
                             'columnDefinition' => isset($discrColumnAttribute->columnDefinition) ? (string) $discrColumnAttribute->columnDefinition : null,
+                            'generated'        => isset($discrColumnAttribute->generated) ? (string) $discrColumnAttribute->generated : null,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
+use Doctrine\ORM\Mapping\GeneratedValue;
 use function sprintf;
 
 /**
@@ -23,10 +24,13 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
     {
         $data = parent::prepareInsertData($entity);
 
-        // Populate the discriminator column
-        $discColumn                                                          = $this->class->getDiscriminatorColumn();
-        $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
-        $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
+        // Populate the discriminator column only if not generated ALWAYS or on INSERT
+        $discColumn = $this->class->getDiscriminatorColumn();
+        if (false === in_array($discColumn['generated'], ['INSERT', 'ALWAYS'])) {
+            $this->columnTypes[$discColumn['name']] = $discColumn['type'];
+            $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] =
+                $this->class->discriminatorValue;
+        }
 
         return $data;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -535,8 +535,12 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Add discriminator column if it is the topmost class.
-        if ($this->class->name === $this->class->rootEntityName) {
-            $columns[] = $this->class->getDiscriminatorColumn()['name'];
+        $discriminatorColumn = $this->class->getDiscriminatorColumn();
+        if (
+            $this->class->name === $this->class->rootEntityName
+            && false === in_array($discriminatorColumn['generated'], ['INSERT', 'ALWAYS'])
+        ) {
+            $columns[] = $discriminatorColumn['name'];
         }
 
         return $columns;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -101,7 +101,10 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $columns = parent::getInsertColumnList();
 
         // Add discriminator column to the INSERT SQL
-        $columns[] = $this->class->getDiscriminatorColumn()['name'];
+        $discriminatorColumn = $this->class->getDiscriminatorColumn();
+        if (false === in_array($discriminatorColumn['generated'], ['INSERT', 'ALWAYS'])) {
+            $columns[] = $discriminatorColumn['name'];
+        }
 
         return $columns;
     }


### PR DESCRIPTION
Situation:

We have a Table which have a discriminator column with a generated value. 

Expected:
If we persist a new Record of the mapped Entity, the Insert should not write the discriminator value because it is auto generated.

ISSUE:
The Insert tries to insert the default value of the entity. This will fail because the value can not be inserted if it is a generated column.

Solution:
This MR allows the dev to use generated Column as a discriminator column. If a new Entity should be persisted and the discriminator column has the generated Value set, the Insert will ignore the Value of the mapped column.

---------------------------------------
I need some help to write the correct Tests. 
Please can you tell me if the solution is done in the right way?