### PR TITLE
Require dev version of phpbench

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,9 +78,6 @@ jobs:
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
 
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:
@@ -156,9 +153,6 @@ jobs:
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
 
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:
@@ -219,9 +213,6 @@ jobs:
       - name: "Require specific DBAL version"
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
-
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -299,9 +290,6 @@ jobs:
       - name: "Require specific DBAL version"
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
-
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -57,9 +57,6 @@ jobs:
       - name: "Require specific persistence version"
         run: "composer require doctrine/persistence ^$([ ${{ matrix.persistence-version }} = default ] && echo '3.1' || echo ${{ matrix.persistence-version }}) --no-update"
 
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:
@@ -96,9 +93,6 @@ jobs:
 
       - name: "Require specific persistence version"
         run: "composer require doctrine/persistence ^3.1 --no-update"
-
-      - name: "Uninstall PHPBench"
-        run: "composer remove --dev --no-update phpbench/phpbench"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^11.0",
-        "phpbench/phpbench": "^0.16.10 || ^1.0",
+        "phpbench/phpbench": "^0.16.10 || ^1.0 || dev-master",
         "phpstan/phpstan": "~1.4.10 || 1.9.4",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "psr/log": "^1 || ^2 || ^3",


### PR DESCRIPTION
It is important to have the same version of all dependencies in dev and in the CI, otherwise it makes it hard to have the right static analysis baseline for every environment.