### PR TITLE
[BC Break] Validate *-to-one relations with subclasses

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -49,6 +49,7 @@ class SchemaValidatorTest extends OrmTestCase
                  ->addPaths([$path]);
 
         self::assertEmpty($this->validator->validateMapping());
+        self::assertEmpty($this->validator->validateToOneRelations());
     }
 
     public function modelSetProvider(): array


### PR DESCRIPTION
Another way to fix an issue #10236 is to validate these *-to-one with inheritance classes
Target: 3.0