### PR TITLE
Move runtime check for to-many associations in mapped superclasses to a more suitable place

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -385,10 +385,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->associationMappings as $field => $mapping) {
             if ($parentClass->isMappedSuperclass) {
-                if ($mapping['type'] & ClassMetadata::TO_MANY && ! $mapping['isOwningSide']) {
-                    throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->name, $field);
-                }
-
                 $mapping['sourceEntity'] = $subClass->name;
             }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1221,6 +1221,14 @@ class ClassMetadataInfo implements ClassMetadata
             ) {
                 throw MappingException::invalidTargetEntityClass($mapping['targetEntity'], $this->name, $mapping['fieldName']);
             }
+
+            // TBD: This might need an extra isset($mapping['declared']) check -
+            // when not set, this association is defined here in the mapped superclass.
+            // when it is set, we may be a mapped superclass but inherit the association from an entity class above.
+            // Is that legit?
+            if ($this->isMappedSuperclass && $mapping['type'] & self::TO_MANY && ! $mapping['isOwningSide']) {
+                throw MappingException::illegalToManyAssociationOnMappedSuperclass($this->name, $mapping['fieldName']);
+            }
         }
     }
 


### PR DESCRIPTION
**Closing this** since #10473 was merged; it removed the check altogether.

<hr>

This PR moves the check that a mapped superclass does not declare to-many associations to a more suitable (IMHO) place.

It is no longer checked when another class inherits the association from the mapped superclass, but at the final runtime validation stage when loading the metadata for the mapped superclass itself.

In addition to that, can we review whether the check is correct for the case where we have 

* a base entity class with a to-many (non-owning) association
* a mapped superclass below it
* possibly another entity class below that

In other words, only the mapped superclass may not define to-many associations, but it is fine if an entity class above it does and when an entity class below inherits all that? My feeling is that should be fine.
 