### PR TITLE
Drop support for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/lexer": "^1.2.3",
         "doctrine/persistence": "^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^4.4 || ^5.4 || ^6.0"
+        "symfony/console": "^5.4 || ^6.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^10.0",
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "^9.5",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.1",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.0",
         "vimeo/psalm": "5.1.0"
     },
     "suggest": {


### PR DESCRIPTION
Symfony 4 is not maintained anymore (except for security fixes). Let's drop it.