### PR TITLE
update help for RunDqlCommand

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -41,7 +41,23 @@ class RunDqlCommand extends AbstractEntityManagerCommand
              ->addOption('max-result', null, InputOption::VALUE_REQUIRED, 'The maximum number of results in the result set.')
              ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Dumping depth of Entity graph.', 7)
              ->addOption('show-sql', null, InputOption::VALUE_NONE, 'Dump generated SQL instead of executing query')
-             ->setHelp('Executes arbitrary DQL directly from the command line.');
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command executes the given DQL query and
+outputs the results:
+
+<info>php %command.full_name% "SELECT u FROM App\Entity\User u"</info>
+
+You can also optional specify some additional options like what type of
+hydration to use when executing the query:
+
+<info>php %command.full_name% "SELECT u FROM App\Entity\User u" --hydrate=array</info>
+
+Additionally you can specify the first result and maximum amount of results to
+show:
+
+<info>php %command.full_name% "SELECT u FROM App\Entity\User u" --first-result=0 --max-result=30</info>
+EOT
+            );
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -41,13 +41,13 @@ class RunDqlCommand extends AbstractEntityManagerCommand
              ->addOption('max-result', null, InputOption::VALUE_REQUIRED, 'The maximum number of results in the result set.')
              ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Dumping depth of Entity graph.', 7)
              ->addOption('show-sql', null, InputOption::VALUE_NONE, 'Dump generated SQL instead of executing query')
-            ->setHelp(<<<'EOT'
+             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command executes the given DQL query and
 outputs the results:
 
 <info>php %command.full_name% "SELECT u FROM App\Entity\User u"</info>
 
-You can also optional specify some additional options like what type of
+You can also optionally specify some additional options like what type of
 hydration to use when executing the query:
 
 <info>php %command.full_name% "SELECT u FROM App\Entity\User u" --hydrate=array</info>
@@ -57,7 +57,7 @@ show:
 
 <info>php %command.full_name% "SELECT u FROM App\Entity\User u" --first-result=0 --max-result=30</info>
 EOT
-            );
+             );
     }
 
     /**


### PR DESCRIPTION
We are in the process of deprecating all commands on DoctrineBundle that are just extending the ORM command classes without adding anymore functionality.

We noticed that for the `RunDqlCommand` the help text on the DoctrineBundle command seems a bit more helpful. 

So I'm proposing to update the help text here with what we have on DoctrineBundle.

See https://github.com/doctrine/DoctrineBundle/pull/1581