### PR TITLE
Add TypedFieldMapper for automatic mapping of typed PHP fields to DBAL types

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -72,6 +72,7 @@ Advanced Topics
 * :doc:`Transactions and Concurrency <reference/transactions-and-concurrency>`
 * :doc:`Filters <reference/filters>`
 * :doc:`NamingStrategy <reference/namingstrategy>`
+* :doc:`TypedFieldMapper <reference/typedfieldmapper>`
 * :doc:`Improving Performance <reference/improving-performance>`
 * :doc:`Caching <reference/caching>`
 * :doc:`Partial Objects <reference/partial-objects>`

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -289,6 +289,13 @@ These are the "automatic" mapping rules:
 As of version 2.11 Doctrine can also automatically map typed properties using a
 PHP 8.1 enum to set the right ``type`` and ``enumType``.
 
+.. versionadded:: 2.14
+
+Since version 2.14 you can specify custom typed field mapping between PHP type and DBAL type using ``Configuration``
+and a custom ``Doctrine\ORM\Mapping\TypedFieldMapper`` implementation.
+
+:doc:`Read more about TypedFieldMapper <typedfieldmapper>`.
+
 .. _reference-mapping-types:
 
 Doctrine Mapping Types

--- a/docs/en/reference/typedfieldmapper.rst
+++ b/docs/en/reference/typedfieldmapper.rst
@@ -1,0 +1,176 @@
+Implementing a TypedFieldMapper
+===============================
+
+.. versionadded:: 2.14
+
+You can specify custom typed field mapping between PHP type and DBAL type using ``Configuration``
+and a custom ``Doctrine\ORM\Mapping\TypedFieldMapper`` implementation.
+
+.. code-block:: php
+
+    <?php
+
+    $configuration->setTypedFieldMapper(new CustomTypedFieldMapper());
+
+
+DefaultTypedFieldMapper
+-----------------------
+
+By default the ``Doctrine\ORM\Mapping\DefaultTypedFieldMapper`` is used, and you can pass an array of
+PHP type => DBAL type mappings into its constructor to override the default behavior or add new mappings.
+
+.. code-block:: php
+
+    <?php
+    use App\CustomIds\CustomIdObject;
+    use App\DBAL\Type\CustomIdObjectType;
+
+    $configuration->setTypedFieldMapper(new DefaultTypedFieldMapper([
+        CustomIdObject::class => CustomIdObjectType::class,
+    ]));
+
+Then, an entity using the ``CustomIdObject`` typed field will be correctly assigned its DBAL type
+(``CustomIdObjectType``) without the need of explicit declaration.
+
+.. configuration-block::
+
+    .. code-block:: attribute
+
+        <?php
+        #[ORM\Entity]
+        #[ORM\Table(name: 'cms_users_typed_with_custom_typed_field')]
+        class UserTypedWithCustomTypedField
+        {
+            #[ORM\Column]
+            public CustomIdObject $customId;
+
+            // ...
+        }
+
+    .. code-block:: annotation
+
+        <?php
+        /**
+         * @Entity
+         * @Table(name="cms_users_typed_with_custom_typed_field")
+         */
+        class UserTypedWithCustomTypedField
+        {
+            /** @Column */
+            public CustomIdObject $customId;
+
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <doctrine-mapping>
+          <entity name="UserTypedWithCustomTypedField">
+            <field name="customId"/>
+            <!-- -->
+          </entity>
+        </doctrine-mapping>
+
+    .. code-block:: yaml
+
+        UserTypedWithCustomTypedField:
+          type: entity
+          fields:
+            customId: ~
+
+It is perfectly valid to override even the "automatic" mapping rules mentioned above:
+
+.. code-block:: php
+
+    <?php
+    use App\DBAL\Type\CustomIntType;
+
+    $configuration->setTypedFieldMapper(new DefaultTypedFieldMapper([
+        'int' => CustomIntType::class,
+    ]));
+
+.. note::
+
+    If chained, once the first ``TypedFieldMapper`` assigns a type to a field, the ``DefaultTypedFieldMapper`` will
+    ignore its mapping and not override it anymore (if it is later in the chain). See below for chaining type mappers.
+
+
+TypedFieldMapper interface
+-------------------------
+The interface ``Doctrine\ORM\Mapping\TypedFieldMapper`` allows you to implement your own
+typed field mapping logic. It consists of just one function
+
+
+.. code-block:: php
+
+    <?php
+    /**
+     * Validates & completes the given field mapping based on typed property.
+     *
+     * @param array{fieldName: string, enumType?: string, type?: mixed}  $mapping The field mapping to validate & complete.
+     * @param \ReflectionProperty                                        $field
+     *
+     * @return array{fieldName: string, enumType?: string, type?: mixed} The updated mapping.
+     */
+    public function validateAndComplete(array $mapping, ReflectionProperty $field): array;
+
+
+ChainTypedFieldMapper
+---------------------
+
+The class ``Doctrine\ORM\Mapping\ChainTypedFieldMapper`` allows you to chain multiple ``TypedFieldMapper`` instances.
+When being evaluated, the ``TypedFieldMapper::validateAndComplete`` is called in the order in which
+the instances were supplied to the ``ChainTypedFieldMapper`` constructor.
+
+.. code-block:: php
+
+    <?php
+    use App\DBAL\Type\CustomIntType;
+
+    $configuration->setTypedFieldMapper(
+        new ChainTypedFieldMapper(
+            DefaultTypedFieldMapper(['int' => CustomIntType::class,]),
+            new CustomTypedFieldMapper()
+        )
+    );
+
+
+Implementing a TypedFieldMapper
+-------------------------------
+
+If you want to assign all ``BackedEnum`` fields to your custom ``BackedEnumDBALType`` or you want to use different
+DBAL types based on whether the entity field is nullable or not, you can achieve this by implementing your own
+typed field mapper.
+
+You need to create a class which implements ``Doctrine\ORM\Mapping\TypedFieldMapper``.
+
+.. code-block:: php
+
+    <?php
+    final class CustomEnumTypedFieldMapper implements TypedFieldMapper
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function validateAndComplete(array $mapping, ReflectionProperty $field): array
+        {
+            $type = $field->getType();
+
+            if (
+                ! isset($mapping['type'])
+                && ($type instanceof ReflectionNamedType)
+            ) {
+                if (! $type->isBuiltin() && enum_exists($type->getName())) {
+                    $mapping['type'] = BackedEnumDBALType::class;
+                }
+            }
+
+            return $mapping;
+        }
+    }
+
+.. note::
+
+    Note that this case checks whether the mapping is already assigned, and if yes, it skips it. This is up to your
+    implementation. You can make a "greedy" mapper which will always override the mapping with its own type, or one
+    that behaves like ``DefaultTypedFieldMapper`` and does not modify the type once its set prior in the chain.

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -35,6 +35,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Mapping\TypedFieldMapper;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Filter\SQLFilter;
@@ -719,7 +720,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|callable|null
-     * @psalm-return class-string|callable|null $name
+     * @psalm-return class-string|callable|null
      */
     public function getCustomDatetimeFunction($name)
     {
@@ -746,6 +747,22 @@ class Configuration extends \Doctrine\DBAL\Configuration
         foreach ($functions as $name => $className) {
             $this->addCustomDatetimeFunction($name, $className);
         }
+    }
+
+    /**
+     * Sets a TypedFieldMapper for php typed fields to DBAL types auto-completion.
+     */
+    public function setTypedFieldMapper(?TypedFieldMapper $typedFieldMapper): void
+    {
+        $this->_attributes['typedFieldMapper'] = $typedFieldMapper;
+    }
+
+    /**
+     * Gets a TypedFieldMapper for php typed fields to DBAL types auto-completion.
+     */
+    public function getTypedFieldMapper(): ?TypedFieldMapper
+    {
+        return $this->_attributes['typedFieldMapper'] ?? null;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ChainTypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/ChainTypedFieldMapper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ReflectionProperty;
+
+final class ChainTypedFieldMapper implements TypedFieldMapper
+{
+    /**
+     * @readonly
+     * @var TypedFieldMapper[] $typedFieldMappers
+     */
+    private array $typedFieldMappers;
+
+    public function __construct(TypedFieldMapper ...$typedFieldMappers)
+    {
+        $this->typedFieldMappers = $typedFieldMappers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateAndComplete(array $mapping, ReflectionProperty $field): array
+    {
+        foreach ($this->typedFieldMappers as $typedFieldMapper) {
+            $mapping = $typedFieldMapper->validateAndComplete($mapping, $field);
+        }
+
+        return $mapping;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -21,8 +21,8 @@ class ClassMetadata extends ClassMetadataInfo
      * @param string $entityName The name of the entity class the new instance is used for.
      * @psalm-param class-string<T> $entityName
      */
-    public function __construct($entityName, ?NamingStrategy $namingStrategy = null)
+    public function __construct($entityName, ?NamingStrategy $namingStrategy = null, ?TypedFieldMapper $typedFieldMapper = null)
     {
-        parent::__construct($entityName, $namingStrategy);
+        parent::__construct($entityName, $namingStrategy, $typedFieldMapper);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -293,7 +293,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function newClassMetadataInstance($className)
     {
-        return new ClassMetadata($className, $this->em->getConfiguration()->getNamingStrategy());
+        return new ClassMetadata(
+            $className,
+            $this->em->getConfiguration()->getNamingStrategy(),
+            $this->em->getConfiguration()->getTypedFieldMapper()
+        );
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -6,12 +6,8 @@ namespace Doctrine\ORM\Mapping;
 
 use BackedEnum;
 use BadMethodCallException;
-use DateInterval;
-use DateTime;
-use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
@@ -23,7 +19,6 @@ use Doctrine\Persistence\Mapping\ReflectionService;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
-use ReflectionEnum;
 use ReflectionNamedType;
 use ReflectionProperty;
 use RuntimeException;
@@ -800,6 +795,9 @@ class ClassMetadataInfo implements ClassMetadata
     /** @var InstantiatorInterface|null */
     private $instantiator;
 
+    /** @var TypedFieldMapper $typedFieldMapper */
+    private $typedFieldMapper;
+
     /**
      * Initializes a new ClassMetadata instance that will hold the object-relational mapping
      * metadata of the class with the given name.
@@ -807,12 +805,13 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $entityName The name of the entity class the new instance is used for.
      * @psalm-param class-string<T> $entityName
      */
-    public function __construct($entityName, ?NamingStrategy $namingStrategy = null)
+    public function __construct($entityName, ?NamingStrategy $namingStrategy = null, ?TypedFieldMapper $typedFieldMapper = null)
     {
-        $this->name           = $entityName;
-        $this->rootEntityName = $entityName;
-        $this->namingStrategy = $namingStrategy ?: new DefaultNamingStrategy();
-        $this->instantiator   = new Instantiator();
+        $this->name             = $entityName;
+        $this->rootEntityName   = $entityName;
+        $this->namingStrategy   = $namingStrategy ?? new DefaultNamingStrategy();
+        $this->instantiator     = new Instantiator();
+        $this->typedFieldMapper = $typedFieldMapper ?? new DefaultTypedFieldMapper();
     }
 
     /**
@@ -1580,50 +1579,9 @@ class ClassMetadataInfo implements ClassMetadata
      */
     private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {
-        $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
+        $field = $this->reflClass->getProperty($mapping['fieldName']);
 
-        if ($type) {
-            if (
-                ! isset($mapping['type'])
-                && ($type instanceof ReflectionNamedType)
-            ) {
-                if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
-                    $mapping['enumType'] = $type->getName();
-
-                    $reflection = new ReflectionEnum($type->getName());
-                    $type       = $reflection->getBackingType();
-
-                    assert($type instanceof ReflectionNamedType);
-                }
-
-                switch ($type->getName()) {
-                    case DateInterval::class:
-                        $mapping['type'] = Types::DATEINTERVAL;
-                        break;
-                    case DateTime::class:
-                        $mapping['type'] = Types::DATETIME_MUTABLE;
-                        break;
-                    case DateTimeImmutable::class:
-                        $mapping['type'] = Types::DATETIME_IMMUTABLE;
-                        break;
-                    case 'array':
-                        $mapping['type'] = Types::JSON;
-                        break;
-                    case 'bool':
-                        $mapping['type'] = Types::BOOLEAN;
-                        break;
-                    case 'float':
-                        $mapping['type'] = Types::FLOAT;
-                        break;
-                    case 'int':
-                        $mapping['type'] = Types::INTEGER;
-                        break;
-                    case 'string':
-                        $mapping['type'] = Types::STRING;
-                        break;
-                }
-            }
-        }
+        $mapping = $this->typedFieldMapper->validateAndComplete($mapping, $field);
 
         return $mapping;
     }

--- a/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use ReflectionEnum;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+use function array_merge;
+use function assert;
+use function enum_exists;
+
+use const PHP_VERSION_ID;
+
+/** @psalm-type ScalarName = 'array'|'bool'|'float'|'int'|'string' */
+final class DefaultTypedFieldMapper implements TypedFieldMapper
+{
+    /** @var array<class-string|ScalarName, class-string<Type>|string> $typedFieldMappings */
+    private $typedFieldMappings;
+
+    private const DEFAULT_TYPED_FIELD_MAPPINGS = [
+        DateInterval::class => Types::DATEINTERVAL,
+        DateTime::class => Types::DATETIME_MUTABLE,
+        DateTimeImmutable::class => Types::DATETIME_IMMUTABLE,
+        'array' => Types::JSON,
+        'bool' => Types::BOOLEAN,
+        'float' => Types::FLOAT,
+        'int' => Types::INTEGER,
+        'string' => Types::STRING,
+    ];
+
+    /** @param array<class-string|ScalarName, class-string<Type>|string> $typedFieldMappings */
+    public function __construct(array $typedFieldMappings = [])
+    {
+        $this->typedFieldMappings = array_merge(self::DEFAULT_TYPED_FIELD_MAPPINGS, $typedFieldMappings);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateAndComplete(array $mapping, ReflectionProperty $field): array
+    {
+        $type = $field->getType();
+
+        if (
+            ! isset($mapping['type'])
+            && ($type instanceof ReflectionNamedType)
+        ) {
+            if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
+                $mapping['enumType'] = $type->getName();
+
+                $reflection = new ReflectionEnum($type->getName());
+                $type       = $reflection->getBackingType();
+
+                assert($type instanceof ReflectionNamedType);
+            }
+
+            if (isset($this->typedFieldMappings[$type->getName()])) {
+                $mapping['type'] = $this->typedFieldMappings[$type->getName()];
+            }
+        }
+
+        return $mapping;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ReflectionProperty;
+
+interface TypedFieldMapper
+{
+    /**
+     * Validates & completes the given field mapping based on typed property.
+     *
+     * @param array{fieldName: string, enumType?: string, type?: mixed} $mapping The field mapping to validate & complete.
+     *
+     * @return array{fieldName: string, enumType?: string, type?: mixed} The updated mapping.
+     */
+    public function validateAndComplete(array $mapping, ReflectionProperty $field): array;
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -741,6 +741,11 @@
       <code>strrpos($className, '\\')</code>
     </PossiblyFalseOperand>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php">
+    <PropertyTypeCoercion occurrences="1">
+      <code>array_merge(self::DEFAULT_TYPED_FIELD_MAPPINGS, $typedFieldMappings)</code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php">
     <DeprecatedMethod occurrences="2">
       <code>canEmulateSchemas</code>

--- a/tests/Doctrine/Tests/DbalTypes/CustomIntType.php
+++ b/tests/Doctrine/Tests/DbalTypes/CustomIntType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Types\IntegerType;
+
+class CustomIntType extends IntegerType
+{
+    public const NAME = 'custom_int_type';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTypedWithCustomTypedField.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTypedWithCustomTypedField.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\TypedProperties;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+
+/**
+ * @Entity
+ * @Table(name="cms_users_typed_with_custom_typed_field")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'cms_users_typed_with_custom_typed_field')]
+class UserTypedWithCustomTypedField
+{
+    /**
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    /** @Column */
+    #[ORM\Column]
+    public CustomIdObject $customId;
+
+    /** @Column */
+    #[ORM\Column]
+    public int $customIntTypedField;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable(
+            ['name' => 'cms_users_typed_with_custom_typed_field']
+        );
+
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+            ]
+        );
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+        $metadata->mapField(
+            ['fieldName' => 'customId']
+        );
+
+        $metadata->mapField(
+            ['fieldName' => 'customIntTypedField']
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\ProxyClassesAlwaysRegenerating;
 use Doctrine\ORM\Mapping as AnnotationNamespace;
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\PrePersist;
@@ -439,6 +440,15 @@ class ConfigurationTest extends DoctrineTestCase
         self::assertNull($this->configuration->getSecondLevelCacheConfiguration());
         $this->configuration->setSecondLevelCacheConfiguration($mockClass);
         self::assertEquals($mockClass, $this->configuration->getSecondLevelCacheConfiguration());
+    }
+
+    /** @group GH10313 */
+    public function testSetGetTypedFieldMapper(): void
+    {
+        self::assertEmpty($this->configuration->getTypedFieldMapper());
+        $defaultTypedFieldMapper = new DefaultTypedFieldMapper();
+        $this->configuration->setTypedFieldMapper($defaultTypedFieldMapper);
+        self::assertSame($defaultTypedFieldMapper, $this->configuration->getTypedFieldMapper());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapper/CustomIntAsStringTypedFieldMapper.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapper/CustomIntAsStringTypedFieldMapper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping\TypedFieldMapper;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\TypedFieldMapper;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+final class CustomIntAsStringTypedFieldMapper implements TypedFieldMapper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validateAndComplete(array $mapping, ReflectionProperty $field): array
+    {
+        $type = $field->getType();
+
+        if (
+            ! isset($mapping['type'])
+            && ($type instanceof ReflectionNamedType)
+        ) {
+            if ($type->getName() === 'int') {
+                $mapping['type'] = Types::STRING;
+            }
+        }
+
+        return $mapping;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapperTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\ORM\Mapping\TypedFieldMapper;
+use Doctrine\Tests\Models\TypedProperties\UserTyped;
+use Doctrine\Tests\ORM\Mapping\TypedFieldMapper\CustomIntAsStringTypedFieldMapper;
+use Doctrine\Tests\OrmTestCase;
+use ReflectionClass;
+
+/**
+ * @group GH10313
+ * @requires PHP 7.4
+ */
+class TypedFieldMapperTest extends OrmTestCase
+{
+    private static function defaultTypedFieldMapper(): DefaultTypedFieldMapper
+    {
+        return new DefaultTypedFieldMapper();
+    }
+
+    private static function customTypedFieldMapper(): CustomIntAsStringTypedFieldMapper
+    {
+        return new CustomIntAsStringTypedFieldMapper();
+    }
+
+    private static function chainTypedFieldMapper(): ChainTypedFieldMapper
+    {
+        return new ChainTypedFieldMapper(self::customTypedFieldMapper(), self::defaultTypedFieldMapper());
+    }
+
+    /**
+     * Data Provider for NamingStrategy#classToTableName
+     *
+     * @return array<
+     *     array{
+     *         TypedFieldMapper,
+     *         ReflectionClass,
+     *         array{fieldName: string, enumType?: string, type?: mixed},
+     *         array{fieldName: string, enumType?: string, type?: mixed}
+     *     }>
+     */
+    public static function dataFieldToMappedField(): array
+    {
+        $reflectionClass = new ReflectionClass(UserTyped::class);
+
+        return [
+            // DefaultTypedFieldMapper
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::INTEGER]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateInterval'], ['fieldName' => 'dateInterval', 'type' => Types::DATEINTERVAL]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTime'], ['fieldName' => 'dateTime', 'type' => Types::DATETIME_MUTABLE]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTimeImmutable'], ['fieldName' => 'dateTimeImmutable', 'type' => Types::DATETIME_IMMUTABLE]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'array'], ['fieldName' => 'array', 'type' => Types::JSON]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'boolean'], ['fieldName' => 'boolean', 'type' => Types::BOOLEAN]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'float'], ['fieldName' => 'float', 'type' => Types::FLOAT]],
+
+            // CustomIntAsStringTypedFieldMapper
+            [self::customTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::STRING]],
+
+            // ChainTypedFieldMapper
+            [self::chainTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::STRING]],
+            [self::chainTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING]],
+        ];
+    }
+
+    /**
+     * @param array{fieldName: string, enumType?: string, type?: mixed} $mapping
+     * @param array{fieldName: string, enumType?: string, type?: mixed} $finalMapping
+     *
+     * @dataProvider dataFieldToMappedField
+     */
+    public function testValidateAndComplete(
+        TypedFieldMapper $typedFieldMapper,
+        ReflectionClass $reflectionClass,
+        array $mapping,
+        array $finalMapping
+    ): void {
+        self::assertSame($finalMapping, $typedFieldMapper->validateAndComplete($mapping, $reflectionClass->getProperty($mapping['fieldName'])));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+$metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
+$metadata->setPrimaryTable(
+    ['name' => 'cms_users_typed_with_custom_typed_field']
+);
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+    ]
+);
+
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+$metadata->mapField(
+    ['fieldName' => 'customId']
+);
+
+$metadata->mapField(
+    ['fieldName' => 'customIntTypedField']
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField" table="cms_users_typed_with_custom_typed_field">
+    <id name="id">
+      <generator strategy="AUTO"/>
+    </id>
+
+    <field name="customId"/>
+    <field name="customIntTypedField"/>
+  </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTypedWithCustomTypedField.dcm.yml
@@ -1,0 +1,10 @@
+Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField:
+    type: entity
+    table: cms_users_typed_with_custom_typed_field
+    id:
+        id:
+            generator:
+                strategy: AUTO
+    fields:
+        customId: ~
+        customIntTypedField: ~


### PR DESCRIPTION
This is an alternative implementation of https://github.com/doctrine/orm/pull/10290, fixes https://github.com/doctrine/orm/issues/9561

Previously, only a predefined set of automatic mappings was allowed for as `array`, `bool`, `int`, `float`, `string`, `DateTime`, `DateTimeImmutable` and `DateInterval`.

With this extension, it is possible to supply custom `TypedFieldMapper` implementation. Its `validateAndComplete` takes as parameter the ReflectionProperty of a given field and decides the appropriate mapping.

A new configuration option was added to set and get the `TypedFieldMapper`.

The old logic was moved into a class `DefaultTypedFieldMapper` which is used by default when no mapper is supplied.

The selected `TypedFieldMapper` is passed into `ClassMetadataInfo`'s constructor. If empty, the `DefaultTypedFieldMapper` is used.

There is also `ChainTypedFieldMapper` class which allows chaining multiple `TypedFieldMappers` and apply them in a cascade (always if a field gets type assigned by the earlier mapper in the list, it will not be changed later).

Documentation has been updated to explain the new features. Tests were added to cover the new classes as well as `ClassMetadataInfo` and all mapping drivers.

