### PR TITLE
Added warning about query cache in relation to parameters

### DIFF
--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -33,6 +33,10 @@ Parameters for the query should be set on the filter object by
 in filters.  The ``SQLFilter#getParameter()`` function takes care of the
 proper quoting of parameters.
 
+.. warning::
+    For the query cache to correctly work the filter must always return the same result from ``SQLFilter#addFilterConstraint()`` for a given set of parameters / values.
+    Do not set parameters inside ``SQLFilter#addFilterConstraint()`` function.
+
 .. code-block:: php
 
     <?php

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -28,14 +28,11 @@ table alias of the SQL table of the entity.
     In the case of joined or single table inheritance, you always get passed the ClassMetadata of the
     inheritance root. This is necessary to avoid edge cases that would break the SQL when applying the filters.
 
-Parameters for the query should be set on the filter object by
-``SQLFilter#setParameter()``. Only parameters set via this function can be used
-in filters.  The ``SQLFilter#getParameter()`` function takes care of the
-proper quoting of parameters.
+For the filter to correctly function the following rules must be followed, failure to do so will lead to unexpected results from the query cache.
+  1. Parameters for the query should be set on the filter object by ``SQLFilter#setParameter()`` before the filter is used by the ORM ( i.e. do not set parameters inside ``SQLFilter#addFilterConstraint()`` function ).
+  2. The filter must be detrimistic. Don't cahange the values base on external inputs.
 
-.. warning::
-    For the query cache to correctly work the filter must always return the same result from ``SQLFilter#addFilterConstraint()`` for a given set of parameters / values.
-    Do not set parameters inside ``SQLFilter#addFilterConstraint()`` function.
+The ``SQLFilter#getParameter()`` function takes care of the proper quoting of parameters.
 
 .. code-block:: php
 

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -30,7 +30,7 @@ table alias of the SQL table of the entity.
 
 For the filter to correctly function, the following rules must be followed. Failure to do so will lead to unexpected results from the query cache.
   1. Parameters for the query should be set on the filter object by ``SQLFilter#setParameter()`` before the filter is used by the ORM ( i.e. do not set parameters inside ``SQLFilter#addFilterConstraint()`` function ).
-  2. The filter must be detrimistic. Don't cahange the values base on external inputs.
+  2. The filter must be deterministic. Don't change the values base on external inputs.
 
 The ``SQLFilter#getParameter()`` function takes care of the proper quoting of parameters.
 

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -28,7 +28,7 @@ table alias of the SQL table of the entity.
     In the case of joined or single table inheritance, you always get passed the ClassMetadata of the
     inheritance root. This is necessary to avoid edge cases that would break the SQL when applying the filters.
 
-For the filter to correctly function the following rules must be followed, failure to do so will lead to unexpected results from the query cache.
+For the filter to correctly function, the following rules must be followed. Failure to do so will lead to unexpected results from the query cache.
   1. Parameters for the query should be set on the filter object by ``SQLFilter#setParameter()`` before the filter is used by the ORM ( i.e. do not set parameters inside ``SQLFilter#addFilterConstraint()`` function ).
   2. The filter must be detrimistic. Don't cahange the values base on external inputs.
 


### PR DESCRIPTION
Hi, 
It's probably not worded the best but I felt the need to add a warning in the docs about the query cache to hopefully help others not make the same mistake I did.

Although the docs do state: _"Parameters for the query should be set on the filter object by ``SQLFilter#setParameter()``. Only parameters set via this function can be used in filters"_ I think it's not quite clear why and if developing with the query cache off can lead to hard to find bugs later on.
