### PR TITLE
Handle readonly public properties

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -17,6 +17,8 @@ use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 
+use function in_array;
+
 /**
  * This factory is used to create proxy objects for entities at runtime.
  *
@@ -170,8 +172,10 @@ class ProxyFactory extends AbstractProxyFactory
                 );
             }
 
+            $identifierFields = $class->identifier;
             foreach ($class->getReflectionProperties() as $property) {
-                if (! $class->hasField($property->name) && ! $class->hasAssociation($property->name)) {
+                // Skip identifiers, too
+                if (in_array($property->name, $identifierFields) || (! $class->hasField($property->name) && ! $class->hasAssociation($property->name))) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2747,6 +2747,15 @@ class UnitOfWork implements PropertyChangedListener
 
         foreach ($data as $field => $value) {
             if (isset($class->fieldMappings[$field])) {
+                // Skip readonly properties that have been already set
+                if (
+                    method_exists($class->reflFields[$field], 'isReadonly') &&
+                    $class->reflFields[$field]->isReadOnly() &&
+                    isset($entity->$field)
+                ) {
+                    continue;
+                }
+
                 $class->reflFields[$field]->setValue($entity, $value);
             }
         }


### PR DESCRIPTION
This modifies the cloner closure and the createEntity method of UnitOfWork to avoid repeat initializations of readonly public properties.

This is related to this pull request https://github.com/doctrine/common/pull/999 which handles readonly public properties in proxies.
