### PR TITLE
Make sure the schema tool does not miss columns from abstract entity classes in a STI tree

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -30,6 +30,7 @@ use function array_diff_key;
 use function array_filter;
 use function array_flip;
 use function array_intersect_key;
+use function array_merge;
 use function assert;
 use function count;
 use function current;
@@ -456,6 +457,8 @@ class SchemaTool
     /**
      * Gathers the column definitions as required by the DBAL of all field mappings
      * found in the given class.
+     *
+     * @param list<class-string> $stiClassesBeingProcessed
      */
     private function gatherColumns(ClassMetadata $class, Table $table, array $stiClassesBeingProcessed = []): void
     {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -226,9 +226,9 @@ class SchemaTool
                 $subclassesToProcess = [];
                 foreach ($class->subClasses as $subClassName) {
                     $subclassesToProcess[] = $subClassName;
-                    $subClass = $this->em->getClassMetadata($subClassName);
+                    $subClass              = $this->em->getClassMetadata($subClassName);
                     foreach (array_merge($subClass->fieldMappings, $subClass->associationMappings) as $mapping) {
-                        if (isset($mapping['inherited']) && $mapping['inherited'] !== $class->name && !in_array($mapping['inherited'], $subclassesToProcess)) {
+                        if (isset($mapping['inherited']) && $mapping['inherited'] !== $class->name && ! in_array($mapping['inherited'], $subclassesToProcess)) {
                             $subclassesToProcess[] = $mapping['inherited'];
                         }
                     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
@@ -34,9 +34,9 @@ class GH10387Test extends OrmTestCase
 
     public function classHierachies(): Generator
     {
-        yield 'hierarchy with Entity classes only' => [[GH10387_EntitiesOnly_Root::class, GH10387_EntitiesOnly_Middle::class, GH10387_EntitiesOnly_Leaf::class]];
-        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH10387_MappedSuperclass_Root::class, GH10387_MappedSuperclass_Middle::class, GH10387_MappedSuperclass_Leaf::class]];
-        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH10387_AbstractEntities_Root::class, GH10387_AbstractEntities_Middle::class, GH10387_AbstractEntities_Leaf::class]];
+        yield 'hierarchy with Entity classes only' => [[GH10387EntitiesOnlyRoot::class, GH10387EntitiesOnlyMiddle::class, GH10387EntitiesOnlyLeaf::class]];
+        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH10387MappedSuperclassRoot::class, GH10387MappedSuperclassMiddle::class, GH10387MappedSuperclassLeaf::class]];
+        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH10387AbstractEntitiesRoot::class, GH10387AbstractEntitiesMiddle::class, GH10387AbstractEntitiesLeaf::class]];
     }
 }
 
@@ -44,11 +44,12 @@ class GH10387Test extends OrmTestCase
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH10387_EntitiesOnly_Root", "B": "GH10387_EntitiesOnly_Middle", "C": "GH10387_EntitiesOnly_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387EntitiesOnlyRoot", "B": "GH10387EntitiesOnlyMiddle", "C": "GH10387EntitiesOnlyLeaf"})
  */
-class GH10387_EntitiesOnly_Root
+class GH10387EntitiesOnlyRoot
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\Column
      */
@@ -58,18 +59,24 @@ class GH10387_EntitiesOnly_Root
 /**
  * @ORM\Entity
  */
-class GH10387_EntitiesOnly_Middle extends GH10387_EntitiesOnly_Root
+class GH10387EntitiesOnlyMiddle extends GH10387EntitiesOnlyRoot
 {
-    /** @ORM\Column(name="middle_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="middle_class_field")
+     */
     private $parentValue;
 }
 
 /**
  * @ORM\Entity
  */
-class GH10387_EntitiesOnly_Leaf extends GH10387_EntitiesOnly_Middle
+class GH10387EntitiesOnlyLeaf extends GH10387EntitiesOnlyMiddle
 {
-    /** @ORM\Column(name="leaf_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="leaf_class_field")
+     */
     private $childValue;
 }
 
@@ -77,12 +84,13 @@ class GH10387_EntitiesOnly_Leaf extends GH10387_EntitiesOnly_Middle
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH10387_MappedSuperclass_Root", "B": "GH10387_MappedSuperclass_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387MappedSuperclassRoot", "B": "GH10387MappedSuperclassLeaf"})
  * ^- This DiscriminatorMap contains the Entity classes only, not the Mapped Superclass
  */
-class GH10387_MappedSuperclass_Root
+class GH10387MappedSuperclassRoot
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\Column
      */
@@ -92,18 +100,24 @@ class GH10387_MappedSuperclass_Root
 /**
  * @ORM\MappedSuperclass
  */
-class GH10387_MappedSuperclass_Middle extends GH10387_MappedSuperclass_Root
+class GH10387MappedSuperclassMiddle extends GH10387MappedSuperclassRoot
 {
-    /** @ORM\Column(name="middle_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="middle_class_field")
+     */
     private $parentValue;
 }
 
 /**
  * @ORM\Entity
  */
-class GH10387_MappedSuperclass_Leaf extends GH10387_MappedSuperclass_Middle
+class GH10387MappedSuperclassLeaf extends GH10387MappedSuperclassMiddle
 {
-    /** @ORM\Column(name="leaf_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="leaf_class_field")
+     */
     private $childValue;
 }
 
@@ -112,12 +126,13 @@ class GH10387_MappedSuperclass_Leaf extends GH10387_MappedSuperclass_Middle
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH10387_AbstractEntities_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387AbstractEntitiesLeaf"})
  * ^- This DiscriminatorMap contains the single non-abstract Entity class only
  */
-abstract class GH10387_AbstractEntities_Root
+abstract class GH10387AbstractEntitiesRoot
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\Column
      */
@@ -127,17 +142,23 @@ abstract class GH10387_AbstractEntities_Root
 /**
  * @ORM\Entity
  */
-abstract class GH10387_AbstractEntities_Middle extends GH10387_AbstractEntities_Root
+abstract class GH10387AbstractEntitiesMiddle extends GH10387AbstractEntitiesRoot
 {
-    /** @ORM\Column(name="middle_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="middle_class_field")
+     */
     private $parentValue;
 }
 
 /**
  * @ORM\Entity
  */
-class GH10387_AbstractEntities_Leaf extends GH10387_AbstractEntities_Middle
+class GH10387AbstractEntitiesLeaf extends GH10387AbstractEntitiesMiddle
 {
-    /** @ORM\Column(name="leaf_class_field") */
+    /**
+     * @var string
+     * @ORM\Column(name="leaf_class_field")
+     */
     private $childValue;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
@@ -12,9 +12,9 @@ use Generator;
 use function array_map;
 
 /**
- * @group GH-9145
+ * @group GH-10387
  */
-class GH9145Test extends OrmTestCase
+class GH10387Test extends OrmTestCase
 {
     /**
      * @dataProvider classHierachies
@@ -34,9 +34,9 @@ class GH9145Test extends OrmTestCase
 
     public function classHierachies(): Generator
     {
-        yield 'hierarchy with Entity classes only' => [[GH9145_EntitiesOnly_Root::class, GH9145_EntitiesOnly_Middle::class, GH9145_EntitiesOnly_Leaf::class]];
-        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH9145_MappedSuperclass_Root::class, GH9145_MappedSuperclass_Middle::class, GH9145_MappedSuperclass_Leaf::class]];
-        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH9145_AbstractEntities_Root::class, GH9145_AbstractEntities_Middle::class, GH9145_AbstractEntities_Leaf::class]];
+        yield 'hierarchy with Entity classes only' => [[GH10387_EntitiesOnly_Root::class, GH10387_EntitiesOnly_Middle::class, GH10387_EntitiesOnly_Leaf::class]];
+        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH10387_MappedSuperclass_Root::class, GH10387_MappedSuperclass_Middle::class, GH10387_MappedSuperclass_Leaf::class]];
+        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH10387_AbstractEntities_Root::class, GH10387_AbstractEntities_Middle::class, GH10387_AbstractEntities_Leaf::class]];
     }
 }
 
@@ -44,9 +44,9 @@ class GH9145Test extends OrmTestCase
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH9145_EntitiesOnly_Root", "B": "GH9145_EntitiesOnly_Middle", "C": "GH9145_EntitiesOnly_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387_EntitiesOnly_Root", "B": "GH10387_EntitiesOnly_Middle", "C": "GH10387_EntitiesOnly_Leaf"})
  */
-class GH9145_EntitiesOnly_Root
+class GH10387_EntitiesOnly_Root
 {
     /**
      * @ORM\Id
@@ -58,7 +58,7 @@ class GH9145_EntitiesOnly_Root
 /**
  * @ORM\Entity
  */
-class GH9145_EntitiesOnly_Middle extends GH9145_EntitiesOnly_Root
+class GH10387_EntitiesOnly_Middle extends GH10387_EntitiesOnly_Root
 {
     /** @ORM\Column(name="middle_class_field") */
     private $parentValue;
@@ -67,7 +67,7 @@ class GH9145_EntitiesOnly_Middle extends GH9145_EntitiesOnly_Root
 /**
  * @ORM\Entity
  */
-class GH9145_EntitiesOnly_Leaf extends GH9145_EntitiesOnly_Middle
+class GH10387_EntitiesOnly_Leaf extends GH10387_EntitiesOnly_Middle
 {
     /** @ORM\Column(name="leaf_class_field") */
     private $childValue;
@@ -77,10 +77,10 @@ class GH9145_EntitiesOnly_Leaf extends GH9145_EntitiesOnly_Middle
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH9145_MappedSuperclass_Root", "B": "GH9145_MappedSuperclass_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387_MappedSuperclass_Root", "B": "GH10387_MappedSuperclass_Leaf"})
  * ^- This DiscriminatorMap contains the Entity classes only, not the Mapped Superclass
  */
-class GH9145_MappedSuperclass_Root
+class GH10387_MappedSuperclass_Root
 {
     /**
      * @ORM\Id
@@ -92,7 +92,7 @@ class GH9145_MappedSuperclass_Root
 /**
  * @ORM\MappedSuperclass
  */
-class GH9145_MappedSuperclass_Middle extends GH9145_MappedSuperclass_Root
+class GH10387_MappedSuperclass_Middle extends GH10387_MappedSuperclass_Root
 {
     /** @ORM\Column(name="middle_class_field") */
     private $parentValue;
@@ -101,7 +101,7 @@ class GH9145_MappedSuperclass_Middle extends GH9145_MappedSuperclass_Root
 /**
  * @ORM\Entity
  */
-class GH9145_MappedSuperclass_Leaf extends GH9145_MappedSuperclass_Middle
+class GH10387_MappedSuperclass_Leaf extends GH10387_MappedSuperclass_Middle
 {
     /** @ORM\Column(name="leaf_class_field") */
     private $childValue;
@@ -112,10 +112,10 @@ class GH9145_MappedSuperclass_Leaf extends GH9145_MappedSuperclass_Middle
  * @ORM\Entity
  * @ORM\Table(name="root")
  * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "A": "GH9145_AbstractEntities_Leaf"})
+ * @ORM\DiscriminatorMap({ "A": "GH10387_AbstractEntities_Leaf"})
  * ^- This DiscriminatorMap contains the single non-abstract Entity class only
  */
-abstract class GH9145_AbstractEntities_Root
+abstract class GH10387_AbstractEntities_Root
 {
     /**
      * @ORM\Id
@@ -127,7 +127,7 @@ abstract class GH9145_AbstractEntities_Root
 /**
  * @ORM\Entity
  */
-abstract class GH9145_AbstractEntities_Middle extends GH9145_AbstractEntities_Root
+abstract class GH10387_AbstractEntities_Middle extends GH10387_AbstractEntities_Root
 {
     /** @ORM\Column(name="middle_class_field") */
     private $parentValue;
@@ -136,7 +136,7 @@ abstract class GH9145_AbstractEntities_Middle extends GH9145_AbstractEntities_Ro
 /**
  * @ORM\Entity
  */
-class GH9145_AbstractEntities_Leaf extends GH9145_AbstractEntities_Middle
+class GH10387_AbstractEntities_Leaf extends GH10387_AbstractEntities_Middle
 {
     /** @ORM\Column(name="leaf_class_field") */
     private $childValue;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
@@ -49,9 +49,10 @@ class GH10387Test extends OrmTestCase
 class GH10387EntitiesOnlyRoot
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column
+     *
+     * @var string
      */
     private $id;
 }
@@ -62,8 +63,9 @@ class GH10387EntitiesOnlyRoot
 class GH10387EntitiesOnlyMiddle extends GH10387EntitiesOnlyRoot
 {
     /**
-     * @var string
      * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
      */
     private $parentValue;
 }
@@ -74,8 +76,9 @@ class GH10387EntitiesOnlyMiddle extends GH10387EntitiesOnlyRoot
 class GH10387EntitiesOnlyLeaf extends GH10387EntitiesOnlyMiddle
 {
     /**
-     * @var string
      * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
      */
     private $childValue;
 }
@@ -90,9 +93,10 @@ class GH10387EntitiesOnlyLeaf extends GH10387EntitiesOnlyMiddle
 class GH10387MappedSuperclassRoot
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column
+     *
+     * @var string
      */
     private $id;
 }
@@ -103,8 +107,9 @@ class GH10387MappedSuperclassRoot
 class GH10387MappedSuperclassMiddle extends GH10387MappedSuperclassRoot
 {
     /**
-     * @var string
      * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
      */
     private $parentValue;
 }
@@ -115,8 +120,9 @@ class GH10387MappedSuperclassMiddle extends GH10387MappedSuperclassRoot
 class GH10387MappedSuperclassLeaf extends GH10387MappedSuperclassMiddle
 {
     /**
-     * @var string
      * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
      */
     private $childValue;
 }
@@ -132,9 +138,10 @@ class GH10387MappedSuperclassLeaf extends GH10387MappedSuperclassMiddle
 abstract class GH10387AbstractEntitiesRoot
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column
+     *
+     * @var string
      */
     private $id;
 }
@@ -145,8 +152,9 @@ abstract class GH10387AbstractEntitiesRoot
 abstract class GH10387AbstractEntitiesMiddle extends GH10387AbstractEntitiesRoot
 {
     /**
-     * @var string
      * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
      */
     private $parentValue;
 }
@@ -157,8 +165,9 @@ abstract class GH10387AbstractEntitiesMiddle extends GH10387AbstractEntitiesRoot
 class GH10387AbstractEntitiesLeaf extends GH10387AbstractEntitiesMiddle
 {
     /**
-     * @var string
      * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
      */
     private $childValue;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9145Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9145Test.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmTestCase;
+use Generator;
+
+use function array_map;
+
+/**
+ * @group GH-9145
+ */
+class GH9145Test extends OrmTestCase
+{
+    /**
+     * @dataProvider classHierachies
+     */
+    public function testSchemaToolCreatesColumnForFieldInTheMiddleClass(array $classes): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $metadata   = array_map(static function (string $class) use ($em) {
+            return $em->getClassMetadata($class);
+        }, $classes);
+        $schema     = $schemaTool->getSchemaFromMetadata([$metadata[0]]);
+
+        self::assertNotNull($schema->getTable('root')->getColumn('middle_class_field'));
+        self::assertNotNull($schema->getTable('root')->getColumn('leaf_class_field'));
+    }
+
+    public function classHierachies(): Generator
+    {
+        yield 'hierarchy with Entity classes only' => [[GH9145_EntitiesOnly_Root::class, GH9145_EntitiesOnly_Middle::class, GH9145_EntitiesOnly_Leaf::class]];
+        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH9145_MappedSuperclass_Root::class, GH9145_MappedSuperclass_Middle::class, GH9145_MappedSuperclass_Leaf::class]];
+        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH9145_AbstractEntities_Root::class, GH9145_AbstractEntities_Middle::class, GH9145_AbstractEntities_Leaf::class]];
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH9145_EntitiesOnly_Root", "B": "GH9145_EntitiesOnly_Middle", "C": "GH9145_EntitiesOnly_Leaf"})
+ */
+class GH9145_EntitiesOnly_Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    private $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH9145_EntitiesOnly_Middle extends GH9145_EntitiesOnly_Root
+{
+    /** @ORM\Column(name="middle_class_field") */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH9145_EntitiesOnly_Leaf extends GH9145_EntitiesOnly_Middle
+{
+    /** @ORM\Column(name="leaf_class_field") */
+    private $childValue;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH9145_MappedSuperclass_Root", "B": "GH9145_MappedSuperclass_Leaf"})
+ * ^- This DiscriminatorMap contains the Entity classes only, not the Mapped Superclass
+ */
+class GH9145_MappedSuperclass_Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    private $id;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH9145_MappedSuperclass_Middle extends GH9145_MappedSuperclass_Root
+{
+    /** @ORM\Column(name="middle_class_field") */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH9145_MappedSuperclass_Leaf extends GH9145_MappedSuperclass_Middle
+{
+    /** @ORM\Column(name="leaf_class_field") */
+    private $childValue;
+}
+
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH9145_AbstractEntities_Leaf"})
+ * ^- This DiscriminatorMap contains the single non-abstract Entity class only
+ */
+abstract class GH9145_AbstractEntities_Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    private $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+abstract class GH9145_AbstractEntities_Middle extends GH9145_AbstractEntities_Root
+{
+    /** @ORM\Column(name="middle_class_field") */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH9145_AbstractEntities_Leaf extends GH9145_AbstractEntities_Middle
+{
+    /** @ORM\Column(name="leaf_class_field") */
+    private $childValue;
+}


### PR DESCRIPTION
This PR fixes `SchemaTool` so it does not miss fields inherited from abstract `@Entity` classes in the middle of a single table inheritance (STI) tree, when these classes are not listed in the Discriminator Map (DM).

Abstract entitiy classes not listed in the DM will not show up in the root entity's ClassMetadata `subClasses` property. Fields inherited from them will show up in the field mapping metadata for subclasses, with `inherited => ...` being set.

The Schema Tool would skip these inherited fields, probably based on the assumption that they will be taken care of when the declaring class is processed. This, however, did not happen for abstract classes not listed in the DM.

**Update**  #10389 discusses whether it should in fact be a requirement to list also `abstract` classes in the DM, which might make this issue go away (masking it).

**Update 2** #10411 fixes this by making sure the missing `subClasses` are filled in
