### PR TITLE
Put up a warning sign that mapping may not be inherited from transient classes

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -25,6 +25,18 @@ appear in the middle of an otherwise mapped inheritance hierarchy
     For further support of inheritance, the single or
     joined table inheritance features have to be used.
 
+.. warning::
+
+    At least when using attributes or annotations to specify your mapping,
+    it _seems_ as if you could inherit from a base class that is neither
+    an entity nor a mapped superclass, but has properties with mapping configuration
+    on them that would also be used in the inheriting class.
+
+    This, however, is due to how the corresponding mapping
+    drivers work and what the PHP reflection API reports for inherited fields.
+
+    Such a configuration is explicitly not supported. To give just one example,
+    it will break for ``private`` properties.
 
 Example:
 


### PR DESCRIPTION
This...

```php
class Parent
{
    /**
     * @Id
     * @Column(type="integer")
     * @GeneratedValue
     */
    protected int $id;

    /**
     * @Column
     */
    protected string $name;

    // ...
}

/** @Entity */
class Child extends Parent
{
    // inherit $id including mapping config

    /**
     * @Column(name="name_override_config")
     */
    protected string $name;

    // ...
}
```

... _seems_ to work, since it results in a single `Child` entity class with both fields, and also the `$name` field is configured with `name="name_override_config"`.

The result comes from the (current) annotations/attribute mapping driver implementation: PHP reflection will report `protected` and `public` properties also for subclasses. Since there is no other entity or mapped superclass above `Child` in this example, the mapping driver assumes that all fields were declared on the `Child` class initially.

It will _not_ work for e. g. class-level annotations like `@Table` on `Parent`, since those are not inherited/reported by the Reflection API for the `Child` subclass. Also, it does _not_ work for `private` properties on the `Parent` class, since those don't show up in the `ReflectionClass::getProperties()` return value for the `Child` class.

We should explicitly warn users that this approach to configuration (and yes, I've seen this in the wild) is beyond what the ORM was designed for.

Note that using traits to horizontally reuse mapped fields is nothing different – it pulls fields into classes, including their attributes and annotations (= docblocks). The PHP Reflection API will report those fields as if they had been declared in the class using the trait. Traits have the extra side effect that `private` fields become part of the class where the trait is used, so they are reported as properties as well.