### PR TITLE
Deprecate the `Annotation` interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,10 @@ As a consequence, the following methods are deprecated:
 - `ORMSetup::createAnnotationMetadataConfiguration`
 - `ORMSetup::createDefaultAnnotationDriver`
 
+The marker interface `Doctrine\ORM\Mapping\Annotation` is deprecated as well.
+All annotation/attribute classes implement
+`Doctrine\ORM\Mapping\MappingAttribute` now.
+
 ## Deprecated `Doctrine\ORM\Proxy\Proxy` interface.
 
 Use `Doctrine\Persistence\Proxy` instead to check whether proxies are initialized.

--- a/lib/Doctrine/ORM/Mapping/Annotation.php
+++ b/lib/Doctrine/ORM/Mapping/Annotation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+/** @deprecated Use {@see MappingAttribute} instead. */
 interface Annotation
 {
 }

--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @NamedArgumentConstructor
  * @Target("ANNOTATION")
  */
-final class AssociationOverride implements Annotation
+final class AssociationOverride implements MappingAttribute
 {
     /**
      * The name of the relationship property whose mapping is being overridden.

--- a/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
@@ -17,7 +17,7 @@ use function is_array;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class AssociationOverrides implements Annotation
+final class AssociationOverrides implements MappingAttribute
 {
     /**
      * Mapping overrides of relationship properties.

--- a/lib/Doctrine/ORM/Mapping/AttributeOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverride.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @NamedArgumentConstructor
  * @Target("ANNOTATION")
  */
-final class AttributeOverride implements Annotation
+final class AttributeOverride implements MappingAttribute
 {
     /**
      * The name of the property whose mapping is being overridden.

--- a/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
@@ -17,7 +17,7 @@ use function is_array;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class AttributeOverrides implements Annotation
+final class AttributeOverrides implements MappingAttribute
 {
     /**
      * One or more field or property mapping overrides.

--- a/lib/Doctrine/ORM/Mapping/Cache.php
+++ b/lib/Doctrine/ORM/Mapping/Cache.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target({"CLASS","PROPERTY"})
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
-final class Cache implements Annotation
+final class Cache implements MappingAttribute
 {
     /**
      * The concurrency strategy.

--- a/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class ChangeTrackingPolicy implements Annotation
+final class ChangeTrackingPolicy implements MappingAttribute
 {
     /**
      * The change tracking policy.

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -14,7 +14,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target({"PROPERTY","ANNOTATION"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Column implements Annotation
+final class Column implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/ColumnResult.php
+++ b/lib/Doctrine/ORM/Mapping/ColumnResult.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class ColumnResult implements Annotation
+final class ColumnResult implements MappingAttribute
 {
     /**
      * The name of a column in the SELECT clause of a SQL query.

--- a/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class CustomIdGenerator implements Annotation
+final class CustomIdGenerator implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class DiscriminatorColumn implements Annotation
+final class DiscriminatorColumn implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class DiscriminatorMap implements Annotation
+final class DiscriminatorMap implements MappingAttribute
 {
     /**
      * @var array<int|string, string>

--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Annotation.php';
+require_once __DIR__ . '/../MappingAttribute.php';
 require_once __DIR__ . '/../Entity.php';
 require_once __DIR__ . '/../Embeddable.php';
 require_once __DIR__ . '/../Embedded.php';

--- a/lib/Doctrine/ORM/Mapping/Embeddable.php
+++ b/lib/Doctrine/ORM/Mapping/Embeddable.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Embeddable implements Annotation
+final class Embeddable implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Embedded implements Annotation
+final class Embedded implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\EntityRepository;
  * @template T of object
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Entity implements Annotation
+final class Entity implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/EntityListeners.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListeners.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class EntityListeners implements Annotation
+final class EntityListeners implements MappingAttribute
 {
     /**
      * Specifies the names of the entity listeners.

--- a/lib/Doctrine/ORM/Mapping/EntityResult.php
+++ b/lib/Doctrine/ORM/Mapping/EntityResult.php
@@ -13,7 +13,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class EntityResult implements Annotation
+final class EntityResult implements MappingAttribute
 {
     /**
      * The class of the result.

--- a/lib/Doctrine/ORM/Mapping/FieldResult.php
+++ b/lib/Doctrine/ORM/Mapping/FieldResult.php
@@ -10,7 +10,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class FieldResult implements Annotation
+final class FieldResult implements MappingAttribute
 {
     /**
      * Name of the column in the SELECT clause.

--- a/lib/Doctrine/ORM/Mapping/GeneratedValue.php
+++ b/lib/Doctrine/ORM/Mapping/GeneratedValue.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class GeneratedValue implements Annotation
+final class GeneratedValue implements MappingAttribute
 {
     /**
      * The type of ID generator.

--- a/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
+++ b/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class HasLifecycleCallbacks implements Annotation
+final class HasLifecycleCallbacks implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/Id.php
+++ b/lib/Doctrine/ORM/Mapping/Id.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Id implements Annotation
+final class Id implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("ANNOTATION")
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class Index implements Annotation
+final class Index implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class InheritanceType implements Annotation
+final class InheritanceType implements MappingAttribute
 {
     /**
      * The inheritance type used by the class and its subclasses.

--- a/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
@@ -8,7 +8,7 @@ namespace Doctrine\ORM\Mapping;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class InverseJoinColumn implements Annotation
+final class InverseJoinColumn implements MappingAttribute
 {
     use JoinColumnProperties;
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target({"PROPERTY","ANNOTATION"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class JoinColumn implements Annotation
+final class JoinColumn implements MappingAttribute
 {
     use JoinColumnProperties;
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumns.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumns.php
@@ -8,7 +8,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("PROPERTY")
  */
-final class JoinColumns implements Annotation
+final class JoinColumns implements MappingAttribute
 {
     /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
     public $value;

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target({"PROPERTY","ANNOTATION"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class JoinTable implements Annotation
+final class JoinTable implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -14,7 +14,7 @@ use Doctrine\Deprecations\Deprecation;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class ManyToMany implements Annotation
+final class ManyToMany implements MappingAttribute
 {
     /**
      * @var class-string|null

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class ManyToOne implements Annotation
+final class ManyToOne implements MappingAttribute
 {
     /**
      * @var class-string|null

--- a/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
+++ b/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\EntityRepository;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class MappedSuperclass implements Annotation
+final class MappedSuperclass implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/MappingAttribute.php
+++ b/lib/Doctrine/ORM/Mapping/MappingAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+/** A marker interface for mapping attributes. */
+interface MappingAttribute extends Annotation
+{
+}

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("CLASS")
  */
-final class NamedNativeQueries implements Annotation
+final class NamedNativeQueries implements MappingAttribute
 {
     /**
      * One or more NamedNativeQuery annotations.

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class NamedNativeQuery implements Annotation
+final class NamedNativeQuery implements MappingAttribute
 {
     /**
      * The name used to refer to the query with the EntityManager methods that create query objects.

--- a/lib/Doctrine/ORM/Mapping/NamedQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQueries.php
@@ -8,7 +8,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("CLASS")
  */
-final class NamedQueries implements Annotation
+final class NamedQueries implements MappingAttribute
 {
     /** @var array<\Doctrine\ORM\Mapping\NamedQuery> */
     public $value;

--- a/lib/Doctrine/ORM/Mapping/NamedQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQuery.php
@@ -8,7 +8,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class NamedQuery implements Annotation
+final class NamedQuery implements MappingAttribute
 {
     /** @var string */
     public $name;

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class OneToMany implements Annotation
+final class OneToMany implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/OneToOne.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOne.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class OneToOne implements Annotation
+final class OneToOne implements MappingAttribute
 {
     /**
      * @var class-string|null

--- a/lib/Doctrine/ORM/Mapping/OrderBy.php
+++ b/lib/Doctrine/ORM/Mapping/OrderBy.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class OrderBy implements Annotation
+final class OrderBy implements MappingAttribute
 {
     /**
      * @var array<string>

--- a/lib/Doctrine/ORM/Mapping/PostLoad.php
+++ b/lib/Doctrine/ORM/Mapping/PostLoad.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PostLoad implements Annotation
+final class PostLoad implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PostPersist.php
+++ b/lib/Doctrine/ORM/Mapping/PostPersist.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PostPersist implements Annotation
+final class PostPersist implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PostRemove.php
+++ b/lib/Doctrine/ORM/Mapping/PostRemove.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PostRemove implements Annotation
+final class PostRemove implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PostUpdate.php
+++ b/lib/Doctrine/ORM/Mapping/PostUpdate.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PostUpdate implements Annotation
+final class PostUpdate implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PreFlush.php
+++ b/lib/Doctrine/ORM/Mapping/PreFlush.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PreFlush implements Annotation
+final class PreFlush implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PrePersist.php
+++ b/lib/Doctrine/ORM/Mapping/PrePersist.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PrePersist implements Annotation
+final class PrePersist implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PreRemove.php
+++ b/lib/Doctrine/ORM/Mapping/PreRemove.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PreRemove implements Annotation
+final class PreRemove implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/PreUpdate.php
+++ b/lib/Doctrine/ORM/Mapping/PreUpdate.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("METHOD")
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class PreUpdate implements Annotation
+final class PreUpdate implements MappingAttribute
 {
 }

--- a/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class SequenceGenerator implements Annotation
+final class SequenceGenerator implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("ANNOTATION")
  */
-final class SqlResultSetMapping implements Annotation
+final class SqlResultSetMapping implements MappingAttribute
 {
     /**
      * The name given to the result set mapping, and used to refer to it in the methods of the Query API.

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Mapping;
  * @Annotation
  * @Target("CLASS")
  */
-final class SqlResultSetMappings implements Annotation
+final class SqlResultSetMappings implements MappingAttribute
 {
     /**
      * One or more SqlResultSetMapping annotations.

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("CLASS")
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Table implements Annotation
+final class Table implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Target("ANNOTATION")
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class UniqueConstraint implements Annotation
+final class UniqueConstraint implements MappingAttribute
 {
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Mapping/Version.php
+++ b/lib/Doctrine/ORM/Mapping/Version.php
@@ -11,6 +11,6 @@ use Attribute;
  * @Target("PROPERTY")
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Version implements Annotation
+final class Version implements MappingAttribute
 {
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -39,6 +39,8 @@
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\EntityManagerProvider\HelperSetManagerProvider"/>
+                <!-- https://github.com/vimeo/psalm/issues/8617 -->
+                <referencedClass name="Doctrine\ORM\Mapping\Annotation"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedConstant>
@@ -52,7 +54,9 @@
         </DeprecatedConstant>
         <DeprecatedInterface>
             <errorLevel type="suppress">
+                <!-- Remove on 3.0.x -->
                 <referencedClass name="Doctrine\ORM\Cache\MultiGetRegion"/>
+                <referencedClass name="Doctrine\ORM\Mapping\Annotation"/>
             </errorLevel>
         </DeprecatedInterface>
         <DeprecatedMethod>

--- a/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -6,8 +6,8 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Attribute;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\Annotation;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\MappingAttribute;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as PersistenceAnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use stdClass;
@@ -149,7 +149,7 @@ class AttributeEntityStartingWithRepeatableAttributes
 }
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
-class AttributeTransientAnnotation implements Annotation
+class AttributeTransientAnnotation implements MappingAttribute
 {
 }
 


### PR DESCRIPTION
Once we remove the support for annotations, having a marker interface named `Annotation` for our attribute classes seems weird. Let's rename it.