### PR TITLE
Rename `AbstractCommandTest`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CommandTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CommandTestCase.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
-abstract class AbstractCommandTest extends OrmFunctionalTestCase
+abstract class CommandTestCase extends OrmFunctionalTestCase
 {
     /** @param class-string<AbstractCommand> $commandClass */
     protected function getCommandTester(string $commandClass): CommandTester

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CreateCommandTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
 
-class CreateCommandTest extends AbstractCommandTest
+class CreateCommandTest extends CommandTestCase
 {
     /** @doesNotPerformAssertions */
     public function testItPrintsTheSql(): void

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/DropCommandTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
 use Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool\Models\Keyboard;
 
-final class DropCommandTest extends AbstractCommandTest
+final class DropCommandTest extends CommandTestCase
 {
     /** @doesNotPerformAssertions */
     public function testItPrintsTheSql(): void

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 
-class UpdateCommandTest extends AbstractCommandTest
+class UpdateCommandTest extends CommandTestCase
 {
     /** @doesNotPerformAssertions */
     public function testItPrintsTheSql(): void


### PR DESCRIPTION
Forward compatibility: PHPUnit 10 will refuse to accept abstract classes with a `Test` suffix.