### PR TITLE
Reverse-engineer actual type from code

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -49,19 +49,19 @@ abstract class Node
     }
 
     /**
-     * @param object $obj
+     * @param mixed $value
      *
      * @return string
      */
-    public function dump($obj)
+    public function dump($value)
     {
         static $ident = 0;
 
         $str = '';
 
-        if ($obj instanceof Node) {
-            $str  .= get_debug_type($obj) . '(' . PHP_EOL;
-            $props = get_object_vars($obj);
+        if ($value instanceof Node) {
+            $str  .= get_debug_type($value) . '(' . PHP_EOL;
+            $props = get_object_vars($value);
 
             foreach ($props as $name => $prop) {
                 $ident += 4;
@@ -71,12 +71,12 @@ abstract class Node
             }
 
             $str .= str_repeat(' ', $ident) . ')';
-        } elseif (is_array($obj)) {
+        } elseif (is_array($value)) {
             $ident += 4;
             $str   .= 'array(';
             $some   = false;
 
-            foreach ($obj as $k => $v) {
+            foreach ($value as $k => $v) {
                 $str .= PHP_EOL . str_repeat(' ', $ident) . '"'
                       . $k . '" => ' . $this->dump($v) . ',';
                 $some = true;
@@ -84,10 +84,10 @@ abstract class Node
 
             $ident -= 4;
             $str   .= ($some ? PHP_EOL . str_repeat(' ', $ident) : '') . ')';
-        } elseif (is_object($obj)) {
-            $str .= 'instanceof(' . get_debug_type($obj) . ')';
+        } elseif (is_object($value)) {
+            $str .= 'instanceof(' . get_debug_type($value) . ')';
         } else {
-            $str .= var_export($obj, true);
+            $str .= var_export($value, true);
         }
 
         return $str;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -426,16 +426,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with object will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/AST/Node.php
-
-		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/AST/Node.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkWhenClauseExpression\\(\\)\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1830,14 +1830,6 @@
       <code>$sqlWalker</code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Node.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_array($obj)</code>
-    </DocblockTypeContradiction>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>is_object($obj)</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
     <ParamNameMismatch occurrences="1">
       <code>$sqlWalker</code>


### PR DESCRIPTION
The code contains tests for `is_array()`, `is object()`, and an `else` clause. The type is wrong, and the variable name misleading.