### PR TITLE
Add `$not` constructor parameter to AST classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade to 2.14
 
+## Deprecated `Doctrine\ORM\Query\AST\InExpression`
+
+The AST parser will create a `InListExpression` or a `InSubselectExpression` when
+encountering an `IN ()` DQL expression instead of a generic `InExpression`.
+
+As a consequence, `SqlWalker::walkInExpression()` has been deprecated in favor of
+`SqlWalker::walkInListExpression()` and `SqlWalker::walkInSubselectExpression()`.
+
 ## Deprecated constructing a `CacheKey` without `$hash`
 
 The `Doctrine\ORM\Cache\CacheKey` class has an explicit constructor now with

--- a/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
@@ -23,11 +23,12 @@ class BetweenExpression extends Node
      * @param ArithmeticExpression $leftExpr
      * @param ArithmeticExpression $rightExpr
      */
-    public function __construct($expr, $leftExpr, $rightExpr)
+    public function __construct($expr, $leftExpr, $rightExpr, bool $not = false)
     {
         $this->expression             = $expr;
         $this->leftBetweenExpression  = $leftExpr;
         $this->rightBetweenExpression = $rightExpr;
+        $this->not                    = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
@@ -24,10 +24,11 @@ class CollectionMemberExpression extends Node
      * @param mixed          $entityExpr
      * @param PathExpression $collValuedPathExpr
      */
-    public function __construct($entityExpr, $collValuedPathExpr)
+    public function __construct($entityExpr, $collValuedPathExpr, bool $not = false)
     {
         $this->entityExpression               = $entityExpr;
         $this->collectionValuedPathExpression = $collValuedPathExpr;
+        $this->not                            = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
@@ -18,9 +18,10 @@ class ConditionalFactor extends Node
     public $conditionalPrimary;
 
     /** @param ConditionalPrimary $conditionalPrimary */
-    public function __construct($conditionalPrimary)
+    public function __construct($conditionalPrimary, bool $not = false)
     {
         $this->conditionalPrimary = $conditionalPrimary;
+        $this->not                = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
@@ -18,9 +18,10 @@ class EmptyCollectionComparisonExpression extends Node
     public $not;
 
     /** @param PathExpression $expression */
-    public function __construct($expression)
+    public function __construct($expression, bool $not = false)
     {
         $this->expression = $expression;
+        $this->not        = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
@@ -18,9 +18,10 @@ class ExistsExpression extends Node
     public $subselect;
 
     /** @param Subselect $subselect */
-    public function __construct($subselect)
+    public function __construct($subselect, bool $not = false)
     {
         $this->subselect = $subselect;
+        $this->not       = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * InExpression ::= ArithmeticExpression ["NOT"] "IN" "(" (Literal {"," Literal}* | Subselect) ")"
  *
- * @link    www.doctrine-project.org
+ * @deprecated Use {@see InListExpression} or {@see InSubselectExpression} instead.
  */
 class InExpression extends Node
 {
@@ -26,6 +28,17 @@ class InExpression extends Node
     /** @param ArithmeticExpression $expression */
     public function __construct($expression)
     {
+        if (! $this instanceof InListExpression && ! $this instanceof InSubselectExpression) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10267',
+                '%s is deprecated, use %s or %s instead.',
+                self::class,
+                InListExpression::class,
+                InSubselectExpression::class
+            );
+        }
+
         $this->expression = $expression;
     }
 
@@ -34,6 +47,7 @@ class InExpression extends Node
      */
     public function dispatch($sqlWalker)
     {
+        // We still call the deprecated method in order to not break existing custom SQL walkers.
         return $sqlWalker->walkInExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/InListExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InListExpression.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+class InListExpression extends InExpression
+{
+    /** @var non-empty-list<mixed> */
+    public $literals;
+
+    /** @param non-empty-list<mixed> $literals */
+    public function __construct(ArithmeticExpression $expression, array $literals, bool $not = false)
+    {
+        $this->literals = $literals;
+        $this->not      = $not;
+
+        parent::__construct($expression);
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/InSubselectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InSubselectExpression.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+class InSubselectExpression extends InExpression
+{
+    /** @var Subselect */
+    public $subselect;
+
+    public function __construct(ArithmeticExpression $expression, Subselect $subselect, bool $not = false)
+    {
+        $this->subselect = $subselect;
+        $this->not       = $not;
+
+        parent::__construct($expression);
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\Deprecations\Deprecation;
+
+use function func_num_args;
+
 /**
  * InstanceOfExpression ::= IdentificationVariable ["NOT"] "INSTANCE" ["OF"] (InstanceOfParameter | "(" InstanceOfParameter {"," InstanceOfParameter}* ")")
  * InstanceOfParameter  ::= AbstractSchemaName | InputParameter
@@ -18,13 +22,27 @@ class InstanceOfExpression extends Node
     /** @var string */
     public $identificationVariable;
 
-    /** @var mixed[] */
+    /** @var non-empty-list<InputParameter|string> */
     public $value;
 
-    /** @param string $identVariable */
-    public function __construct($identVariable)
+    /**
+     * @param string                                $identVariable
+     * @param non-empty-list<InputParameter|string> $value
+     */
+    public function __construct($identVariable, array $value = [], bool $not = false)
     {
+        if (func_num_args() < 2) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10267',
+                'Not passing a value for $value to %s() is deprecated.',
+                __METHOD__
+            );
+        }
+
         $this->identificationVariable = $identVariable;
+        $this->value                  = $value;
+        $this->not                    = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/LikeExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/LikeExpression.php
@@ -30,11 +30,12 @@ class LikeExpression extends Node
      * @param InputParameter|FunctionNode|PathExpression|Literal $stringPattern
      * @param Literal|null                                       $escapeChar
      */
-    public function __construct($stringExpression, $stringPattern, $escapeChar = null)
+    public function __construct($stringExpression, $stringPattern, $escapeChar = null, bool $not = false)
     {
         $this->stringExpression = $stringExpression;
         $this->stringPattern    = $stringPattern;
         $this->escapeChar       = $escapeChar;
+        $this->not              = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
@@ -18,9 +18,10 @@ class NullComparisonExpression extends Node
     public $expression;
 
     /** @param Node $expression */
-    public function __construct($expression)
+    public function __construct($expression, bool $not = false)
     {
         $this->expression = $expression;
+        $this->not        = $not;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\QuoteStrategy;
@@ -2207,12 +2208,28 @@ class SqlWalker implements TreeWalker
     /**
      * Walks down an InExpression AST node, thereby generating the appropriate SQL.
      *
+     * @deprecated Use {@see walkInListExpression()} or {@see walkInSubselectExpression()} instead.
+     *
      * @param AST\InExpression $inExpr
      *
      * @return string
      */
     public function walkInExpression($inExpr)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            '%s() is deprecated, call walkInListExpression() or walkInSubselectExpression() instead.',
+            __METHOD__
+        );
+
+        if ($inExpr instanceof AST\InListExpression) {
+            return $this->walkInListExpression($inExpr);
+        }
+
+        if ($inExpr instanceof AST\InSubselectExpression) {
+            return $this->walkInSubselectExpression($inExpr);
+        }
+
         $sql = $this->walkArithmeticExpression($inExpr->expression) . ($inExpr->not ? ' NOT' : '') . ' IN (';
 
         $sql .= $inExpr->subselect
@@ -2222,6 +2239,28 @@ class SqlWalker implements TreeWalker
         $sql .= ')';
 
         return $sql;
+    }
+
+    /**
+     * Walks down an InExpression AST node, thereby generating the appropriate SQL.
+     */
+    public function walkInListExpression(AST\InListExpression $inExpr): string
+    {
+        return $this->walkArithmeticExpression($inExpr->expression)
+            . ($inExpr->not ? ' NOT' : '') . ' IN ('
+            . implode(', ', array_map([$this, 'walkInParameter'], $inExpr->literals))
+            . ')';
+    }
+
+    /**
+     * Walks down an InExpression AST node, thereby generating the appropriate SQL.
+     */
+    public function walkInSubselectExpression(AST\InSubselectExpression $inExpr): string
+    {
+        return $this->walkArithmeticExpression($inExpr->expression)
+            . ($inExpr->not ? ' NOT' : '') . ' IN ('
+            . $this->walkSubselect($inExpr->subselect)
+            . ')';
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Query\AST\ConditionalExpression;
 use Doctrine\ORM\Query\AST\ConditionalFactor;
 use Doctrine\ORM\Query\AST\ConditionalPrimary;
 use Doctrine\ORM\Query\AST\ConditionalTerm;
-use Doctrine\ORM\Query\AST\InExpression;
+use Doctrine\ORM\Query\AST\InListExpression;
 use Doctrine\ORM\Query\AST\InputParameter;
 use Doctrine\ORM\Query\AST\NullComparisonExpression;
 use Doctrine\ORM\Query\AST\PathExpression;
@@ -76,8 +76,10 @@ class WhereInWalker extends TreeWalkerAdapter
             $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
                 [$pathExpression]
             );
-            $expression                                       = new InExpression($arithmeticExpression);
-            $expression->literals[]                           = new InputParameter(':' . self::PAGINATOR_ID_ALIAS);
+            $expression                                       = new InListExpression(
+                $arithmeticExpression,
+                [new InputParameter(':' . self::PAGINATOR_ID_ALIAS)]
+            );
 
             $this->convertWhereInIdentifiersToDatabaseValue(
                 PersisterHelper::getTypeOfField(
@@ -88,8 +90,7 @@ class WhereInWalker extends TreeWalkerAdapter
                 )[0]
             );
         } else {
-            $expression      = new NullComparisonExpression($pathExpression);
-            $expression->not = false;
+            $expression = new NullComparisonExpression($pathExpression);
         }
 
         $conditionalPrimary                              = new ConditionalPrimary();

--- a/phpstan-params.neon
+++ b/phpstan-params.neon
@@ -9,3 +9,7 @@ parameters:
         Doctrine\ORM\Query\Parser:
             - syntaxError
     phpVersion: 80100
+
+    ignoreErrors:
+        # Remove on 3.0.x
+        - '~^Default value of the parameter #2 \$value \(array\{\}\) of method Doctrine\\ORM\\Query\\AST\\InstanceOfExpression\:\:__construct\(\) is incompatible with type non\-empty\-array<int, Doctrine\\ORM\\Query\\AST\\InputParameter\|string>\.$~'

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,7 @@
                 <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs"/>
                 <referencedClass name="Doctrine\ORM\Exception\UnknownEntityNamespace"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
+                <referencedClass name="Doctrine\ORM\Query\AST\InExpression"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand"/>
@@ -85,6 +86,7 @@
                 <referencedMethod name="Doctrine\ORM\Id\AbstractIdGenerator::generate"/>
                 <referencedMethod name="Doctrine\ORM\ORMInvalidArgumentException::invalidEntityName"/>
                 <referencedMethod name="Doctrine\ORM\ORMSetup::createDefaultAnnotationDriver"/>
+                <referencedMethod name="Doctrine\ORM\Query\SqlWalker::walkInExpression"/>
                 <referencedMethod name="Doctrine\ORM\Query\TreeWalkerAdapter::_getQueryComponents"/>
                 <file name="lib/Doctrine/ORM/Query/TreeWalkerChain.php"/>
             </errorLevel>
@@ -119,6 +121,12 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform" />
             </errorLevel>
         </InvalidClass>
+        <InvalidParamDefault>
+            <errorLevel type="suppress">
+                <!-- Remove on 3.0.x -->
+                <file name="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php"/>
+            </errorLevel>
+        </InvalidParamDefault>
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <!-- https://github.com/vimeo/psalm/issues/8819 -->
@@ -147,6 +155,13 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
             </errorLevel>
         </MissingParamType>
+        <NonInvariantDocblockPropertyType>
+            <errorLevel type="suppress">
+                <!-- Remove on 3.0.x -->
+                <file name="lib/Doctrine/ORM/Query/AST/InListExpression.php"/>
+                <file name="lib/Doctrine/ORM/Query/AST/InSubselectExpression.php"/>
+            </errorLevel>
+        </NonInvariantDocblockPropertyType>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <!-- Remove on 3.0.x -->

--- a/tests/Doctrine/Tests/ORM/Query/AST/InExpressionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/AST/InExpressionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query\AST;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Query\AST\ArithmeticExpression;
+use Doctrine\ORM\Query\AST\InExpression;
+use Doctrine\ORM\Query\AST\InListExpression;
+use Doctrine\ORM\Query\AST\InSubselectExpression;
+use Doctrine\ORM\Query\AST\Literal;
+use Doctrine\ORM\Query\AST\Subselect;
+use PHPUnit\Framework\TestCase;
+
+class InExpressionTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testDeprecation(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10267');
+
+        new InExpression(new ArithmeticExpression());
+    }
+
+    public function testNoDeprecations(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10267');
+
+        new InListExpression(new ArithmeticExpression(), [new Literal(Literal::STRING, 'foo')]);
+        new InSubselectExpression(new ArithmeticExpression(), $this->createMock(Subselect::class));
+    }
+}


### PR DESCRIPTION
While reviewing #10219, I noticed the inconsistent typing of negation flags (`$not`) on various AST classes. In most cases, we populate `$someAstExpression->not` right after construction the object. In some cases, we don't assign any value to it, but assume it to be `false` afterwards.

With all those public properties, I think we should aim at making all those classes immutable in 3.0. Adding `$not` to constructors is a first step in that direction. I've also split the `InExpression` class into two classes because it actually covers two distinct cases that we need to distinguish whenever we deal with an instance of that class.