### PR TITLE
Widen parameter type

### DIFF
--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -824,7 +824,8 @@ class MappingException extends ORMException
         return new self("Entity '" . $className . "' has a mapping with invalid fetch mode '" . $annotation . "'");
     }
 
-    public static function invalidGeneratedMode(string $annotation): MappingException
+    /** @param int|string $annotation */
+    public static function invalidGeneratedMode($annotation): MappingException
     {
         return new self("Invalid generated mode '" . $annotation . "'");
     }


### PR DESCRIPTION
This exception is used in two places, one where $generatedMode is clearly a string, and another where typing it as a string will cause a type error, because $generatedMode is supposed to be an int there.

Supposed to be an int: https://github.com/doctrine/orm/blob/465c02fe68d683efd32a314417940629c54374c4/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1720-L1728

Supposed to be a string: https://github.com/doctrine/orm/blob/465c02fe68d683efd32a314417940629c54374c4/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php#L680-L682

@mehldau this was introduced in https://github.com/doctrine/orm/pull/9118, please review