### PR TITLE
Add Fully-Qualified class name in UnrecognizedField exception

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.14
 
+## Deprecated `Doctrine\ORM\Persisters\Exception\UnrecognizedField::byName($field)` method.
+
+It will be removed in 3.0. Use `Doctrine\ORM\Persisters\Exception\UnrecognizedField::byFullyQualifiedName($className, $field)` instead.
+
 ## Deprecated constants of `Doctrine\ORM\Internal\CommitOrderCalculator`
 
 The following public constants have been deprecated:

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -487,7 +487,7 @@ class BasicEntityPersister implements EntityPersister
             $targetType    = PersisterHelper::getTypeOfField($targetMapping->identifier[0], $targetMapping, $this->em);
 
             if ($targetType === []) {
-                throw UnrecognizedField::byName($targetMapping->identifier[0]);
+                throw UnrecognizedField::byFullyQualifiedName($this->class->name, $targetMapping->identifier[0]);
             }
 
             $types[] = reset($targetType);
@@ -1199,7 +1199,7 @@ class BasicEntityPersister implements EntityPersister
                 continue;
             }
 
-            throw UnrecognizedField::byName($fieldName);
+            throw UnrecognizedField::byFullyQualifiedName($this->class->name, $fieldName);
         }
 
         return ' ORDER BY ' . implode(', ', $orderByList);
@@ -1757,7 +1757,7 @@ class BasicEntityPersister implements EntityPersister
             return [$field];
         }
 
-        throw UnrecognizedField::byName($field);
+        throw UnrecognizedField::byFullyQualifiedName($this->class->name, $field);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Exception/UnrecognizedField.php
+++ b/lib/Doctrine/ORM/Persisters/Exception/UnrecognizedField.php
@@ -10,8 +10,15 @@ use function sprintf;
 
 final class UnrecognizedField extends PersisterException
 {
+    /** @deprecated This method is deprecated and will be removed in Doctrine ORM 3.0. Use {@see byFullyQualifiedName} instead */
     public static function byName(string $field): self
     {
         return new self(sprintf('Unrecognized field: %s', $field));
+    }
+
+    /** @param class-string $className */
+    public static function byFullyQualifiedName(string $className, string $field): self
+    {
+        return new self(sprintf('Unrecognized field: %s::$%s', $className, $field));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/Exception/UnrecognizedFieldTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/Exception/UnrecognizedFieldTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Persisters\Exception;
+
+use Doctrine\ORM\Persisters\Exception\UnrecognizedField;
+use Doctrine\Tests\Models\Taxi\Car;
+use PHPUnit\Framework\TestCase;
+
+class UnrecognizedFieldTest extends TestCase
+{
+    public function testByFullyQualifiedName(): void
+    {
+        static::expectException(UnrecognizedField::class);
+        static::expectExceptionMessage('Unrecognized field: Doctrine\Tests\Models\Taxi\Car::$color');
+
+        throw UnrecognizedField::byFullyQualifiedName(Car::class, 'color');
+    }
+}


### PR DESCRIPTION
Currently if we use a field that is not properly registered in our mapping, we end up with the following exception from the `BasicEntityPersister`:

```
Unrecognized field: {field}
```

As with a complete stack trace we may be able to dig enough to find the right mapping, it can take more time to find the concerned entity in a context with less informations, such as logs.

This PR adds the entity FQCN to the exception message to ease debugging in such cases, using the class metadata available in `BasicEntityPersister::class` property. We end up with:

```
Unrecognized field: {fqcn}::{field}
```

As I didn't encountered any tests for the existing `UnrecognizedException` class behavior, I didn't add some but I can if needed.