### PR TITLE
Allow "Expr\Func" as condition in join in PHPDoc

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Join.php
+++ b/lib/Doctrine/ORM/Query/Expr/Join.php
@@ -37,19 +37,19 @@ class Join
      */
     protected $conditionType;
 
-    /** @var string|Comparison|Composite|null */
+    /** @var string|Comparison|Composite|Func|null */
     protected $condition;
 
     /** @var string|null */
     protected $indexBy;
 
     /**
-     * @param string                           $joinType      The condition type constant. Either INNER_JOIN or LEFT_JOIN.
-     * @param string                           $join          The relationship to join.
-     * @param string|null                      $alias         The alias of the join.
-     * @param string|null                      $conditionType The condition type constant. Either ON or WITH.
-     * @param string|Comparison|Composite|null $condition     The condition for the join.
-     * @param string|null                      $indexBy       The index for the join.
+     * @param string                                $joinType      The condition type constant. Either INNER_JOIN or LEFT_JOIN.
+     * @param string                                $join          The relationship to join.
+     * @param string|null                           $alias         The alias of the join.
+     * @param string|null                           $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Comparison|Composite|Func|null $condition     The condition for the join.
+     * @param string|null                           $indexBy       The index for the join.
      * @psalm-param self::INNER_JOIN|self::LEFT_JOIN $joinType
      * @psalm-param self::ON|self::WITH|null $conditionType
      */
@@ -93,7 +93,7 @@ class Join
         return $this->conditionType;
     }
 
-    /** @return string|Comparison|Composite|null */
+    /** @return string|Comparison|Composite|Func|null */
     public function getCondition()
     {
         return $this->condition;

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -992,11 +992,11 @@ class QueryBuilder
      *         ->join('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      * </code>
      *
-     * @param string                                     $join          The relationship to join.
-     * @param string                                     $alias         The alias of the join.
-     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
-     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
-     * @param string|null                                $indexBy       The index for the join.
+     * @param string                                               $join          The relationship to join.
+     * @param string                                               $alias         The alias of the join.
+     * @param string|null                                          $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition     The condition for the join.
+     * @param string|null                                          $indexBy       The index for the join.
      * @psalm-param Expr\Join::ON|Expr\Join::WITH|null $conditionType
      *
      * @return $this
@@ -1019,11 +1019,11 @@ class QueryBuilder
      *         ->from('User', 'u')
      *         ->innerJoin('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      *
-     * @param string                                     $join          The relationship to join.
-     * @param string                                     $alias         The alias of the join.
-     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
-     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
-     * @param string|null                                $indexBy       The index for the join.
+     * @param string                                               $join          The relationship to join.
+     * @param string                                               $alias         The alias of the join.
+     * @param string|null                                          $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition     The condition for the join.
+     * @param string|null                                          $indexBy       The index for the join.
      * @psalm-param Expr\Join::ON|Expr\Join::WITH|null $conditionType
      *
      * @return $this
@@ -1060,11 +1060,11 @@ class QueryBuilder
      *         ->leftJoin('u.Phonenumbers', 'p', Expr\Join::WITH, 'p.is_primary = 1');
      * </code>
      *
-     * @param string                                     $join          The relationship to join.
-     * @param string                                     $alias         The alias of the join.
-     * @param string|null                                $conditionType The condition type constant. Either ON or WITH.
-     * @param string|Expr\Comparison|Expr\Composite|null $condition     The condition for the join.
-     * @param string|null                                $indexBy       The index for the join.
+     * @param string                                               $join          The relationship to join.
+     * @param string                                               $alias         The alias of the join.
+     * @param string|null                                          $conditionType The condition type constant. Either ON or WITH.
+     * @param string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition     The condition for the join.
+     * @param string|null                                          $indexBy       The index for the join.
      * @psalm-param Expr\Join::ON|Expr\Join::WITH|null $conditionType
      *
      * @return $this

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -183,6 +183,23 @@ class QueryBuilderTest extends OrmTestCase
         );
     }
 
+    public function testComplexInnerJoinWithFuncCondition(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->select('u', 'a')
+            ->from(CmsUser::class, 'u')
+            ->innerJoin('u.articles', 'a', Join::WITH, $qb->expr()->in(
+                'u.id',
+                [1, 2, 3]
+            ));
+
+        $this->assertValidQueryBuilder(
+            $qb,
+            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a WITH u.id IN(1, 2, 3)'
+        );
+    }
+
     public function testComplexInnerJoinWithIndexBy(): void
     {
         $qb = $this->entityManager->createQueryBuilder()


### PR DESCRIPTION
I use "Expr\Func" as 4th parameter of innerJoin, but according to the PHPDoc it's not allowed:

Solves #8151

Current parameter is https://github.com/doctrine/orm/blob/2.13.x/lib/Doctrine/ORM/QueryBuilder.php#L1025

For example when I use the "in" expression in the join condition:

```mysql
$qb = $this->entityManager->createQueryBuilder();
$qb
    ->select('u', 'a')
    ->from(CmsUser::class, 'u')
    ->innerJoin('u.articles', 'a', Join::WITH, $qb->expr()->in(
        'u.id',
        [1, 2, 3]
    ));
```

it generates the query .... WITH u.id IN(1, 2, 3), but currently it's not allowed according to the PHPDoc.