### PR TITLE
Add a functional test covering #8127

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH8127Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH8127Root::class,
+            GH8127Middle::class,
+            GH8127Leaf::class
+        );
+    }
+
+    /**
+     * @dataProvider queryClasses
+     */
+    public function testLoadFieldsFromAllClassesInHierarchy(string $queryClass): void
+    {
+        $entity = new GH8127Leaf();
+        $entity->root = 'root';
+        $entity->middle = 'middle';
+        $entity->leaf = 'leaf';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $loadedEntity = $this->_em->find(GH8127Root::class, $entity->id);
+
+        self::assertSame('root', $loadedEntity->root);
+        self::assertSame('middle', $loadedEntity->middle);
+        self::assertSame('leaf', $loadedEntity->leaf);
+    }
+
+    public function queryClasses(): array
+    {
+        return [
+            'query via root entity' => [GH8127Root::class],
+            'query via leaf entity' => [GH8127Leaf::class],
+        ];
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({ "root": "GH8127Root", "middle": "GH8127Middle", "leaf": "GH8127Leaf"})
+ */
+abstract class GH8127Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $root;
+}
+
+/**
+ * @ORM\Entity
+ */
+abstract class GH8127Middle extends GH8127Root
+{
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $middle;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8127Leaf extends GH8127Middle
+{
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $leaf;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
@@ -25,10 +25,10 @@ class GH8127Test extends OrmFunctionalTestCase
      */
     public function testLoadFieldsFromAllClassesInHierarchy(string $queryClass): void
     {
-        $entity = new GH8127Leaf();
-        $entity->root = 'root';
+        $entity         = new GH8127Leaf();
+        $entity->root   = 'root';
         $entity->middle = 'middle';
-        $entity->leaf = 'leaf';
+        $entity->leaf   = 'leaf';
 
         $this->_em->persist($entity);
         $this->_em->flush();


### PR DESCRIPTION
**Before merging, let's wait what conclusions #10411 or #10389 make.**

This PR adds a functional test covering the use case reported in #8127.

It uses joined table inheritance across a hierarchy of three entity classes, with the root and middle class even being abstract entity classes. All three classes contain a mapped field.

_As long as all three entity classes are declared in the Discriminator Map_, the leaf (concrete entity) class can be queried through either the root or leaf class name, and all fields will be initialized correctly. 

When the middle class is not included in the DM, its fields will not be queried and the entity is not hydrated correctly.

When the middle class is not an `@Entity` class, but an abstract `@MappedSuperclass`, it need not be included in the DM for things to work.