### PR TITLE
Make the code easier to statically analyse

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1574,9 +1574,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param  mixed[] $mapping The field mapping to validate & complete.
+     * @param  array{fieldName: string, type?: mixed} $mapping The field mapping to validate & complete.
      *
-     * @return mixed[] The updated mapping.
+     * @return array{fieldName: string, enumType?: string, type?: mixed} The updated mapping.
      */
     private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {
@@ -1631,7 +1631,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the basic mapping information based on typed property.
      *
-     * @param mixed[] $mapping The mapping.
+     * @param array{type: self::ONE_TO_ONE|self::MANY_TO_ONE|self::ONE_TO_MANY|self::MANY_TO_MANY, fieldName: string, targetEntity?: class-string} $mapping The mapping.
      *
      * @return mixed[] The updated mapping.
      */
@@ -1653,7 +1653,13 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the given field mapping.
      *
-     * @psalm-param array<string, mixed> $mapping The field mapping to validate & complete.
+     * @psalm-param array{
+     *     fieldName?: string,
+     *     columnName?: string,
+     *     id?: bool,
+     *     generated?: int,
+     *     enumType?: class-string,
+     * } $mapping The field mapping to validate & complete.
      *
      * @return mixed[] The updated mapping.
      *
@@ -1896,7 +1902,6 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes a one-to-one association mapping.
      *
-     * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      *
      * @return mixed[] The validated & completed mapping.

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -66,7 +66,7 @@ class DatabaseDriver implements MappingDriver
     /** @var array<string,Table>|null */
     private $tables = null;
 
-    /** @var mixed[] */
+    /** @var array<class-string, string> */
     private $classToTableNames = [];
 
     /** @psalm-var array<string, Table> */

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -9,9 +9,9 @@ use Traversable;
 use function func_get_args;
 use function implode;
 use function is_bool;
+use function is_float;
+use function is_int;
 use function is_iterable;
-use function is_numeric;
-use function is_string;
 use function iterator_to_array;
 use function str_replace;
 
@@ -608,7 +608,7 @@ class Expr
     /**
      * Creates a literal expression of the given argument.
      *
-     * @param mixed $literal Argument to be converted to literal.
+     * @param scalar $literal Argument to be converted to literal.
      *
      * @return Expr\Literal
      */
@@ -620,13 +620,15 @@ class Expr
     /**
      * Quotes a literal value, if necessary, according to the DQL syntax.
      *
-     * @param mixed $literal The literal value.
+     * @param scalar $literal The literal value.
      */
     private function quoteLiteral($literal): string
     {
-        if (is_numeric($literal) && ! is_string($literal)) {
+        if (is_int($literal) || is_float($literal)) {
             return (string) $literal;
-        } elseif (is_bool($literal)) {
+        }
+
+        if (is_bool($literal)) {
             return $literal ? 'true' : 'false';
         }
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -685,7 +685,7 @@ class Parser
             $fromClassName = $AST->fromClause->identificationVariableDeclarations[0]->rangeVariableDeclaration->abstractSchemaName ?? null;
 
             // If the namespace is not given then assumes the first FROM entity namespace
-            if (! str_contains($className, '\\') && ! class_exists($className) && str_contains($fromClassName, '\\')) {
+            if (! str_contains($className, '\\') && ! class_exists($className) && is_string($fromClassName) && str_contains($fromClassName, '\\')) {
                 $namespace = substr($fromClassName, 0, strrpos($fromClassName, '\\'));
                 $fqcn      = $namespace . '\\' . $className;
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -66,7 +66,7 @@ class RunDqlCommand extends AbstractEntityManagerCommand
             throw new LogicException("Option 'depth' must contain an integer value");
         }
 
-        $hydrationModeName = $input->getOption('hydrate');
+        $hydrationModeName = (string) $input->getOption('hydrate');
         $hydrationMode     = 'Doctrine\ORM\Query::HYDRATE_' . strtoupper(str_replace('-', '_', $hydrationModeName));
 
         if (! defined($hydrationMode)) {


### PR DESCRIPTION
While working on migrating the codebase to PHP 8, I noticed that a rule (`NullToStrictStringFuncCallArgRector`) often triggered that consists in adding casts to string, because internal functions have become more strict in PHP 8.1 (they no longer accept anything than a string).

I tried finding why those arguments were not considered already strings, and tried to fix some of that with this PR.