### PR TITLE
Leverage Lexer's Token type (follow up)

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -551,7 +551,7 @@ class Parser
      * @param bool $resetPeek Reset peek after finding the closing parenthesis.
      *
      * @return mixed[]
-     * @psalm-return array{value: string, type: int|null|string, position: int}|null
+     * @psalm-return Token|null
      */
     private function peekBeyondClosingParenthesis(bool $resetPeek = true): ?array
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2221,15 +2221,11 @@
       <code>new $functionClass($functionName)</code>
       <code>new $functionClass($functionName)</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="4">
+    <LessSpecificReturnStatement occurrences="3">
       <code>$function</code>
       <code>$function</code>
       <code>$function</code>
-      <code>$token</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>array{value: string, type: int|null|string, position: int}|null</code>
-    </MoreSpecificReturnType>
     <NullableReturnStatement occurrences="9">
       <code>$aliasIdentVariable</code>
       <code>$factors[0]</code>
@@ -2286,7 +2282,7 @@
       <code>$this-&gt;query-&gt;getDQL()</code>
       <code>$token['value']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="73">
+    <PossiblyNullArrayAccess occurrences="72">
       <code>$glimpse['type']</code>
       <code>$glimpse['value']</code>
       <code>$lookahead['type']</code>


### PR DESCRIPTION
Follow-up of f82db6a8946ed43bfc9294f6fd90ee81ed8264f6. The previous value introduced in
dc37c2cd2fd22fe8b57ddb1743aa629db98b76e3 was too restrictive, hence the changes to the Psalm baseline.