### PR TITLE
Support `NOT` expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer-runtime-api": "^2",
         "ext-ctype": "*",
         "doctrine/cache": "^1.12.1 || ^2.1.1",
-        "doctrine/collections": "^1.5 || ^2.0",
+        "doctrine/collections": "^1.5 || ^2.1",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.1 || ^3.2",
         "doctrine/deprecations": "^0.5.3 || ^1",

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -718,6 +718,7 @@ methods:
 
 * ``andX($arg1, $arg2, ...)``
 * ``orX($arg1, $arg2, ...)``
+* ``not($expression)``
 * ``eq($field, $value)``
 * ``gt($field, $value)``
 * ``lt($field, $value)``

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use RuntimeException;
 
+use function defined;
 use function implode;
 use function in_array;
 use function is_object;
@@ -81,6 +82,11 @@ class SqlExpressionVisitor extends ExpressionVisitor
                 return '(' . implode(' OR ', $expressionList) . ')';
 
             default:
+                // Multiversion support for `doctrine/collections` before and after v2.1.0
+                if (defined(CompositeExpression::class . '::TYPE_NOT') && $expr->getType() === CompositeExpression::TYPE_NOT) {
+                    return 'NOT (' . $expressionList[0] . ')';
+                }
+
                 throw new RuntimeException('Unknown composite ' . $expr->getType());
         }
     }

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Expr\Value;
 use RuntimeException;
 
 use function count;
+use function defined;
 use function str_replace;
 use function str_starts_with;
 
@@ -96,6 +97,11 @@ class QueryExpressionVisitor extends ExpressionVisitor
                 return new Expr\Orx($expressionList);
 
             default:
+                // Multiversion support for `doctrine/collections` before and after v2.1.0
+                if (defined(CompositeExpression::class . '::TYPE_NOT') && $expr->getType() === CompositeExpression::TYPE_NOT) {
+                    return $this->expr->not($expressionList[0]);
+                }
+
                 throw new RuntimeException('Unknown composite ' . $expr->getType());
         }
     }

--- a/tests/Doctrine/Tests/ORM/Query/SqlExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SqlExpressionVisitorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query;
+
+use Doctrine\Common\Collections\ExpressionBuilder as CriteriaBuilder;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Persisters\SqlExpressionVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function method_exists;
+
+class SqlExpressionVisitorTest extends TestCase
+{
+    /** @var SqlExpressionVisitor */
+    private $visitor;
+
+    /** @var BasicEntityPersister&MockObject */
+    private $persister;
+    /** @var ClassMetadata */
+    private $classMetadata;
+
+    protected function setUp(): void
+    {
+        $this->persister     = $this->createMock(BasicEntityPersister::class);
+        $this->classMetadata = new ClassMetadata('Dummy');
+        $this->visitor       = new SqlExpressionVisitor($this->persister, $this->classMetadata);
+    }
+
+    public function testWalkNotCompositeExpression(): void
+    {
+        if (! method_exists(CriteriaBuilder::class, 'not')) {
+            self::markTestSkipped('doctrine/collections in version ^2.1 is required for this test to run.');
+        }
+
+        $cb = new CriteriaBuilder();
+
+        $this->persister
+            ->expects(self::once())
+            ->method('getSelectConditionStatementSQL')
+            ->will(self::returnValue('dummy expression'));
+
+        $expr = $this->visitor->walkCompositeExpression(
+            $cb->not(
+                $cb->eq('foo', 1)
+            )
+        );
+
+        self::assertEquals('NOT (dummy expression)', $expr);
+    }
+}


### PR DESCRIPTION
This PR aims at providing support for the `NOT` expression which might to be a part of [`doctrine/collections`](https://github.com/doctrine/collections) in the future.

~It is not mergeable as it references a branch that has not been merged yet into `doctrine/collections` (see [PR #348 on `doctrine/collections`](https://github.com/doctrine/collections/pull/348)) but will be updated as soon as it is.~ `doctrine/collections` `2.1.0` having been released, this PR is now complete.

Given the fact that the `not` expression is already supported by [`Doctrine\ORM\Query\Expr`](https://github.com/doctrine/orm/blob/827cb0c10bd0440b5e1b8ec7f5dc1fc1810f1821/lib/Doctrine/ORM/Query/Expr.php#L323), it is pretty straightforward.