### PR TITLE
Use more accurate phpdoc for OptimisticLockException

### DIFF
--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -13,12 +13,12 @@ use Doctrine\ORM\Exception\ORMException;
  */
 class OptimisticLockException extends ORMException
 {
-    /** @var object|null */
+    /** @var object|string|null */
     private $entity;
 
     /**
-     * @param string      $msg
-     * @param object|null $entity
+     * @param string             $msg
+     * @param object|string|null $entity
      */
     public function __construct($msg, $entity)
     {
@@ -30,7 +30,7 @@ class OptimisticLockException extends ORMException
     /**
      * Gets the entity that caused the exception.
      *
-     * @return object|null
+     * @return object|string|null
      */
     public function getEntity()
     {
@@ -38,7 +38,7 @@ class OptimisticLockException extends ORMException
     }
 
     /**
-     * @param object $entity
+     * @param object|class-string $entity
      *
      * @return OptimisticLockException
      */
@@ -48,9 +48,9 @@ class OptimisticLockException extends ORMException
     }
 
     /**
-     * @param object                $entity
-     * @param int|DateTimeInterface $expectedLockVersion
-     * @param int|DateTimeInterface $actualLockVersion
+     * @param object                       $entity
+     * @param int|string|DateTimeInterface $expectedLockVersion
+     * @param int|string|DateTimeInterface $actualLockVersion
      *
      * @return OptimisticLockException
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -441,11 +441,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-
-			message: "#^Parameter \\#1 \\$entity of static method Doctrine\\\\ORM\\\\OptimisticLockException\\:\\:lockFailed\\(\\) expects object, class\\-string\\<object\\> given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/SqlWalker.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2216,12 +2216,11 @@
     <ImplicitToStringCast occurrences="1">
       <code>$expr</code>
     </ImplicitToStringCast>
-    <InvalidArgument occurrences="5">
+    <InvalidArgument occurrences="4">
       <code>$assoc</code>
       <code>$condExpr</code>
       <code>$condTerm</code>
       <code>$factor</code>
-      <code>$selectedClass['class']-&gt;name</code>
     </InvalidArgument>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>


### PR DESCRIPTION
While working on migrating this part of the codebase to PHP 8, I found phpdoc that is wrong.