### PR TITLE
Add missing `throws` annotations

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\PersistentCollection;
@@ -190,6 +192,9 @@ interface EntityPersister
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
      *
+     * @throws Exception
+     * @throws ORMException
+     *
      * @todo Check identity map? loadById method? Try to guess whether $criteria is the id?
      */
     public function load(
@@ -209,6 +214,9 @@ interface EntityPersister
      * @psalm-param array<string, mixed> $identifier The entity identifier.
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
+     *
+     * @throws Exception
+     * @throws ORMException
      *
      * @todo Check parameters
      */


### PR DESCRIPTION
This PR is from a discussion we had on Slack.

Basically, the `Repositoru::find()` method might throw an exception. However, it is not in the interface, this PR fix that.

Here's the missing `throws` annotations.

A following PR is incoming for `doctrine/persistence`.