### PR TITLE
Use more precise phpdoc

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -770,6 +770,8 @@ final class Query extends AbstractQuery
      * @param int $lockMode
      * @psalm-param LockMode::* $lockMode
      *
+     * @return $this
+     *
      * @throws TransactionRequiredException
      */
     public function setLockMode($lockMode): self


### PR DESCRIPTION
Will solve https://github.com/phpstan/phpstan-doctrine/issues/393

```
@return $this
```
is more precise than self.

@greg0ire should I target 2.14 ?