### PR TITLE
Implement entity identifier in PostRemoveEventArgs

### DIFF
--- a/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
@@ -4,6 +4,31 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\ORM\EntityManagerInterface;
+
 final class PostRemoveEventArgs extends LifecycleEventArgs
 {
+    /**
+     * @var mixed
+     */
+    private $identifier;
+
+    /**
+     * @param mixed $identifier
+     */
+    public function __construct($entity, EntityManagerInterface $objectManager, $identifier)
+    {
+        parent::__construct($entity, $objectManager);
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * Retrieves the first entity identifier as it was before removal.
+     *
+     * @return mixed
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
 }

--- a/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
@@ -19,6 +19,7 @@ final class PostRemoveEventArgs extends LifecycleEventArgs
     public function __construct($entity, EntityManagerInterface $objectManager, $identifier)
     {
         parent::__construct($entity, $objectManager);
+
         $this->identifier = $identifier;
     }
 

--- a/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostRemoveEventArgs.php
@@ -8,13 +8,12 @@ use Doctrine\ORM\EntityManagerInterface;
 
 final class PostRemoveEventArgs extends LifecycleEventArgs
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $identifier;
 
     /**
-     * @param mixed $identifier
+     * @param object $entity
+     * @param mixed  $identifier
      */
     public function __construct($entity, EntityManagerInterface $objectManager, $identifier)
     {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1262,12 +1262,13 @@ class UnitOfWork implements PropertyChangedListener
             // Entity with this $oid after deletion treated as NEW, even if the $oid
             // is obtained by a new entity because the old one went out of scope.
             //$this->entityStates[$oid] = self::STATE_NEW;
+            $identifier = $class->reflFields[$class->identifier[0]]->getValue($entity);
             if (! $class->isIdentifierNatural()) {
                 $class->reflFields[$class->identifier[0]]->setValue($entity, null);
             }
 
             if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new PostRemoveEventArgs($entity, $this->em), $invoke);
+                $this->listenersInvoker->invoke($class, Events::postRemove, $entity, new PostRemoveEventArgs($entity, $this->em, $identifier), $invoke);
             }
         }
     }


### PR DESCRIPTION
Implement setting and getting of entity identifier in PostRemoveEventArgs.

Fixes #2326

## TODO

- [ ] update documentation
- [ ] implement real test case checking if id is available
  - [ ] What happens with multiple identifier fields? I'm not sure because only the first identifer seems to be set to null anyway.