### PR TITLE
Add runtime validation that the discriminator map contains all entity classes, also abstract ones?

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -268,6 +268,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     throw MappingException::missingDiscriminatorColumn($class->name);
                 }
 
+                if (! in_array($class->name, $class->discriminatorMap, true)) {
+                    throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
+                }
+
                 foreach ($class->subClasses as $subClass) {
                     if ((new ReflectionClass($subClass))->name !== $subClass) {
                         throw MappingException::invalidClassInDiscriminatorMap($subClass, $class->name);
@@ -275,10 +279,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 }
             } else {
                 assert($parent instanceof ClassMetadataInfo); // https://github.com/doctrine/orm/issues/8746
-                if (
-                    ! $class->reflClass->isAbstract()
-                    && ! in_array($class->name, $class->discriminatorMap, true)
-                ) {
+                if (! in_array($class->name, $class->discriminatorMap, true)) {
                     throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
                 }
             }

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -762,8 +762,8 @@ class MappingException extends ORMException
     {
         return new self(
             "Entity '" . $className . "' has to be part of the discriminator map of '" . $rootClassName . "' " .
-            "to be properly mapped in the inheritance hierarchy. Alternatively you can make '" . $className . "' an abstract class " .
-            'to avoid this exception from occurring.'
+            'to be properly mapped in the inheritance hierarchy. The discriminator map needs to contain all ' .
+            'entity classes from the hierarchy, including abstract ones.'
         );
     }
 


### PR DESCRIPTION
A general decision needs to be made here.

This PR adds a runtime metadata check, requiring all entity classes – including `abstract` intermediate ones – to be listed in the Discriminator Map (DM).

### Why?

#8378 (with a fix in #8903) added this requirement to the _SchemaValidator_ tool.

At least #8736 and #9095 pointed out this was a policy change. #9096 briefly removed the requirement for listing `abstract` entities, but #9142 opposed and put the check back in.

_If_ we think that it is necessary to have all classes in the DM to ensure correct ORM behaviour, then this should not only be checked by the `SchemaValidator` tool, but instead deserves a runtime check in the `ClassMetadataFactory`.

### Reasons for this requirement

The _pro_ arguments are somewhat sketchy.

* @beberlei in https://github.com/doctrine/orm/issues/8736#issuecomment-853044536:
> Having all classes in the discriminator map is important for some operations.

* @olsavmic in https://github.com/doctrine/orm/issues/8771#issuecomment-893266118
> I even found a case [in the schema generation tool] when the behaviour is unexpected if the abstract class in the middle of hierarchy is not present

A failing test for that was provided in #9145 as POC, #10387 might be a fix.

* In #8127, @lsrzj reported an issue with JTI, where fields from abstract intermediate entity classes are not loaded when that class is not present in the DM. 

That problem goes away when the abstract class is included in the DM (shown in #10388), but it may well be a real issue in its own right.

### Reasons against the requirement

* Since no instances of abstract entities can be created, the corresponding value from the DM is never actually used. Users would be required to put in a dummy discriminator value.

* Doctrine could/should be able to figure out abstract intermediate entity classes by itself, given that all relevant _leaf_ classes are listed in the DM.

* Archaeological research as follows

Runtime validation of DM requirements was already in place, with abstract classes being explicitly exempted.

https://github.com/doctrine/orm/blob/c5e4e41e0517887b7ce5ffd2d825f9c337bc5cd4/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L278-L283

That goes back to https://github.com/doctrine/orm/commit/5ff44b5ec75f6d716ec3dc49f5a79082d3f700da where DM checking was initially added (corresponding issues #1809, #1810).

The exemption for `abstract` classes was added briefly afterwards in https://github.com/doctrine/orm/commit/a0a81db045359496974a490bb6e37bf765106a3c.

Until today, the exception thrown for an incomplete DM explicitly mentions `abstract` entity classes as an option:

https://github.com/doctrine/orm/blob/c5e4e41e0517887b7ce5ffd2d825f9c337bc5cd4/lib/Doctrine/ORM/Mapping/MappingException.php#L761-L768

### Consequences

#### Merging

* Will cause breakage for users with "misconfigured" DMs. They may complain, pointing to our own exception suggesting `abstract` entity classes in the past.
* Even some of our own tests break due to the discouraged pattern being used
* Will require extra DM entries that are meaningless to users; maybe schema updates are necessary? (DM values as `ENUM`s and the like?)
* Will solve or at least mask some issues – they could be rejected as invalid
* Will improve consistency between the Schema Validator tool and runtime checks
* Slight documentation updates should be made to explain the need

#### Not merging

* Committing ourselves to not requiring abstract entities being in the DM
* Slight documentation updates should be made to mention the possibility of abstract entities in inheritance trees
* Relax the `SchemaValidator` check (#9096)
* Deal with issues like #10387, #8127 and probably others
* Ideally, understand their root cause and work on that. Hypothesis: When working with `ClassMetadataInfo::$subclasses`, it is not obvious what may/may not be included there.

#### To-Do

- [ ] Review if it works correctly (does not object) when loading a mapped superclass that lives between two entity classes (check should not trigger for mapped superclasses in general?)
- [ ] Review if it plays nicely with the feature from #1257, where interface names in the DM are converted to classes
- [ ] When the Event Listener from #1257 substitutes an interface name with an entity class, what happens if that class has another entity class above it that is not declared in the DM? Will we ever notice?

👇🏻 What do you think about this – Merge (:+1:) or do not merge (:-1:)?