### PR TITLE
Allow custom DBAL types autoconfiguration from PHP types

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -289,6 +289,77 @@ These are the "automatic" mapping rules:
 As of version 2.11 Doctrine can also automatically map typed properties using a
 PHP 8.1 enum to set the right ``type`` and ``enumType``.
 
+.. versionadded:: 2.14
+
+Since version 2.14 you can specify custom typed field mapping between PHP type and DBAL type using ``Configuration``
+
+.. code-block:: php
+
+    <?php
+    use App\CustomIds\CustomIdObject;
+    use App\DBAL\Type\CustomIdObjectType;
+
+    $configuration->addTypedFieldMapping(CustomIdObject::class, CustomIdType::class);
+
+Then, an entity using the ``CustomIdObject`` typed field will be correctly assigned its DBAL type
+(``CustomIdObjectType``) without the need of explicit declaration.
+
+.. configuration-block::
+
+    .. code-block:: attribute
+
+        <?php
+        #[ORM\Entity]
+        #[ORM\Table(name: 'cms_users_typed_with_custom_typed_field')]
+        class UserTypedWithCustomTypedField
+        {
+            #[ORM\Column]
+            public CustomIdObject $customId;
+
+            // ...
+        }
+
+    .. code-block:: annotation
+
+        <?php
+        /**
+         * @Entity
+         * @Table(name="cms_users_typed_with_custom_typed_field")
+         */
+        class UserTypedWithCustomTypedField
+        {
+            /** @Column */
+            public CustomIdObject $customId;
+
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <doctrine-mapping>
+          <entity name="UserTypedWithCustomTypedField">
+            <field name="customId"/>
+            <!-- -->
+          </entity>
+        </doctrine-mapping>
+
+    .. code-block:: yaml
+
+        UserTypedWithCustomTypedField:
+          type: entity
+          fields:
+            customId: ~
+
+It is perfectly valid to override even the "automatic" mapping rules mentioned above:
+
+.. code-block:: php
+
+    <?php
+    use App\CustomIds\CustomIdObject;
+    use App\DBAL\Type\CustomIdObjectType;
+
+    $configuration->addTypedFieldMapping('int', CustomIntType::class);
+
 .. _reference-mapping-types:
 
 Doctrine Mapping Types

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\DBAL\Types\Type;
+
 /**
  * {@inheritDoc}
  *
+ * @psalm-import-type ScalarName from ClassMetadataInfo
  * @todo remove or rename ClassMetadataInfo to ClassMetadata
  * @template-covariant T of object
  * @template-extends ClassMetadataInfo<T>
@@ -18,11 +21,12 @@ class ClassMetadata extends ClassMetadataInfo
      *
      * @see https://github.com/doctrine/orm/issues/8709
      *
-     * @param string $entityName The name of the entity class the new instance is used for.
+     * @param string                                                    $entityName         The name of the entity class the new instance is used for.
+     * @param array<class-string|ScalarName, class-string<Type>|string> $typedFieldMappings
      * @psalm-param class-string<T> $entityName
      */
-    public function __construct($entityName, ?NamingStrategy $namingStrategy = null)
+    public function __construct($entityName, ?NamingStrategy $namingStrategy = null, array $typedFieldMappings = [])
     {
-        parent::__construct($entityName, $namingStrategy);
+        parent::__construct($entityName, $namingStrategy, $typedFieldMappings);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -293,7 +293,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function newClassMetadataInstance($className)
     {
-        return new ClassMetadata($className, $this->em->getConfiguration()->getNamingStrategy());
+        return new ClassMetadata(
+            $className,
+            $this->em->getConfiguration()->getNamingStrategy(),
+            $this->em->getConfiguration()->getTypedFieldMappings()
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DbalTypes/CustomIntType.php
+++ b/tests/Doctrine/Tests/DbalTypes/CustomIntType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Types\IntegerType;
+
+class CustomIntType extends IntegerType
+{
+    public const NAME = 'custom_int_type';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTypedWithCustomTypedField.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTypedWithCustomTypedField.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\TypedProperties;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+
+/**
+ * @Entity
+ * @Table(name="cms_users_typed_with_custom_typed_field")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'cms_users_typed_with_custom_typed_field')]
+class UserTypedWithCustomTypedField
+{
+    /**
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    /** @Column */
+    #[ORM\Column]
+    public CustomIdObject $customId;
+
+    /** @Column */
+    #[ORM\Column]
+    public int $customIntTypedField;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable(
+            ['name' => 'cms_users_typed_with_custom_typed_field']
+        );
+
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+            ]
+        );
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+        $metadata->mapField(
+            ['fieldName' => 'customId']
+        );
+
+        $metadata->mapField(
+            ['fieldName' => 'customIntTypedField']
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -440,6 +440,22 @@ class ConfigurationTest extends DoctrineTestCase
         $this->configuration->setSecondLevelCacheConfiguration($mockClass);
         self::assertEquals($mockClass, $this->configuration->getSecondLevelCacheConfiguration());
     }
+
+    /** @group GH10290 */
+    public function testAddGetTypedFieldMapping(): void
+    {
+        self::assertNull($this->configuration->getTypedFieldMapping(CacheConfiguration::class));
+        $this->configuration->addTypedFieldMapping(CacheConfiguration::class, self::class);
+        self::assertSame(self::class, $this->configuration->getTypedFieldMapping(CacheConfiguration::class));
+    }
+
+    /** @group GH10290 */
+    public function testSetGetTypedFieldMappings(): void
+    {
+        self::assertEmpty($this->configuration->getTypedFieldMappings());
+        $this->configuration->setTypedFieldMappings([CacheConfiguration::class => self::class]);
+        self::assertSame([CacheConfiguration::class => self::class], $this->configuration->getTypedFieldMappings());
+    }
 }
 
 class ConfigurationTestAnnotationReaderChecker

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -14,6 +14,9 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\Mapping\StaticReflectionService;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+use Doctrine\Tests\DbalTypes\CustomIdObjectType;
+use Doctrine\Tests\DbalTypes\CustomIntType;
 use Doctrine\Tests\Models\CMS;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\Company\CompanyContract;
@@ -175,6 +178,22 @@ class ClassMetadataTest extends OrmTestCase
         // float
         $cm->mapField(['fieldName' => 'float']);
         self::assertEquals('float', $cm->getTypeOfField('float'));
+
+        $cm = new ClassMetadata(
+            TypedProperties\UserTypedWithCustomTypedField::class,
+            null,
+            [
+                CustomIdObject::class => CustomIdObjectType::class,
+                'int' => CustomIntType::class,
+            ]
+        );
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        // Integer
+        $cm->mapField(['fieldName' => 'customId']);
+        $cm->mapField(['fieldName' => 'customIntTypedField']);
+        self::assertEquals(CustomIdObjectType::class, $cm->getTypeOfField('customId'));
+        self::assertEquals(CustomIntType::class, $cm->getTypeOfField('customIntTypedField'));
     }
 
     /** @group DDC-115 */

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
+$metadata->setPrimaryTable(
+    ['name' => 'cms_users_typed_with_custom_typed_field']
+);
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+    ]
+);
+
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+$metadata->mapField(
+    ['fieldName' => 'customId']
+);
+
+$metadata->mapField(
+    ['fieldName' => 'customIntTypedField']
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField" table="cms_users_typed_with_custom_typed_field">
+    <id name="id">
+      <generator strategy="AUTO"/>
+    </id>
+
+    <field name="customId"/>
+    <field name="customIntTypedField"/>
+  </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.yml
@@ -1,0 +1,10 @@
+Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField:
+    type: entity
+    table: cms_users_typed_with_custom_typed_field
+    id:
+        id:
+            generator:
+                strategy: AUTO
+    fields:
+        customId: ~
+        customIntTypedField: ~


### PR DESCRIPTION
Work in progress to implement https://github.com/doctrine/orm/issues/9561

I wanted to use this syntax in configuration:

```yaml
doctrine:
    orm:
        typed_field_mapping:
            App\Objects\CustomObject: App\DBAL\Types\CustomTypeFQCN
            App\Objects\CustomObject2: custom_type2_using_name_from_dbal
```

The problem I am facing is that `ClassMetadataInfo` does not seem to have access to the `Configuration` object. I wonder what would be the proper strategy here?

I've explored some ideas, like adding another param to the `ClassMetadataInfo::mapField($mapping)` function, but even its callers do not have access to the `Configuration` object.

@beberlei @derrabus @greg0ire please, any ideas?