### PR TITLE
Address new behavior of $firstResult

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -677,11 +677,11 @@ final class Query extends AbstractQuery
 
     /**
      * Gets the position of the first result the query object was set to retrieve (the "offset").
-     * Returns NULL if {@link setFirstResult} was not applied to this query.
+     * Returns 0 if {@link setFirstResult} was not applied to this query.
      *
-     * @return int|null The position of the first result.
+     * @return int The position of the first result.
      */
-    public function getFirstResult(): ?int
+    public function getFirstResult(): int
     {
         return $this->firstResult;
     }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -566,7 +566,7 @@ class SqlWalker implements TreeWalker
             $sql .= ' ORDER BY ' . $orderBySql;
         }
 
-        $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset ?? 0);
+        $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset);
 
         if ($lockMode === LockMode::NONE) {
             return $sql;


### PR DESCRIPTION
Following https://github.com/doctrine/orm/pull/9730, `0` is now used as a default value, and `Query::$firstResult` is no longer nullable, but it seems `getFirstResult()` was overlooked. The class is final, so this is no breaking change. Found by Rector while working on the PHP 8 migration.