### PR TITLE
Allow enum discriminator columns

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -366,6 +366,8 @@ Optional parameters:
 
 -  **type**: By default this is string.
 -  **length**: By default this is 255.
+-  **columnDefinition**: By default this is null the definition according to the type will be used. This option allows to override it.
+-  **enumType**: By default this is `null`. Allows to map discriminatorColumn value to PHP enum
 
 .. _attrref_discriminatormap:
 

--- a/docs/en/reference/php-mapping.rst
+++ b/docs/en/reference/php-mapping.rst
@@ -167,7 +167,7 @@ The API of the ClassMetadataBuilder has the following methods with a fluent inte
 -   ``addNamedQuery($name, $dqlQuery)``
 -   ``setJoinedTableInheritance()``
 -   ``setSingleTableInheritance()``
--   ``setDiscriminatorColumn($name, $type = 'string', $length = 255)``
+-   ``setDiscriminatorColumn($name, $type = 'string', $length = 255, $columnDefinition = null, $enumType = null)``
 -   ``addDiscriminatorMapClass($name, $class)``
 -   ``setChangeTrackingPolicyDeferredExplicit()``
 -   ``setChangeTrackingPolicyNotify()``

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -337,6 +337,7 @@
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="column-definition" type="xs:string" />
+    <xs:attribute name="enum-type" type="xs:string" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -617,6 +617,7 @@ abstract class AbstractHydrator
                     'fieldName'    => $fieldName,
                     'type'         => $type,
                     'dqlAlias'     => $dqlAlias,
+                    'enumType'     => $this->_rsm->enumMappings[$key] ?? null,
                 ];
         }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
+use BackedEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
@@ -246,7 +247,12 @@ class ObjectHydrator extends AbstractHydrator
             }
 
             $discrMap           = $this->_metadataCache[$className]->discriminatorMap;
-            $discriminatorValue = (string) $data[$discrColumn];
+            $discriminatorValue = $data[$discrColumn];
+            if ($discriminatorValue instanceof BackedEnum) {
+                $discriminatorValue = $discriminatorValue->value;
+            }
+
+            $discriminatorValue = (string) $discriminatorValue;
 
             if (! isset($discrMap[$discriminatorValue])) {
                 throw HydrationException::invalidDiscriminatorValue($discriminatorValue, array_keys($discrMap));

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Builder;
 
+use BackedEnum;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -218,16 +219,19 @@ class ClassMetadataBuilder
      * @param string $name
      * @param string $type
      * @param int    $length
+     * @psalm-param class-string<BackedEnum>|null $enumType
      *
      * @return $this
      */
-    public function setDiscriminatorColumn($name, $type = 'string', $length = 255)
+    public function setDiscriminatorColumn($name, $type = 'string', $length = 255, ?string $columnDefinition = null, ?string $enumType = null)
     {
         $this->cm->setDiscriminatorColumn(
             [
                 'name' => $name,
                 'type' => $type,
                 'length' => $length,
+                'columnDefinition' => $columnDefinition,
+                'enumType' => $enumType,
             ]
         );
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -574,7 +574,7 @@ class ClassMetadataInfo implements ClassMetadata
      * READ-ONLY: The definition of the discriminator column used in JOINED and SINGLE_TABLE
      * inheritance mappings.
      *
-     * @psalm-var array{name: string, fieldName: string, type: string, length?: int, columnDefinition?: string|null}|null
+     * @psalm-var array{name: string, fieldName: string, type: string, length?: int, columnDefinition?: string|null, enumType?: class-string<BackedEnum>|null}|null
      */
     public $discriminatorColumn;
 
@@ -3220,7 +3220,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @see getDiscriminatorColumn()
      *
      * @param mixed[]|null $columnDef
-     * @psalm-param array{name: string|null, fieldName?: string, type?: string, length?: int, columnDefinition?: string|null}|null $columnDef
+     * @psalm-param array{name: string|null, fieldName?: string, type?: string, length?: int, columnDefinition?: string|null, enumType?: class-string<BackedEnum>|null}|null $columnDef
      *
      * @return void
      *

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -39,15 +39,24 @@ final class DiscriminatorColumn implements MappingAttribute
      */
     public $columnDefinition;
 
+    /**
+     * @var class-string<\BackedEnum>|null
+     * @readonly
+     */
+    public $enumType = null;
+
+    /** @param class-string<\BackedEnum>|null $enumType */
     public function __construct(
         ?string $name = null,
         ?string $type = null,
         ?int $length = null,
-        ?string $columnDefinition = null
+        ?string $columnDefinition = null,
+        ?string $enumType = null
     ) {
         $this->name             = $name;
         $this->type             = $type;
         $this->length           = $length;
         $this->columnDefinition = $columnDefinition;
+        $this->enumType         = $enumType;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -319,6 +319,7 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
                             'type'             => $discrColumnAnnot->type ?: 'string',
                             'length'           => $discrColumnAnnot->length ?? 255,
                             'columnDefinition' => $discrColumnAnnot->columnDefinition,
+                            'enumType'         => $discrColumnAnnot->enumType,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -271,6 +271,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
                             'type'             => isset($discrColumnAttribute->type) ? (string) $discrColumnAttribute->type : 'string',
                             'length'           => isset($discrColumnAttribute->length) ? (int) $discrColumnAttribute->length : 255,
                             'columnDefinition' => isset($discrColumnAttribute->columnDefinition) ? (string) $discrColumnAttribute->columnDefinition : null,
+                            'enumType'         => isset($discrColumnAttribute->enumType) ? (string) $discrColumnAttribute->enumType : null,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -210,6 +210,7 @@ class XmlDriver extends FileDriver
                             'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
                             'length' => isset($discrColumn['length']) ? (int) $discrColumn['length'] : 255,
                             'columnDefinition' => isset($discrColumn['column-definition']) ? (string) $discrColumn['column-definition'] : null,
+                            'enumType' => isset($discrColumn['enum-type']) ? (string) $discrColumn['enum-type'] : null,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -201,6 +201,7 @@ class YamlDriver extends FileDriver
                             'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
                             'length' => isset($discrColumn['length']) ? (int) $discrColumn['length'] : 255,
                             'columnDefinition' => isset($discrColumn['columnDefinition']) ? (string) $discrColumn['columnDefinition'] : null,
+                            'enumType' => isset($discrColumn['enumType']) ? (string) $discrColumn['enumType'] : null,
                         ]
                     );
                 } else {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -775,6 +775,9 @@ class SqlWalker implements TreeWalker
 
                 $this->rsm->setDiscriminatorColumn($dqlAlias, $columnAlias);
                 $this->rsm->addMetaResult($dqlAlias, $columnAlias, $discrColumn['fieldName'], false, $discrColumn['type']);
+                if (! empty($discrColumn['enumType'])) {
+                    $this->rsm->addEnumResult($columnAlias, $discrColumn['enumType']);
+                }
             }
 
             // Add foreign key columns to SQL, if necessary

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -785,7 +785,7 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php">
-    <InvalidArgument occurrences="1"/>
+    <InvalidArgument occurrences="2"/>
     <InvalidArrayAccess occurrences="4">
       <code>$value[0]</code>
       <code>$value[0]</code>
@@ -865,7 +865,7 @@
       <code>addNamedNativeQuery</code>
       <code>addNamedQuery</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="5">
       <code>$this-&gt;cacheToArray($manyToManyElement-&gt;cache)</code>
       <code>$this-&gt;cacheToArray($manyToOneElement-&gt;cache)</code>
       <code>$this-&gt;cacheToArray($oneToManyElement-&gt;cache)</code>
@@ -931,6 +931,7 @@
       <code>addNamedNativeQuery</code>
       <code>addNamedQuery</code>
     </DeprecatedMethod>
+    <InvalidArgument occurrences="1"/>
     <InvalidDocblock occurrences="1">
       <code>private function cacheToArray(array $cacheMapping): array</code>
     </InvalidDocblock>

--- a/tests/Doctrine/Tests/Models/GH10288/GH10288People.php
+++ b/tests/Doctrine/Tests/Models/GH10288/GH10288People.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10288;
+
+enum GH10288People: string
+{
+    case BOSS     = 'boss';
+    case EMPLOYEE = 'employee';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10288Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10288Test.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\Tests\Models\GH10288\GH10288People;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * This test makes sure that Discriminator columns can use both custom types using PHP enums as well as
+ * enumType definition of enums.
+ *
+ * @requires PHP 8.1
+ */
+class GH10288Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (Type::hasType(GH10288PeopleType::NAME)) {
+            Type::overrideType(GH10288PeopleType::NAME, GH10288PeopleType::class);
+        } else {
+            Type::addType(GH10288PeopleType::NAME, GH10288PeopleType::class);
+        }
+
+        $this->createSchemaForModels(
+            GH10288PersonWithEnumType::class,
+            GH10288BossWithEnumType::class,
+            GH10288EmployeeWithEnumType::class,
+            GH10288PersonCustomEnumType::class,
+            GH10288BossCustomEnumType::class,
+            GH10288EmployeeCustomEnumType::class
+        );
+    }
+
+    /**
+     * @param class-string $personType
+     * @psalm-param GH10288BossWithEnumType|GH10288BossCustomEnumType $boss
+     * @psalm-param GH10288EmployeeWithEnumType|GH10288EmployeeCustomEnumType $employee
+     */
+    private function performEnumDiscriminatorTest($boss, $employee, string $personType): void
+    {
+        $boss->bossId = 1;
+
+        $this->_em->persist($boss);
+        $this->_em->persist($employee);
+        $this->_em->flush();
+        $bossId = $boss->id;
+        $this->_em->clear();
+
+        // Using DQL here to make sure that we'll use ObjectHydrator instead of SimpleObjectHydrator
+        $query = $this->_em->createQueryBuilder()
+            ->select('person')
+            ->from($personType, 'person')
+            ->where('person.name = :name')
+            ->setMaxResults(1)
+            ->getQuery();
+
+        $query->setParameter('name', 'John');
+
+        self::assertEquals($boss, $query->getOneOrNullResult(AbstractQuery::HYDRATE_OBJECT));
+        self::assertEquals(
+            GH10288People::BOSS,
+            $query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)['discr']
+        );
+
+        $query->setParameter('name', 'Bob');
+        self::assertEquals($employee, $query->getOneOrNullResult(AbstractQuery::HYDRATE_OBJECT));
+        self::assertEquals(
+            GH10288People::EMPLOYEE,
+            $query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)['discr']
+        );
+
+        $this->_em->clear();
+
+        // test SimpleObjectHydrator
+        $bossFetched = $this->_em->find($personType, $bossId);
+        self::assertEquals($boss, $bossFetched);
+    }
+
+    /**
+     * @group GH10288
+     */
+    public function testEnumDiscriminatorWithEnumType(): void
+    {
+        $boss     = new GH10288BossWithEnumType('John');
+        $employee = new GH10288EmployeeWithEnumType('Bob');
+
+        $this->performEnumDiscriminatorTest($boss, $employee, GH10288PersonWithEnumType::class);
+    }
+
+    /**
+     * @group GH10288
+     */
+    public function testEnumDiscriminatorWithCustomEnumType(): void
+    {
+        $boss     = new GH10288BossCustomEnumType('John');
+        $employee = new GH10288EmployeeCustomEnumType('Bob');
+
+        $this->performEnumDiscriminatorTest($boss, $employee, GH10288PersonCustomEnumType::class);
+    }
+}
+
+class GH10288PeopleType extends StringType
+{
+    public const NAME = 'GH10288PeopleType';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (! $value instanceof GH10288People) {
+            $value = GH10288People::from($value);
+        }
+
+        return $value->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return GH10288People::from($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", enumType=GH10288People::class)
+ * @DiscriminatorMap({
+ *      "boss"     = GH10288BossWithEnumType::class,
+ *      "employee" = GH10288EmployeeWithEnumType::class
+ * })
+ */
+abstract class GH10288PersonWithEnumType
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255)
+     */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+/** @Entity */
+class GH10288BossWithEnumType extends GH10288PersonWithEnumType
+{
+    /**
+     * @var int
+     * @Column(type="integer")
+     */
+    public $bossId;
+}
+
+/** @Entity */
+class GH10288EmployeeWithEnumType extends GH10288PersonWithEnumType
+{
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="GH10288PeopleType")
+ * @DiscriminatorMap({
+ *      "boss"     = GH10288BossCustomEnumType::class,
+ *      "employee" = GH10288EmployeeCustomEnumType::class
+ * })
+ */
+abstract class GH10288PersonCustomEnumType
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=255)
+     */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+/** @Entity */
+class GH10288BossCustomEnumType extends GH10288PersonCustomEnumType
+{
+    /**
+     * @var int
+     * @Column(type="integer")
+     */
+    public $bossId;
+}
+
+/** @Entity */
+class GH10288EmployeeCustomEnumType extends GH10288PersonCustomEnumType
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -182,8 +182,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
     public function testSetDiscriminatorColumn(): void
     {
-        $this->assertIsFluent($this->builder->setDiscriminatorColumn('discr', 'string', '124'));
-        self::assertEquals(['fieldName' => 'discr', 'name' => 'discr', 'type' => 'string', 'length' => '124'], $this->cm->discriminatorColumn);
+        $this->assertIsFluent($this->builder->setDiscriminatorColumn('discr', 'string', '124', null, null));
+        self::assertEquals(['fieldName' => 'discr', 'name' => 'discr', 'type' => 'string', 'length' => '124', 'columnDefinition' => null, 'enumType' => null], $this->cm->discriminatorColumn);
     }
 
     public function testAddDiscriminatorMapClass(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -65,6 +65,7 @@ use Doctrine\Tests\Models\DDC964\DDC964Admin;
 use Doctrine\Tests\Models\DDC964\DDC964Guest;
 use Doctrine\Tests\Models\Enums\Card;
 use Doctrine\Tests\Models\Enums\Suit;
+use Doctrine\Tests\Models\GH10288\GH10288People;
 use Doctrine\Tests\Models\TypedProperties\Contact;
 use Doctrine\Tests\Models\TypedProperties\UserTyped;
 use Doctrine\Tests\Models\Upsertable\Insertable;
@@ -448,7 +449,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
         $class = $this->createClassMetadata(Animal::class);
 
         self::assertEquals(
-            ['name' => 'discr', 'type' => 'string', 'length' => '32', 'fieldName' => 'discr', 'columnDefinition' => null],
+            ['name' => 'discr', 'type' => 'string', 'length' => 32, 'fieldName' => 'discr', 'columnDefinition' => null, 'enumType' => null],
             $class->discriminatorColumn
         );
     }
@@ -553,6 +554,20 @@ abstract class MappingDriverTestCase extends OrmTestCase
 
         self::assertEquals("ENUM('ONE','TWO')", $class->discriminatorColumn['columnDefinition']);
         self::assertEquals('dtype', $class->discriminatorColumn['name']);
+    }
+
+    /**
+     * @group GH10288
+     */
+    public function testDiscriminatorColumnEnumTypeDefinition(): void
+    {
+        $class = $this->createClassMetadata(GH10288EnumTypePerson::class);
+
+        self::assertArrayHasKey('enumType', $class->discriminatorColumn);
+        self::assertArrayHasKey('name', $class->discriminatorColumn);
+
+        self::assertEquals(GH10288People::class, $class->discriminatorColumn['enumType']);
+        self::assertEquals('discr', $class->discriminatorColumn['name']);
     }
 
     /** @group DDC-889 */
@@ -1793,5 +1808,54 @@ class UserIncorrectAttributes extends User
 }
 
 class UserMissingAttributes extends User
+{
+}
+
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", enumType=GH10288People::class)
+ * @DiscriminatorMap({
+ *      "boss"     = GH10288EnumTypeBoss::class
+ * })
+ */
+#[Entity]
+#[InheritanceType('SINGLE_TABLE')]
+#[DiscriminatorColumn(name: 'discr', enumType: GH10288People::class)]
+#[DiscriminatorMap(['boss' => GH10288EnumTypeBoss::class])]
+abstract class GH10288EnumTypePerson
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField(
+            [
+                'id'                 => true,
+                'fieldName'          => 'id',
+            ]
+        );
+
+        $metadata->setDiscriminatorColumn(
+            [
+                'name'     => 'discr',
+                'enumType' =>  GH10288People::class,
+            ]
+        );
+
+        $metadata->setIdGeneratorType(ORM\ClassMetadataInfo::GENERATOR_TYPE_NONE);
+    }
+}
+
+/** @Entity */
+#[Entity]
+class GH10288EnumTypeBoss extends GH10288EnumTypePerson
 {
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Tests\Models\GH10288\GH10288People;
+
+$metadata->mapField(
+    [
+        'id'                 => true,
+        'fieldName'          => 'id',
+    ]
+);
+
+$metadata->setDiscriminatorColumn(
+    [
+        'name'     => 'discr',
+        'enumType' => GH10288People::class,
+    ]
+);
+
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\GH10288EnumTypePerson" inheritance-type="SINGLE_TABLE">
+        <discriminator-column name="discr" enum-type="Doctrine\Tests\Models\GH10288\GH10288People"/>
+        
+        <discriminator-map>
+            <discriminator-mapping value="boss" class="Doctrine\Tests\ORM\Mapping\GH10288EnumTypeBoss" />
+        </discriminator-map>
+
+        <id name="id">
+            <generator strategy="NONE"/>
+        </id>
+    </entity>
+        
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.GH10288EnumTypePerson.dcm.yml
@@ -1,0 +1,12 @@
+Doctrine\Tests\ORM\Mapping\GH10288EnumTypePerson:
+  type: entity
+  inheritanceType: SINGLE_TABLE
+  discriminatorMap:
+    boss: Doctrine\Tests\ORM\Mapping\GH10288EnumTypeBoss
+  discriminatorColumn:
+    name: discr
+    enumType: Doctrine\Tests\Models\GH10288\GH10288People
+  id:
+    id: 
+      generator:
+        strategy: NONE


### PR DESCRIPTION
In all hydrators, discriminator columns are for all purposes converted to string using explicit (string) conversion. This is not allowed with PHP enums. Therefore, I added code which checks whether the variable is a BackedEnum instance and if so, instead its ->value is used (which can be cast to string without issues as its a scalar)

The test builds upon https://github.com/doctrine/orm/pull/6141 which allowed objects to be discriminator column values. This fix further extends the use-case to allow PHP enums also.