### PR TITLE
Remove `setAccessible()` calls

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -236,7 +236,6 @@ EOPHP;
                     continue;
                 }
 
-                $property->setAccessible(true);
                 $property->setValue($proxy, $property->getValue($entity));
             }
         };

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -242,8 +242,6 @@ class DefaultCacheTest extends OrmTestCase
         $method     = new ReflectionMethod($this->cache, 'toIdentifierArray');
         $property   = new ReflectionProperty($entity, 'id');
 
-        $property->setAccessible(true);
-        $method->setAccessible(true);
         $property->setValue($entity, $identifier);
 
         self::assertEquals(['id' => $identifier], $method->invoke($this->cache, $metadata, $identifier));

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -580,8 +580,6 @@ class DefaultQueryCacheTest extends OrmTestCase
         $rsm        = new ResultSetMappingBuilder($this->em);
         $key        = new QueryCacheKey('query.key1', 0);
 
-        $reflection->setAccessible(true);
-
         $germany  = new Country('Germany');
         $bavaria  = new State('Bavaria', $germany);
         $wurzburg = new City('Würzburg', $bavaria);

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -122,8 +122,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
@@ -153,8 +151,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
-
-        $property->setAccessible(true);
 
         $this->region->expects(self::once())
             ->method('lock')
@@ -186,8 +182,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
@@ -218,8 +212,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
@@ -249,8 +241,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
@@ -273,8 +263,6 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::class, 'cities', ['id' => 1]);
         $property   = new ReflectionProperty(ReadWriteCachedCollectionPersister::class, 'queuedCache');
-
-        $property->setAccessible(true);
 
         $this->region->expects(self::once())
             ->method('lock')

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -29,8 +29,6 @@ class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCas
         $persister = $this->createPersisterDefault();
         $property  = new ReflectionProperty($persister, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->em->getUnitOfWork()->registerManaged($entity, ['id' => 1], ['id' => 1, 'name' => 'Foo']);
 
         $persister->update($entity);
@@ -50,8 +48,6 @@ class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCas
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $entry     = new EntityCacheEntry(Country::class, ['id' => 1, 'name' => 'Foo']);
         $property  = new ReflectionProperty($persister, 'queuedCache');
-
-        $property->setAccessible(true);
 
         $this->region->expects(self::once())
             ->method('put')
@@ -88,8 +84,6 @@ class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCas
         $entry     = new EntityCacheEntry(Country::class, ['id' => 1, 'name' => 'Foo']);
         $property  = new ReflectionProperty($persister, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('put')
             ->with(self::equalTo($key), self::equalTo($entry));
@@ -115,8 +109,6 @@ class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCas
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $property  = new ReflectionProperty($persister, 'queuedCache');
-
-        $property->setAccessible(true);
 
         $this->region->expects(self::once())
             ->method('evict')

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -117,8 +117,6 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $property  = new ReflectionProperty(ReadWriteCachedEntityPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::exactly(2))
             ->method('lock')
             ->with(self::equalTo($key))
@@ -148,8 +146,6 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $property  = new ReflectionProperty(ReadWriteCachedEntityPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::exactly(2))
             ->method('lock')
             ->with(self::equalTo($key))
@@ -178,8 +174,6 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $property  = new ReflectionProperty(ReadWriteCachedEntityPersister::class, 'queuedCache');
 
-        $property->setAccessible(true);
-
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
@@ -201,8 +195,6 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::class, ['id' => 1]);
         $property  = new ReflectionProperty(ReadWriteCachedEntityPersister::class, 'queuedCache');
-
-        $property->setAccessible(true);
 
         $this->region->expects(self::once())
             ->method('lock')

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -637,8 +637,6 @@ class PaginationTest extends OrmFunctionalTestCase
 
         $getCountQuery = new ReflectionMethod($paginator, 'getCountQuery');
 
-        $getCountQuery->setAccessible(true);
-
         self::assertCount(2, $getCountQuery->invoke($paginator)->getParameters());
         self::assertCount(9, $paginator);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -273,7 +273,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $filter = new MyLocaleFilter($em);
 
         $reflMethod = new ReflectionMethod(SQLFilter::class, 'getConnection');
-        $reflMethod->setAccessible(true);
 
         self::assertSame($conn, $reflMethod->invoke($filter));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -805,7 +805,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $getHash = static function (AbstractQuery $query) {
             $method = new ReflectionMethod($query, 'getHash');
-            $method->setAccessible(true);
 
             return $method->invoke($query);
         };

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
@@ -43,7 +43,6 @@ class DDC3123Test extends OrmFunctionalTestCase
             public function postFlush(): void
             {
                 $property = new ReflectionProperty(UnitOfWork::class, 'extraUpdates');
-                $property->setAccessible(true);
 
                 Assert::assertEmpty(
                     $property->getValue($this->uow),

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -414,7 +414,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         // not really the cleanest way to check it, but we won't add a getter to the CMF just for the sake of testing.
         $class    = new ReflectionClass(ClassMetadataFactory::class);
         $property = $class->getProperty('em');
-        $property->setAccessible(true);
         self::assertSame($entityManager, $property->getValue($classMetadataFactory));
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -77,46 +77,37 @@ class ReflectionEmbeddedPropertyTest extends TestCase
     {
         return [
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
+                new ReflectionProperty(BooleanModel::class, 'id'),
+                new ReflectionProperty(BooleanModel::class, 'id'),
                 BooleanModel::class,
             ],
             // reflection on embeddables that have properties defined in abstract ancestors:
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(AbstractEmbeddable::class, 'propertyInAbstractClass'),
+                new ReflectionProperty(BooleanModel::class, 'id'),
+                new ReflectionProperty(AbstractEmbeddable::class, 'propertyInAbstractClass'),
                 ConcreteEmbeddable::class,
             ],
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(ConcreteEmbeddable::class, 'propertyInConcreteClass'),
+                new ReflectionProperty(BooleanModel::class, 'id'),
+                new ReflectionProperty(ConcreteEmbeddable::class, 'propertyInConcreteClass'),
                 ConcreteEmbeddable::class,
             ],
             // reflection on classes extending internal PHP classes:
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'privateProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'privateProperty'),
                 ArrayObjectExtendingClass::class,
             ],
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'protectedProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'protectedProperty'),
                 ArrayObjectExtendingClass::class,
             ],
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                new ReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
                 ArrayObjectExtendingClass::class,
             ],
         ];
-    }
-
-    private function getReflectionProperty(string $className, string $propertyName): ReflectionProperty
-    {
-        $reflectionProperty = new ReflectionProperty($className, $propertyName);
-
-        $reflectionProperty->setAccessible(true);
-
-        return $reflectionProperty;
     }
 }

--- a/tests/Doctrine/Tests/ORM/ORMSetupTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMSetupTest.php
@@ -44,7 +44,6 @@ class ORMSetupTest extends TestCase
         $cache  = $config->getMetadataCache();
 
         $namespaceProperty = new ReflectionProperty(AbstractAdapter::class, 'namespace');
-        $namespaceProperty->setAccessible(true);
 
         self::assertInstanceOf(ApcuAdapter::class, $cache);
         self::assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf:', $namespaceProperty->getValue($cache));

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -49,9 +49,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     public function testGetInsertSQLUsesTypeValuesSQL(): void
     {
         $method = new ReflectionMethod($this->persister, 'getInsertSQL');
-        $method->setAccessible(true);
-
-        $sql = $method->invoke($this->persister);
+        $sql    = $method->invoke($this->persister);
 
         self::assertEquals('INSERT INTO customtype_parents (customInteger, child_id) VALUES (ABS(?), ?)', $sql);
     }
@@ -101,9 +99,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     public function testGetSelectConditionSQLUsesTypeValuesSQL(): void
     {
         $method = new ReflectionMethod($this->persister, 'getSelectConditionSQL');
-        $method->setAccessible(true);
-
-        $sql = $method->invoke($this->persister, ['customInteger' => 1, 'child' => 1]);
+        $sql    = $method->invoke($this->persister, ['customInteger' => 1, 'child' => 1]);
 
         self::assertEquals('t0.customInteger = ABS(?) AND t0.child_id = ?', $sql);
     }
@@ -113,7 +109,6 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     {
         $persister = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(NonAlphaColumnsEntity::class));
         $method    = new ReflectionMethod($persister, 'getSelectColumnsSQL');
-        $method->setAccessible(true);
 
         self::assertEquals('t0."simple-entity-id" AS simpleentityid_1, t0."simple-entity-value" AS simpleentityvalue_2', $method->invoke($persister));
     }

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -179,8 +179,6 @@ class ProxyFactoryTest extends OrmTestCase
 
         // Set the id of the CompanyEmployee (which is in the parent CompanyPerson)
         $property = new ReflectionProperty(CompanyPerson::class, 'id');
-
-        $property->setAccessible(true);
         $property->setValue($companyEmployee, 42);
 
         $classMetaData = $this->emMock->getClassMetadata(CompanyEmployee::class);


### PR DESCRIPTION
`ReflectionProperty::setAccessible()` and `ReflectionMethod::setAccessible()` are no-ops in PHP 8.1. Let's remove all calls.