### PR TITLE
Migrate Cache namespace to php 8

### DIFF
--- a/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
@@ -4,35 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
-/**
- * Association cache entry
- */
 class AssociationCacheEntry implements CacheEntry
 {
     /**
-     * The entity identifier
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var array<string, mixed>
-     */
-    public array $identifier;
-
-    /**
-     * The entity class name
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @psalm-var class-string
-     */
-    public string $class;
-
-    /**
      * @param array<string, mixed> $identifier The entity identifier.
-     * @psalm-param class-string $class
+     * @param class-string         $class      The entity class name
      */
-    public function __construct(string $class, array $identifier)
-    {
-        $this->class      = $class;
-        $this->identifier = $identifier;
+    public function __construct(
+        public readonly string $class,
+        public readonly array $identifier,
+    ) {
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/CacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CacheKey.php
@@ -10,10 +10,7 @@ namespace Doctrine\ORM\Cache;
  */
 abstract class CacheKey
 {
-    /**
-     * Unique identifier
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     */
-    public string $hash;
+    public function __construct(public readonly string $hash)
+    {
+    }
 }

--- a/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
@@ -4,23 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
-/**
- * Collection cache entry
- */
 class CollectionCacheEntry implements CacheEntry
 {
-    /**
-     * The list of entity identifiers hold by the collection
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var CacheKey[]
-     */
-    public array $identifiers;
-
     /** @param CacheKey[] $identifiers List of entity identifiers hold by the collection */
-    public function __construct(array $identifiers)
+    public function __construct(public readonly array $identifiers)
     {
-        $this->identifiers = $identifiers;
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
@@ -17,37 +17,22 @@ class CollectionCacheKey extends CacheKey
     /**
      * The owner entity identifier
      *
-     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed>
      */
-    public array $ownerIdentifier;
-
-    /**
-     * The owner entity class
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @psalm-var class-string
-     */
-    public string $entityClass;
-
-    /**
-     * The association name
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     */
-    public string $association;
+    public readonly array $ownerIdentifier;
 
     /**
      * @param array<string, mixed> $ownerIdentifier The identifier of the owning entity.
-     * @psalm-param class-string $entityClass
+     * @param class-string         $entityClass     The owner entity class
      */
-    public function __construct(string $entityClass, string $association, array $ownerIdentifier)
-    {
+    public function __construct(
+        public readonly string $entityClass,
+        public readonly string $association,
+        array $ownerIdentifier,
+    ) {
         ksort($ownerIdentifier);
 
         $this->ownerIdentifier = $ownerIdentifier;
-        $this->entityClass     = $entityClass;
-        $this->association     = $association;
-        $this->hash            = str_replace('\\', '.', strtolower($entityClass)) . '_' . implode(' ', $ownerIdentifier) . '__' . $association;
+        parent::__construct(str_replace('\\', '.', strtolower($entityClass)) . '_' . implode(' ', $ownerIdentifier) . '__' . $association);
     }
 }

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -31,7 +31,6 @@ use const DIRECTORY_SEPARATOR;
 
 class DefaultCacheFactory implements CacheFactory
 {
-    private RegionsConfiguration $regionsConfig;
     private TimestampRegion|null $timestampRegion = null;
 
     /** @var Region[] */
@@ -39,9 +38,8 @@ class DefaultCacheFactory implements CacheFactory
 
     private string|null $fileLockRegionDirectory = null;
 
-    public function __construct(RegionsConfiguration $cacheConfig, private CacheItemPoolInterface $cacheItemPool)
+    public function __construct(private readonly RegionsConfiguration $regionsConfig, private readonly CacheItemPoolInterface $cacheItemPool)
     {
-        $this->regionsConfig = $cacheConfig;
     }
 
     public function setFileLockRegionDirectory(string $fileLockRegionDirectory): void

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 
-use function array_merge;
 use function assert;
 use function is_array;
 use function is_object;
@@ -22,14 +21,14 @@ use function reset;
  */
 class DefaultEntityHydrator implements EntityHydrator
 {
-    private UnitOfWork $uow;
-    private IdentifierFlattener $identifierFlattener;
+    private readonly UnitOfWork $uow;
+    private readonly IdentifierFlattener $identifierFlattener;
 
     /** @var array<string,mixed> */
     private static array $hints = [Query::HINT_CACHE_ENABLED => true];
 
     public function __construct(
-        private EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
     ) {
         $this->uow                 = $em->getUnitOfWork();
         $this->identifierFlattener = new IdentifierFlattener($em->getUnitOfWork(), $em->getMetadataFactory());
@@ -38,7 +37,7 @@ class DefaultEntityHydrator implements EntityHydrator
     public function buildCacheEntry(ClassMetadata $metadata, EntityCacheKey $key, object $entity): EntityCacheEntry
     {
         $data = $this->uow->getOriginalEntityData($entity);
-        $data = array_merge($data, $metadata->getIdentifierValues($entity)); // why update has no identifier values ?
+        $data = [...$data, ...$metadata->getIdentifierValues($entity)]; // why update has no identifier values ?
 
         if ($metadata->requiresFetchAfterChange) {
             if ($metadata->isVersioned) {

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Proxy;
 
@@ -82,9 +83,7 @@ class DefaultQueryCache implements QueryCache
 
         $cm = $this->em->getClassMetadata($entityName);
 
-        $generateKeys = static function (array $entry) use ($cm): EntityCacheKey {
-            return new EntityCacheKey($cm->rootEntityName, $entry['identifier']);
-        };
+        $generateKeys = static fn (array $entry): EntityCacheKey => new EntityCacheKey($cm->rootEntityName, $entry['identifier']);
 
         $cacheKeys = new CollectionCacheEntry(array_map($generateKeys, $cacheEntry->result));
         $entries   = $region->getMultiple($cacheKeys) ?? [];
@@ -139,9 +138,7 @@ class DefaultQueryCache implements QueryCache
                     continue;
                 }
 
-                $generateKeys = static function ($id) use ($assocMetadata): EntityCacheKey {
-                    return new EntityCacheKey($assocMetadata->rootEntityName, $id);
-                };
+                $generateKeys = static fn (array $id): EntityCacheKey => new EntityCacheKey($assocMetadata->rootEntityName, $id);
 
                 $collection   = new PersistentCollection($this->em, $assocMetadata, new ArrayCollection());
                 $assocKeys    = new CollectionCacheEntry(array_map($generateKeys, $assoc['list']));
@@ -214,7 +211,7 @@ class DefaultQueryCache implements QueryCache
             throw FeatureNotImplemented::nonSelectStatements();
         }
 
-        if (($hints[Query\SqlWalker::HINT_PARTIAL] ?? false) === true || ($hints[Query::HINT_FORCE_PARTIAL_LOAD] ?? false) === true) {
+        if (($hints[SqlWalker::HINT_PARTIAL] ?? false) === true || ($hints[Query::HINT_FORCE_PARTIAL_LOAD] ?? false) === true) {
             throw FeatureNotImplemented::partialEntities();
         }
 

--- a/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
@@ -8,41 +8,22 @@ use Doctrine\ORM\EntityManagerInterface;
 
 use function array_map;
 
-/**
- * Entity cache entry
- */
 class EntityCacheEntry implements CacheEntry
 {
     /**
-     * The entity map data
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var array<string,mixed>
+     * @param array<string,mixed> $data The entity map data
+     * @psalm-param class-string $class The entity class name
      */
-    public array $data;
-
-    /**
-     * The entity class name
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @psalm-var class-string
-     */
-    public string $class;
-
-    /**
-     * @param array<string,mixed> $data The entity data.
-     * @psalm-param class-string $class
-     */
-    public function __construct(string $class, array $data)
-    {
-        $this->class = $class;
-        $this->data  = $data;
+    public function __construct(
+        public readonly string $class,
+        public readonly array $data,
+    ) {
     }
 
     /**
      * Creates a new EntityCacheEntry
      *
-     * This method allow Doctrine\Common\Cache\PhpFileCache compatibility
+     * This method allows Doctrine\Common\Cache\PhpFileCache compatibility
      *
      * @param array<string,mixed> $values array containing property values
      */

--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -17,30 +17,21 @@ class EntityCacheKey extends CacheKey
     /**
      * The entity identifier
      *
-     * @readonly Public only for performance reasons, it should be considered immutable.
      * @var array<string, mixed>
      */
-    public array $identifier;
+    public readonly array $identifier;
 
     /**
-     * The entity class name
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @psalm-var class-string
-     */
-    public string $entityClass;
-
-    /**
-     * @param string               $entityClass The entity class name. In a inheritance hierarchy it should always be the root entity class.
+     * @param class-string         $entityClass The entity class name. In a inheritance hierarchy it should always be the root entity class.
      * @param array<string, mixed> $identifier  The entity identifier
-     * @psalm-param class-string $entityClass
      */
-    public function __construct(string $entityClass, array $identifier)
-    {
+    public function __construct(
+        public readonly string $entityClass,
+        array $identifier,
+    ) {
         ksort($identifier);
 
-        $this->identifier  = $identifier;
-        $this->entityClass = $entityClass;
-        $this->hash        = str_replace('\\', '.', strtolower($entityClass) . '_' . implode(' ', $identifier));
+        $this->identifier = $identifier;
+        parent::__construct(str_replace('\\', '.', strtolower($entityClass) . '_' . implode(' ', $identifier)));
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -6,8 +6,6 @@ namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\EntityCacheKey;
 
-use function get_class;
-
 /**
  * Specific non-strict read/write cached entity persister
  */
@@ -72,7 +70,7 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
 
     private function updateCache(object $entity, bool $isChanged): bool
     {
-        $class     = $this->metadataFactory->getMetadataFor(get_class($entity));
+        $class     = $this->metadataFactory->getMetadataFor($entity::class);
         $key       = new EntityCacheKey($class->rootEntityName, $this->uow->getEntityIdentifier($entity));
         $entry     = $this->hydrator->buildCacheEntry($class, $key, $entity);
         $cached    = $this->region->put($key, $entry);

--- a/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
@@ -6,31 +6,19 @@ namespace Doctrine\ORM\Cache;
 
 use function microtime;
 
-/**
- * Query cache entry
- */
 class QueryCacheEntry implements CacheEntry
 {
     /**
-     * List of entity identifiers
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var array<string, mixed>
-     */
-    public array $result;
-
-    /**
      * Time creation of this cache entry
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
      */
-    public float $time;
+    public readonly float $time;
 
-    /** @param array<string, mixed> $result */
-    public function __construct(array $result, float|null $time = null)
-    {
-        $this->result = $result;
-        $this->time   = $time ?: microtime(true);
+    /** @param array<string, mixed> $result List of entity identifiers */
+    public function __construct(
+        public readonly array $result,
+        float|null $time = null,
+    ) {
+        $this->time = $time ?: microtime(true);
     }
 
     /** @param array<string, mixed> $values */

--- a/lib/Doctrine/ORM/Cache/QueryCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheKey.php
@@ -11,34 +11,13 @@ use Doctrine\ORM\Cache;
  */
 class QueryCacheKey extends CacheKey
 {
-    /**
-     * Cache key lifetime
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     */
-    public int $lifetime;
-
-    /**
-     * Cache mode
-     *
-     * @readonly Public only for performance reasons, it should be considered immutable.
-     * @psalm-var Cache::MODE_*
-     */
-    public int $cacheMode;
-
-    /** @readonly Public only for performance reasons, it should be considered immutable. */
-    public TimestampCacheKey|null $timestampKey = null;
-
-    /** @psalm-param Cache::MODE_* $cacheMode */
+    /** @param Cache::MODE_* $cacheMode */
     public function __construct(
         string $cacheId,
-        int $lifetime = 0,
-        int $cacheMode = Cache::MODE_NORMAL,
-        TimestampCacheKey|null $timestampKey = null,
+        public readonly int $lifetime = 0,
+        public readonly int $cacheMode = Cache::MODE_NORMAL,
+        public readonly TimestampCacheKey|null $timestampKey = null,
     ) {
-        $this->hash         = $cacheId;
-        $this->lifetime     = $lifetime;
-        $this->cacheMode    = $cacheMode;
-        $this->timestampKey = $timestampKey;
+        parent::__construct($cacheId);
     }
 }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Region;
 
-use Closure;
 use Doctrine\ORM\Cache\CacheEntry;
 use Doctrine\ORM\Cache\CacheKey;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
@@ -58,7 +57,7 @@ class DefaultRegion implements Region
     public function getMultiple(CollectionCacheEntry $collection): array|null
     {
         $keys = array_map(
-            Closure::fromCallable([$this, 'getCacheEntryKey']),
+            $this->getCacheEntryKey(...),
             $collection->identifiers,
         );
         /** @var iterable<string, CacheItemInterface> $items */

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -35,7 +35,7 @@ use const LOCK_EX;
  */
 class FileLockRegion implements ConcurrentRegion
 {
-    public const LOCK_EXTENSION = 'lock';
+    final public const LOCK_EXTENSION = 'lock';
 
     /**
      * @param numeric-string|int $lockLifetime
@@ -127,7 +127,7 @@ class FileLockRegion implements ConcurrentRegion
 
     public function getMultiple(CollectionCacheEntry $collection): array|null
     {
-        if (array_filter(array_map([$this, 'isLocked'], $collection->identifiers))) {
+        if (array_filter(array_map($this->isLocked(...), $collection->identifiers))) {
             return null;
         }
 

--- a/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
@@ -6,13 +6,9 @@ namespace Doctrine\ORM\Cache;
 
 use function microtime;
 
-/**
- * Timestamp cache entry
- */
 class TimestampCacheEntry implements CacheEntry
 {
-    /** @readonly Public only for performance reasons, it should be considered immutable. */
-    public float $time;
+    public readonly float $time;
 
     public function __construct(float|null $time = null)
     {

--- a/lib/Doctrine/ORM/Cache/TimestampCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheKey.php
@@ -12,6 +12,6 @@ class TimestampCacheKey extends CacheKey
     /** @param string $space Result cache id */
     public function __construct(string $space)
     {
-        $this->hash = $space;
+        parent::__construct($space);
     }
 }

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -8,7 +8,7 @@ use function microtime;
 
 class TimestampQueryCacheValidator implements QueryCacheValidator
 {
-    public function __construct(private TimestampRegion $timestampRegion)
+    public function __construct(private readonly TimestampRegion $timestampRegion)
     {
     }
 

--- a/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
@@ -23,9 +23,8 @@ final class AttributeOverrides implements MappingAttribute
      * One or more field or property mapping overrides.
      *
      * @var list<AttributeOverride>
-     * @readonly
      */
-    public array $overrides = [];
+    public readonly array $overrides;
 
     /** @param array<AttributeOverride>|AttributeOverride $overrides */
     public function __construct(array|AttributeOverride $overrides)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -43,6 +43,9 @@
     </NullableReturnStatement>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$data</code>
+    </InvalidScalarArgument>
     <PossiblyNullArrayOffset occurrences="1">
       <code>$targetClassMetadata-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>

--- a/tests/Doctrine/Tests/Mocks/CacheKeyMock.php
+++ b/tests/Doctrine/Tests/Mocks/CacheKeyMock.php
@@ -13,9 +13,4 @@ use Doctrine\ORM\Cache\CacheKey;
  */
 class CacheKeyMock extends CacheKey
 {
-    /** @param string $hash The string hash that represend this cache key */
-    public function __construct(string $hash)
-    {
-        $this->hash = $hash;
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -504,13 +504,12 @@ class DefaultQueryCacheTest extends OrmTestCase
                 ['identifier' => ['id' => 1]],
                 ['identifier' => ['id' => 2]],
             ],
+            microtime(true) - 100,
         );
         $entities = [
             ['id' => 1, 'name' => 'Foo'],
             ['id' => 2, 'name' => 'Bar'],
         ];
-
-        $entry->time = microtime(true) - 100;
 
         $this->region->addReturn('get', $entry);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -830,7 +830,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
             ->get($key);
 
         self::assertInstanceOf(QueryCacheEntry::class, $entry);
-        $entry->time /= 2;
+        $entry = new QueryCacheEntry($entry->result, $entry->time / 2);
 
         $this->cache->getQueryCache()
             ->getRegion()


### PR DESCRIPTION
This one comes with a controversial change that I did not have the courage to extract to a separate commit PR/commit (feel free to insist I do so): switching `@readonly` properties to native `readonly`. I had to tweak some tests to achieve that, and I've extracted that part in a separate commit, which I can backport if you think it should happen. 