### PR TITLE
Migrate files with the least changes to PHP 8

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -47,7 +47,7 @@ class DefaultCacheFactory implements CacheFactory
         $this->fileLockRegionDirectory = $fileLockRegionDirectory;
     }
 
-    public function getFileLockRegionDirectory(): string
+    public function getFileLockRegionDirectory(): string|null
     {
         return $this->fileLockRegionDirectory;
     }

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -196,7 +196,7 @@ class EntityRepository implements ObjectRepository, Selectable
      *
      * @psalm-return AbstractLazyCollection<int, T>&Selectable<int, T>
      */
-    public function matching(Criteria $criteria): AbstractLazyCollection
+    public function matching(Criteria $criteria): AbstractLazyCollection&Selectable
     {
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->entityName);
 

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -7,8 +7,6 @@ namespace Doctrine\ORM\Id;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\EntityMissingAssignedId;
 
-use function get_class;
-
 /**
  * Special generator for application-assigned identifiers (doesn't really generate anything).
  */
@@ -23,7 +21,7 @@ class AssignedGenerator extends AbstractIdGenerator
      */
     public function generateId(EntityManagerInterface $em, object|null $entity): array
     {
-        $class      = $em->getClassMetadata(get_class($entity));
+        $class      = $em->getClassMetadata($entity::class);
         $idFields   = $class->getIdentifierFieldNames();
         $identifier = [];
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -45,7 +45,7 @@ class ObjectHydrator extends AbstractHydrator
     private array $initializedCollections = [];
 
     /** @var array<string, PersistentCollection> */
-    private $uninitializedCollections = [];
+    private array $uninitializedCollections = [];
 
     /** @var mixed[] */
     private array $existingCollections = [];

--- a/lib/Doctrine/ORM/Mapping/ChainTypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/ChainTypedFieldMapper.php
@@ -12,7 +12,7 @@ final class ChainTypedFieldMapper implements TypedFieldMapper
      * @readonly
      * @var TypedFieldMapper[] $typedFieldMappers
      */
-    private array $typedFieldMappers;
+    private readonly array $typedFieldMappers;
 
     public function __construct(TypedFieldMapper ...$typedFieldMappers)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -588,6 +588,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     protected function getDriver(): MappingDriver
     {
+        assert($this->driver !== null);
+
         return $this->driver;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
@@ -60,7 +60,7 @@ final class AttributeReader
      *
      * @template T of MappingAttribute
      */
-    public function getPropertyAttribute(ReflectionProperty $property, $attributeName)
+    public function getPropertyAttribute(ReflectionProperty $property, string $attributeName)
     {
         if ($this->isRepeatable($attributeName)) {
             throw new LogicException(sprintf(

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use InvalidArgumentException;
+use Stringable;
 
 use function array_map;
 use function implode;
@@ -23,7 +24,7 @@ use function serialize;
  *
  * @abstract
  */
-abstract class SQLFilter
+abstract class SQLFilter implements Stringable
 {
     /**
      * Parameters for the filter.


### PR DESCRIPTION
These are the lowest hanging fruits I could find after running Rector: I looked for files with a diff of 2 lines.
I did not include some changes that I find controversial, such as marking some constants as final when we should maybe consider making classes themselves final.