### PR TITLE
Fix entity refresh after cleared em

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -165,6 +165,10 @@ class SimpleObjectHydrator extends AbstractHydrator
             }
         }
 
+        if (isset($this->_hints[Query::HINT_REFRESH_ENTITY])) {
+            $this->registerManaged($this->class, $this->_hints[Query::HINT_REFRESH_ENTITY], $data);
+        }
+
         $uow    = $this->_em->getUnitOfWork();
         $entity = $uow->createEntity($entityName, $data, $this->_hints);
 

--- a/tests/Doctrine/Tests/Models/GH10336/GH10336Entity.php
+++ b/tests/Doctrine/Tests/Models/GH10336/GH10336Entity.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10336;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh10336_entities")
+ */
+class GH10336Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH10336Relation")
+     * @ORM\JoinColumn(name="relation_id", referencedColumnName="id", nullable=true)
+     */
+    public ?GH10336Relation $relation = null;
+}

--- a/tests/Doctrine/Tests/Models/GH10336/GH10336Relation.php
+++ b/tests/Doctrine/Tests/Models/GH10336/GH10336Relation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10336;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh10336_relations")
+ */
+class GH10336Relation
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    public string $value;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10336Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10336Test.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH10336\GH10336Entity;
+use Doctrine\Tests\Models\GH10336\GH10336Relation;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @requires PHP 7.4
+ */
+final class GH10336Test extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH10336Entity::class,
+            GH10336Relation::class
+        );
+    }
+
+    public function testCanAccessRelationPropertyAfterClear(): void
+    {
+        $relation         = new GH10336Relation();
+        $relation->value  = 'foo';
+        $entity           = new GH10336Entity();
+        $entity->relation = $relation;
+
+        $this->_em->persist($entity);
+        $this->_em->persist($relation);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(GH10336Entity::class, 1);
+
+        $this->_em->clear();
+
+        $this->assertSame('foo', $entity->relation->value);
+    }
+}


### PR DESCRIPTION
Fixes #10336 

Includes reproducing test of #10337 

This fixes a missing handling of HINT_REFRESH_ENTITY and ignored private identifier property in a parent class.