### PR TITLE
Check if the intermediate table already exists before trying to generate it using associated mappings

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -191,6 +191,9 @@ class SchemaTool
         $processedClasses     = [];
         $eventManager         = $this->em->getEventManager();
         $metadataSchemaConfig = $this->schemaManager->createSchemaConfig();
+        $allTableNames        = array_map(function ($class) {
+            return $class->getTableName();
+        }, $classes);
 
         $schema = new Schema([], [], $metadataSchemaConfig);
 
@@ -206,7 +209,7 @@ class SchemaTool
 
             if ($class->isInheritanceTypeSingleTable()) {
                 $this->gatherColumns($class, $table);
-                $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
+                $this->gatherRelationsSql($class, $table, $schema, $allTableNames, $addedFks, $blacklistedFks);
 
                 // Add the discriminator column
                 $this->addDiscriminatorColumnDefinition($class, $table);
@@ -220,7 +223,7 @@ class SchemaTool
                 foreach ($class->subClasses as $subClassName) {
                     $subClass = $this->em->getClassMetadata($subClassName);
                     $this->gatherColumns($subClass, $table);
-                    $this->gatherRelationsSql($subClass, $table, $schema, $addedFks, $blacklistedFks);
+                    $this->gatherRelationsSql($subClass, $table, $schema, $allTableNames, $addedFks, $blacklistedFks);
                     $processedClasses[$subClassName] = true;
                 }
             } elseif ($class->isInheritanceTypeJoined()) {
@@ -231,7 +234,7 @@ class SchemaTool
                     }
                 }
 
-                $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
+                $this->gatherRelationsSql($class, $table, $schema, $allTableNames, $addedFks, $blacklistedFks);
 
                 // Add the discriminator column only to the root table
                 if ($class->name === $class->rootEntityName) {
@@ -307,7 +310,7 @@ class SchemaTool
                 throw NotSupported::create();
             } else {
                 $this->gatherColumns($class, $table);
-                $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
+                $this->gatherRelationsSql($class, $table, $schema, $allTableNames, $addedFks, $blacklistedFks);
             }
 
             $pkColumns = [];
@@ -545,6 +548,7 @@ class SchemaTool
         ClassMetadata $class,
         Table $table,
         Schema $schema,
+        array $allTableNames,
         array &$addedFks,
         array &$blacklistedFks
     ): void {
@@ -573,42 +577,43 @@ class SchemaTool
             } elseif ($mapping['type'] === ClassMetadata::MANY_TO_MANY && $mapping['isOwningSide']) {
                 // create join table
                 $joinTable = $mapping['joinTable'];
+                if (!$schema->hasTable($joinTable['name']) && !in_array($joinTable['name'], $allTableNames)) {
+                    $theJoinTable = $schema->createTable(
+                        $this->quoteStrategy->getJoinTableName($mapping, $foreignClass, $this->platform)
+                    );
 
-                $theJoinTable = $schema->createTable(
-                    $this->quoteStrategy->getJoinTableName($mapping, $foreignClass, $this->platform)
-                );
-
-                if (isset($joinTable['options'])) {
-                    foreach ($joinTable['options'] as $key => $val) {
-                        $theJoinTable->addOption($key, $val);
+                    if (isset($joinTable['options'])) {
+                        foreach ($joinTable['options'] as $key => $val) {
+                            $theJoinTable->addOption($key, $val);
+                        }
                     }
+
+                    $primaryKeyColumns = [];
+
+                    // Build first FK constraint (relation table => source table)
+                    $this->gatherRelationJoinColumns(
+                        $joinTable['joinColumns'],
+                        $theJoinTable,
+                        $class,
+                        $mapping,
+                        $primaryKeyColumns,
+                        $addedFks,
+                        $blacklistedFks
+                    );
+
+                    // Build second FK constraint (relation table => target table)
+                    $this->gatherRelationJoinColumns(
+                        $joinTable['inverseJoinColumns'],
+                        $theJoinTable,
+                        $foreignClass,
+                        $mapping,
+                        $primaryKeyColumns,
+                        $addedFks,
+                        $blacklistedFks
+                    );
+
+                    $theJoinTable->setPrimaryKey($primaryKeyColumns);
                 }
-
-                $primaryKeyColumns = [];
-
-                // Build first FK constraint (relation table => source table)
-                $this->gatherRelationJoinColumns(
-                    $joinTable['joinColumns'],
-                    $theJoinTable,
-                    $class,
-                    $mapping,
-                    $primaryKeyColumns,
-                    $addedFks,
-                    $blacklistedFks
-                );
-
-                // Build second FK constraint (relation table => target table)
-                $this->gatherRelationJoinColumns(
-                    $joinTable['inverseJoinColumns'],
-                    $theJoinTable,
-                    $foreignClass,
-                    $mapping,
-                    $primaryKeyColumns,
-                    $addedFks,
-                    $blacklistedFks
-                );
-
-                $theJoinTable->setPrimaryKey($primaryKeyColumns);
             }
         }
     }


### PR DESCRIPTION
Doctrine already supports using customized intermediate entities in ManyToMany joins on multiple sides. However there is a problem when trying to migrate with this setup because SchemaTool will attempt to generate the table from both entity classes which contain ManyToMany joins and finally from the intermediate entity class. This makes sense because SchemaTool is not "aware" of the intermediate entity class' existence when parsing association mappings.

[EntityTest.zip](https://github.com/doctrine/orm/files/10195340/EntityTest.zip)
