### PR TITLE
Upgrade to Psalm v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "vimeo/psalm": "4.30.0"
+        "vimeo/psalm": "4.30.0 || 5.0.0-rc1"
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >= 2.0"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+<files psalm-version="5.0.0-rc1@8f39de9001c995eb203cee3399307570f322076a">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
     <DeprecatedClass occurrences="1">
       <code>IterableResult</code>
@@ -107,9 +107,9 @@
     <PossiblyNullReference occurrences="1">
       <code>getCacheLogger</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantCondition occurrences="1">
       <code>assert($cm instanceof ClassMetadata)</code>
-    </RedundantConditionGivenDocblockType>
+    </RedundantCondition>
     <UndefinedInterfaceMethod occurrences="5">
       <code>getCacheRegion</code>
       <code>resolveAssociationEntries</code>
@@ -258,6 +258,12 @@
       <code>transactional</code>
       <code>transactional</code>
     </DeprecatedMethod>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;wrapped-&gt;getClassMetadata($className)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>getClassMetadata</code>
+    </InvalidReturnType>
     <MissingParamType occurrences="3">
       <code>$entity</code>
       <code>$lockMode</code>
@@ -315,12 +321,13 @@
     <MissingReturnType occurrences="1">
       <code>wrapInTransaction</code>
     </MissingReturnType>
-    <ParamNameMismatch occurrences="6">
+    <ParamNameMismatch occurrences="7">
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
+      <code>$entityName</code>
       <code>$entityName</code>
     </ParamNameMismatch>
     <PossiblyNullArgument occurrences="2">
@@ -337,7 +344,8 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $hydrationMode</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition occurrences="2">
+      <code>$repository instanceof EntityRepository</code>
       <code>is_object($connection)</code>
     </RedundantCondition>
     <TypeDoesNotContainType occurrences="1">
@@ -378,6 +386,12 @@
       <code>$entity</code>
     </PossiblyNullArgument>
   </file>
+  <file src="lib/Doctrine/ORM/Id/SequenceGenerator.php">
+    <MethodSignatureMustProvideReturnType occurrences="2">
+      <code>serialize</code>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Id/TableGenerator.php">
     <PossiblyFalseOperand occurrences="3">
       <code>$currentLevel</code>
@@ -404,7 +418,8 @@
       <code>$class-&gt;associationMappings[$fieldName]['joinColumns']</code>
       <code>$class-&gt;associationMappings[$fieldName]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation occurrences="2">
+      <code>return $rowData;</code>
       <code>return $rowData;</code>
     </ReferenceConstraintViolation>
   </file>
@@ -422,11 +437,21 @@
     <ReferenceConstraintViolation occurrences="1">
       <code>$result</code>
     </ReferenceConstraintViolation>
+    <ReferenceReusedFromConfusingScope occurrences="1">
+      <code>$baseElement</code>
+    </ReferenceReusedFromConfusingScope>
+    <UnsupportedReferenceUsage occurrences="2">
+      <code>$baseElement =&amp; $this-&gt;_resultPointers[$parent][key($first)]</code>
+      <code>$this-&gt;_resultPointers[$dqlAlias] =&amp; $coll[key($coll)]</code>
+    </UnsupportedReferenceUsage>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/IterableResult.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>mixed[]|false</code>
     </ImplementedReturnTypeMismatch>
+    <MissingTemplateParam occurrences="1">
+      <code>Iterator</code>
+    </MissingTemplateParam>
     <PossiblyFalsePropertyAssignmentValue occurrences="2">
       <code>$this-&gt;_hydrator-&gt;hydrateRow()</code>
       <code>$this-&gt;next()</code>
@@ -448,8 +473,7 @@
       <code>$parentObject</code>
       <code>$parentObject</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="2">
-      <code>$objectClass</code>
+    <PossiblyNullArgument occurrences="1">
       <code>$relation['mappedBy']</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayOffset occurrences="1">
@@ -501,7 +525,6 @@
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadata.php">
     <PropertyNotSetInConstructor occurrences="4">
-      <code>ClassMetadata</code>
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
       <code>ClassMetadata</code>
@@ -586,8 +609,9 @@
       <code>ReflectionProperty</code>
       <code>getAssociationMappedByTargetField</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="2">
+    <InvalidPropertyAssignmentValue occurrences="3">
       <code>$definition</code>
+      <code>$this-&gt;sqlResultSetMappings</code>
       <code>$this-&gt;subClasses</code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement occurrences="1">
@@ -602,6 +626,9 @@
       <code>$className</code>
       <code>$this-&gt;namespace . '\\' . $className</code>
     </LessSpecificReturnStatement>
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingReturnType occurrences="3">
       <code>_validateAndCompleteAssociationMapping</code>
       <code>_validateAndCompleteManyToManyMapping</code>
@@ -663,13 +690,12 @@
       <code>$table</code>
       <code>$tableGeneratorDefinition</code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="12">
+    <PropertyTypeCoercion occurrences="11">
       <code>$this-&gt;associationMappings</code>
       <code>$this-&gt;associationMappings</code>
       <code>$this-&gt;entityListeners</code>
       <code>$this-&gt;fieldMappings</code>
       <code>$this-&gt;fullyQualifiedClassName($repositoryClassName)</code>
-      <code>$this-&gt;sqlResultSetMappings</code>
       <code>$this-&gt;table</code>
       <code>$this-&gt;table</code>
       <code>$this-&gt;table</code>
@@ -729,9 +755,6 @@
       <code>addNamedNativeQuery</code>
       <code>addNamedQuery</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="1">
-      <code>new ReflectionClass($metadata-&gt;name)</code>
-    </DocblockTypeContradiction>
     <LessSpecificReturnStatement occurrences="1">
       <code>$mapping</code>
     </LessSpecificReturnStatement>
@@ -746,9 +769,12 @@
       <code>$primaryTable['indexes']</code>
       <code>$primaryTable['uniqueConstraints']</code>
     </PossiblyUndefinedArrayOffset>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantCondition occurrences="1">
       <code>$metadata-&gt;getReflectionClass()</code>
-    </RedundantConditionGivenDocblockType>
+    </RedundantCondition>
+    <TypeDoesNotContainNull occurrences="1">
+      <code>new ReflectionClass($metadata-&gt;name)</code>
+    </TypeDoesNotContainNull>
     <UndefinedInterfaceMethod occurrences="5">
       <code>mapEmbedded</code>
       <code>mapManyToMany</code>
@@ -758,9 +784,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>new ReflectionClass($metadata-&gt;name)</code>
-    </DocblockTypeContradiction>
     <InvalidArrayAccess occurrences="4">
       <code>$value[0]</code>
       <code>$value[0]</code>
@@ -777,15 +800,18 @@
     <PossiblyNullArgument occurrences="1">
       <code>$listenerClassName</code>
     </PossiblyNullArgument>
-    <RedundantCondition occurrences="3">
+    <RedundantCondition occurrences="4">
+      <code>$metadata-&gt;getReflectionClass()</code>
       <code>assert($method instanceof ReflectionMethod)</code>
       <code>assert($method instanceof ReflectionMethod)</code>
       <code>assert($property instanceof ReflectionProperty)</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$metadata-&gt;getReflectionClass()</code>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>assert($cacheAttribute instanceof Mapping\Cache)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainNull occurrences="1">
+      <code>new ReflectionClass($metadata-&gt;name)</code>
+    </TypeDoesNotContainNull>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">
     <DocblockTypeContradiction occurrences="1">
@@ -841,11 +867,6 @@
       <code>addNamedNativeQuery</code>
       <code>addNamedQuery</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="3">
-      <code>$xmlRoot-&gt;getName() === 'embeddable'</code>
-      <code>$xmlRoot-&gt;getName() === 'entity'</code>
-      <code>$xmlRoot-&gt;getName() === 'mapped-superclass'</code>
-    </DocblockTypeContradiction>
     <InvalidArgument occurrences="4">
       <code>$this-&gt;cacheToArray($manyToManyElement-&gt;cache)</code>
       <code>$this-&gt;cacheToArray($manyToOneElement-&gt;cache)</code>
@@ -855,6 +876,10 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$metadata-&gt;table</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$mapping</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1"/>
     <LessSpecificReturnStatement occurrences="1"/>
     <MissingParamType occurrences="2">
       <code>$fileExtension</code>
@@ -866,15 +891,19 @@
     <MoreSpecificReturnType occurrences="1">
       <code>array{usage: int|null, region?: string}</code>
     </MoreSpecificReturnType>
-    <NoInterfaceProperties occurrences="2">
+    <NoInterfaceProperties occurrences="4">
       <code>$indexXml-&gt;options</code>
       <code>$uniqueXml-&gt;options</code>
+      <code>$xmlRoot-&gt;{'discriminator-column'}</code>
+      <code>$xmlRoot-&gt;{'discriminator-map'}</code>
     </NoInterfaceProperties>
-    <PossiblyInvalidPropertyFetch occurrences="2">
+    <PossiblyInvalidPropertyFetch occurrences="4">
       <code>$indexXml-&gt;options</code>
       <code>$uniqueXml-&gt;options</code>
+      <code>$xmlRoot-&gt;{'discriminator-column'}</code>
+      <code>$xmlRoot-&gt;{'discriminator-map'}</code>
     </PossiblyInvalidPropertyFetch>
-    <RedundantCondition occurrences="19">
+    <RedundantCondition occurrences="17">
       <code>isset($xmlRoot-&gt;cache)</code>
       <code>isset($xmlRoot-&gt;embedded)</code>
       <code>isset($xmlRoot-&gt;field)</code>
@@ -882,8 +911,6 @@
       <code>isset($xmlRoot-&gt;options)</code>
       <code>isset($xmlRoot-&gt;{'association-overrides'})</code>
       <code>isset($xmlRoot-&gt;{'attribute-overrides'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-column'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-map'})</code>
       <code>isset($xmlRoot-&gt;{'entity-listeners'})</code>
       <code>isset($xmlRoot-&gt;{'lifecycle-callbacks'})</code>
       <code>isset($xmlRoot-&gt;{'many-to-many'})</code>
@@ -895,6 +922,11 @@
       <code>isset($xmlRoot-&gt;{'sql-result-set-mappings'})</code>
       <code>isset($xmlRoot-&gt;{'unique-constraints'})</code>
     </RedundantCondition>
+    <TypeDoesNotContainType occurrences="3">
+      <code>$xmlRoot-&gt;getName() === 'embeddable'</code>
+      <code>$xmlRoot-&gt;getName() === 'entity'</code>
+      <code>$xmlRoot-&gt;getName() === 'mapped-superclass'</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php">
     <DeprecatedMethod occurrences="2">
@@ -1032,9 +1064,25 @@
       <code>$object</code>
       <code>$value</code>
     </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ReflectionEmbeddedProperty</code>
+      <code>ReflectionEmbeddedProperty</code>
+    </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $embeddedClass</code>
     </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ReflectionEnumProperty</code>
+      <code>ReflectionEnumProperty</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ReflectionReadonlyProperty</code>
+      <code>ReflectionReadonlyProperty</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/SequenceGenerator.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">
@@ -1062,8 +1110,9 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/PersistentCollection.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch occurrences="3">
       <code>Collection&lt;TKey, T&gt;</code>
+      <code>object|null</code>
       <code>object|null</code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnStatement occurrences="2">
@@ -1072,7 +1121,8 @@
     <MissingParamType occurrences="1">
       <code>$offset</code>
     </MissingParamType>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch occurrences="2">
+      <code>$value</code>
       <code>$value</code>
     </ParamNameMismatch>
     <PossiblyNullArgument occurrences="5">
@@ -1160,7 +1210,7 @@
       <code>$mapping['targetEntity']</code>
       <code>$owner</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="36">
+    <PossiblyNullArrayAccess occurrences="42">
       <code>$mapping['indexBy']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
@@ -1173,6 +1223,10 @@
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
+      <code>$mapping['joinTable']['inverseJoinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
@@ -1180,7 +1234,9 @@
       <code>$mapping['relationToSourceKeyColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns'][$joinTableColumn]</code>
       <code>$mapping['relationToTargetKeyColumns']</code>
+      <code>$mapping['relationToTargetKeyColumns'][$joinTableColumn]</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
@@ -1275,19 +1331,17 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$value === null</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="6">
       <code>$em-&gt;getMetadataFactory()</code>
       <code>$hints</code>
-    </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
-      <code>loadOneToOneEntity</code>
-    </InvalidNullableReturnType>
-    <InvalidScalarArgument occurrences="4">
       <code>$hints</code>
       <code>[Query::HINT_REFRESH =&gt; true]</code>
       <code>[UnitOfWork::HINT_DEFEREAGERLOAD =&gt; true]</code>
       <code>[UnitOfWork::HINT_DEFEREAGERLOAD =&gt; true]</code>
-    </InvalidScalarArgument>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="1">
+      <code>loadOneToOneEntity</code>
+    </InvalidNullableReturnType>
     <LessSpecificReturnStatement occurrences="3">
       <code>$postInsertIds</code>
       <code>[$params, $types]</code>
@@ -1384,6 +1438,11 @@
       <code>$columnList</code>
     </PossiblyUndefinedVariable>
   </file>
+  <file src="lib/Doctrine/ORM/Proxy/Proxy.php">
+    <MissingTemplateParam occurrences="1">
+      <code>BaseProxy</code>
+    </MissingTemplateParam>
+  </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>$classMetadata</code>
@@ -1415,17 +1474,9 @@
     <DeprecatedMethod occurrences="1">
       <code>parent::iterate($parameters, $hydrationMode)</code>
     </DeprecatedMethod>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidArgument occurrences="1">
       <code>$sqlParams</code>
-    </InvalidScalarArgument>
-    <LessSpecificReturnStatement occurrences="2">
-      <code>parent::setHint($name, $value)</code>
-      <code>parent::setHydrationMode($hydrationMode)</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="2">
-      <code>self</code>
-      <code>self</code>
-    </MoreSpecificReturnType>
+    </InvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;getDQL()</code>
     </PossiblyNullArgument>
@@ -1830,6 +1881,11 @@
       <code>$sqlWalker</code>
     </ParamNameMismatch>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Node.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
     <ParamNameMismatch occurrences="1">
       <code>$sqlWalker</code>
@@ -1990,12 +2046,16 @@
     <PossiblyInvalidIterator occurrences="1">
       <code>$this-&gt;_sqlStatements</code>
     </PossiblyInvalidIterator>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>MultiTableUpdateExecutor</code>
       <code>MultiTableUpdateExecutor</code>
     </PropertyNotSetInConstructor>
     <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;_sqlStatements</code>
     </PropertyTypeCoercion>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </UninitializedProperty>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php">
     <PossiblyInvalidArgument occurrences="1">
@@ -2031,10 +2091,33 @@
       <code>$parts</code>
     </NonInvariantDocblockPropertyType>
   </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Base.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Comparison.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Query/Expr/Composite.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <PossiblyInvalidCast occurrences="1">
       <code>$part</code>
     </PossiblyInvalidCast>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/From.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Func.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/GroupBy.php">
     <NonInvariantDocblockPropertyType occurrences="1">
@@ -2042,6 +2125,9 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/Join.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;conditionType</code>
     </PossiblyNullArgument>
@@ -2050,6 +2136,16 @@
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$parts</code>
     </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Math.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/OrderBy.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/Orx.php">
     <NonInvariantDocblockPropertyType occurrences="2">
@@ -2064,6 +2160,9 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Filter/SQLFilter.php">
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingClosureParamType occurrences="1">
       <code>$value</code>
     </MissingClosureParamType>
@@ -2084,6 +2183,9 @@
     <InvalidNullableReturnType occurrences="1">
       <code>SelectStatement|UpdateStatement|DeleteStatement</code>
     </InvalidNullableReturnType>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;queryComponents</code>
+    </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement occurrences="17">
       <code>$aliasIdentVariable</code>
       <code>$factors[0]</code>
@@ -2114,21 +2216,6 @@
       <code>string</code>
       <code>string</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="13">
-      <code>$field</code>
-      <code>$field</code>
-      <code>$functionName</code>
-      <code>$functionName</code>
-      <code>$functionName</code>
-      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
-      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
-      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;lexer-&gt;token['value']</code>
-    </InvalidScalarArgument>
     <InvalidStringClass occurrences="3">
       <code>new $functionClass($functionName)</code>
       <code>new $functionClass($functionName)</code>
@@ -2157,17 +2244,30 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strrpos($fromClassName, '\\')</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="13">
+    <PossiblyInvalidArgument occurrences="26">
       <code>$AST</code>
       <code>$conditionalExpression</code>
       <code>$expr</code>
+      <code>$field</code>
+      <code>$field</code>
+      <code>$functionName</code>
+      <code>$functionName</code>
+      <code>$functionName</code>
       <code>$pathExp</code>
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
       <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$token['value']</code>
       <code>$token['value']</code>
@@ -2291,6 +2391,9 @@
       <code>addNamedNativeQueryResultClassMapping</code>
       <code>addNamedNativeQueryResultSetMapping</code>
     </DeprecatedMethod>
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <PossiblyUndefinedArrayOffset occurrences="3">
       <code>$associationMapping['joinColumns']</code>
       <code>$associationMapping['joinColumns']</code>
@@ -2362,16 +2465,14 @@
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
-    <InvalidScalarArgument occurrences="3">
-      <code>$this-&gt;queryComponents[$expr]['token']['value']</code>
-      <code>$this-&gt;queryComponents[$factor]['token']['value']</code>
-      <code>$this-&gt;queryComponents[$term]['token']['value']</code>
-    </InvalidScalarArgument>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$query</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument occurrences="5">
       <code>$aggExpression-&gt;pathExpression</code>
+      <code>$this-&gt;queryComponents[$expr]['token']['value']</code>
+      <code>$this-&gt;queryComponents[$factor]['token']['value']</code>
+      <code>$this-&gt;queryComponents[$term]['token']['value']</code>
       <code>$whereClause-&gt;conditionalExpression</code>
     </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="8">
@@ -2461,6 +2562,9 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>Parameter|null</code>
     </InvalidFalsableReturnType>
+    <MethodSignatureMustProvideReturnType occurrences="1">
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <PossiblyFalseArgument occurrences="2">
       <code>$spacePos</code>
       <code>$spacePos</code>
@@ -2674,6 +2778,14 @@
       <code>configure</code>
     </MissingReturnType>
   </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/MetadataFilter.php">
+    <InvalidArgument occurrences="1">
+      <code>new ArrayIterator($metadatas)</code>
+    </InvalidArgument>
+    <MissingTemplateParam occurrences="1">
+      <code>MetadataFilter</code>
+    </MissingTemplateParam>
+  </file>
   <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">
     <PossiblyNullArgument occurrences="2">
       <code>$entity</code>
@@ -2690,9 +2802,6 @@
       <code>$this-&gt;getClassToExtend() ?: $metadata-&gt;name</code>
       <code>array_map('strlen', $paramTypes)</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
-      <code>class_exists($metadata-&gt;name)</code>
-    </DocblockTypeContradiction>
     <PossiblyFalseArgument occurrences="2">
       <code>$last</code>
       <code>strrpos($metadata-&gt;name, '\\')</code>
@@ -2781,8 +2890,7 @@
       <code>$associationMapping['joinColumns']</code>
       <code>$associationMapping['orphanRemoval']</code>
     </PossiblyUndefinedArrayOffset>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$metadata-&gt;table</code>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$metadata-&gt;table</code>
     </RedundantConditionGivenDocblockType>
   </file>
@@ -2794,6 +2902,9 @@
     <DeprecatedClass occurrences="1">
       <code>AbstractExporter</code>
     </DeprecatedClass>
+    <InvalidArrayOffset occurrences="1">
+      <code>$field['version']</code>
+    </InvalidArrayOffset>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$_extension</code>
     </NonInvariantDocblockPropertyType>
@@ -2812,8 +2923,7 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$array</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$metadata-&gt;changeTrackingPolicy</code>
     </ArgumentTypeCoercion>
     <DeprecatedClass occurrences="1">
@@ -2822,6 +2932,9 @@
     <DocblockTypeContradiction occurrences="1">
       <code>['name' =&gt; null]</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>$array</code>
+    </InvalidArgument>
     <LessSpecificReturnStatement occurrences="1">
       <code>$array</code>
     </LessSpecificReturnStatement>
@@ -2941,9 +3054,6 @@
       <code>$assoc['orderBy'] !== null</code>
       <code>isset($assoc['orderBy']) &amp;&amp; $assoc['orderBy'] !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>! class_exists($assoc['targetEntity'])</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Setup.php">
     <DeprecatedClass occurrences="2">
@@ -2967,7 +3077,8 @@
       <code>! is_object($object)</code>
       <code>is_object($object)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="2">
+      <code>$collectionToDelete</code>
       <code>$em-&gt;getMetadataFactory()</code>
     </InvalidArgument>
     <InvalidNullableReturnType occurrences="1">
@@ -2982,6 +3093,10 @@
       <code>$prevManagedCopy</code>
       <code>$previousManagedCopy</code>
     </MissingParamType>
+    <NoValue occurrences="2">
+      <code>$entityState</code>
+      <code>$entityState</code>
+    </NoValue>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
     </NullableReturnStatement>
@@ -3055,6 +3170,10 @@
       <code>unwrap</code>
       <code>unwrap</code>
     </PossiblyUndefinedMethod>
+    <RedundantCondition occurrences="2">
+      <code>$i &gt;= 0 &amp;&amp; $this-&gt;entityDeletions</code>
+      <code>$this-&gt;entityDeletions</code>
+    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array($entity)</code>
     </RedundantConditionGivenDocblockType>


### PR DESCRIPTION
It is not stable yet, but should be good enough, and this will help taking care of #10118

Let us baseline all the new issues, just because they are new does not mean they are more important than already-baselined errors. Besides, it is more important to have higher standards for new code than to get an increased baseline.

Here are the errors getting baselined:

```
ERROR: RedundantCondition - lib/Doctrine/ORM/Cache/DefaultQueryCache.php:264:9 - Type Doctrine\ORM\Mapping\ClassMetadata<object> for $cm is always Doctrine\ORM\Mapping\ClassMetadata (see https://psalm.dev/122)
        assert($cm instanceof ClassMetadata);


ERROR: InvalidReturnType - lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php:64:21 - The declared return type 'Doctrine\ORM\Mapping\ClassMetadata<T:fn-doctrine\orm\entitymanagerinterface::getclassmetadata as object>' for Doctrine\ORM\Decorator\EntityManagerDecorator::getClassMetadata is incorrect, got 'Doctrine\ORM\Mapping\ClassMetadata<object>' (see https://psalm.dev/011)
    public function getClassMetadata($className)


ERROR: InvalidReturnStatement - lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php:66:16 - The inferred type 'Doctrine\ORM\Mapping\ClassMetadata<object>' does not match the declared return type 'Doctrine\ORM\Mapping\ClassMetadata<T:fn-doctrine\orm\entitymanagerinterface::getclassmetadata as object>' for Doctrine\ORM\Decorator\EntityManagerDecorator::getClassMetadata (see https://psalm.dev/128)
        return $this->wrapped->getClassMetadata($className);


ERROR: ParamNameMismatch - lib/Doctrine/ORM/EntityManager.php:802:35 - Argument 1 of Doctrine\ORM\EntityManager::getRepository has wrong name $entityName, expecting $className as defined by Doctrine\Persistence\ObjectManager::getRepository (see https://psalm.dev/230)
    public function getRepository($entityName)


ERROR: RedundantCondition - lib/Doctrine/ORM/EntityManager.php:822:15 - Doctrine\Persistence\ObjectRepository<T:fn-doctrine\orm\entitymanager::getrepository as object> cannot be identical to Doctrine\ORM\EntityRepository (see https://psalm.dev/122)
        if (! $repository instanceof EntityRepository) {


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Id/SequenceGenerator.php:97:21 - Method Doctrine\ORM\Id\SequenceGenerator::serialize must have a return type signature! (see https://psalm.dev/282)
    public function serialize()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Id/SequenceGenerator.php:118:21 - Method Doctrine\ORM\Id\SequenceGenerator::unserialize must have a return type signature! (see https://psalm.dev/282)
    public function unserialize($serialized)


ERROR: ReferenceConstraintViolation - lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php:484:9 - Variable $nonemptyComponents is limited to values of type array<string, bool> because it is passed by reference, array<array-key, bool> type found. Use @param-out to specify a different output type (see https://psalm.dev/086)
        return $rowData;


ERROR: UnsupportedReferenceUsage - lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php:97:21 - This reference cannot be analyzed by Psalm (see https://psalm.dev/312)
                    $baseElement =& $this->_resultPointers[$parent][key($first)];


ERROR: ReferenceReusedFromConfusingScope - lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php:97:21 - $baseElement is possibly a reference defined at lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php:97:21. Reusing this variable may cause the referenced value to change. (see https://psalm.dev/308)
                    $baseElement =& $this->_resultPointers[$parent][key($first)];


ERROR: UnsupportedReferenceUsage - lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php:278:9 - This reference cannot be analyzed by Psalm (see https://psalm.dev/312)
        $this->_resultPointers[$dqlAlias] =& $coll[key($coll)];


ERROR: MissingTemplateParam - lib/Doctrine/ORM/Internal/Hydration/IterableResult.php:16:33 - Doctrine\ORM\Internal\Hydration\IterableResult has missing template params when extending Iterator, expecting 2 (see https://psalm.dev/182)
class IterableResult implements Iterator


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:944:21 - Method Doctrine\ORM\Mapping\ClassMetadataInfo::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: InvalidPropertyAssignmentValue - lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:2995:9 - $this->sqlResultSetMappings with declared type 'array<string, array{columns: array<array-key, mixed>, entities: array<array-key, mixed>, name: string}>' cannot be assigned type 'non-empty-array<array-key, array{entities: array<array-key, mixed>|mixed, name: mixed|string, ...<string, mixed>}>' (see https://psalm.dev/145)
        $this->sqlResultSetMappings[$resultMapping['name']] = $resultMapping;


ERROR: RedundantCondition - lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php:80:18 - Type ReflectionClass<T:Doctrine\ORM\Mapping\ClassMetadata as object> for $<tmp coalesce var>2110 is never null (see https://psalm.dev/122)
        $class = $metadata->getReflectionClass()


ERROR: TypeDoesNotContainNull - lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php:83:16 - Cannot resolve types for $<tmp coalesce var>2110 - ReflectionClass<T> does not contain null (see https://psalm.dev/090)
            ?? new ReflectionClass($metadata->name);


ERROR: RedundantCondition - lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php:109:28 - Type ReflectionClass<T:Doctrine\ORM\Mapping\ClassMetadata as object> for $<tmp coalesce var>2791 is never null (see https://psalm.dev/122)
        $reflectionClass = $metadata->getReflectionClass()


ERROR: TypeDoesNotContainNull - lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php:112:16 - Cannot resolve types for $<tmp coalesce var>2791 - ReflectionClass<T> does not contain null (see https://psalm.dev/090)
            ?? new ReflectionClass($metadata->name);


ERROR: TypeDoesNotContainType - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:94:13 - 'entity' cannot be identical to class-string (see https://psalm.dev/056)
        if ($xmlRoot->getName() === 'entity') {


ERROR: TypeDoesNotContainType - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:102:19 - 'mapped-superclass' cannot be identical to class-string (see https://psalm.dev/056)
        } elseif ($xmlRoot->getName() === 'mapped-superclass') {


ERROR: TypeDoesNotContainType - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:107:19 - 'embeddable' cannot be identical to class-string (see https://psalm.dev/056)
        } elseif ($xmlRoot->getName() === 'embeddable') {


ERROR: NoInterfaceProperties - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:205:27 - Interfaces cannot have properties (see https://psalm.dev/028)
                if (isset($xmlRoot->{'discriminator-column'})) {


ERROR: PossiblyInvalidPropertyFetch - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:205:27 - Cannot fetch property on possible non-object $xmlRoot of type non-empty-array<array-key, mixed> (see https://psalm.dev/114)
                if (isset($xmlRoot->{'discriminator-column'})) {


ERROR: NoInterfaceProperties - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:220:27 - Interfaces cannot have properties (see https://psalm.dev/028)
                if (isset($xmlRoot->{'discriminator-map'})) {


ERROR: PossiblyInvalidPropertyFetch - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:220:27 - Cannot fetch property on possible non-object $xmlRoot of type array{'inheritance-type': mixed, ...<array-key, mixed>} (see https://psalm.dev/114)
                if (isset($xmlRoot->{'discriminator-map'})) {


ERROR: InvalidReturnType - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:848:23 - The declared return type 'array{columnDefinition?: string, columnName?: string, enumType?: string, fieldName: string, length?: int, notInsertable?: bool, notUpdatable?: bool, nullable?: bool, options?: array<array-key, mixed>, precision?: int, scale?: int, type?: string, unique?: bool, version?: bool}' for Doctrine\ORM\Mapping\Driver\XmlDriver::columnToArray is incorrect, got 'array{columnDefinition?: string, columnName?: string, enumType?: string, fieldName: string, generated?: mixed, length?: int, notInsertable?: true, notUpdatable?: true, nullable?: bool, options?: array<int|string, array<int|string, mixed|string>|bool|string>, precision?: int, scale?: int, type?: string, unique?: bool, version?: bool}' (see https://psalm.dev/011)
      * @psalm-return array{
      *                   fieldName: string,
      *                   type?: string,
      *                   columnName?: string,
      *                   length?: int,
      *                   precision?: int,
      *                   scale?: int,
      *                   unique?: bool,
      *                   nullable?: bool,
      *                   notInsertable?: bool,
      *                   notUpdatable?: bool,
      *                   enumType?: string,
      *                   version?: bool,
      *                   columnDefinition?: string,
      *                   options?: array
      *               }


ERROR: InvalidReturnStatement - lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php:927:16 - The inferred type 'array{columnDefinition?: string, columnName?: string, enumType?: string, fieldName: string, generated?: mixed, length?: int, notInsertable?: true, notUpdatable?: true, nullable?: bool, options?: array<int|string, array<int|string, mixed|string>|bool|string>, precision?: int, scale?: int, type?: string, unique?: bool, version?: bool}' does not match the declared return type 'array{columnDefinition?: string, columnName?: string, enumType?: string, fieldName: string, length?: int, notInsertable?: bool, notUpdatable?: bool, nullable?: bool, options?: array<array-key, mixed>, precision?: int, scale?: int, type?: string, unique?: bool, version?: bool}' for Doctrine\ORM\Mapping\Driver\XmlDriver::columnToArray (see https://psalm.dev/128)
        return $mapping;


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php:20:7 - Property Doctrine\ORM\Mapping\ReflectionEmbeddedProperty::$name is not defined in constructor of Doctrine\ORM\Mapping\ReflectionEmbeddedProperty or in any private or final methods called in the constructor (see https://psalm.dev/074)
class ReflectionEmbeddedProperty extends ReflectionProperty


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php:20:7 - Property Doctrine\ORM\Mapping\ReflectionEmbeddedProperty::$class is not defined in constructor of Doctrine\ORM\Mapping\ReflectionEmbeddedProperty or in any private or final methods called in the constructor (see https://psalm.dev/074)
class ReflectionEmbeddedProperty extends ReflectionProperty


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php:16:7 - Property Doctrine\ORM\Mapping\ReflectionEnumProperty::$name is not defined in constructor of Doctrine\ORM\Mapping\ReflectionEnumProperty or in any private or final methods called in the constructor (see https://psalm.dev/074)
class ReflectionEnumProperty extends ReflectionProperty


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php:16:7 - Property Doctrine\ORM\Mapping\ReflectionEnumProperty::$class is not defined in constructor of Doctrine\ORM\Mapping\ReflectionEnumProperty or in any private or final methods called in the constructor (see https://psalm.dev/074)
class ReflectionEnumProperty extends ReflectionProperty


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php:18:13 - Property Doctrine\ORM\Mapping\ReflectionReadonlyProperty::$name is not defined in constructor of Doctrine\ORM\Mapping\ReflectionReadonlyProperty or in any methods called in the constructor (see https://psalm.dev/074)
final class ReflectionReadonlyProperty extends ReflectionProperty


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php:18:13 - Property Doctrine\ORM\Mapping\ReflectionReadonlyProperty::$class is not defined in constructor of Doctrine\ORM\Mapping\ReflectionReadonlyProperty or in any methods called in the constructor (see https://psalm.dev/074)
final class ReflectionReadonlyProperty extends ReflectionProperty


ERROR: ParamNameMismatch - lib/Doctrine/ORM/PersistentCollection.php:458:25 - Argument 1 of Doctrine\ORM\PersistentCollection::add has wrong name $value, expecting $element as defined by Doctrine\Common\Collections\AbstractLazyCollection::add (see https://psalm.dev/230)
    public function add($value): bool


ERROR: ImplementedReturnTypeMismatch - lib/Doctrine/ORM/PersistentCollection.php:507:16 - The inherited return type 'null' for Doctrine\Common\Collections\AbstractLazyCollection::offsetUnset is different to the implemented return type for Doctrine\ORM\PersistentCollection::offsetunset 'null|object' (see https://psalm.dev/123)
     * @return object|null


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:44:18 - Cannot access array value on possibly null variable $mapping['joinTable'] of type mixed|null (see https://psalm.dev/079)
        foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:429:18 - Cannot access array value on possibly null variable $mapping['joinTable'] of type mixed|null (see https://psalm.dev/079)
        foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:477:18 - Cannot access array value on possibly null variable $mapping['joinTable'] of type mixed|null (see https://psalm.dev/079)
        foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:548:69 - Cannot access array value on possibly null variable $mapping['relationToSourceKeyColumns'] of type mixed|null (see https://psalm.dev/079)
                $params[] = $identifier1[$class1->getFieldForColumn($mapping['relationToSourceKeyColumns'][$joinTableColumn])];


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:553:65 - Cannot access array value on possibly null variable $mapping['relationToTargetKeyColumns'] of type mixed|null (see https://psalm.dev/079)
            $params[] = $identifier2[$class2->getFieldForColumn($mapping['relationToTargetKeyColumns'][$joinTableColumn])];


ERROR: PossiblyNullArrayAccess - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:589:39 - Cannot access array value on possibly null variable $mapping['joinTable'] of type mixed|null (see https://psalm.dev/079)
            $joinColumns            = $mapping['joinTable']['inverseJoinColumns'];


ERROR: InvalidArgument - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:841:75 - Argument 3 of Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateAll expects array<string, string>, but array{'doctrine.refresh': true} provided (see https://psalm.dev/004)
        $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [Query::HINT_REFRESH => true]);


ERROR: InvalidArgument - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:873:82 - Argument 3 of Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateAll expects array<string, string>, but array{deferEagerLoad: true} provided (see https://psalm.dev/004)
        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);


ERROR: InvalidArgument - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:920:82 - Argument 3 of Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateAll expects array<string, string>, but array{deferEagerLoad: true} provided (see https://psalm.dev/004)
        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);


ERROR: InvalidArgument - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:978:87 - Argument 3 of Doctrine\ORM\Internal\Hydration\AbstractHydrator::hydrateAll expects array<string, string>, but array{collection: Doctrine\ORM\PersistentCollection<array-key, mixed>, deferEagerLoad: true} provided (see https://psalm.dev/004)
        return $this->em->newHydrator(Query::HYDRATE_OBJECT)->hydrateAll($stmt, $rsm, $hints);


ERROR: MissingTemplateParam - lib/Doctrine/ORM/Proxy/Proxy.php:12:25 - Doctrine\ORM\Proxy\Proxy has missing template params when extending Doctrine\Common\Proxy\Proxy, expecting 1 (see https://psalm.dev/182)
interface Proxy extends BaseProxy


ERROR: InvalidArgument - lib/Doctrine/ORM/Query.php:320:13 - Argument 2 of Doctrine\ORM\Query::evictResultSetCache expects array<string, mixed>, but list<mixed> provided (see https://psalm.dev/004)
            $sqlParams,


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/AST/Node.php:46:21 - Method Doctrine\ORM\Query\AST\Node::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: PropertyNotSetInConstructor - lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php:25:7 - Property Doctrine\ORM\Query\Exec\MultiTableUpdateExecutor::$queryCacheProfile is not defined in constructor of Doctrine\ORM\Query\Exec\MultiTableUpdateExecutor or in any private or final methods called in the constructor (see https://psalm.dev/074)
class MultiTableUpdateExecutor extends AbstractSqlExecutor


ERROR: UninitializedProperty - lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php:122:17 - Cannot use uninitialized property $this->_sqlStatements (see https://psalm.dev/186)
                $this->_sqlStatements[$i] = $updateSql . ' WHERE (' . $idColumnList . ') IN (' . $idSubselect . ')';


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Base.php:95:21 - Method Doctrine\ORM\Query\Expr\Base::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Comparison.php:63:21 - Method Doctrine\ORM\Query\Expr\Comparison::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Composite.php:19:21 - Method Doctrine\ORM\Query\Expr\Composite::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/From.php:54:21 - Method Doctrine\ORM\Query\Expr\From::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Func.php:48:21 - Method Doctrine\ORM\Query\Expr\Func::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Join.php:109:21 - Method Doctrine\ORM\Query\Expr\Join::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/Math.php:56:21 - Method Doctrine\ORM\Query\Expr\Math::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Expr/OrderBy.php:71:21 - Method Doctrine\ORM\Query\Expr\OrderBy::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/Filter/SQLFilter.php:176:27 - Method Doctrine\ORM\Query\Filter\SQLFilter::__toString must have a return type signature! (see https://psalm.dev/282)
    final public function __toString()


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:362:32 - Argument 1 of Doctrine\ORM\Query\Parser::syntaxError expects string, but possibly different type int|string provided (see https://psalm.dev/092)
            $this->syntaxError($this->lexer->getLiteral($token));


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:367:32 - Argument 1 of Doctrine\ORM\Query\Parser::syntaxError expects string, but possibly different type int|string provided (see https://psalm.dev/092)
            $this->syntaxError($this->lexer->getLiteral($token));


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:372:32 - Argument 1 of Doctrine\ORM\Query\Parser::syntaxError expects string, but possibly different type int|string provided (see https://psalm.dev/092)
            $this->syntaxError($this->lexer->getLiteral($token));


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:1129:70 - Argument 2 of Doctrine\ORM\Query\AST\JoinAssociationPathExpression::__construct expects string, but possibly different type int|string provided (see https://psalm.dev/092)
        return new AST\JoinAssociationPathExpression($identVariable, $field);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:1162:76 - Argument 3 of Doctrine\ORM\Query\AST\PathExpression::__construct expects null|string, but possibly different type int|null|string provided (see https://psalm.dev/092)
        $pathExpr = new AST\PathExpression($expectedTypes, $identVariable, $field);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:1641:43 - Argument 1 of Doctrine\ORM\Query\AST\InputParameter::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
            return new AST\InputParameter($this->lexer->token['value']);


ERROR: InvalidPropertyAssignmentValue - lib/Doctrine/ORM/Query/Parser.php:2464:13 - $this->queryComponents with declared type 'array<string, array{map?: null|string, metadata?: Doctrine\ORM\Mapping\ClassMetadata<object>, nestingLevel: int, parent?: null|string, relation?: array<array-key, mixed>|null, resultVariable?: Doctrine\ORM\Query\AST\Node|string, token: array{position: int, type: int|null|string, value: int|string}}>' cannot be assigned type 'non-empty-array<string, array{map?: null|string, metadata?: Doctrine\ORM\Mapping\ClassMetadata<object>, nestingLevel: int, parent?: null|string, relation?: array<array-key, mixed>|null, resultVariable?: Doctrine\ORM\Query\AST\Node|string, resultvariable?: Doctrine\ORM\Query\AST\SimpleSelectExpression, token: array{position: int, type: int|null|string, value: int|string}}>' (see https://psalm.dev/145)
            $this->queryComponents[$resultVariable] = [


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:2811:39 - Argument 1 of Doctrine\ORM\Query\AST\InputParameter::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
        return new AST\InputParameter($this->lexer->token['value']);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3111:44 - Argument 1 of Doctrine\ORM\Query\AST\AggregateExpression::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
        return new AST\AggregateExpression($functionName, $pathExp, $isDistinct);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3273:43 - Argument 1 of Doctrine\ORM\Query\AST\InputParameter::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
            return new AST\InputParameter($this->lexer->token['value']);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3302:53 - Argument 1 of Doctrine\ORM\Query\AST\InputParameter::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
            $stringPattern = new AST\InputParameter($this->lexer->token['value']);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3333:48 - Argument 1 of Doctrine\ORM\Query\AST\InputParameter::__construct expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
                $expr = new AST\InputParameter($this->lexer->token['value']);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3596:83 - Argument 1 of Doctrine\ORM\Configuration::getCustomDatetimeFunction expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
        $functionClass = $this->em->getConfiguration()->getCustomDatetimeFunction($functionName);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/Parser.php:3636:81 - Argument 1 of Doctrine\ORM\Configuration::getCustomStringFunction expects string, but possibly different type int|null|string provided (see https://psalm.dev/092)
        $functionClass = $this->em->getConfiguration()->getCustomStringFunction($functionName);


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php:491:21 - Method Doctrine\ORM\Query\ResultSetMappingBuilder::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/SqlWalker.php:1199:41 - Argument 1 of Doctrine\ORM\Query\SqlWalker::walkResultVariable expects string, but possibly different type int|string provided (see https://psalm.dev/092)
            : $this->walkResultVariable($this->queryComponents[$expr]['token']['value']);


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/SqlWalker.php:2455:45 - Argument 1 of Doctrine\ORM\Query\SqlWalker::walkResultVariable expects string, but possibly different type int|string provided (see https://psalm.dev/092)
                ? $this->walkResultVariable($this->queryComponents[$term]['token']['value'])


ERROR: PossiblyInvalidArgument - lib/Doctrine/ORM/Query/SqlWalker.php:2479:45 - Argument 1 of Doctrine\ORM\Query\SqlWalker::walkResultVariable expects string, but possibly different type int|string provided (see https://psalm.dev/092)
                ? $this->walkResultVariable($this->queryComponents[$factor]['token']['value'])


ERROR: MethodSignatureMustProvideReturnType - lib/Doctrine/ORM/QueryBuilder.php:1536:21 - Method Doctrine\ORM\QueryBuilder::__toString must have a return type signature! (see https://psalm.dev/282)
    public function __toString()


ERROR: MissingTemplateParam - lib/Doctrine/ORM/Tools/Console/MetadataFilter.php:25:7 - Doctrine\ORM\Tools\Console\MetadataFilter has missing template params when extending FilterIterator, expecting 3 (see https://psalm.dev/182)
class MetadataFilter extends FilterIterator implements Countable


ERROR: InvalidArgument - lib/Doctrine/ORM/Tools/Console/MetadataFilter.php:40:41 - Argument 1 of Doctrine\ORM\Tools\Console\MetadataFilter::__construct expects ArrayIterator<array-key, mixed>, but ArrayIterator<array-key, Doctrine\Persistence\Mapping\ClassMetadata<object>> provided (see https://psalm.dev/004)
        $metadatas = new MetadataFilter(new ArrayIterator($metadatas), $filter);


ERROR: InvalidArrayOffset - lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php:207:27 - Cannot access value on variable $field using offset value of 'version', expecting 'type', 'fieldName', 'columnName', 'length', 'id', 'nullable', 'notInsertable', 'notUpdatable', 'generated', 'enumType', 'columnDefinition', 'precision', 'scale', 'unique', 'inherited', 'originalClass', 'originalField', 'quoted', 'requireSQLConversion', 'declared', 'declaredField' or 'options' (see https://psalm.dev/115)
                if (isset($field['version'])) {


ERROR: InvalidArgument - lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php:244:57 - Argument 1 of Doctrine\ORM\Tools\Export\Driver\YamlExporter::processEntityListenerConfig expects array{entityListeners: array<class-string, array<string, list{string}>>}, but array{entityListeners: array<class-string, array<string, list{string}>>, ...<string, mixed>} provided (see https://psalm.dev/004)
            $array = $this->processEntityListenerConfig($array, $entityListenerConfig, $event);


ERROR: InvalidArgument - lib/Doctrine/ORM/UnitOfWork.php:425:94 - Argument 1 of Doctrine\ORM\Persisters\Collection\CollectionPersister::delete expects Doctrine\ORM\PersistentCollection<array-key, mixed>, but Doctrine\ORM\PersistentCollection<array-key, object> provided (see https://psalm.dev/004)
                    $this->getCollectionPersister($collectionToDelete->getMapping())->delete($collectionToDelete);


ERROR: RedundantCondition - lib/Doctrine/ORM/UnitOfWork.php:453:69 - Type non-empty-array<int, object> for $this->entityDeletions is never falsy (see https://psalm.dev/122)
                for ($count = count($commitOrder), $i = $count - 1; $i >= 0 && $this->entityDeletions; --$i) {


ERROR: RedundantCondition - lib/Doctrine/ORM/UnitOfWork.php:453:80 - Operand of type non-empty-array<int, object> is always truthy (see https://psalm.dev/122)
                for ($count = count($commitOrder), $i = $count - 1; $i >= 0 && $this->entityDeletions; --$i) {


ERROR: NoValue - lib/Doctrine/ORM/UnitOfWork.php:1846:21 - This function or method call never returns output (see https://psalm.dev/179)
                    $entityState,


ERROR: NoValue - lib/Doctrine/ORM/UnitOfWork.php:1919:21 - This function or method call never returns output (see https://psalm.dev/179)
                    $entityState,


------------------------------
87 errors found
------------------------------
4432 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 68 of these issues.
Run Psalm again with
--alter --issues=InvalidFalsableReturnType,InvalidNullableReturnType,InvalidReturnType,MissingReturnType,MissingParamType --dry-run
to see what it can fix.
```