### PR TITLE
Use more precise types for class strings

### DIFF
--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -33,7 +33,7 @@ class MappingException extends ORMException
     }
 
     /**
-     * @param string $entityName
+     * @param class-string $entityName
      *
      * @return MappingException
      */
@@ -346,7 +346,7 @@ class MappingException extends ORMException
     }
 
     /**
-     * @param string $className
+     * @param class-string $className
      *
      * @return MappingException
      */

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1014,10 +1014,6 @@
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/MappingException.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$className</code>
-      <code>$entityName</code>
-    </ArgumentTypeCoercion>
     <MissingParamType occurrences="4">
       <code>$className</code>
       <code>$className</code>


### PR DESCRIPTION
There are other places in this class where `class-string` could be use. These are places that have a consequence on the Psalm baseline.