### PR TITLE
Modernize QueryExpressionVisitor

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -12,7 +12,6 @@ use Doctrine\Common\Collections\Expr\Value;
 use RuntimeException;
 
 use function count;
-use function defined;
 use function str_replace;
 use function str_starts_with;
 
@@ -21,23 +20,22 @@ use function str_starts_with;
  */
 class QueryExpressionVisitor extends ExpressionVisitor
 {
-    /** @var array<string,string> */
-    private static $operatorMap = [
+    private const OPERATOR_MAP = [
         Comparison::GT => Expr\Comparison::GT,
         Comparison::GTE => Expr\Comparison::GTE,
         Comparison::LT  => Expr\Comparison::LT,
         Comparison::LTE => Expr\Comparison::LTE,
     ];
 
-    /** @var Expr */
-    private $expr;
+    private readonly Expr $expr;
 
     /** @var list<mixed> */
-    private $parameters = [];
+    private array $parameters = [];
 
     /** @param mixed[] $queryAliases */
-    public function __construct(private $queryAliases)
-    {
+    public function __construct(
+        private readonly array $queryAliases,
+    ) {
         $this->expr = new Expr();
     }
 
@@ -47,37 +45,25 @@ class QueryExpressionVisitor extends ExpressionVisitor
      *
      * @return ArrayCollection<int, mixed>
      */
-    public function getParameters()
+    public function getParameters(): ArrayCollection
     {
         return new ArrayCollection($this->parameters);
     }
 
-    /**
-     * Clears parameters.
-     *
-     * @return void
-     */
-    public function clearParameters()
+    public function clearParameters(): void
     {
         $this->parameters = [];
     }
 
     /**
      * Converts Criteria expression to Query one based on static map.
-     *
-     * @param string $criteriaOperator
-     *
-     * @return string|null
      */
-    private static function convertComparisonOperator($criteriaOperator)
+    private static function convertComparisonOperator(string $criteriaOperator): string|null
     {
-        return self::$operatorMap[$criteriaOperator] ?? null;
+        return self::OPERATOR_MAP[$criteriaOperator] ?? null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function walkCompositeExpression(CompositeExpression $expr)
+    public function walkCompositeExpression(CompositeExpression $expr): mixed
     {
         $expressionList = [];
 
@@ -85,27 +71,15 @@ class QueryExpressionVisitor extends ExpressionVisitor
             $expressionList[] = $this->dispatch($child);
         }
 
-        switch ($expr->getType()) {
-            case CompositeExpression::TYPE_AND:
-                return new Expr\Andx($expressionList);
-
-            case CompositeExpression::TYPE_OR:
-                return new Expr\Orx($expressionList);
-
-            default:
-                // Multiversion support for `doctrine/collections` before and after v2.1.0
-                if (defined(CompositeExpression::class . '::TYPE_NOT') && $expr->getType() === CompositeExpression::TYPE_NOT) {
-                    return $this->expr->not($expressionList[0]);
-                }
-
-                throw new RuntimeException('Unknown composite ' . $expr->getType());
-        }
+        return match ($expr->getType()) {
+            CompositeExpression::TYPE_AND => new Expr\Andx($expressionList),
+            CompositeExpression::TYPE_OR => new Expr\Orx($expressionList),
+            CompositeExpression::TYPE_NOT => $this->expr->not($expressionList[0]),
+            default => throw new RuntimeException('Unknown composite ' . $expr->getType()),
+        };
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function walkComparison(Comparison $comparison)
+    public function walkComparison(Comparison $comparison): mixed
     {
         if (! isset($this->queryAliases[0])) {
             throw new QueryException('No aliases are set before invoking walkComparison().');
@@ -199,10 +173,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function walkValue(Value $value)
+    public function walkValue(Value $value): mixed
     {
         return $value->getValue();
     }

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -13,8 +13,6 @@ use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryExpressionVisitor;
 use PHPUnit\Framework\TestCase;
 
-use function method_exists;
-
 /**
  * Test for QueryExpressionVisitor
  */
@@ -108,10 +106,6 @@ class QueryExpressionVisitorTest extends TestCase
 
     public function testWalkNotCompositeExpression(): void
     {
-        if (! method_exists(CriteriaBuilder::class, 'not')) {
-            self::markTestSkipped('doctrine/collections in version ^2.1 is required for this test to run.');
-        }
-
         $qb = new QueryBuilder();
         $cb = new CriteriaBuilder();
 

--- a/tests/Doctrine/Tests/ORM/Query/SqlExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SqlExpressionVisitorTest.php
@@ -11,17 +11,11 @@ use Doctrine\ORM\Persisters\SqlExpressionVisitor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function method_exists;
-
 class SqlExpressionVisitorTest extends TestCase
 {
-    /** @var SqlExpressionVisitor */
-    private $visitor;
-
-    /** @var BasicEntityPersister&MockObject */
-    private $persister;
-    /** @var ClassMetadata */
-    private $classMetadata;
+    private SqlExpressionVisitor $visitor;
+    private BasicEntityPersister&MockObject $persister;
+    private ClassMetadata $classMetadata;
 
     protected function setUp(): void
     {
@@ -32,10 +26,6 @@ class SqlExpressionVisitorTest extends TestCase
 
     public function testWalkNotCompositeExpression(): void
     {
-        if (! method_exists(CriteriaBuilder::class, 'not')) {
-            self::markTestSkipped('doctrine/collections in version ^2.1 is required for this test to run.');
-        }
-
         $cb = new CriteriaBuilder();
 
         $this->persister


### PR DESCRIPTION
This PR migrates `QueryExpressionVisitor` to PHP 8 syntax and cleans up compat code from #10234.