### PR TITLE
[Documentation] Changing `int|null` to `?int`

### DIFF
--- a/docs/en/tutorials/composite-primary-keys.rst
+++ b/docs/en/tutorials/composite-primary-keys.rst
@@ -180,7 +180,7 @@ We keep up the example of an Article with arbitrary attributes, the mapping look
         class Article
         {
             #[Id, Column, GeneratedValue]
-            private int|null $id = null;
+            private ?int $id = null;
             #[Column]
             private string $title;
 
@@ -227,7 +227,7 @@ We keep up the example of an Article with arbitrary attributes, the mapping look
         class Article
         {
             /** @Id @Column(type="integer") @GeneratedValue */
-            private int|null $id = null;
+            private ?int $id = null;
             /** @Column(type="string") */
             private string $title;
 
@@ -249,7 +249,7 @@ We keep up the example of an Article with arbitrary attributes, the mapping look
         class ArticleAttribute
         {
             /** @Id @ManyToOne(targetEntity="Article", inversedBy="attributes") */
-            private Article|null $article;
+            private ?Article $article;
 
             /** @Id @Column(type="string") */
             private string $attribute;
@@ -318,14 +318,14 @@ One good example for this is a user-address relationship:
         class User
         {
             #[Id, Column, GeneratedValue]
-            private int|null $id = null;
+            private ?int $id = null;
         }
 
         #[Entity]
         class Address
         {
             #[Id, OneToOne(targetEntity: User::class)]
-            private User|null $user = null;
+            private ?User $user = null;
         }
 
     .. code-block:: yaml
@@ -366,7 +366,7 @@ of products purchased and maybe even the current price.
     class Order
     {
         #[Id, Column, GeneratedValue]
-        private int|null $id = null;
+        private ?int $id = null;
 
         /** @var ArrayCollection<int, OrderItem> */
         #[OneToMany(targetEntity: OrderItem::class, mappedBy: 'order')]
@@ -392,7 +392,7 @@ of products purchased and maybe even the current price.
     class Product
     {
         #[Id, Column, GeneratedValue]
-        private int|null $id = null;
+        private ?int $id = null;
 
         #[Column]
         private string $name;
@@ -410,10 +410,10 @@ of products purchased and maybe even the current price.
     class OrderItem
     {
         #[Id, ManyToOne(targetEntity: Order::class)]
-        private Order|null $order = null;
+        private ?Order $order = null;
 
         #[Id, ManyToOne(targetEntity: Product::class)]
-        private Product|null $product = null;
+        private ?Product $product = null;
 
         #[Column]
         private int $amount = 1;


### PR DESCRIPTION
Answer to https://github.com/doctrine/orm/pull/10368#issuecomment-1370320653 :

PSR-12 https://www.php-fig.org/psr/psr-12/ has this example, so it looks like it's preferring `?string`:
```php
public function functionName(?string $arg1, ?int &$arg2): ?string
```
But changing it in `ruleset.xml` would lead to errors allover the Doctrine code itself, right?