### PR TITLE
Bump Psalm to 5.0.0 and fix errors for Symfony 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "vimeo/psalm": "4.30.0 || 5.0.0-rc1"
+        "vimeo/psalm": "4.30.0 || 5.0.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >= 2.0"

--- a/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
@@ -7,8 +7,11 @@ namespace Doctrine\ORM\Tools\Console\Command;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+
+use function assert;
 
 abstract class AbstractEntityManagerCommand extends Command
 {
@@ -33,7 +36,10 @@ abstract class AbstractEntityManagerCommand extends Command
                 $this->getName()
             );
 
-            return $this->getHelper('em')->getEntityManager();
+            $helper = $this->getHelper('em');
+            assert($helper instanceof EntityManagerHelper);
+
+            return $helper->getEntityManager();
         }
 
         return $input->getOption('em') === null

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.0.0-rc1@8f39de9001c995eb203cee3399307570f322076a">
+<files psalm-version="5.0.0@4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
     <DeprecatedClass occurrences="1">
       <code>IterableResult</code>

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
@@ -11,6 +11,9 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function preg_replace;
+use function trim;
+
 /** @group DDC-2183 */
 class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
 {
@@ -80,12 +83,10 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             ['decorated' => false]
         );
 
-        self::assertStringContainsString(
-            ' // Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by',
-            $tester->getDisplay()
+        self::assertSame(
+            'Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by "1"',
+            trim(preg_replace('#\s+//\s#', ' ', $tester->getDisplay()))
         );
-
-        self::assertStringContainsString(' // "1"', $tester->getDisplay());
     }
 
     public function testFlushRegionName(): void


### PR DESCRIPTION
The Symfony 6.2 release breaks our static analysis once again. This PR should fix the issue.