### PR TITLE
Control proxy implementation via env

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,10 +78,6 @@ jobs:
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
 
-      - name: "Require specific lazy-proxy implementation"
-        run: "composer require symfony/var-exporter ^6.2 doctrine/persistence ^3.1 --no-update"
-        if: "${{ matrix.proxy == 'lazy-ghost' }}"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:
@@ -91,11 +87,13 @@ jobs:
         run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage-no-cache.xml"
         env:
             ENABLE_SECOND_LEVEL_CACHE: 0
+            ORM_PROXY_IMPLEMENTATION: "${{ matrix.proxy }}"
 
       - name: "Run PHPUnit with Second Level Cache"
         run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --exclude-group performance,non-cacheable,locking_functional --coverage-clover=coverage-cache.xml"
         env:
             ENABLE_SECOND_LEVEL_CACHE: 1
+            ORM_PROXY_IMPLEMENTATION: "${{ matrix.proxy }}"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -60,7 +60,7 @@ jobs:
         if: "${{ matrix.dbal-version != 'default' }}"
 
       - name: "Require specific persistence version"
-        run: "composer require symfony/var-exporter ^6.2 doctrine/persistence ^$([ ${{ matrix.persistence-version }} = default ] && echo '3.1' || echo ${{ matrix.persistence-version }}) --no-update"
+        run: "composer require doctrine/persistence ^$([ ${{ matrix.persistence-version }} = default ] && echo '3.1' || echo ${{ matrix.persistence-version }}) --no-update"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
@@ -100,7 +100,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
 
       - name: "Require specific persistence version"
-        run: "composer require symfony/var-exporter ^6.2 doctrine/persistence ^3.1 --no-update"
+        run: "composer require doctrine/persistence ^3.1 --no-update"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+        "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "vimeo/psalm": "4.30.0 || 5.1.0"
     },

--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -16,14 +16,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\Mocks\DriverResultMock;
-use Symfony\Component\VarExporter\LazyGhostTrait;
+use Doctrine\Tests\TestUtil;
 
 use function array_map;
-use function class_exists;
 use function realpath;
-use function trait_exists;
 
 final class EntityManagerFactory
 {
@@ -31,9 +28,7 @@ final class EntityManagerFactory
     {
         $config = new Configuration();
 
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
@@ -58,9 +53,7 @@ final class EntityManagerFactory
     {
         $config = new Configuration();
 
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -12,12 +12,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
-use Symfony\Component\VarExporter\LazyGhostTrait;
+use Doctrine\Tests\TestUtil;
 
-use function class_exists;
 use function sprintf;
-use function trait_exists;
 
 /**
  * Special EntityManager mock used for testing purposes.
@@ -34,9 +31,7 @@ class EntityManagerMock extends EntityManager
     {
         if ($config === null) {
             $config = new Configuration();
-            $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-            $config->setProxyDir(__DIR__ . '/../Proxies');
-            $config->setProxyNamespace('Doctrine\Tests\Proxies');
+            TestUtil::configureProxies($config);
             $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -10,18 +10,15 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
+use Doctrine\Tests\TestUtil;
 use GearmanWorker;
 use InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\VarExporter\LazyGhostTrait;
 
 use function assert;
-use function class_exists;
 use function is_array;
 use function microtime;
 use function sleep;
-use function trait_exists;
 use function unserialize;
 
 class LockAgentWorker
@@ -117,9 +114,7 @@ class LockAgentWorker
     protected function createEntityManager(Connection $conn): EntityManagerInterface
     {
         $config = new Configuration();
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../../../Proxies');
-        $config->setProxyNamespace('MyProject\Proxies');
+        TestUtil::configureProxies($config);
         $config->setAutoGenerateProxyClasses(true);
 
         $annotDriver = ORMSetup::createDefaultAnnotationDriver([__DIR__ . '/../../../Models/']);

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -12,18 +12,15 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Proxy;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\DbalExtensions\Connection;
 use Doctrine\Tests\DbalExtensions\QueryLog;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Symfony\Component\VarExporter\LazyGhostTrait;
+use Doctrine\Tests\TestUtil;
 
 use function assert;
-use function class_exists;
 use function realpath;
 use function serialize;
-use function trait_exists;
 use function unserialize;
 
 class MergeProxiesTest extends OrmFunctionalTestCase
@@ -243,9 +240,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
     {
         $config = new Configuration();
 
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(realpath(__DIR__ . '/../../Proxies'));
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver(
             [realpath(__DIR__ . '/../../Models/Cache')]
         ));

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -29,7 +29,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\MetadataDriverMock;
 use Doctrine\Tests\Models\CMS\CmsArticle;
@@ -41,18 +40,17 @@ use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
 use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
+use Doctrine\Tests\TestUtil;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
 use ReflectionClass;
-use Symfony\Component\VarExporter\LazyGhostTrait;
 
 use function array_search;
 use function assert;
 use function class_exists;
 use function count;
 use function sprintf;
-use function trait_exists;
 
 class ClassMetadataFactoryTest extends OrmTestCase
 {
@@ -286,9 +284,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     protected function createEntityManager(MappingDriver $metadataDriver, $conn = null): EntityManagerMock
     {
         $config = new Configuration();
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../../Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $eventManager = new EventManager();
         if (! $conn) {
             $platform = $this->createMock(AbstractPlatform::class);

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -13,16 +13,14 @@ use Doctrine\ORM\Tools\ConvertDoctrine1Schema;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\OrmTestCase;
-use Symfony\Component\VarExporter\LazyGhostTrait;
+use Doctrine\Tests\TestUtil;
 
 use function class_exists;
 use function count;
 use function file_exists;
 use function rmdir;
-use function trait_exists;
 use function unlink;
 
 /**
@@ -45,9 +43,7 @@ class ConvertDoctrine1SchemaTest extends OrmTestCase
             ->willReturn(new EventManager());
 
         $config = new Configuration();
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../../Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $config->setMetadataDriverImpl($metadataDriver);
 
         return new EntityManagerMock($connection, $config);

--- a/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
@@ -20,13 +20,11 @@ use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\OrmTestCase;
-use Symfony\Component\VarExporter\LazyGhostTrait;
+use Doctrine\Tests\TestUtil;
 use Symfony\Component\Yaml\Parser;
 
-use function class_exists;
 use function count;
 use function current;
 use function file_get_contents;
@@ -38,7 +36,6 @@ use function rmdir;
 use function rtrim;
 use function simplexml_load_file;
 use function str_replace;
-use function trait_exists;
 use function unlink;
 
 /**
@@ -66,9 +63,7 @@ abstract class ClassMetadataExporterTestCase extends OrmTestCase
             ->willReturn(new EventManager());
 
         $config = new Configuration();
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
-        $config->setProxyDir(__DIR__ . '/../../Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        TestUtil::configureProxies($config);
         $config->setMetadataDriverImpl($metadataDriver);
 
         return new EntityManagerMock($connection, $config);

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -26,7 +26,6 @@ use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\DbalExtensions\QueryLog;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\EventListener\CacheMetadataListener;
@@ -37,7 +36,6 @@ use PHPUnit\Framework\Warning;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\VarExporter\LazyGhostTrait;
 use Throwable;
 
 use function array_map;
@@ -45,7 +43,6 @@ use function array_pop;
 use function array_reverse;
 use function array_slice;
 use function assert;
-use function class_exists;
 use function explode;
 use function get_debug_type;
 use function getenv;
@@ -56,7 +53,6 @@ use function realpath;
 use function sprintf;
 use function str_contains;
 use function strtolower;
-use function trait_exists;
 use function var_export;
 
 use const PHP_EOL;
@@ -768,11 +764,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         //FIXME: two different configs! $conn and the created entity manager have
         // different configs.
         $config = new Configuration();
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
+        TestUtil::configureProxies($config);
         $config->setMetadataCache(self::$metadataCache);
         $config->setQueryCache(self::$queryCache);
-        $config->setProxyDir(__DIR__ . '/Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
 
         if ($this->resultCache !== null) {
             $config->setResultCache($this->resultCache);

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -14,15 +14,11 @@ use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\ORMSetup;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\VarExporter\LazyGhostTrait;
 
-use function class_exists;
 use function realpath;
-use function trait_exists;
 
 /**
  * Base testcase class for all ORM testcases.
@@ -80,11 +76,9 @@ abstract class OrmTestCase extends DoctrineTestCase
 
         $config = new Configuration();
 
-        $config->setLazyGhostObjectEnabled(trait_exists(LazyGhostTrait::class) && class_exists(RuntimeReflectionProperty::class));
+        TestUtil::configureProxies($config);
         $config->setMetadataCache($metadataCache);
         $config->setQueryCache(self::getSharedQueryCache());
-        $config->setProxyDir(__DIR__ . '/Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
         ]));


### PR DESCRIPTION
Our test suite is currently run with the lazy ghost implementation if the var-exporter component is installed. In our CI, we install the component if we want to test the lazy ghost implementation.

This is a bit brittle given that Symfony Cache depends on VarExporter, so the component will be installed no matter what. Also, if I want to run tests locally, it's a bit annoying that I have to install the component and live with local changes in my composer.json.

With this PR, I'm adding VarExporter to the dev requirements. I'm introducing an environment variable `ORM_PROXY_IMPLEMENTATION` which allows us to control the proxy implementation that should be used by the tests.