### PR TITLE
Bump CI to PHP 8.2 and latest database versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,11 +47,11 @@ jobs:
           - php-version: "8.0"
             dbal-version: "2.13"
             extension: "pdo_sqlite"
-          - php-version: "8.1"
+          - php-version: "8.2"
             dbal-version: "3@dev"
             extension: "pdo_sqlite"
-          - php-version: "8.1"
-            dbal-version: "3@dev"
+          - php-version: "8.2"
+            dbal-version: "default"
             extension: "sqlite3"
 
     steps:
@@ -102,19 +102,19 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.2"
         dbal-version:
           - "default"
+          - "3@dev"
         postgres-version:
-          - "9.6"
-          - "14"
+          - "15"
         include:
           - php-version: "8.0"
             dbal-version: "2.13"
             postgres-version: "14"
           - php-version: "8.2"
-            dbal-version: "3@dev"
-            postgres-version: "14"
+            dbal-version: "default"
+            postgres-version: "9.6"
 
     services:
       postgres:
@@ -168,11 +168,12 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.2"
         dbal-version:
           - "default"
+          - "3@dev"
         mariadb-version:
-          - "10.6"
+          - "10.9"
         extension:
           - "mysqli"
           - "pdo_mysql"
@@ -181,14 +182,6 @@ jobs:
             dbal-version: "2.13"
             mariadb-version: "10.6"
             extension: "pdo_mysql"
-          - php-version: "8.2"
-            dbal-version: "3@dev"
-            mariadb-version: "10.6"
-            extension: "pdo_mysql"
-          - php-version: "8.2"
-            dbal-version: "3@dev"
-            mariadb-version: "10.6"
-            extension: "mysqli"
 
     services:
       mariadb:
@@ -244,9 +237,10 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.2"
         dbal-version:
           - "default"
+          - "3@dev"
         mysql-version:
           - "5.7"
           - "8.0"
@@ -256,14 +250,6 @@ jobs:
         include:
           - php-version: "8.0"
             dbal-version: "2.13"
-            mysql-version: "8.0"
-            extension: "pdo_mysql"
-          - php-version: "8.2"
-            dbal-version: "3@dev"
-            mysql-version: "8.0"
-            extension: "mysqli"
-          - php-version: "8.2"
-            dbal-version: "3@dev"
             mysql-version: "8.0"
             extension: "pdo_mysql"
 


### PR DESCRIPTION
PHP 8.2 will be released soon and should be the default PHP version for our CI jobs by then. We should also update our CI to use the latest versions of all supported database engines.