### PR TITLE
Extract mappings to their  own DTOs

### DIFF
--- a/lib/Doctrine/ORM/Cache/CacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/CacheFactory.php
@@ -8,14 +8,13 @@ use Doctrine\ORM\Cache;
 use Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 /**
  * Contract for building second level cache regions components.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 interface CacheFactory
 {
@@ -24,12 +23,12 @@ interface CacheFactory
      */
     public function buildCachedEntityPersister(EntityManagerInterface $em, EntityPersister $persister, ClassMetadata $metadata): CachedEntityPersister;
 
-    /**
-     * Build a collection persister for the given relation mapping.
-     *
-     * @param AssociationMapping $mapping The association mapping.
-     */
-    public function buildCachedCollectionPersister(EntityManagerInterface $em, CollectionPersister $persister, array $mapping): CachedCollectionPersister;
+    /** Build a collection persister for the given relation mapping. */
+    public function buildCachedCollectionPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        AssociationMapping $mapping,
+    ): CachedCollectionPersister;
 
     /**
      * Build a query cache based on the given region name
@@ -43,10 +42,8 @@ interface CacheFactory
 
     /**
      * Build a collection hydrator
-     *
-     * @param mixed[] $mapping The association mapping.
      */
-    public function buildCollectionHydrator(EntityManagerInterface $em, array $mapping): CollectionHydrator;
+    public function buildCollectionHydrator(EntityManagerInterface $em, AssociationMapping $mapping): CollectionHydrator;
 
     /**
      * Build a cache region

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Cache;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\UnitOfWork;
 
@@ -157,7 +158,7 @@ class DefaultCache implements Cache
 
         foreach ($metadatas as $metadata) {
             foreach ($metadata->associationMappings as $association) {
-                if (! $association['type'] & ClassMetadata::TO_MANY) {
+                if (! $association instanceof ToManyAssociationMapping) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache\Region\FileLockRegion;
 use Doctrine\ORM\Cache\Region\UpdateTimestampCache;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
@@ -87,12 +88,11 @@ class DefaultCacheFactory implements CacheFactory
         throw new InvalidArgumentException(sprintf('Unrecognized access strategy type [%s]', $usage));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildCachedCollectionPersister(EntityManagerInterface $em, CollectionPersister $persister, array $mapping): CachedCollectionPersister
-    {
-        assert(isset($mapping['cache']));
+    public function buildCachedCollectionPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        AssociationMapping $mapping,
+    ): CachedCollectionPersister {
         $usage  = $mapping['cache']['usage'];
         $region = $this->getRegion($mapping['cache']);
 
@@ -128,10 +128,7 @@ class DefaultCacheFactory implements CacheFactory
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildCollectionHydrator(EntityManagerInterface $em, array $mapping): CollectionHydrator
+    public function buildCollectionHydrator(EntityManagerInterface $em, AssociationMapping $mapping): CollectionHydrator
     {
         return new DefaultCollectionHydrator($em);
     }

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Cache;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
@@ -57,7 +58,7 @@ class DefaultEntityHydrator implements EntityHydrator
                 continue;
             }
 
-            if (! ($assoc['type'] & ClassMetadata::TO_ONE)) {
+            if (! ($assoc instanceof ToOneAssociationMapping)) {
                 unset($data[$name]);
 
                 continue;

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
@@ -59,7 +58,7 @@ class DefaultEntityHydrator implements EntityHydrator
                 continue;
             }
 
-            if (! ($assoc instanceof ToOneAssociationMapping)) {
+            if (! $assoc->isToOne()) {
                 unset($data[$name]);
 
                 continue;

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Cache;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
@@ -66,7 +67,7 @@ class DefaultEntityHydrator implements EntityHydrator
 
             if (! isset($assoc['cache'])) {
                 $targetClassMetadata = $this->em->getClassMetadata($assoc['targetEntity']);
-                $owningAssociation   = ! $assoc['isOwningSide']
+                $owningAssociation   = ! $assoc->isOwningSide()
                     ? $targetClassMetadata->associationMappings[$assoc['mappedBy']]
                     : $assoc;
                 $associationIds      = $this->identifierFlattener->flattenIdentifier(
@@ -142,7 +143,7 @@ class DefaultEntityHydrator implements EntityHydrator
 
             $assocClass  = $data[$name]->class;
             $assocId     = $data[$name]->identifier;
-            $isEagerLoad = ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ($assoc['type'] === ClassMetadata::ONE_TO_ONE && ! $assoc['isOwningSide']));
+            $isEagerLoad = ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ($assoc instanceof OneToOneAssociationMapping && ! $assoc->isOwningSide()));
 
             if (! $isEagerLoad) {
                 $data[$name] = $this->em->getReference($assocClass, $assocId);

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Cache\Exception\NonCacheableEntity;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
@@ -30,8 +31,6 @@ use function reset;
 
 /**
  * Default query cache implementation.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class DefaultQueryCache implements QueryCache
 {
@@ -298,12 +297,10 @@ class DefaultQueryCache implements QueryCache
     }
 
     /**
-     * @param AssociationMapping $assoc
-     *
      * @return mixed[]|null
      * @psalm-return array{targetEntity: class-string, type: mixed, list?: array[], identifier?: array}|null
      */
-    private function storeAssociationCache(QueryCacheKey $key, array $assoc, mixed $assocValue): array|null
+    private function storeAssociationCache(QueryCacheKey $key, AssociationMapping $assoc, mixed $assocValue): array|null
     {
         $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
         $assocMetadata  = $assocPersister->getClassMetadata();

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\PersistentCollection;
@@ -23,7 +24,6 @@ use function array_values;
 use function assert;
 use function count;
 
-/** @psalm-import-type AssociationMapping from ClassMetadata */
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
     protected UnitOfWork $uow;
@@ -38,12 +38,11 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     protected CollectionHydrator $hydrator;
     protected CacheLogger|null $cacheLogger;
 
-    /** @param AssociationMapping $association The association mapping. */
     public function __construct(
         protected CollectionPersister $persister,
         protected Region $region,
         EntityManagerInterface $em,
-        protected array $association,
+        protected AssociationMapping $association,
     ) {
         $configuration = $em->getConfiguration();
         $cacheConfig   = $configuration->getSecondLevelCacheConfiguration();

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -7,18 +7,20 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
 use function spl_object_id;
 
-/** @psalm-import-type AssociationMapping from ClassMetadata */
 class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {
-    /** @param AssociationMapping $association The association mapping. */
-    public function __construct(CollectionPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, array $association)
-    {
+    public function __construct(
+        CollectionPersister $persister,
+        ConcurrentRegion $region,
+        EntityManagerInterface $em,
+        AssociationMapping $association,
+    ) {
         parent::__construct($persister, $region, $em, $association);
     }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\Cache\TimestampCacheKey;
 use Doctrine\ORM\Cache\TimestampRegion;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\PersistentCollection;
@@ -86,7 +87,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
     public function getSelectSQL(
         array|Criteria $criteria,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         LockMode|int|null $lockMode = null,
         int|null $limit = null,
         int|null $offset = null,
@@ -113,7 +114,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     public function getSelectConditionStatementSQL(
         string $field,
         mixed $value,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         string|null $comparison = null,
     ): string {
         return $this->persister->getSelectConditionStatementSQL($field, $value, $assoc, $comparison);
@@ -241,7 +242,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      * {@inheritdoc}
      */
     public function getManyToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         int|null $offset = null,
         int|null $limit = null,
@@ -253,7 +254,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      * {@inheritdoc}
      */
     public function getOneToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         int|null $offset = null,
         int|null $limit = null,
@@ -282,7 +283,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     public function load(
         array $criteria,
         object|null $entity = null,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         array $hints = [],
         LockMode|int|null $lockMode = null,
         int|null $limit = null,
@@ -455,7 +456,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      * {@inheritdoc}
      */
     public function loadManyToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         PersistentCollection $collection,
     ): array {
@@ -485,11 +486,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         return $list;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function loadOneToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         PersistentCollection $collection,
     ): mixed {
@@ -522,7 +520,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToOneEntity(array $assoc, object $sourceEntity, array $identifier = []): object|null
+    public function loadOneToOneEntity(AssociationMapping $assoc, object $sourceEntity, array $identifier = []): object|null
     {
         return $this->persister->loadOneToOneEntity($assoc, $sourceEntity, $identifier);
     }
@@ -543,11 +541,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $this->persister->refresh($id, $entity, $lockMode);
     }
 
-    /**
-     * @param array<string, mixed> $association
-     * @param array<string, mixed> $ownerId
-     */
-    protected function buildCollectionCacheKey(array $association, array $ownerId): CollectionCacheKey
+    /** @param array<string, mixed> $ownerId */
+    protected function buildCollectionCacheKey(AssociationMapping $association, array $ownerId): CollectionCacheKey
     {
         $metadata = $this->metadataFactory->getMetadataFor($association['sourceEntity']);
         assert($metadata instanceof ClassMetadata);

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -170,7 +171,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             foreach ($this->class->associationMappings as $name => $assoc) {
                 if (
                     isset($assoc['cache']) &&
-                    ($assoc['type'] & ClassMetadata::TO_ONE) &&
+                    ($assoc instanceof ToOneAssociationMapping) &&
                     ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ! $assoc['isOwningSide'])
                 ) {
                     $associations[] = $name;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -172,7 +172,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
                 if (
                     isset($assoc['cache']) &&
                     ($assoc instanceof ToOneAssociationMapping) &&
-                    ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ! $assoc['isOwningSide'])
+                    ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ! $assoc->isOwningSide())
                 ) {
                     $associations[] = $name;
                 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -21,7 +21,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -171,7 +170,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             foreach ($this->class->associationMappings as $name => $assoc) {
                 if (
                     isset($assoc['cache']) &&
-                    ($assoc instanceof ToOneAssociationMapping) &&
+                    ($assoc->isToOne()) &&
                     ($assoc['fetch'] === ClassMetadata::FETCH_EAGER || ! $assoc->isOwningSide())
                 ) {
                     $associations[] = $name;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 
 use function array_key_last;
 use function count;
@@ -103,7 +103,7 @@ class ArrayHydrator extends AbstractHydrator
                 $relation      = $parentClass->associationMappings[$relationAlias];
 
                 // Check the type of the relation (many or single-valued)
-                if (! ($relation['type'] & ClassMetadata::TO_ONE)) {
+                if (! ($relation instanceof ToOneAssociationMapping)) {
                     $oneToOne = false;
 
                     if (! isset($baseElement[$relationAlias])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
-
 use function array_key_last;
 use function count;
 use function is_array;
@@ -103,7 +101,7 @@ class ArrayHydrator extends AbstractHydrator
                 $relation      = $parentClass->associationMappings[$relationAlias];
 
                 // Check the type of the relation (many or single-valued)
-                if (! ($relation instanceof ToOneAssociationMapping)) {
+                if (! $relation->isToOne()) {
                     $oneToOne = false;
 
                     if (! isset($baseElement[$relationAlias])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Internal\Hydration;
 use BackedEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
@@ -95,7 +94,7 @@ class ObjectHydrator extends AbstractHydrator
                 $class        = $this->getClassMetadata($className);
                 $inverseAssoc = $class->associationMappings[$assoc['inversedBy']];
 
-                if (! ($inverseAssoc instanceof ToOneAssociationMapping)) {
+                if (! $inverseAssoc->isToOne()) {
                     continue;
                 }
 
@@ -365,7 +364,7 @@ class ObjectHydrator extends AbstractHydrator
                 $oid = spl_object_id($parentObject);
 
                 // Check the type of the relation (many or single-valued)
-                if (! ($relation instanceof ToOneAssociationMapping)) {
+                if (! $relation->isToOne()) {
                     // PATH A: Collection-valued association
                     $reflFieldValue = $reflField->getValue($parentObject);
 
@@ -436,7 +435,7 @@ class ObjectHydrator extends AbstractHydrator
                                 // If there is an inverse mapping on the target class its bidirectional
                                 if ($relation['inversedBy']) {
                                     $inverseAssoc = $targetClass->associationMappings[$relation['inversedBy']];
-                                    if ($inverseAssoc instanceof ToOneAssociationMapping) {
+                                    if ($inverseAssoc->isToOne()) {
                                         $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($element, $parentObject);
                                         $this->uow->setOriginalEntityProperty(spl_object_id($element), $inverseAssoc['fieldName'], $parentObject);
                                     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 use BackedEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
@@ -94,7 +95,7 @@ class ObjectHydrator extends AbstractHydrator
                 $class        = $this->getClassMetadata($className);
                 $inverseAssoc = $class->associationMappings[$assoc['inversedBy']];
 
-                if (! ($inverseAssoc['type'] & ClassMetadata::TO_ONE)) {
+                if (! ($inverseAssoc instanceof ToOneAssociationMapping)) {
                     continue;
                 }
 
@@ -364,7 +365,7 @@ class ObjectHydrator extends AbstractHydrator
                 $oid = spl_object_id($parentObject);
 
                 // Check the type of the relation (many or single-valued)
-                if (! ($relation['type'] & ClassMetadata::TO_ONE)) {
+                if (! ($relation instanceof ToOneAssociationMapping)) {
                     // PATH A: Collection-valued association
                     $reflFieldValue = $reflField->getValue($parentObject);
 
@@ -435,7 +436,7 @@ class ObjectHydrator extends AbstractHydrator
                                 // If there is an inverse mapping on the target class its bidirectional
                                 if ($relation['inversedBy']) {
                                     $inverseAssoc = $targetClass->associationMappings[$relation['inversedBy']];
-                                    if ($inverseAssoc['type'] & ClassMetadata::TO_ONE) {
+                                    if ($inverseAssoc instanceof ToOneAssociationMapping) {
                                         $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($element, $parentObject);
                                         $this->uow->setOriginalEntityProperty(spl_object_id($element), $inverseAssoc['fieldName'], $parentObject);
                                     }

--- a/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
@@ -36,13 +36,13 @@ class AnsiQuoteStrategy implements QuoteStrategy
         return $definition['sequenceName'];
     }
 
-    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
+    public function getJoinColumnName(JoinColumnMapping $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return $joinColumn['name'];
     }
 
     public function getReferencedJoinColumnName(
-        JoinColumnData $joinColumn,
+        JoinColumnMapping $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string {

--- a/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
@@ -36,30 +36,24 @@ class AnsiQuoteStrategy implements QuoteStrategy
         return $definition['sequenceName'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getJoinColumnName(array $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
+    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return $joinColumn['name'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getReferencedJoinColumnName(
-        array $joinColumn,
+        JoinColumnData $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string {
         return $joinColumn['referencedColumnName'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getJoinTableName(array $association, ClassMetadata $class, AbstractPlatform $platform): string
-    {
+    public function getJoinTableName(
+        AssociationMapping $association,
+        ClassMetadata $class,
+        AbstractPlatform $platform,
+    ): string {
         return $association['joinTable']['name'];
     }
 

--- a/lib/Doctrine/ORM/Mapping/ArrayAccessImplementation.php
+++ b/lib/Doctrine/ORM/Mapping/ArrayAccessImplementation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use InvalidArgumentException;
+
+use function property_exists;
+
+/** @internal */
+trait ArrayAccessImplementation
+{
+    /** @param string $offset */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    /** @param string $offset */
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (! property_exists($this, $offset)) {
+            throw new InvalidArgumentException('Undefined property: ' . $offset);
+        }
+
+        return $this->$offset;
+    }
+
+    /** @param string $offset */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /** @param string $offset */
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -81,9 +81,6 @@ class AssociationMapping implements ArrayAccess
 
     public bool $isOwningSide = true;
 
-    /** @var list<JoinColumnData> */
-    public array|null $joinColumns = null;
-
     /** @var array<string, string> */
     public array|null $joinColumnFieldNames = null;
 
@@ -228,17 +225,6 @@ class AssociationMapping implements ArrayAccess
     /** @return mixed[] */
     public function toArray(): array
     {
-        $array = (array) $this;
-
-        if ($array['joinColumns'] !== null) {
-            $joinColumns = [];
-            foreach ($array['joinColumns'] as $column) {
-                $joinColumns[] = (array) $column;
-            }
-
-            $array['joinColumns'] = $joinColumns;
-        }
-
-        return $array;
+        return (array) $this;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+
+use function in_array;
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class AssociationMapping implements ArrayAccess
+{
+    /**
+     * required for bidirectional associations
+     * The name of the field that completes the bidirectional association on
+     * the owning side. This key must be specified on the inverse side of a
+     * bidirectional association.
+     */
+    public string|null $mappedBy = null;
+
+    /**
+     * required for bidirectional associations
+     * The name of the field that completes the bidirectional association on
+     * the inverse side. This key must be specified on the owning side of a
+     * bidirectional association.
+     */
+    public string|null $inversedBy = null;
+
+    /**
+     * The names of persistence operations to cascade on the association.
+     *
+     * @var list<'persist'|'remove'|'detach'|'merge'|'refresh'|'all'>
+     */
+    public array|null $cascade = null;
+
+    /**
+     * one-to-many/many-to-many only
+     * A map of field names (of the target entity) to sorting directions
+     *
+     * @var array<string, 'asc'|'desc'>
+     */
+    public array|null $orderBy = null;
+
+    /**
+     * The fetching strategy to use for the association, usually defaults to FETCH_LAZY.
+     *
+     * @var ClassMetadata::FETCH_EAGER|ClassMetadata::FETCH_LAZY
+     */
+    public int|null $fetch = null;
+
+    /**
+     * many-to-many only
+     * Specification of the join table and its join columns (foreign keys).
+     * Only valid for many-to-many mappings. Note that one-to-many associations
+     * can be mapped through a join table by simply mapping the association as
+     * many-to-many with a unique constraint on the join table.
+     */
+    public JoinTableMapping|null $joinTable = null;
+
+    /**
+     * to-many only
+     * Specification of a field on target-entity that is used to index the
+     * collection by. This field HAS to be either the primary key or a unique
+     * column. Otherwise the collection does not contain all the entities that
+     * are actually related.
+     */
+    public string|null $indexBy = null;
+
+    /**
+     * This is set when the association is inherited by this class from another
+     * (inheritance) parent <em>entity</em> class. The value is the FQCN of the
+     * topmost entity class that contains this association. (If there are
+     * transient classes in the class hierarchy, these are ignored, so the
+     * class property may in fact come from a class further up in the PHP class
+     * hierarchy.) To-many associations initially declared in mapped
+     * superclasses are <em>not</em> considered 'inherited' in the nearest
+     * entity subclasses.
+     *
+     * @var class-string
+     */
+    public string|null $inherited = null;
+
+    /**
+     * This is set when the association does not appear in the current class
+     * for the first time, but is initially declared in another parent
+     * <em>entity or mapped superclass</em>. The value is the FQCN of the
+     * topmost non-transient class that contains association information for
+     * this relationship.
+     */
+    public string|null $declared = null;
+
+    public array|null $cache = null;
+
+    public bool|null $id = null;
+
+    public bool $isCascadeRemove  = false;
+    public bool $isCascadePersist = false;
+    public bool $isCascadeRefresh = false;
+    public bool $isCascadeMerge   = false;
+    public bool $isCascadeDetach  = false;
+
+    public bool|null $isOnDeleteCascade = null;
+
+    public bool $isOwningSide = true;
+
+    /** @var list<JoinColumnData> */
+    public array|null $joinColumns = null;
+
+    /** @var array<string, string> */
+    public array|null $joinColumnFieldNames = null;
+
+    /** @var list<mixed> */
+    public array|null $joinTableColumns = null;
+
+    /** @var class-string */
+    public string|null $originalClass = null;
+
+    /** @var string */
+    public string|null $originalField = null;
+
+    public bool|null $orphanRemoval = null;
+
+    public array|null $relationToSourceKeyColumns = null;
+    public array|null $relationToTargetKeyColumns = null;
+
+    /** @var array<string, string> */
+    public array|null $sourceToTargetKeyColumns = null;
+
+    /** @var array<string, string> */
+    public array|null $targetToSourceKeyColumns = null;
+
+    public bool|null $unique = null;
+
+    /**
+     * @param string       $fieldName    The name of the field in the entity
+     *                                   the association is mapped to.
+     * @param class-string $sourceEntity The class name of the source entity.
+     *                                   In the case of to-many associations
+     *                                   initially present in mapped
+     *                                   superclasses, the nearest
+     *                                   <em>entity</em> subclasses will be
+     *                                   considered the respective source
+     *                                   entities.
+     * @param class-string $targetEntity The class name of the target entity.
+     *                                   If it is fully-qualified it is used as
+     *                                   is. If it is a simple, unqualified
+     *                                   class name the namespace is assumed to
+     *                                   be the same as the namespace of the
+     *                                   source entity.
+     */
+    public function __construct(
+        public int $type,
+        public string $fieldName,
+        public string $sourceEntity,
+        public string $targetEntity,
+    ) {
+    }
+
+    /**
+     * @psalm-param array{
+     *     fieldName: string,
+     *     sourceEntity: class-string,
+     *     targetEntity: class-string,
+     *     type: int,
+     *     joinColumns?: mixed[]|null,
+     *     joinTable?: mixed[]|null, ...} $mappingArray
+     */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self(
+            $mappingArray['type'],
+            $mappingArray['fieldName'],
+            $mappingArray['sourceEntity'],
+            $mappingArray['targetEntity'],
+        );
+        foreach ($mappingArray as $key => $value) {
+            if (in_array($key, ['type', 'fieldName', 'sourceEntity', 'targetEntity'])) {
+                continue;
+            }
+
+            if ($key === 'joinColumns') {
+                if ($value === null) {
+                    continue;
+                }
+
+                $joinColumns = [];
+                foreach ($value as $column) {
+                    $joinColumns[] = JoinColumnData::fromMappingArray($column);
+                }
+
+                $mapping->joinColumns = $joinColumns;
+
+                continue;
+            }
+
+            if ($key === 'joinTable') {
+                if ($value === [] || $value === null) {
+                    continue;
+                }
+
+                $mapping->joinTable = JoinTableMapping::fromMappingArray($value);
+
+                continue;
+            }
+
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if ($offset === 'joinColumns') {
+            $joinColumns = [];
+            foreach ($value as $column) {
+                $joinColumns[] = JoinColumnData::fromMappingArray($column);
+            }
+
+            $value = $joinColumns;
+        }
+
+        if ($offset === 'joinTable') {
+            $value = JoinTableMapping::fromMappingArray($value);
+        }
+
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+
+    /** @return mixed[] */
+    public function toArray(): array
+    {
+        $array = (array) $this;
+
+        if ($array['joinColumns'] !== null) {
+            $joinColumns = [];
+            foreach ($array['joinColumns'] as $column) {
+                $joinColumns[] = (array) $column;
+            }
+
+            $array['joinColumns'] = $joinColumns;
+        }
+
+        if ($array['joinTable'] !== null) {
+            $array['joinTable'] = $array['joinTable']->toArray();
+        }
+
+        return $array;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -165,30 +165,30 @@ abstract class AssociationMapping implements ArrayAccess
     }
 
     /** @psalm-assert-if-true AssociationOwningSideMapping $this */
-    public function isOwningSide(): bool
+    final public function isOwningSide(): bool
     {
         return $this instanceof AssociationOwningSideMapping;
     }
 
     /** @psalm-assert-if-true ToOneAssociationMapping $this */
-    public function isToOne(): bool
+    final public function isToOne(): bool
     {
         return $this instanceof ToOneAssociationMapping;
     }
 
     /** @psalm-assert-if-true OneToOneOwningSideMapping|ManyToOneAssociationMapping $this */
-    public function isToOneOwningSide(): bool
+    final public function isToOneOwningSide(): bool
     {
         return $this->isToOne() && $this->isOwningSide();
     }
 
     /** @psalm-assert-if-true ManyToManyOwningSideMapping $this */
-    public function isManyToManyOwningSide(): bool
+    final public function isManyToManyOwningSide(): bool
     {
         return $this instanceof ManyToManyOwningSideMapping;
     }
 
-    public function type(): int
+    final public function type(): int
     {
         return match (true) {
             $this instanceof OneToOneAssociationMapping => ClassMetadata::ONE_TO_ONE,
@@ -199,7 +199,7 @@ abstract class AssociationMapping implements ArrayAccess
         };
     }
 
-    public function offsetGet($offset): mixed
+    final public function offsetGet($offset): mixed
     {
         return match ($offset) {
             'isOwningSide' => $this->isOwningSide(),

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -124,7 +124,6 @@ abstract class AssociationMapping implements ArrayAccess
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
-     *     joinColumns?: mixed[]|null,
      *     joinTable?: mixed[]|null,
      *     isOwningSide: bool, ...} $mappingArray
      */

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -129,7 +129,7 @@ abstract class AssociationMapping implements ArrayAccess
      *     joinTable?: mixed[]|null,
      *     isOwningSide: bool, ...} $mappingArray
      */
-    public static function fromMappingArray(array $mappingArray): OneToOneAssociationMapping|ManyToOneAssociationMapping|OneToManyAssociationMapping|ManyToManyAssociationMapping
+    public static function fromMappingArray(array $mappingArray): static
     {
         unset($mappingArray['isOwningSide']);
         $mapping = new static(

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -92,7 +92,7 @@ abstract class AssociationMapping implements ArrayAccess
     /** @var string */
     public string|null $originalField = null;
 
-    public bool|null $orphanRemoval = null;
+    public bool $orphanRemoval = false;
 
     public bool|null $unique = null;
 

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -14,6 +14,8 @@ use function property_exists;
 /** @template-implements ArrayAccess<string, mixed> */
 abstract class AssociationMapping implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     /**
      * required for bidirectional associations
      * The name of the field that completes the bidirectional association on
@@ -164,27 +166,6 @@ abstract class AssociationMapping implements ArrayAccess
         return $mapping;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        if ($offset === 'isOwningSide') {
-            return $this->isOwningSide();
-        }
-
-        if ($offset === 'type') {
-            return $this->type();
-        }
-
-        return $this->$offset;
-    }
-
     /** @psalm-assert-if-true AssociationOwningSideMapping $this */
     public function isOwningSide(): bool
     {
@@ -220,6 +201,15 @@ abstract class AssociationMapping implements ArrayAccess
         };
     }
 
+    public function offsetGet($offset): mixed
+    {
+        return match ($offset) {
+            'isOwningSide' => $this->isOwningSide(),
+            'type' => $this->type(),
+            default => $this->$offset,
+        };
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -230,14 +220,6 @@ abstract class AssociationMapping implements ArrayAccess
         }
 
         $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 
     /** @return mixed[] */

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -245,4 +245,50 @@ abstract class AssociationMapping implements ArrayAccess
 
         return $array;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = ['fieldName', 'sourceEntity', 'targetEntity'];
+
+        foreach (
+            [
+                'mappedBy',
+                'inversedBy',
+                'cascade',
+                'fetch',
+                'inherited',
+                'declared',
+                'cache',
+                'joinColumnFieldNames',
+                'joinTableColumns',
+                'originalClass',
+                'originalField',
+            ] as $stringOrArrayProperty
+        ) {
+            if ($this->$stringOrArrayProperty !== null) {
+                $serialized[] = $stringOrArrayProperty;
+            }
+        }
+
+        foreach (
+            [
+                'id',
+                'isCascadeRemove',
+                'isCascadePersist',
+                'isCascadeRefresh',
+                'isCascadeMerge',
+                'isCascadeDetach',
+                'isOnDeleteCascade',
+                'orphanRemoval',
+                'unique',
+            ] as $boolProperty
+        ) {
+            if ($this->$boolProperty) {
+                $serialized[] = $boolProperty;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -125,7 +125,8 @@ abstract class AssociationMapping implements ArrayAccess
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
      *     joinColumns?: mixed[]|null,
-     *     joinTable?: mixed[]|null, ...} $mappingArray
+     *     joinTable?: mixed[]|null,
+     *     isOwningSide: bool, ...} $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): static
     {

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -8,7 +8,6 @@ use ArrayAccess;
 use Exception;
 
 use function assert;
-use function in_array;
 use function property_exists;
 
 /** @template-implements ArrayAccess<string, mixed> */
@@ -115,9 +114,9 @@ abstract class AssociationMapping implements ArrayAccess
      *                                   source entity.
      */
     final public function __construct(
-        public string $fieldName,
+        public readonly string $fieldName,
         public string $sourceEntity,
-        public string $targetEntity,
+        public readonly string $targetEntity,
     ) {
     }
 
@@ -127,21 +126,20 @@ abstract class AssociationMapping implements ArrayAccess
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
      *     joinTable?: mixed[]|null,
+     *     type?: int,
      *     isOwningSide: bool, ...} $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): static
     {
-        unset($mappingArray['isOwningSide']);
+        unset($mappingArray['isOwningSide'], $mappingArray['type']);
         $mapping = new static(
             $mappingArray['fieldName'],
             $mappingArray['sourceEntity'],
             $mappingArray['targetEntity'],
         );
-        foreach ($mappingArray as $key => $value) {
-            if (in_array($key, ['type', 'fieldName', 'sourceEntity', 'targetEntity'])) {
-                continue;
-            }
+        unset($mappingArray['fieldName'], $mappingArray['sourceEntity'], $mappingArray['targetEntity']);
 
+        foreach ($mappingArray as $key => $value) {
             if ($key === 'joinTable') {
                 assert($mapping instanceof ManyToManyAssociationMapping);
 

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -128,7 +128,7 @@ abstract class AssociationMapping implements ArrayAccess
      *     joinTable?: mixed[]|null,
      *     isOwningSide: bool, ...} $mappingArray
      */
-    public static function fromMappingArray(array $mappingArray): static
+    public static function fromMappingArray(array $mappingArray): OneToOneAssociationMapping|ManyToOneAssociationMapping|OneToManyAssociationMapping|ManyToManyAssociationMapping
     {
         unset($mappingArray['isOwningSide']);
         $mapping = new static(
@@ -186,22 +186,19 @@ abstract class AssociationMapping implements ArrayAccess
         return $this->$offset;
     }
 
-    /** @psalm-assert AssociationOwningSideMapping $this */
+    /** @psalm-assert-if-true AssociationOwningSideMapping $this */
     public function isOwningSide(): bool
     {
         return $this instanceof AssociationOwningSideMapping;
     }
 
-    /** @psalm-assert ToOneAssociationMapping $this */
+    /** @psalm-assert-if-true ToOneAssociationMapping $this */
     public function isToOne(): bool
     {
         return $this instanceof ToOneAssociationMapping;
     }
 
-    /**
-     * @psalm-assert-if-true ToOneAssociationMapping $this
-     * @psalm-assert-if-true AssociationOwningSideMapping $this
-     */
+    /** @psalm-assert-if-true OneToOneOwningSideMapping|ManyToOneAssociationMapping $this */
     public function isToOneOwningSide(): bool
     {
         return $this->isToOne() && $this->isOwningSide();

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -8,13 +8,12 @@ use ArrayAccess;
 use Exception;
 
 use function assert;
+use function in_array;
 use function property_exists;
 
 /** @template-implements ArrayAccess<string, mixed> */
 abstract class AssociationMapping implements ArrayAccess
 {
-    use ArrayAccessImplementation;
-
     /**
      * required for bidirectional associations
      * The name of the field that completes the bidirectional association on
@@ -199,6 +198,12 @@ abstract class AssociationMapping implements ArrayAccess
         };
     }
 
+    /** @param string $offset */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->$offset) || in_array($offset, ['isOwningSide', 'type'], true);
+    }
+
     final public function offsetGet($offset): mixed
     {
         return match ($offset) {
@@ -218,6 +223,16 @@ abstract class AssociationMapping implements ArrayAccess
         }
 
         $this->$offset = $value;
+    }
+
+    /** @param string $offset */
+    public function offsetUnset(mixed $offset): void
+    {
+        if (in_array($offset, ['isOwningSide', 'type'], true)) {
+            throw new Exception('Cannot unset ' . $offset);
+        }
+
+        $this->$offset = null;
     }
 
     /** @return mixed[] */

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -190,13 +190,19 @@ class AssociationMapping implements ArrayAccess
         return $this instanceof AssociationOwningSideMapping;
     }
 
+    /** @psalm-assert ToOneAssociationMapping $this */
+    public function isToOne(): bool
+    {
+        return $this instanceof ToOneAssociationMapping;
+    }
+
     /**
      * @psalm-assert-if-true ToOneAssociationMapping $this
      * @psalm-assert-if-true AssociationOwningSideMapping $this
      */
     public function isToOneOwningSide(): bool
     {
-        return $this instanceof ToOneAssociationMapping && $this->isOwningSide();
+        return $this->isToOne() && $this->isOwningSide();
     }
 
     /** @psalm-assert-if-true ManyToManyOwningSideMapping $this */

--- a/lib/Doctrine/ORM/Mapping/AssociationOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOwningSideMapping.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-class OneToOneAssociationMapping extends ToOneAssociationMapping
+interface AssociationOwningSideMapping
 {
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1523,7 +1523,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
             // Association defined as Id field
             $joinColumns      = $this->associationMappings[$idProperty]['joinColumns'];
-            $assocColumnNames = array_map(static fn (JoinColumnData $joinColumn): string => $joinColumn['name'], $joinColumns);
+            $assocColumnNames = array_map(static fn (JoinColumnMapping $joinColumn): string => $joinColumn['name'], $joinColumns);
 
             $columnNames = array_merge($columnNames, $assocColumnNames);
         }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -67,51 +67,6 @@ use function trim;
  *
  * @template-covariant T of object
  * @template-implements PersistenceClassMetadata<T>
- * @psalm-type JoinColumnData = array{
- *     name: string,
- *     referencedColumnName: string,
- *     unique?: bool,
- *     quoted?: bool,
- *     fieldName?: string,
- *     onDelete?: string,
- *     columnDefinition?: string,
- *     nullable?: bool,
- * }
- * @psalm-type AssociationMapping = array{
- *     cache?: array,
- *     cascade: array<string>,
- *     declared?: class-string,
- *     fetch: mixed,
- *     fieldName: string,
- *     id?: bool,
- *     inherited?: class-string,
- *     indexBy?: string,
- *     inversedBy: string|null,
- *     isCascadeRemove: bool,
- *     isCascadePersist: bool,
- *     isCascadeRefresh: bool,
- *     isCascadeMerge: bool,
- *     isCascadeDetach: bool,
- *     isOnDeleteCascade?: bool,
- *     isOwningSide: bool,
- *     joinColumns?: array<JoinColumnData>,
- *     joinColumnFieldNames?: array<string, string>,
- *     joinTable?: array,
- *     joinTableColumns?: list<mixed>,
- *     mappedBy: string|null,
- *     orderBy?: array,
- *     originalClass?: class-string,
- *     originalField?: string,
- *     orphanRemoval?: bool,
- *     relationToSourceKeyColumns?: array,
- *     relationToTargetKeyColumns?: array,
- *     sourceEntity: class-string,
- *     sourceToTargetKeyColumns?: array<string, string>,
- *     targetEntity: class-string,
- *     targetToSourceKeyColumns?: array<string, string>,
- *     type: int,
- *     unique?: bool,
- * }
  * @psalm-type DiscriminatorColumnMapping = array{
  *     name: string,
  *     fieldName: string,
@@ -511,66 +466,6 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
     /**
      * READ-ONLY: The association mappings of this class.
-     *
-     * The mapping definition array supports the following keys:
-     *
-     * - <b>fieldName</b> (string)
-     * The name of the field in the entity the association is mapped to.
-     *
-     * - <b>sourceEntity</b> (string)
-     * The class name of the source entity. In the case of to-many associations initially
-     * present in mapped superclasses, the nearest <em>entity</em> subclasses will be
-     * considered the respective source entities.
-     *
-     * - <b>targetEntity</b> (string)
-     * The class name of the target entity. If it is fully-qualified it is used as is.
-     * If it is a simple, unqualified class name the namespace is assumed to be the same
-     * as the namespace of the source entity.
-     *
-     * - <b>mappedBy</b> (string, required for bidirectional associations)
-     * The name of the field that completes the bidirectional association on the owning side.
-     * This key must be specified on the inverse side of a bidirectional association.
-     *
-     * - <b>inversedBy</b> (string, required for bidirectional associations)
-     * The name of the field that completes the bidirectional association on the inverse side.
-     * This key must be specified on the owning side of a bidirectional association.
-     *
-     * - <b>cascade</b> (array, optional)
-     * The names of persistence operations to cascade on the association. The set of possible
-     * values are: "persist", "remove", "detach", "merge", "refresh", "all" (implies all others).
-     *
-     * - <b>orderBy</b> (array, one-to-many/many-to-many only)
-     * A map of field names (of the target entity) to sorting directions (ASC/DESC).
-     * Example: array('priority' => 'desc')
-     *
-     * - <b>fetch</b> (integer, optional)
-     * The fetching strategy to use for the association, usually defaults to FETCH_LAZY.
-     * Possible values are: ClassMetadata::FETCH_EAGER, ClassMetadata::FETCH_LAZY.
-     *
-     * - <b>joinTable</b> (array, optional, many-to-many only)
-     * Specification of the join table and its join columns (foreign keys).
-     * Only valid for many-to-many mappings. Note that one-to-many associations can be mapped
-     * through a join table by simply mapping the association as many-to-many with a unique
-     * constraint on the join table.
-     *
-     * - <b>indexBy</b> (string, optional, to-many only)
-     * Specification of a field on target-entity that is used to index the collection by.
-     * This field HAS to be either the primary key or a unique column. Otherwise the collection
-     * does not contain all the entities that are actually related.
-     *
-     * - <b>'inherited'</b> (string, optional)
-     * This is set when the association is inherited by this class from another (inheritance) parent
-     * <em>entity</em> class. The value is the FQCN of the topmost entity class that contains
-     * this association. (If there are transient classes in the
-     * class hierarchy, these are ignored, so the class property may in fact come
-     * from a class further up in the PHP class hierarchy.)
-     * To-many associations initially declared in mapped superclasses are
-     * <em>not</em> considered 'inherited' in the nearest entity subclasses.
-     *
-     * - <b>'declared'</b> (string, optional)
-     * This is set when the association does not appear in the current class for the first time, but
-     * is initially declared in another parent <em>entity or mapped superclass</em>. The value is the FQCN
-     * of the topmost non-transient class that contains association information for this relationship.
      *
      * A join table definition has the following structure:
      * <pre>
@@ -1220,12 +1115,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * @param string $fieldName The field name that represents the association in
      *                          the object model.
      *
-     * @return mixed[] The mapping.
-     * @psalm-return AssociationMapping
-     *
      * @throws MappingException
      */
-    public function getAssociationMapping(string $fieldName): array
+    public function getAssociationMapping(string $fieldName): AssociationMapping
     {
         if (! isset($this->associationMappings[$fieldName])) {
             throw MappingException::mappingNotFound($this->name, $fieldName);
@@ -1399,12 +1291,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @psalm-param array<string, mixed> $mapping The mapping.
      *
-     * @return mixed[] The updated mapping.
-     * @psalm-return AssociationMapping
-     *
      * @throws MappingException If something is wrong with the mapping.
      */
-    protected function _validateAndCompleteAssociationMapping(array $mapping): array
+    protected function _validateAndCompleteAssociationMapping(array $mapping): AssociationMapping
     {
         if (! isset($mapping['mappedBy'])) {
             $mapping['mappedBy'] = null;
@@ -1480,12 +1369,14 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             throw MappingException::missingTargetEntity($mapping['fieldName']);
         }
 
+        $mapping = AssociationMapping::fromMappingArray($mapping);
+
         // Mandatory and optional attributes for either side
         if (! $mapping['mappedBy']) {
-            if (isset($mapping['joinTable']) && $mapping['joinTable']) {
+            if (isset($mapping->joinTable)) {
                 if (isset($mapping['joinTable']['name']) && $mapping['joinTable']['name'][0] === '`') {
-                    $mapping['joinTable']['name']   = trim($mapping['joinTable']['name'], '`');
-                    $mapping['joinTable']['quoted'] = true;
+                    $mapping->joinTable['name']   = trim($mapping['joinTable']['name'], '`');
+                    $mapping->joinTable['quoted'] = true;
                 }
             }
         } else {
@@ -1530,13 +1421,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      *
-     * @return mixed[] The validated & completed mapping.
-     * @psalm-return AssociationMapping
-     *
      * @throws RuntimeException
      * @throws MappingException
      */
-    protected function _validateAndCompleteOneToOneMapping(array $mapping): array
+    protected function _validateAndCompleteOneToOneMapping(array $mapping): AssociationMapping
     {
         $mapping = $this->_validateAndCompleteAssociationMapping($mapping);
 
@@ -1557,7 +1445,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
             $uniqueConstraintColumns = [];
 
-            foreach ($mapping['joinColumns'] as &$joinColumn) {
+            assert($mapping->joinColumns !== null);
+            foreach ($mapping->joinColumns as $joinColumn) {
                 if ($mapping['type'] === self::ONE_TO_ONE && ! $this->isInheritanceTypeSingleTable()) {
                     if (count($mapping['joinColumns']) === 1) {
                         if (empty($mapping['id'])) {
@@ -1586,8 +1475,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                     $joinColumn['quoted']               = true;
                 }
 
-                $mapping['sourceToTargetKeyColumns'][$joinColumn['name']] = $joinColumn['referencedColumnName'];
-                $mapping['joinColumnFieldNames'][$joinColumn['name']]     = $joinColumn['fieldName'] ?? $joinColumn['name'];
+                $mapping->sourceToTargetKeyColumns[$joinColumn['name']] = $joinColumn['referencedColumnName'];
+                $mapping->joinColumnFieldNames[$joinColumn['name']]     = $joinColumn['fieldName'] ?? $joinColumn['name'];
             }
 
             if ($uniqueConstraintColumns) {
@@ -1620,13 +1509,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @psalm-param array<string, mixed> $mapping The mapping to validate and complete.
      *
-     * @return mixed[] The validated and completed mapping.
-     * @psalm-return AssociationMapping
+     * @return AssociationMapping The validated and completed mapping.
      *
      * @throws MappingException
      * @throws InvalidArgumentException
      */
-    protected function _validateAndCompleteOneToManyMapping(array $mapping): array
+    protected function _validateAndCompleteOneToManyMapping(array $mapping): AssociationMapping
     {
         $mapping = $this->_validateAndCompleteAssociationMapping($mapping);
 
@@ -1648,47 +1536,57 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      *
-     * @return mixed[] The validated & completed mapping.
-     * @psalm-return AssociationMapping
+     * @return AssociationMapping The validated & completed mapping.
      *
      * @throws InvalidArgumentException
      */
-    protected function _validateAndCompleteManyToManyMapping(array $mapping): array
+    protected function _validateAndCompleteManyToManyMapping(array $mapping): AssociationMapping
     {
         $mapping = $this->_validateAndCompleteAssociationMapping($mapping);
 
         if ($mapping['isOwningSide']) {
             // owning side MUST have a join table
             if (! isset($mapping['joinTable']['name'])) {
-                $mapping['joinTable']['name'] = $this->namingStrategy->joinTableName($mapping['sourceEntity'], $mapping['targetEntity'], $mapping['fieldName']);
+                if (! isset($mapping->joinTable)) {
+                    $mapping->joinTable = new JoinTableMapping();
+                }
+
+                $mapping->joinTable['name'] = $this->namingStrategy->joinTableName(
+                    $mapping['sourceEntity'],
+                    $mapping['targetEntity'],
+                    $mapping['fieldName'],
+                );
             }
 
             $selfReferencingEntityWithoutJoinColumns = $mapping['sourceEntity'] === $mapping['targetEntity']
                 && (! (isset($mapping['joinTable']['joinColumns']) || isset($mapping['joinTable']['inverseJoinColumns'])));
 
             if (! isset($mapping['joinTable']['joinColumns'])) {
-                $mapping['joinTable']['joinColumns'] = [
-                    [
+                assert(isset($mapping->joinTable));
+                $mapping->joinTable->joinColumns = [
+                    JoinColumnData::fromMappingArray([
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
                         'onDelete' => 'CASCADE',
-                    ],
+                    ]),
                 ];
             }
 
             if (! isset($mapping['joinTable']['inverseJoinColumns'])) {
-                $mapping['joinTable']['inverseJoinColumns'] = [
-                    [
+                $mapping->joinTable->inverseJoinColumns = [
+                    JoinColumnData::fromMappingArray([
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
                         'onDelete' => 'CASCADE',
-                    ],
+                    ]),
                 ];
             }
 
             $mapping['joinTableColumns'] = [];
 
-            foreach ($mapping['joinTable']['joinColumns'] as &$joinColumn) {
+            assert($mapping->joinTable !== null);
+            assert($mapping->joinTable['joinColumns'] !== null);
+            foreach ($mapping->joinTable['joinColumns'] as $joinColumn) {
                 if (empty($joinColumn['name'])) {
                     $joinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $joinColumn['referencedColumnName']);
                 }
@@ -1711,11 +1609,11 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                     $mapping['isOnDeleteCascade'] = true;
                 }
 
-                $mapping['relationToSourceKeyColumns'][$joinColumn['name']] = $joinColumn['referencedColumnName'];
-                $mapping['joinTableColumns'][]                              = $joinColumn['name'];
+                $mapping->relationToSourceKeyColumns[$joinColumn['name']] = $joinColumn['referencedColumnName'];
+                $mapping->joinTableColumns[]                              = $joinColumn['name'];
             }
 
-            foreach ($mapping['joinTable']['inverseJoinColumns'] as &$inverseJoinColumn) {
+            foreach ($mapping->joinTable['inverseJoinColumns'] as $inverseJoinColumn) {
                 if (empty($inverseJoinColumn['name'])) {
                     $inverseJoinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $inverseJoinColumn['referencedColumnName']);
                 }
@@ -1738,8 +1636,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                     $mapping['isOnDeleteCascade'] = true;
                 }
 
-                $mapping['relationToTargetKeyColumns'][$inverseJoinColumn['name']] = $inverseJoinColumn['referencedColumnName'];
-                $mapping['joinTableColumns'][]                                     = $inverseJoinColumn['name'];
+                $mapping->relationToTargetKeyColumns[$inverseJoinColumn['name']] = $inverseJoinColumn['referencedColumnName'];
+                $mapping->joinTableColumns[]                                     = $inverseJoinColumn['name'];
             }
         }
 
@@ -1849,7 +1747,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
             // Association defined as Id field
             $joinColumns      = $this->associationMappings[$idProperty]['joinColumns'];
-            $assocColumnNames = array_map(static fn ($joinColumn) => $joinColumn['name'], $joinColumns);
+            $assocColumnNames = array_map(static fn (JoinColumnData $joinColumn): string => $joinColumn['name'], $joinColumns);
 
             $columnNames = array_merge($columnNames, $assocColumnNames);
         }
@@ -2024,7 +1922,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             throw MappingException::invalidOverrideFieldName($this->name, $fieldName);
         }
 
-        $mapping = $this->associationMappings[$fieldName];
+        $mapping = $this->associationMappings[$fieldName]->toArray();
 
         //if (isset($mapping['inherited']) && (count($overrideMapping) !== 1 || ! isset($overrideMapping['fetch']))) {
             // TODO: Deprecate overriding the fetch mode via association override for 3.0,
@@ -2239,11 +2137,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * Adds an association mapping without completing/validating it.
      * This is mainly used to add inherited association mappings to derived classes.
      *
-     * @psalm-param AssociationMapping $mapping
-     *
      * @throws MappingException
      */
-    public function addInheritedAssociationMapping(array $mapping/*, $owningClassName = null*/): void
+    public function addInheritedAssociationMapping(AssociationMapping $mapping/*, $owningClassName = null*/): void
     {
         if (isset($this->associationMappings[$mapping['fieldName']])) {
             throw MappingException::duplicateAssociationMapping($this->name, $mapping['fieldName']);
@@ -2324,11 +2220,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Stores the association mapping.
      *
-     * @psalm-param array<string, mixed> $assocMapping
-     *
      * @throws MappingException
      */
-    protected function _storeAssociationMapping(array $assocMapping): void
+    protected function _storeAssociationMapping(AssociationMapping $assocMapping): void
     {
         $sourceFieldName = $assocMapping['fieldName'];
 
@@ -2929,8 +2823,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         return $sequencePrefix;
     }
 
-    /** @psalm-param array<string, mixed> $mapping */
-    private function assertMappingOrderBy(array $mapping): void
+    private function assertMappingOrderBy(AssociationMapping $mapping): void
     {
         if (isset($mapping['orderBy']) && ! is_array($mapping['orderBy'])) {
             throw new InvalidArgumentException("'orderBy' is expected to be an array, not " . gettype($mapping['orderBy']));

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1368,7 +1368,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             $mapping['isOwningSide'] = false;
         }
 
-        if (isset($mapping['id']) && $mapping['id'] === true && $mapping['type'] & self::TO_MANY) {
+        if (isset($mapping['id']) && $mapping['id'] === true && $mapping instanceof ToManyAssociationMapping) {
             throw MappingException::illegalToManyIdentifierAssociation($this->name, $mapping['fieldName']);
         }
 
@@ -2446,13 +2446,13 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public function isSingleValuedAssociation(string $fieldName): bool
     {
         return isset($this->associationMappings[$fieldName])
-            && ($this->associationMappings[$fieldName]['type'] & self::TO_ONE);
+            && ($this->associationMappings[$fieldName] instanceof ToOneAssociationMapping);
     }
 
     public function isCollectionValuedAssociation(string $fieldName): bool
     {
         return isset($this->associationMappings[$fieldName])
-            && ! ($this->associationMappings[$fieldName]['type'] & self::TO_ONE);
+            && ! ($this->associationMappings[$fieldName] instanceof ToOneAssociationMapping);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -2454,13 +2454,13 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public function isSingleValuedAssociation(string $fieldName): bool
     {
         return isset($this->associationMappings[$fieldName])
-            && ($this->associationMappings[$fieldName] instanceof ToOneAssociationMapping);
+            && ($this->associationMappings[$fieldName]->isToOne());
     }
 
     public function isCollectionValuedAssociation(string $fieldName): bool
     {
         return isset($this->associationMappings[$fieldName])
-            && ! ($this->associationMappings[$fieldName] instanceof ToOneAssociationMapping);
+            && ! $this->associationMappings[$fieldName]->isToOne();
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1365,12 +1365,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             );
         }
 
-        $mapping['cascade']          = $cascades;
-        $mapping['isCascadeRemove']  = in_array('remove', $cascades, true);
-        $mapping['isCascadePersist'] = in_array('persist', $cascades, true);
-        $mapping['isCascadeRefresh'] = in_array('refresh', $cascades, true);
-        $mapping['isCascadeMerge']   = in_array('merge', $cascades, true);
-        $mapping['isCascadeDetach']  = in_array('detach', $cascades, true);
+        $mapping['cascade'] = $cascades;
 
         switch ($mapping['type']) {
             case self::ONE_TO_ONE:

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -67,14 +67,6 @@ use function trim;
  *
  * @template-covariant T of object
  * @template-implements PersistenceClassMetadata<T>
- * @psalm-type EmbeddedClassMapping = array{
- *    class: class-string,
- *    columnPrefix: string|null,
- *    declaredField: string|null,
- *    originalField: string|null,
- *    inherited?: class-string,
- *    declared?: class-string,
- * }
  */
 class ClassMetadata implements PersistenceClassMetadata, Stringable
 {
@@ -318,22 +310,6 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
     /**
      * READ-ONLY: The names of all embedded classes based on properties.
-     *
-     * The value (definition) array may contain, among others, the following values:
-     *
-     * - <b>'inherited'</b> (string, optional)
-     * This is set when this embedded-class field is inherited by this class from another (inheritance) parent
-     * <em>entity</em> class. The value is the FQCN of the topmost entity class that contains
-     * mapping information for this field. (If there are transient classes in the
-     * class hierarchy, these are ignored, so the class property may in fact come
-     * from a class further up in the PHP class hierarchy.)
-     * Fields initially declared in mapped superclasses are
-     * <em>not</em> considered 'inherited' in the nearest entity subclasses.
-     *
-     * - <b>'declared'</b> (string, optional)
-     * This is set when the embedded-class field does not appear for the first time in this class, but is originally
-     * declared in another parent <em>entity or mapped superclass</em>. The value is the FQCN
-     * of the topmost non-transient class that contains mapping information for this field.
      *
      * @psalm-var array<string, EmbeddedClassMapping>
      */
@@ -2730,12 +2706,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         assert($fqcn !== null);
 
-        $this->embeddedClasses[$mapping['fieldName']] = [
+        $this->embeddedClasses[$mapping['fieldName']] = EmbeddedClassMapping::fromMappingArray([
             'class' => $fqcn,
             'columnPrefix' => $mapping['columnPrefix'] ?? null,
             'declaredField' => $mapping['declaredField'] ?? null,
             'originalField' => $mapping['originalField'] ?? null,
-        ];
+        ]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -442,7 +442,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * )
      * </pre>
      *
-     * @psalm-var array<string, AssociationMapping>
+     * @psalm-var array<string, OneToOneAssociationMapping|ManyToOneAssociationMapping|OneToManyAssociationMapping|ManyToManyAssociationMapping>
      */
     public array $associationMappings = [];
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -95,7 +95,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     ): void {
         if ($parent) {
             $class->setInheritanceType($parent->inheritanceType);
-            $class->setDiscriminatorColumn($parent->discriminatorColumn);
+            $class->setDiscriminatorColumn($parent->discriminatorColumn === null ? null : clone $parent->discriminatorColumn);
             $class->setIdGeneratorType($parent->generatorType);
             $this->addInheritedFields($class, $parent);
             $this->addInheritedRelations($class, $parent);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -47,7 +47,6 @@ use function substr;
  * @extends AbstractClassMetadataFactory<ClassMetadata>
  * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-import-type EmbeddedClassMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {
@@ -399,7 +398,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      *
      * @param AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping
      */
-    private function addMappingInheritanceInformation(array &$mapping, ClassMetadata $parentClass): void
+    private function addMappingInheritanceInformation(array|FieldMapping &$mapping, ClassMetadata $parentClass): void
     {
         if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
             $mapping['inherited'] = $parentClass->name;
@@ -416,8 +415,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->fieldMappings as $mapping) {
-            $this->addMappingInheritanceInformation($mapping, $parentClass);
-            $subClass->addInheritedFieldMapping($mapping);
+            $subClassMapping = clone $mapping;
+            $this->addMappingInheritanceInformation($subClassMapping, $parentClass);
+            $subClass->addInheritedFieldMapping($subClassMapping);
         }
 
         foreach ($parentClass->reflFields as $name => $field) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -45,7 +45,6 @@ use function substr;
  * to a relational database.
  *
  * @extends AbstractClassMetadataFactory<ClassMetadata>
- * @psalm-import-type EmbeddedClassMapping from ClassMetadata
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {
@@ -394,11 +393,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * Puts the `inherited` and `declared` values into mapping information for fields, associations
      * and embedded classes.
-     *
-     * @param AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping
      */
     private function addMappingInheritanceInformation(
-        array|FieldMapping|AssociationMapping &$mapping,
+        AssociationMapping|EmbeddedClassMapping|FieldMapping &$mapping,
         ClassMetadata $parentClass,
     ): void {
         if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
@@ -453,8 +450,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedEmbeddedClasses(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->embeddedClasses as $field => $embeddedClass) {
-            $this->addMappingInheritanceInformation($embeddedClass, $parentClass);
-            $subClass->embeddedClasses[$field] = $embeddedClass;
+            $subClassMapping = clone $embeddedClass;
+            $this->addMappingInheritanceInformation($subClassMapping, $parentClass);
+            $subClass->embeddedClasses[$field] = $subClassMapping;
         }
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -395,7 +395,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * and embedded classes.
      */
     private function addMappingInheritanceInformation(
-        AssociationMapping|EmbeddedClassMapping|FieldMapping &$mapping,
+        AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping,
         ClassMetadata $parentClass,
     ): void {
         if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -55,7 +55,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
             : $definition['sequenceName'];
     }
 
-    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
+    public function getJoinColumnName(JoinColumnMapping $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return isset($joinColumn['quoted'])
             ? $platform->quoteIdentifier($joinColumn['name'])
@@ -63,7 +63,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
     }
 
     public function getReferencedJoinColumnName(
-        JoinColumnData $joinColumn,
+        JoinColumnMapping $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string {
@@ -109,7 +109,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
             // Association defined as Id field
             $joinColumns            = $class->associationMappings[$fieldName]['joinColumns'];
             $assocQuotedColumnNames = array_map(
-                static fn (JoinColumnData $joinColumn) => isset($joinColumn['quoted'])
+                static fn (JoinColumnMapping $joinColumn) => isset($joinColumn['quoted'])
                     ? $platform->quoteIdentifier($joinColumn['name'])
                     : $joinColumn['name'],
                 $joinColumns,

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -55,21 +55,15 @@ class DefaultQuoteStrategy implements QuoteStrategy
             : $definition['sequenceName'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getJoinColumnName(array $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
+    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return isset($joinColumn['quoted'])
             ? $platform->quoteIdentifier($joinColumn['name'])
             : $joinColumn['name'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getReferencedJoinColumnName(
-        array $joinColumn,
+        JoinColumnData $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string {
@@ -78,11 +72,11 @@ class DefaultQuoteStrategy implements QuoteStrategy
             : $joinColumn['referencedColumnName'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getJoinTableName(array $association, ClassMetadata $class, AbstractPlatform $platform): string
-    {
+    public function getJoinTableName(
+        AssociationMapping $association,
+        ClassMetadata $class,
+        AbstractPlatform $platform,
+    ): string {
         $schema = '';
 
         if (isset($association['joinTable']['schema'])) {
@@ -115,7 +109,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
             // Association defined as Id field
             $joinColumns            = $class->associationMappings[$fieldName]['joinColumns'];
             $assocQuotedColumnNames = array_map(
-                static fn (array $joinColumn) => isset($joinColumn['quoted'])
+                static fn (JoinColumnData $joinColumn) => isset($joinColumn['quoted'])
                     ? $platform->quoteIdentifier($joinColumn['name'])
                     : $joinColumn['name'],
                 $joinColumns,

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
@@ -14,6 +14,8 @@ use function property_exists;
 /** @template-implements ArrayAccess<string, mixed> */
 final class DiscriminatorColumnMapping implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     /** The database length of the column. Optional. Default value taken from the type. */
     public int|null $length = null;
 
@@ -59,34 +61,5 @@ final class DiscriminatorColumnMapping implements ArrayAccess
         }
 
         return $mapping;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->$offset;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetSet($offset, $value): void
-    {
-        $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+use BackedEnum;
+use Exception;
+
+use function in_array;
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class DiscriminatorColumnMapping implements ArrayAccess
+{
+    /** The database length of the column. Optional. Default value taken from the type. */
+    public int|null $length = null;
+
+    public string|null $columnDefinition = null;
+
+    /** @var class-string<BackedEnum>|null */
+    public string|null $enumType = null;
+
+    public function __construct(
+        public string $type,
+        public string $fieldName,
+        public string $name,
+    ) {
+    }
+
+    /**
+     * @psalm-param array{
+     *     type: string,
+     *     fieldName: string,
+     *     name: string,
+     *     length?: int,
+     *     columnDefinition?: string,
+     *     enumType?: class-string<BackedEnum>,
+     * } $mappingArray
+     */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self(
+            $mappingArray['type'],
+            $mappingArray['fieldName'],
+            $mappingArray['name'],
+        );
+        foreach ($mappingArray as $key => $value) {
+            if (in_array($key, ['type', 'fieldName', 'name'])) {
+                continue;
+            }
+
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            } else {
+                throw new Exception('Unknown property ' . $key . ' on class ' . static::class);
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumnMapping.php
@@ -62,4 +62,18 @@ final class DiscriminatorColumnMapping implements ArrayAccess
 
         return $mapping;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = ['type', 'fieldName', 'name'];
+
+        foreach (['length', 'columnDefinition', 'enumType'] as $stringOrArrayKey) {
+            if ($this->$stringOrArrayKey !== null) {
+                $serialized[] = $stringOrArrayKey;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
+++ b/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
@@ -63,4 +63,22 @@ final class EmbeddedClassMapping implements ArrayAccess
 
         return $mapping;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = ['class'];
+
+        if ($this->columnPrefix) {
+            $serialized[] = 'columnPrefix';
+        }
+
+        foreach (['declaredField', 'originalField', 'inherited', 'declared'] as $property) {
+            if ($this->$property !== null) {
+                $serialized[] = $property;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
+++ b/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
@@ -11,6 +11,8 @@ use function property_exists;
 /** @template-implements ArrayAccess<string, mixed> */
 final class EmbeddedClassMapping implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     public string|bool|null $columnPrefix = null;
     public string|null $declaredField     = null;
     public string|null $originalField     = null;
@@ -60,34 +62,5 @@ final class EmbeddedClassMapping implements ArrayAccess
         }
 
         return $mapping;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->$offset;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetSet($offset, $value): void
-    {
-        $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
+++ b/lib/Doctrine/ORM/Mapping/EmbeddedClassMapping.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class EmbeddedClassMapping implements ArrayAccess
+{
+    public string|bool|null $columnPrefix = null;
+    public string|null $declaredField     = null;
+    public string|null $originalField     = null;
+
+    /**
+     * This is set when this embedded-class field is inherited by this class
+     * from another (inheritance) parent <em>entity</em> class. The value is
+     * the FQCN of the topmost entity class that contains mapping information
+     * for this field. (If there are transient classes in the class hierarchy,
+     * these are ignored, so the class property may in fact come from a class
+     * further up in the PHP class hierarchy.) Fields initially declared in
+     * mapped superclasses are <em>not</em> considered 'inherited' in the
+     * nearest entity subclasses.
+     *
+     * @var class-string|null
+     */
+    public string|null $inherited = null;
+
+    /**
+     * This is set when the embedded-class field does not appear for the first
+     * time in this class, but is originally declared in another parent
+     * <em>entity or mapped superclass</em>. The value is the FQCN of the
+     * topmost non-transient class that contains mapping information for this
+     * field.
+     *
+     * @var class-string|null
+     */
+    public string|null $declared = null;
+
+    /** @param class-string $class */
+    public function __construct(public string $class)
+    {
+    }
+
+    /** @param array{class: class-string, columnPrefix: string|null, declaredField: string|null, originalField: string|null} $mappingArray */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self($mappingArray['class']);
+        foreach ($mappingArray as $key => $value) {
+            if ($key === 'class') {
+                continue;
+            }
+
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/FieldMapping.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMapping.php
@@ -103,4 +103,40 @@ final class FieldMapping implements ArrayAccess
 
         return $mapping;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = ['type', 'fieldName', 'columnName'];
+
+        foreach (['nullable', 'notInsertable', 'notUpdatable', 'id', 'unique', 'version', 'quoted'] as $boolKey) {
+            if ($this->$boolKey) {
+                $serialized[] = $boolKey;
+            }
+        }
+
+        foreach (
+            [
+                'length',
+                'columnDefinition',
+                'generated',
+                'enumType',
+                'precision',
+                'scale',
+                'inherited',
+                'originalClass',
+                'originalField',
+                'declared',
+                'declaredField',
+                'options',
+                'default',
+            ] as $key
+        ) {
+            if ($this->$key !== null) {
+                $serialized[] = $key;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/FieldMapping.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMapping.php
@@ -13,6 +13,8 @@ use function property_exists;
 /** @template-implements ArrayAccess<string, mixed> */
 final class FieldMapping implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     /** @var int|null The database length of the column. Optional. Default value taken from the type. */
     public int|null $length = null;
     /**
@@ -100,34 +102,5 @@ final class FieldMapping implements ArrayAccess
         }
 
         return $mapping;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->$offset;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetSet($offset, $value): void
-    {
-        $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/FieldMapping.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMapping.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+use BackedEnum;
+
+use function in_array;
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class FieldMapping implements ArrayAccess
+{
+    /** @var int|null The database length of the column. Optional. Default value taken from the type. */
+    public int|null $length = null;
+    /**
+     * @var bool|null Marks the field as the primary key of the entity. Multiple
+     * fields of an entity can have the id attribute, forming a composite key.
+     */
+    public bool|null $id                 = null;
+    public bool|null $nullable           = null;
+    public bool|null $notInsertable      = null;
+    public bool|null $notUpdatable       = null;
+    public string|null $columnDefinition = null;
+    /** ClassMetadata::GENERATED_* */
+    public int|null $generated = null;
+    /** @var class-string<BackedEnum>|null */
+    public string|null $enumType = null;
+    /**
+     * @var int|null The precision of a decimal column.
+     * Only valid if the column type is decimal
+     */
+    public int|null $precision = null;
+    /**
+     * @var int|null The scale of a decimal column.
+     * Only valid if the column type is decimal
+     */
+    public int|null $scale = null;
+    /** @var bool|null Whether a unique constraint should be generated for the column. */
+    public bool|null $unique = null;
+    /**
+     * @var class-string|null This is set when the field is inherited by this
+     * class from another (inheritance) parent <em>entity</em> class. The value
+     * is the FQCN of the topmost entity class that contains mapping information
+     * for this field. (If there are transient classes in the class hierarchy,
+     * these are ignored, so the class property may in fact come from a class
+     * further up in the PHP class hierarchy.)
+     * Fields initially declared in mapped superclasses are
+     * <em>not</em> considered 'inherited' in the nearest entity subclasses.
+     */
+    public string|null $inherited = null;
+
+    public string|null $originalClass = null;
+    public string|null $originalField = null;
+    public bool|null $quoted          = null;
+    /**
+     * @var class-string|null This is set when the field does not appear for
+     * the first time in this class, but is originally declared in another
+     * parent <em>entity or mapped superclass</em>. The value is the FQCN of
+     * the topmost non-transient class that contains mapping information for
+     * this field.
+     */
+    public string|null $declared      = null;
+    public string|null $declaredField = null;
+    public array|null $options        = null;
+    public bool|null $version         = null;
+    public string|int|null $default   = null;
+
+    /**
+     * @param string $type       The type name of the mapped field. Can be one of
+     *                           Doctrine's mapping types or a custom mapping type.
+     * @param string $fieldName  The name of the field in the Entity.
+     * @param string $columnName The column name. Optional. Defaults to the field name.
+     */
+    public function __construct(
+        public string $type,
+        public string $fieldName,
+        public string $columnName,
+    ) {
+    }
+
+    /** @param array{type: string, fieldName: string, columnName: string} $mappingArray */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self(
+            $mappingArray['type'],
+            $mappingArray['fieldName'],
+            $mappingArray['columnName'],
+        );
+        foreach ($mappingArray as $key => $value) {
+            if (in_array($key, ['type', 'fieldName', 'columnName'])) {
+                continue;
+            }
+
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/JoinColumnData.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnData.php
@@ -11,6 +11,8 @@ use function property_exists;
 /** @template-implements ArrayAccess<string, mixed> */
 final class JoinColumnData implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     public string|null $name                 = null;
     public bool|null $unique                 = null;
     public bool|null $quoted                 = null;
@@ -40,34 +42,5 @@ final class JoinColumnData implements ArrayAccess
         }
 
         return $mapping;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->$offset;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetSet($offset, $value): void
-    {
-        $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumnData.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnData.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class JoinColumnData implements ArrayAccess
+{
+    public string|null $name                 = null;
+    public bool|null $unique                 = null;
+    public bool|null $quoted                 = null;
+    public string|null $fieldName            = null;
+    public string|null $onDelete             = null;
+    public string|null $columnDefinition     = null;
+    public bool|null $nullable               = null;
+    public string|null $referencedColumnName = null;
+    /** @var array<string, mixed> */
+    public array|null $options = null;
+
+    public function __construct()
+    {
+    }
+
+    /** @psalm-param array{name: string, referencedColumnName: string, ...} $mappingArray */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self();
+        foreach ($mappingArray as $key => $value) {
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/JoinColumnData.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnData.php
@@ -26,7 +26,10 @@ final class JoinColumnData implements ArrayAccess
     {
     }
 
-    /** @psalm-param array{name: string, referencedColumnName: string, ...} $mappingArray */
+    /**
+     * @param array<string, mixed> $mappingArray
+     * @psalm-param array{name: string, referencedColumnName: string, ...} $mappingArray
+     */
     public static function fromMappingArray(array $mappingArray): self
     {
         $mapping = new self();

--- a/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
@@ -9,7 +9,7 @@ use ArrayAccess;
 use function property_exists;
 
 /** @template-implements ArrayAccess<string, mixed> */
-final class JoinColumnData implements ArrayAccess
+final class JoinColumnMapping implements ArrayAccess
 {
     use ArrayAccessImplementation;
 

--- a/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
@@ -24,10 +24,6 @@ final class JoinColumnMapping implements ArrayAccess
     /** @var array<string, mixed> */
     public array|null $options = null;
 
-    public function __construct()
-    {
-    }
-
     /**
      * @param array<string, mixed> $mappingArray
      * @psalm-param array{name: string, referencedColumnName: string, ...} $mappingArray

--- a/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
@@ -13,16 +13,20 @@ final class JoinColumnMapping implements ArrayAccess
 {
     use ArrayAccessImplementation;
 
-    public string|null $name                 = null;
-    public bool|null $unique                 = null;
-    public bool|null $quoted                 = null;
-    public string|null $fieldName            = null;
-    public string|null $onDelete             = null;
-    public string|null $columnDefinition     = null;
-    public bool|null $nullable               = null;
-    public string|null $referencedColumnName = null;
+    public string|null $name             = null;
+    public bool|null $unique             = null;
+    public bool|null $quoted             = null;
+    public string|null $fieldName        = null;
+    public string|null $onDelete         = null;
+    public string|null $columnDefinition = null;
+    public bool|null $nullable           = null;
     /** @var array<string, mixed> */
     public array|null $options = null;
+
+    public function __construct(
+        public string $referencedColumnName,
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $mappingArray
@@ -30,9 +34,9 @@ final class JoinColumnMapping implements ArrayAccess
      */
     public static function fromMappingArray(array $mappingArray): self
     {
-        $mapping = new self();
+        $mapping = new self($mappingArray['referencedColumnName']);
         foreach ($mappingArray as $key => $value) {
-            if (property_exists($mapping, $key)) {
+            if (property_exists($mapping, $key) && $value !== null) {
                 $mapping->$key = $value;
             }
         }

--- a/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
@@ -39,4 +39,24 @@ final class JoinColumnMapping implements ArrayAccess
 
         return $mapping;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = [];
+
+        foreach (['name', 'fieldName', 'onDelete', 'columnDefinition', 'referencedColumnName', 'options'] as $stringOrArrayKey) {
+            if ($this->$stringOrArrayKey !== null) {
+                $serialized[] = $stringOrArrayKey;
+            }
+        }
+
+        foreach (['unique', 'quoted', 'nullable'] as $boolKey) {
+            if ($this->$boolKey !== null) {
+                $serialized[] = $boolKey;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -12,6 +12,8 @@ use function in_array;
 /** @template-implements ArrayAccess<string, mixed> */
 final class JoinTableMapping implements ArrayAccess
 {
+    use ArrayAccessImplementation;
+
     public bool|null $quoted = null;
 
     /** @var list<JoinColumnData> */
@@ -53,19 +55,6 @@ final class JoinTableMapping implements ArrayAccess
     /**
      * {@inheritDoc}
      */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->$offset);
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->$offset;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function offsetSet($offset, $value): void
     {
         if (in_array($offset, ['joinColumns', 'inverseJoinColumns'], true)) {
@@ -78,14 +67,6 @@ final class JoinTableMapping implements ArrayAccess
         }
 
         $this->$offset = $value;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function offsetUnset($offset): void
-    {
-        $this->$offset = null;
     }
 
     /** @return mixed[] */

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -16,10 +16,10 @@ final class JoinTableMapping implements ArrayAccess
 
     public bool|null $quoted = null;
 
-    /** @var list<JoinColumnMapping> */
+    /** @var list<JoinColumnMapping>|null */
     public array|null $joinColumns = null;
 
-    /** @var list<JoinColumnMapping> */
+    /** @var list<JoinColumnMapping>|null */
     public array|null $inverseJoinColumns = null;
 
     public string|null $schema = null;

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -16,10 +16,10 @@ final class JoinTableMapping implements ArrayAccess
 
     public bool|null $quoted = null;
 
-    /** @var list<JoinColumnData> */
+    /** @var list<JoinColumnMapping> */
     public array|null $joinColumns = null;
 
-    /** @var list<JoinColumnData> */
+    /** @var list<JoinColumnMapping> */
     public array|null $inverseJoinColumns = null;
 
     public string|null $schema = null;
@@ -39,13 +39,13 @@ final class JoinTableMapping implements ArrayAccess
 
         if (isset($mappingArray['joinColumns'])) {
             foreach ($mappingArray['joinColumns'] as $column) {
-                $mapping->joinColumns[] = JoinColumnData::fromMappingArray($column);
+                $mapping->joinColumns[] = JoinColumnMapping::fromMappingArray($column);
             }
         }
 
         if (isset($mappingArray['inverseJoinColumns'])) {
             foreach ($mappingArray['inverseJoinColumns'] as $column) {
-                $mapping->inverseJoinColumns[] = JoinColumnData::fromMappingArray($column);
+                $mapping->inverseJoinColumns[] = JoinColumnMapping::fromMappingArray($column);
             }
         }
 
@@ -60,7 +60,7 @@ final class JoinTableMapping implements ArrayAccess
         if (in_array($offset, ['joinColumns', 'inverseJoinColumns'], true)) {
             $joinColumns = [];
             foreach ($value as $column) {
-                $joinColumns[] = JoinColumnData::fromMappingArray($column);
+                $joinColumns[] = JoinColumnMapping::fromMappingArray($column);
             }
 
             $value = $joinColumns;
@@ -75,11 +75,11 @@ final class JoinTableMapping implements ArrayAccess
         $array = (array) $this;
 
         if (isset($array['joinColumns'])) {
-            $array['joinColumns'] = array_map(static fn (JoinColumnData $column): array => (array) $column, $array['joinColumns']);
+            $array['joinColumns'] = array_map(static fn (JoinColumnMapping $column): array => (array) $column, $array['joinColumns']);
         }
 
         if (isset($array['inverseJoinColumns'])) {
-            $array['inverseJoinColumns'] = array_map(static fn (JoinColumnData $column): array => (array) $column, $array['inverseJoinColumns']);
+            $array['inverseJoinColumns'] = array_map(static fn (JoinColumnMapping $column): array => (array) $column, $array['inverseJoinColumns']);
         }
 
         return $array;

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -16,11 +16,11 @@ final class JoinTableMapping implements ArrayAccess
 
     public bool|null $quoted = null;
 
-    /** @var list<JoinColumnMapping>|null */
-    public array|null $joinColumns = null;
+    /** @var list<JoinColumnMapping> */
+    public array $joinColumns = [];
 
-    /** @var list<JoinColumnMapping>|null */
-    public array|null $inverseJoinColumns = null;
+    /** @var list<JoinColumnMapping> */
+    public array $inverseJoinColumns = [];
 
     public string|null $schema = null;
 
@@ -74,13 +74,9 @@ final class JoinTableMapping implements ArrayAccess
     {
         $array = (array) $this;
 
-        if (isset($array['joinColumns'])) {
-            $array['joinColumns'] = array_map(static fn (JoinColumnMapping $column): array => (array) $column, $array['joinColumns']);
-        }
-
-        if (isset($array['inverseJoinColumns'])) {
-            $array['inverseJoinColumns'] = array_map(static fn (JoinColumnMapping $column): array => (array) $column, $array['inverseJoinColumns']);
-        }
+        $toArray                     = static fn (JoinColumnMapping $column): array => (array) $column;
+        $array['joinColumns']        = array_map($toArray, $array['joinColumns']);
+        $array['inverseJoinColumns'] = array_map($toArray, $array['inverseJoinColumns']);
 
         return $array;
     }

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+
+use function array_map;
+use function in_array;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class JoinTableMapping implements ArrayAccess
+{
+    public bool|null $quoted = null;
+
+    /** @var list<JoinColumnData> */
+    public array|null $joinColumns = null;
+
+    /** @var list<JoinColumnData> */
+    public array|null $inverseJoinColumns = null;
+
+    public string|null $schema = null;
+
+    public string|null $name = null;
+
+    /** @param array{name?: string, quoted?: bool, joinColumns?: mixed[], inverseJoinColumns?: mixed[], schema?: string} $mappingArray */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self();
+
+        foreach (['name', 'quoted', 'schema'] as $key) {
+            if (isset($mappingArray[$key])) {
+                $mapping[$key] = $mappingArray[$key];
+            }
+        }
+
+        if (isset($mappingArray['joinColumns'])) {
+            foreach ($mappingArray['joinColumns'] as $column) {
+                $mapping->joinColumns[] = JoinColumnData::fromMappingArray($column);
+            }
+        }
+
+        if (isset($mappingArray['inverseJoinColumns'])) {
+            foreach ($mappingArray['inverseJoinColumns'] as $column) {
+                $mapping->inverseJoinColumns[] = JoinColumnData::fromMappingArray($column);
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (in_array($offset, ['joinColumns', 'inverseJoinColumns'], true)) {
+            $joinColumns = [];
+            foreach ($value as $column) {
+                $joinColumns[] = JoinColumnData::fromMappingArray($column);
+            }
+
+            $value = $joinColumns;
+        }
+
+        $this->$offset = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->$offset = null;
+    }
+
+    /** @return mixed[] */
+    public function toArray(): array
+    {
+        $array = (array) $this;
+
+        if (isset($array['joinColumns'])) {
+            $array['joinColumns'] = array_map(static fn (JoinColumnData $column): array => (array) $column, $array['joinColumns']);
+        }
+
+        if (isset($array['inverseJoinColumns'])) {
+            $array['inverseJoinColumns'] = array_map(static fn (JoinColumnData $column): array => (array) $column, $array['inverseJoinColumns']);
+        }
+
+        return $array;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -80,4 +80,24 @@ final class JoinTableMapping implements ArrayAccess
 
         return $array;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = [];
+
+        foreach (['joinColumns', 'inverseJoinColumns', 'name', 'schema'] as $stringOrArrayKey) {
+            if ($this->$stringOrArrayKey !== null) {
+                $serialized[] = $stringOrArrayKey;
+            }
+        }
+
+        foreach (['quoted'] as $boolKey) {
+            if ($this->$boolKey) {
+                $serialized[] = $boolKey;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class ManyToManyAssociationMapping extends ToManyAssociationMapping
+{
+    /**
+     * Specification of the join table and its join columns (foreign keys).
+     * Only valid for many-to-many mappings. Note that one-to-many associations
+     * can be mapped through a join table by simply mapping the association as
+     * many-to-many with a unique constraint on the join table.
+     */
+    public JoinTableMapping|null $joinTable = null;
+
+    public array|null $relationToSourceKeyColumns = null;
+    public array|null $relationToTargetKeyColumns = null;
+
+    /** @return mixed[] */
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        $array['joinTable'] = $this->joinTable->toArray();
+
+        return $array;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -8,4 +8,16 @@ class ManyToManyAssociationMapping extends ToManyAssociationMapping
 {
     public array|null $relationToSourceKeyColumns = null;
     public array|null $relationToTargetKeyColumns = null;
+
+    /** @param mixed[] $mappingArray */
+    public static function fromMappingArray(array $mappingArray): static
+    {
+        $mapping = parent::fromMappingArray($mappingArray);
+
+        $mapping['orphanRemoval'] = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
+
+        $mapping->assertMappingOrderBy();
+
+        return $mapping;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -8,14 +8,4 @@ class ManyToManyAssociationMapping extends ToManyAssociationMapping
 {
     public array|null $relationToSourceKeyColumns = null;
     public array|null $relationToTargetKeyColumns = null;
-
-    /** @param mixed[] $mappingArray */
-    public static function fromMappingArray(array $mappingArray): static
-    {
-        $mapping = parent::fromMappingArray($mappingArray);
-
-        $mapping->assertMappingOrderBy();
-
-        return $mapping;
-    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -8,4 +8,18 @@ class ManyToManyAssociationMapping extends ToManyAssociationMapping
 {
     public array|null $relationToSourceKeyColumns = null;
     public array|null $relationToTargetKeyColumns = null;
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = parent::__sleep();
+
+        foreach (['relationToSourceKeyColumns', 'relationToTargetKeyColumns'] as $arrayKey) {
+            if ($this->$arrayKey !== null) {
+                $serialized[] = $arrayKey;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -4,26 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-final class ManyToManyAssociationMapping extends ToManyAssociationMapping
+class ManyToManyAssociationMapping extends ToManyAssociationMapping
 {
-    /**
-     * Specification of the join table and its join columns (foreign keys).
-     * Only valid for many-to-many mappings. Note that one-to-many associations
-     * can be mapped through a join table by simply mapping the association as
-     * many-to-many with a unique constraint on the join table.
-     */
-    public JoinTableMapping|null $joinTable = null;
-
     public array|null $relationToSourceKeyColumns = null;
     public array|null $relationToTargetKeyColumns = null;
-
-    /** @return mixed[] */
-    public function toArray(): array
-    {
-        $array = parent::toArray();
-
-        $array['joinTable'] = $this->joinTable->toArray();
-
-        return $array;
-    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php
@@ -14,8 +14,6 @@ class ManyToManyAssociationMapping extends ToManyAssociationMapping
     {
         $mapping = parent::fromMappingArray($mappingArray);
 
-        $mapping['orphanRemoval'] = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
-
         $mapping->assertMappingOrderBy();
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -35,10 +35,7 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
 
         // owning side MUST have a join table
         if (! isset($mapping['joinTable']['name'])) {
-            if (! isset($mapping->joinTable)) {
-                $mapping->joinTable = new JoinTableMapping();
-            }
-
+            $mapping->joinTable       ??= new JoinTableMapping();
             $mapping->joinTable['name'] = $namingStrategy->joinTableName(
                 $mapping['sourceEntity'],
                 $mapping['targetEntity'],

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use function assert;
 use function strtolower;
 use function trim;
 
@@ -34,93 +33,92 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
         $mapping = parent::fromMappingArray($mappingArray);
 
         // owning side MUST have a join table
-        if (! isset($mapping['joinTable']['name'])) {
-            $mapping->joinTable       ??= new JoinTableMapping();
-            $mapping->joinTable['name'] = $namingStrategy->joinTableName(
-                $mapping['sourceEntity'],
-                $mapping['targetEntity'],
-                $mapping['fieldName'],
+        if (! isset($mapping->joinTable->name)) {
+            $mapping->joinTable     ??= new JoinTableMapping();
+            $mapping->joinTable->name = $namingStrategy->joinTableName(
+                $mapping->sourceEntity,
+                $mapping->targetEntity,
+                $mapping->fieldName,
             );
         }
 
-        $selfReferencingEntityWithoutJoinColumns = $mapping['sourceEntity'] === $mapping['targetEntity']
-            && (! (isset($mapping['joinTable']['joinColumns']) || isset($mapping['joinTable']['inverseJoinColumns'])));
+        $selfReferencingEntityWithoutJoinColumns = $mapping->sourceEntity === $mapping->targetEntity
+            && (! (isset($mapping->joinTable->joinColumns) || isset($mapping->joinTable->inverseJoinColumns)));
 
-        if (! isset($mapping['joinTable']['joinColumns'])) {
+        if (! isset($mapping->joinTable->joinColumns)) {
             $mapping->joinTable->joinColumns = [
                 JoinColumnMapping::fromMappingArray([
-                    'name' => $namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
+                    'name' => $namingStrategy->joinKeyColumnName($mapping->sourceEntity, $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
                     'referencedColumnName' => $namingStrategy->referenceColumnName(),
                     'onDelete' => 'CASCADE',
                 ]),
             ];
         }
 
-        if (! isset($mapping['joinTable']['inverseJoinColumns'])) {
+        if (! isset($mapping->joinTable->inverseJoinColumns)) {
             $mapping->joinTable->inverseJoinColumns = [
                 JoinColumnMapping::fromMappingArray([
-                    'name' => $namingStrategy->joinKeyColumnName($mapping['targetEntity'], $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
+                    'name' => $namingStrategy->joinKeyColumnName($mapping->targetEntity, $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
                     'referencedColumnName' => $namingStrategy->referenceColumnName(),
                     'onDelete' => 'CASCADE',
                 ]),
             ];
         }
 
-        $mapping['joinTableColumns'] = [];
+        $mapping->joinTableColumns = [];
 
-        assert($mapping->joinTable['joinColumns'] !== null);
-        foreach ($mapping->joinTable['joinColumns'] as $joinColumn) {
-            if (empty($joinColumn['name'])) {
-                $joinColumn['name'] = $namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $joinColumn['referencedColumnName']);
+        foreach ($mapping->joinTable->joinColumns as $joinColumn) {
+            if (empty($joinColumn->name)) {
+                $joinColumn->name = $namingStrategy->joinKeyColumnName($mapping->sourceEntity, $joinColumn->referencedColumnName);
             }
 
-            if (empty($joinColumn['referencedColumnName'])) {
-                $joinColumn['referencedColumnName'] = $namingStrategy->referenceColumnName();
+            if (empty($joinColumn->referencedColumnName)) {
+                $joinColumn->referencedColumnName = $namingStrategy->referenceColumnName();
             }
 
-            if ($joinColumn['name'][0] === '`') {
-                $joinColumn['name']   = trim($joinColumn['name'], '`');
-                $joinColumn['quoted'] = true;
+            if ($joinColumn->name[0] === '`') {
+                $joinColumn->name   = trim($joinColumn->name, '`');
+                $joinColumn->quoted = true;
             }
 
-            if ($joinColumn['referencedColumnName'][0] === '`') {
-                $joinColumn['referencedColumnName'] = trim($joinColumn['referencedColumnName'], '`');
-                $joinColumn['quoted']               = true;
+            if ($joinColumn->referencedColumnName[0] === '`') {
+                $joinColumn->referencedColumnName = trim($joinColumn->referencedColumnName, '`');
+                $joinColumn->quoted               = true;
             }
 
-            if (isset($joinColumn['onDelete']) && strtolower($joinColumn['onDelete']) === 'cascade') {
-                $mapping['isOnDeleteCascade'] = true;
+            if (isset($joinColumn->onDelete) && strtolower($joinColumn->onDelete) === 'cascade') {
+                $mapping->isOnDeleteCascade = true;
             }
 
-            $mapping->relationToSourceKeyColumns[$joinColumn['name']] = $joinColumn['referencedColumnName'];
-            $mapping->joinTableColumns[]                              = $joinColumn['name'];
+            $mapping->relationToSourceKeyColumns[$joinColumn->name] = $joinColumn->referencedColumnName;
+            $mapping->joinTableColumns[]                            = $joinColumn->name;
         }
 
-        foreach ($mapping->joinTable['inverseJoinColumns'] as $inverseJoinColumn) {
-            if (empty($inverseJoinColumn['name'])) {
-                $inverseJoinColumn['name'] = $namingStrategy->joinKeyColumnName($mapping['targetEntity'], $inverseJoinColumn['referencedColumnName']);
+        foreach ($mapping->joinTable->inverseJoinColumns as $inverseJoinColumn) {
+            if (empty($inverseJoinColumn->name)) {
+                $inverseJoinColumn->name = $namingStrategy->joinKeyColumnName($mapping->targetEntity, $inverseJoinColumn->referencedColumnName);
             }
 
-            if (empty($inverseJoinColumn['referencedColumnName'])) {
-                $inverseJoinColumn['referencedColumnName'] = $namingStrategy->referenceColumnName();
+            if (empty($inverseJoinColumn->referencedColumnName)) {
+                $inverseJoinColumn->referencedColumnName = $namingStrategy->referenceColumnName();
             }
 
-            if ($inverseJoinColumn['name'][0] === '`') {
-                $inverseJoinColumn['name']   = trim($inverseJoinColumn['name'], '`');
-                $inverseJoinColumn['quoted'] = true;
+            if ($inverseJoinColumn->name[0] === '`') {
+                $inverseJoinColumn->name   = trim($inverseJoinColumn->name, '`');
+                $inverseJoinColumn->quoted = true;
             }
 
-            if ($inverseJoinColumn['referencedColumnName'][0] === '`') {
-                $inverseJoinColumn['referencedColumnName'] = trim($inverseJoinColumn['referencedColumnName'], '`');
-                $inverseJoinColumn['quoted']               = true;
+            if ($inverseJoinColumn->referencedColumnName[0] === '`') {
+                $inverseJoinColumn->referencedColumnName = trim($inverseJoinColumn->referencedColumnName, '`');
+                $inverseJoinColumn->quoted               = true;
             }
 
-            if (isset($inverseJoinColumn['onDelete']) && strtolower($inverseJoinColumn['onDelete']) === 'cascade') {
-                $mapping['isOnDeleteCascade'] = true;
+            if (isset($inverseJoinColumn->onDelete) && strtolower($inverseJoinColumn->onDelete) === 'cascade') {
+                $mapping->isOnDeleteCascade = true;
             }
 
-            $mapping->relationToTargetKeyColumns[$inverseJoinColumn['name']] = $inverseJoinColumn['referencedColumnName'];
-            $mapping->joinTableColumns[]                                     = $inverseJoinColumn['name'];
+            $mapping->relationToTargetKeyColumns[$inverseJoinColumn->name] = $inverseJoinColumn->referencedColumnName;
+            $mapping->joinTableColumns[]                                   = $inverseJoinColumn->name;
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -51,7 +51,7 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
 
         if (! isset($mapping['joinTable']['joinColumns'])) {
             $mapping->joinTable->joinColumns = [
-                JoinColumnData::fromMappingArray([
+                JoinColumnMapping::fromMappingArray([
                     'name' => $namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
                     'referencedColumnName' => $namingStrategy->referenceColumnName(),
                     'onDelete' => 'CASCADE',
@@ -61,7 +61,7 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
 
         if (! isset($mapping['joinTable']['inverseJoinColumns'])) {
             $mapping->joinTable->inverseJoinColumns = [
-                JoinColumnData::fromMappingArray([
+                JoinColumnMapping::fromMappingArray([
                     'name' => $namingStrategy->joinKeyColumnName($mapping['targetEntity'], $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
                     'referencedColumnName' => $namingStrategy->referenceColumnName(),
                     'onDelete' => 'CASCADE',

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping implements AssociationOwningSideMapping
+{
+    /**
+     * Specification of the join table and its join columns (foreign keys).
+     * Only valid for many-to-many mappings. Note that one-to-many associations
+     * can be mapped through a join table by simply mapping the association as
+     * many-to-many with a unique constraint on the join table.
+     */
+    public JoinTableMapping $joinTable;
+
+    /** @return mixed[] */
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        $array['joinTable'] = $this->joinTable->toArray();
+
+        return $array;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -124,4 +124,13 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
 
         return $mapping;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized   = parent::__sleep();
+        $serialized[] = 'joinTable';
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -43,9 +43,10 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
         }
 
         $selfReferencingEntityWithoutJoinColumns = $mapping->sourceEntity === $mapping->targetEntity
-            && (! (isset($mapping->joinTable->joinColumns) || isset($mapping->joinTable->inverseJoinColumns)));
+            && $mapping->joinTable->joinColumns === []
+            && $mapping->joinTable->inverseJoinColumns === [];
 
-        if (! isset($mapping->joinTable->joinColumns)) {
+        if ($mapping->joinTable->joinColumns === []) {
             $mapping->joinTable->joinColumns = [
                 JoinColumnMapping::fromMappingArray([
                     'name' => $namingStrategy->joinKeyColumnName($mapping->sourceEntity, $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
@@ -55,7 +56,7 @@ final class ManyToManyOwningSideMapping extends ManyToManyAssociationMapping imp
             ];
         }
 
-        if (! isset($mapping->joinTable->inverseJoinColumns)) {
+        if ($mapping->joinTable->inverseJoinColumns === []) {
             $mapping->joinTable->inverseJoinColumns = [
                 JoinColumnMapping::fromMappingArray([
                     'name' => $namingStrategy->joinKeyColumnName($mapping->targetEntity, $selfReferencingEntityWithoutJoinColumns ? 'target' : null),

--- a/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
@@ -11,4 +11,14 @@ final class ManyToOneAssociationMapping extends ToOneAssociationMapping implemen
 {
     /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = parent::__sleep();
+
+        $serialized[] = 'joinColumns';
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-final class ManyToOneAssociationMapping extends ToOneAssociationMapping
+/**
+ * The "many" side of a many-to-one association mapping is always the owning side.
+ */
+final class ManyToOneAssociationMapping extends ToOneAssociationMapping implements AssociationOwningSideMapping
 {
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class ManyToOneAssociationMapping extends ToOneAssociationMapping
+{
+}

--- a/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
@@ -9,4 +9,6 @@ namespace Doctrine\ORM\Mapping;
  */
 final class ManyToOneAssociationMapping extends ToOneAssociationMapping implements AssociationOwningSideMapping
 {
+    /** @var list<JoinColumnData> */
+    public array $joinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOneAssociationMapping.php
@@ -9,6 +9,6 @@ namespace Doctrine\ORM\Mapping;
  */
 final class ManyToOneAssociationMapping extends ToOneAssociationMapping implements AssociationOwningSideMapping
 {
-    /** @var list<JoinColumnData> */
+    /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -44,6 +44,16 @@ class MappingException extends Exception implements ORMException
         ));
     }
 
+    public static function invalidAssociationType(string $entityName, string $fieldName, int $type): self
+    {
+        return new self(sprintf(
+            'The association "%s#%s" must be of type "ClassMetadata::ONE_TO_MANY", "ClassMetadata::MANY_TO_MANY" or "ClassMetadata::MANY_TO_ONE", "%d" given.',
+            $entityName,
+            $fieldName,
+            $type,
+        ));
+    }
+
     public static function invalidInheritanceType(string $entityName, int $type): self
     {
         return new self(sprintf("The inheritance type '%s' specified for '%s' does not exist.", $type, $entityName));

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -6,4 +6,21 @@ namespace Doctrine\ORM\Mapping;
 
 final class OneToManyAssociationMapping extends ToManyAssociationMapping
 {
+    /** @param mixed[] $mappingArray */
+    public static function fromMappingArrayAndName(array $mappingArray, string $name): self
+    {
+        $mapping = parent::fromMappingArray($mappingArray);
+
+        // OneToMany-side MUST be inverse (must have mappedBy)
+        if (! isset($mapping['mappedBy'])) {
+            throw MappingException::oneToManyRequiresMappedBy($name, $mapping['fieldName']);
+        }
+
+        $mapping['orphanRemoval']   = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
+        $mapping['isCascadeRemove'] = $mapping['orphanRemoval'] || $mapping['isCascadeRemove'];
+
+        $mapping->assertMappingOrderBy();
+
+        return $mapping;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Mapping;
 final class OneToManyAssociationMapping extends ToManyAssociationMapping
 {
     /** @param mixed[] $mappingArray */
-    public static function fromMappingArrayAndName(array $mappingArray, string $name): self
+    public static function fromMappingArrayAndName(array $mappingArray, string $name): static
     {
         $mapping = parent::fromMappingArray($mappingArray);
 

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -16,7 +16,6 @@ final class OneToManyAssociationMapping extends ToManyAssociationMapping
             throw MappingException::oneToManyRequiresMappedBy($name, $mapping['fieldName']);
         }
 
-        $mapping['orphanRemoval']   = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
         $mapping['isCascadeRemove'] = $mapping['orphanRemoval'] || $mapping['isCascadeRemove'];
 
         $mapping->assertMappingOrderBy();

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -7,16 +7,26 @@ namespace Doctrine\ORM\Mapping;
 final class OneToManyAssociationMapping extends ToManyAssociationMapping
 {
     /** @param mixed[] $mappingArray */
-    public static function fromMappingArrayAndName(array $mappingArray, string $name): static
+    public static function fromMappingArray(array $mappingArray): static
     {
         $mapping = parent::fromMappingArray($mappingArray);
+
+        if ($mapping->orphanRemoval && ! $mapping->isCascadeRemove()) {
+            $mapping->cascade[] = 'remove';
+        }
+
+        return $mapping;
+    }
+
+    /** @param mixed[] $mappingArray */
+    public static function fromMappingArrayAndName(array $mappingArray, string $name): static
+    {
+        $mapping = self::fromMappingArray($mappingArray);
 
         // OneToMany-side MUST be inverse (must have mappedBy)
         if (! isset($mapping->mappedBy)) {
             throw MappingException::oneToManyRequiresMappedBy($name, $mapping->fieldName);
         }
-
-        $mapping->isCascadeRemove = $mapping->orphanRemoval || $mapping->isCascadeRemove;
 
         return $mapping;
     }

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class OneToManyAssociationMapping extends ToManyAssociationMapping
+{
+}

--- a/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php
@@ -12,13 +12,11 @@ final class OneToManyAssociationMapping extends ToManyAssociationMapping
         $mapping = parent::fromMappingArray($mappingArray);
 
         // OneToMany-side MUST be inverse (must have mappedBy)
-        if (! isset($mapping['mappedBy'])) {
-            throw MappingException::oneToManyRequiresMappedBy($name, $mapping['fieldName']);
+        if (! isset($mapping->mappedBy)) {
+            throw MappingException::oneToManyRequiresMappedBy($name, $mapping->fieldName);
         }
 
-        $mapping['isCascadeRemove'] = $mapping['orphanRemoval'] || $mapping['isCascadeRemove'];
-
-        $mapping->assertMappingOrderBy();
+        $mapping->isCascadeRemove = $mapping->orphanRemoval || $mapping->isCascadeRemove;
 
         return $mapping;
     }

--- a/lib/Doctrine/ORM/Mapping/OneToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOneAssociationMapping.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class OneToOneAssociationMapping extends ToOneAssociationMapping
+{
+}

--- a/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+final class OneToOneOwningSideMapping extends OneToOneAssociationMapping implements AssociationOwningSideMapping
+{
+}

--- a/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
@@ -6,4 +6,6 @@ namespace Doctrine\ORM\Mapping;
 
 final class OneToOneOwningSideMapping extends OneToOneAssociationMapping implements AssociationOwningSideMapping
 {
+    /** @var list<JoinColumnData> */
+    public array $joinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
@@ -6,6 +6,6 @@ namespace Doctrine\ORM\Mapping;
 
 final class OneToOneOwningSideMapping extends OneToOneAssociationMapping implements AssociationOwningSideMapping
 {
-    /** @var list<JoinColumnData> */
+    /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOneOwningSideMapping.php
@@ -8,4 +8,14 @@ final class OneToOneOwningSideMapping extends OneToOneAssociationMapping impleme
 {
     /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = parent::__sleep();
+
+        $serialized[] = 'joinColumns';
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -8,9 +8,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * A set of rules for determining the column, alias and table quotes.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
- * @psalm-import-type JoinColumnData from ClassMetadata
  */
 interface QuoteStrategy
 {
@@ -31,27 +28,19 @@ interface QuoteStrategy
      */
     public function getSequenceName(array $definition, ClassMetadata $class, AbstractPlatform $platform): string;
 
-    /**
-     * Gets the (possibly quoted) name of the join table.
-     *
-     * @param AssociationMapping $association
-     */
-    public function getJoinTableName(array $association, ClassMetadata $class, AbstractPlatform $platform): string;
+    /** Gets the (possibly quoted) name of the join table. */
+    public function getJoinTableName(AssociationMapping $association, ClassMetadata $class, AbstractPlatform $platform): string;
 
     /**
      * Gets the (possibly quoted) join column name.
-     *
-     * @param JoinColumnData $joinColumn
      */
-    public function getJoinColumnName(array $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string;
+    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string;
 
     /**
      * Gets the (possibly quoted) join column name.
-     *
-     * @param JoinColumnData $joinColumn
      */
     public function getReferencedJoinColumnName(
-        array $joinColumn,
+        JoinColumnData $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string;

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -34,13 +34,13 @@ interface QuoteStrategy
     /**
      * Gets the (possibly quoted) join column name.
      */
-    public function getJoinColumnName(JoinColumnData $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string;
+    public function getJoinColumnName(JoinColumnMapping $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string;
 
     /**
      * Gets the (possibly quoted) join column name.
      */
     public function getReferencedJoinColumnName(
-        JoinColumnData $joinColumn,
+        JoinColumnMapping $joinColumn,
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string;

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -20,4 +20,18 @@ abstract class ToManyAssociationMapping extends AssociationMapping
      * @var array<string, 'asc'|'desc'>|null
      */
     public array|null $orderBy = null;
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = parent::__sleep();
+
+        foreach (['indexBy', 'orderBy'] as $stringOrArrayKey) {
+            if ($this->$stringOrArrayKey !== null) {
+                $serialized[] = $stringOrArrayKey;
+            }
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use InvalidArgumentException;
+
+use function gettype;
+use function is_array;
+
 abstract class ToManyAssociationMapping extends AssociationMapping
 {
     /**
@@ -20,4 +25,11 @@ abstract class ToManyAssociationMapping extends AssociationMapping
      * @var array<string, 'asc'|'desc'>
      */
     public array|null $orderBy = null;
+
+    final protected function assertMappingOrderBy(): void
+    {
+        if (isset($this['orderBy']) && ! is_array($this['orderBy'])) {
+            throw new InvalidArgumentException("'orderBy' is expected to be an array, not " . gettype($this['orderBy']));
+        }
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+class ToManyAssociationMapping extends AssociationMapping
+{
+    /**
+     * Specification of a field on target-entity that is used to index the
+     * collection by. This field HAS to be either the primary key or a unique
+     * column. Otherwise the collection does not contain all the entities that
+     * are actually related.
+     */
+    public string|null $indexBy = null;
+
+    /**
+     * A map of field names (of the target entity) to sorting directions
+     *
+     * @var array<string, 'asc'|'desc'>
+     */
+    public array|null $orderBy = null;
+}

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use InvalidArgumentException;
-
-use function gettype;
-use function is_array;
-
 abstract class ToManyAssociationMapping extends AssociationMapping
 {
     /**
@@ -22,14 +17,7 @@ abstract class ToManyAssociationMapping extends AssociationMapping
     /**
      * A map of field names (of the target entity) to sorting directions
      *
-     * @var array<string, 'asc'|'desc'>
+     * @var array<string, 'asc'|'desc'>|null
      */
     public array|null $orderBy = null;
-
-    final protected function assertMappingOrderBy(): void
-    {
-        if (isset($this['orderBy']) && ! is_array($this['orderBy'])) {
-            throw new InvalidArgumentException("'orderBy' is expected to be an array, not " . gettype($this['orderBy']));
-        }
-    }
 }

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-class ToManyAssociationMapping extends AssociationMapping
+abstract class ToManyAssociationMapping extends AssociationMapping
 {
     /**
      * Specification of a field on target-entity that is used to index the

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -14,7 +14,10 @@ abstract class ToOneAssociationMapping extends AssociationMapping
     /** @var array<string, string> */
     public array|null $targetToSourceKeyColumns = null;
 
-    /** @psalm-param array{joinColumns?: mixed[], ...} $mapping */
+    /**
+     * @param array<string, mixed> $mapping
+     * @psalm-param array{joinColumns?: mixed[], ...} $mapping
+     */
     public static function fromMappingArray(array $mapping): static
     {
         $joinColumns = $mapping['joinColumns'] ?? [];

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use function assert;
+
 abstract class ToOneAssociationMapping extends AssociationMapping
 {
     /** @var array<string, string> */
@@ -11,9 +13,6 @@ abstract class ToOneAssociationMapping extends AssociationMapping
 
     /** @var array<string, string> */
     public array|null $targetToSourceKeyColumns = null;
-
-    /** @var list<JoinColumnData>|null */
-    public array|null $joinColumns = null;
 
     /** @psalm-param array{joinColumns?: mixed[], ...} $mapping */
     public static function fromMappingArray(array $mapping): static
@@ -27,6 +26,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
         $instance = parent::fromMappingArray($mapping);
 
         foreach ($joinColumns as $column) {
+            assert($mapping['isOwningSide']);
             $instance->joinColumns[] = JoinColumnData::fromMappingArray($column);
         }
 
@@ -39,6 +39,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
     public function offsetSet($offset, $value): void
     {
         if ($offset === 'joinColumns') {
+            assert($this->isOwningSide());
             $joinColumns = [];
             foreach ($value as $column) {
                 $joinColumns[] = JoinColumnData::fromMappingArray($column);

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -28,7 +28,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
      *     joinColumns?: mixed[]|null,
      *     isOwningSide: bool, ...} $mappingArray
      */
-    public static function fromMappingArray(array $mappingArray): OneToOneAssociationMapping|ManyToOneAssociationMapping
+    public static function fromMappingArray(array $mappingArray): static
     {
         $joinColumns = $mappingArray['joinColumns'] ?? [];
 

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -15,21 +15,26 @@ abstract class ToOneAssociationMapping extends AssociationMapping
     public array|null $targetToSourceKeyColumns = null;
 
     /**
-     * @param array<string, mixed> $mapping
-     * @psalm-param array{joinColumns?: mixed[], ...} $mapping
+     * @param array<string, mixed> $mappingArray
+     * @psalm-param array{
+     *     fieldName: string,
+     *     sourceEntity: class-string,
+     *     targetEntity: class-string,
+     *     joinColumns?: mixed[]|null,
+     *     isOwningSide: bool, ...} $mappingArray
      */
-    public static function fromMappingArray(array $mapping): static
+    public static function fromMappingArray(array $mappingArray): OneToOneAssociationMapping|ManyToOneAssociationMapping
     {
-        $joinColumns = $mapping['joinColumns'] ?? [];
+        $joinColumns = $mappingArray['joinColumns'] ?? [];
 
-        if (isset($mapping['joinColumns'])) {
-            unset($mapping['joinColumns']);
+        if (isset($mappingArray['joinColumns'])) {
+            unset($mappingArray['joinColumns']);
         }
 
-        $instance = parent::fromMappingArray($mapping);
+        $instance = parent::fromMappingArray($mappingArray);
 
         foreach ($joinColumns as $column) {
-            assert($mapping['isOwningSide']);
+            assert($instance->isToOneOwningSide());
             $instance->joinColumns[] = JoinColumnData::fromMappingArray($column);
         }
 
@@ -42,7 +47,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
     public function offsetSet($offset, $value): void
     {
         if ($offset === 'joinColumns') {
-            assert($this->isOwningSide());
+            assert($this->isToOneOwningSide());
             $joinColumns = [];
             foreach ($value as $column) {
                 $joinColumns[] = JoinColumnData::fromMappingArray($column);

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -11,4 +11,24 @@ class ToOneAssociationMapping extends AssociationMapping
 
     /** @var array<string, string> */
     public array|null $targetToSourceKeyColumns = null;
+
+    /** @var list<JoinColumnData> */
+    public array|null $joinColumns = null;
+
+    /** @return mixed[] */
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        if ($array['joinColumns'] !== null) {
+            $joinColumns = [];
+            foreach ($array['joinColumns'] as $column) {
+                $joinColumns[] = (array) $column;
+            }
+
+            $array['joinColumns'] = $joinColumns;
+        }
+
+        return $array;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -162,7 +162,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
     {
         $array = parent::toArray();
 
-        if ($array['joinColumns'] !== null) {
+        if ($array['joinColumns'] !== []) {
             $joinColumns = [];
             foreach ($array['joinColumns'] as $column) {
                 $joinColumns[] = (array) $column;

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -16,7 +16,7 @@ class ToOneAssociationMapping extends AssociationMapping
     public array|null $joinColumns = null;
 
     /** @psalm-param array{joinColumns?: mixed[], ...} $mapping */
-    public static function fromMappingArray(array $mapping): self
+    public static function fromMappingArray(array $mapping): static
     {
         $joinColumns = $mapping['joinColumns'] ?? [];
 

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -124,7 +124,6 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             $mapping['targetToSourceKeyColumns'] = array_flip($mapping['sourceToTargetKeyColumns']);
         }
 
-        $mapping['orphanRemoval']   = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
         $mapping['isCascadeRemove'] = $mapping['orphanRemoval'] || $mapping['isCascadeRemove'];
 
         if ($mapping['orphanRemoval']) {

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -40,7 +40,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
 
         foreach ($joinColumns as $column) {
             assert($instance->isToOneOwningSide());
-            $instance->joinColumns[] = JoinColumnData::fromMappingArray($column);
+            $instance->joinColumns[] = JoinColumnMapping::fromMappingArray($column);
         }
 
         return $instance;
@@ -70,7 +70,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             if (empty($mapping->joinColumns)) {
                 // Apply default join column
                 $mapping->joinColumns = [
-                    JoinColumnData::fromMappingArray([
+                    JoinColumnMapping::fromMappingArray([
                         'name' => $namingStrategy->joinColumnName($mapping['fieldName'], $name),
                         'referencedColumnName' => $namingStrategy->referenceColumnName(),
                     ]),
@@ -147,7 +147,7 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             assert($this->isToOneOwningSide());
             $joinColumns = [];
             foreach ($value as $column) {
-                $joinColumns[] = JoinColumnData::fromMappingArray($column);
+                $joinColumns[] = JoinColumnMapping::fromMappingArray($column);
             }
 
             $this->joinColumns = $joinColumns;

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-class ToOneAssociationMapping extends AssociationMapping
+abstract class ToOneAssociationMapping extends AssociationMapping
 {
     /** @var array<string, string> */
     public array|null $sourceToTargetKeyColumns = null;

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -43,6 +43,14 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             $instance->joinColumns[] = JoinColumnMapping::fromMappingArray($column);
         }
 
+        if ($instance->orphanRemoval) {
+            if (! $instance->isCascadeRemove()) {
+                $instance->cascade[] = 'remove';
+            }
+
+            $instance->unique = null;
+        }
+
         return $instance;
     }
 
@@ -122,12 +130,6 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             }
 
             $mapping->targetToSourceKeyColumns = array_flip($mapping->sourceToTargetKeyColumns);
-        }
-
-        $mapping->isCascadeRemove = $mapping->orphanRemoval || $mapping->isCascadeRemove;
-
-        if ($mapping->orphanRemoval) {
-            $mapping->unique = null;
         }
 
         if (isset($mapping->id) && $mapping->id === true && ! $mapping->isOwningSide()) {

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -80,37 +80,37 @@ abstract class ToOneAssociationMapping extends AssociationMapping
             $uniqueConstraintColumns = [];
 
             foreach ($mapping->joinColumns as $joinColumn) {
-                if ($mapping['type'] === ClassMetadata::ONE_TO_ONE && ! $isInheritanceTypeSingleTable) {
+                if ($mapping->type() === ClassMetadata::ONE_TO_ONE && ! $isInheritanceTypeSingleTable) {
                     assert($mapping instanceof OneToOneAssociationMapping);
-                    if (count($mapping['joinColumns']) === 1) {
-                        if (empty($mapping['id'])) {
-                            $joinColumn['unique'] = true;
+                    if (count($mapping->joinColumns) === 1) {
+                        if (empty($mapping->id)) {
+                            $joinColumn->unique = true;
                         }
                     } else {
-                        $uniqueConstraintColumns[] = $joinColumn['name'];
+                        $uniqueConstraintColumns[] = $joinColumn->name;
                     }
                 }
 
-                if (empty($joinColumn['name'])) {
-                    $joinColumn['name'] = $namingStrategy->joinColumnName($mapping['fieldName'], $name);
+                if (empty($joinColumn->name)) {
+                    $joinColumn->name = $namingStrategy->joinColumnName($mapping->fieldName, $name);
                 }
 
-                if (empty($joinColumn['referencedColumnName'])) {
-                    $joinColumn['referencedColumnName'] = $namingStrategy->referenceColumnName();
+                if (empty($joinColumn->referencedColumnName)) {
+                    $joinColumn->referencedColumnName = $namingStrategy->referenceColumnName();
                 }
 
-                if ($joinColumn['name'][0] === '`') {
-                    $joinColumn['name']   = trim($joinColumn['name'], '`');
-                    $joinColumn['quoted'] = true;
+                if ($joinColumn->name[0] === '`') {
+                    $joinColumn->name   = trim($joinColumn->name, '`');
+                    $joinColumn->quoted = true;
                 }
 
-                if ($joinColumn['referencedColumnName'][0] === '`') {
-                    $joinColumn['referencedColumnName'] = trim($joinColumn['referencedColumnName'], '`');
-                    $joinColumn['quoted']               = true;
+                if ($joinColumn->referencedColumnName[0] === '`') {
+                    $joinColumn->referencedColumnName = trim($joinColumn->referencedColumnName, '`');
+                    $joinColumn->quoted               = true;
                 }
 
-                $mapping->sourceToTargetKeyColumns[$joinColumn['name']] = $joinColumn['referencedColumnName'];
-                $mapping->joinColumnFieldNames[$joinColumn['name']]     = $joinColumn['fieldName'] ?? $joinColumn['name'];
+                $mapping->sourceToTargetKeyColumns[$joinColumn->name] = $joinColumn->referencedColumnName;
+                $mapping->joinColumnFieldNames[$joinColumn->name]     = $joinColumn->fieldName ?? $joinColumn->name;
             }
 
             if ($uniqueConstraintColumns) {
@@ -118,20 +118,20 @@ abstract class ToOneAssociationMapping extends AssociationMapping
                     throw new RuntimeException('ClassMetadata::setTable() has to be called before defining a one to one relationship.');
                 }
 
-                $table['uniqueConstraints'][$mapping['fieldName'] . '_uniq'] = ['columns' => $uniqueConstraintColumns];
+                $table['uniqueConstraints'][$mapping->fieldName . '_uniq'] = ['columns' => $uniqueConstraintColumns];
             }
 
-            $mapping['targetToSourceKeyColumns'] = array_flip($mapping['sourceToTargetKeyColumns']);
+            $mapping->targetToSourceKeyColumns = array_flip($mapping->sourceToTargetKeyColumns);
         }
 
-        $mapping['isCascadeRemove'] = $mapping['orphanRemoval'] || $mapping['isCascadeRemove'];
+        $mapping->isCascadeRemove = $mapping->orphanRemoval || $mapping->isCascadeRemove;
 
-        if ($mapping['orphanRemoval']) {
-            unset($mapping['unique']);
+        if ($mapping->orphanRemoval) {
+            $mapping->unique = null;
         }
 
-        if (isset($mapping['id']) && $mapping['id'] === true && ! $mapping['isOwningSide']) {
-            throw MappingException::illegalInverseIdentifierAssociation($name, $mapping['fieldName']);
+        if (isset($mapping->id) && $mapping->id === true && ! $mapping->isOwningSide()) {
+            throw MappingException::illegalInverseIdentifierAssociation($name, $mapping->fieldName);
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -12,8 +12,45 @@ class ToOneAssociationMapping extends AssociationMapping
     /** @var array<string, string> */
     public array|null $targetToSourceKeyColumns = null;
 
-    /** @var list<JoinColumnData> */
+    /** @var list<JoinColumnData>|null */
     public array|null $joinColumns = null;
+
+    /** @psalm-param array{joinColumns?: mixed[], ...} $mapping */
+    public static function fromMappingArray(array $mapping): self
+    {
+        $joinColumns = $mapping['joinColumns'] ?? [];
+
+        if (isset($mapping['joinColumns'])) {
+            unset($mapping['joinColumns']);
+        }
+
+        $instance = parent::fromMappingArray($mapping);
+
+        foreach ($joinColumns as $column) {
+            $instance->joinColumns[] = JoinColumnData::fromMappingArray($column);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if ($offset === 'joinColumns') {
+            $joinColumns = [];
+            foreach ($value as $column) {
+                $joinColumns[] = JoinColumnData::fromMappingArray($column);
+            }
+
+            $this->joinColumns = $joinColumns;
+
+            return;
+        }
+
+        parent::offsetSet($offset, $value);
+    }
 
     /** @return mixed[] */
     public function toArray(): array

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+class ToOneAssociationMapping extends AssociationMapping
+{
+    /** @var array<string, string> */
+    public array|null $sourceToTargetKeyColumns = null;
+
+    /** @var array<string, string> */
+    public array|null $targetToSourceKeyColumns = null;
+}

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
@@ -173,4 +173,20 @@ abstract class ToOneAssociationMapping extends AssociationMapping
 
         return $array;
     }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = parent::__sleep();
+
+        if ($this->sourceToTargetKeyColumns !== null) {
+            $serialized[] = 'sourceToTargetKeyColumns';
+        }
+
+        if ($this->targetToSourceKeyColumns !== null) {
+            $serialized[] = 'targetToSourceKeyColumns';
+        }
+
+        return $serialized;
+    }
 }

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use InvalidArgumentException;
 use Stringable;
@@ -19,8 +20,6 @@ use function sprintf;
 
 /**
  * Contains exception messages for all invalid lifecycle state exceptions inside UnitOfWork
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ORMInvalidArgumentException extends InvalidArgumentException
 {
@@ -52,10 +51,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
         return new self('Only managed entities can be marked or checked as read only. But ' . self::objToStr($entity) . ' is not');
     }
 
-    /**
-     * @psalm-param non-empty-list<array{AssociationMapping, object}> $newEntitiesWithAssociations non-empty an array
-     *                                                                of [array $associationMapping, object $entity] pairs
-     */
+    /** @param non-empty-list<array{AssociationMapping, object}> $newEntitiesWithAssociations */
     public static function newEntitiesFoundThroughRelationships(array $newEntitiesWithAssociations): self
     {
         $errorMessages = array_map(
@@ -78,14 +74,12 @@ class ORMInvalidArgumentException extends InvalidArgumentException
         );
     }
 
-    /** @psalm-param AssociationMapping $associationMapping */
-    public static function newEntityFoundThroughRelationship(array $associationMapping, object $entry): self
+    public static function newEntityFoundThroughRelationship(AssociationMapping $associationMapping, object $entry): self
     {
         return new self(self::newEntityFoundThroughRelationshipMessage($associationMapping, $entry));
     }
 
-    /** @psalm-param AssociationMapping $assoc */
-    public static function detachedEntityFoundThroughRelationship(array $assoc, object $entry): self
+    public static function detachedEntityFoundThroughRelationship(AssociationMapping $assoc, object $entry): self
     {
         return new self('A detached entity of type ' . $assoc['targetEntity'] . ' (' . self::objToStr($entry) . ') '
             . " was found through the relationship '" . $assoc['sourceEntity'] . '#' . $assoc['fieldName'] . "' "
@@ -137,8 +131,7 @@ EXCEPTION
         ));
     }
 
-    /** @param AssociationMapping $assoc */
-    public static function invalidAssociation(ClassMetadata $targetClass, array $assoc, mixed $actualValue): self
+    public static function invalidAssociation(ClassMetadata $targetClass, AssociationMapping $assoc, mixed $actualValue): self
     {
         $expectedType = $targetClass->getName();
 
@@ -159,8 +152,7 @@ EXCEPTION
         return $obj instanceof Stringable ? (string) $obj : get_debug_type($obj) . '@' . spl_object_id($obj);
     }
 
-    /** @psalm-param AssociationMapping $associationMapping */
-    private static function newEntityFoundThroughRelationshipMessage(array $associationMapping, object $entity): string
+    private static function newEntityFoundThroughRelationshipMessage(AssociationMapping $associationMapping, object $entity): string
     {
         return 'A new entity was found through the relationship \''
             . $associationMapping['sourceEntity'] . '#' . $associationMapping['fieldName'] . '\' that was not'

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use RuntimeException;
 
 use function array_combine;
@@ -314,7 +315,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['type'] & ClassMetadata::TO_MANY &&
+            $this->association instanceof ToManyAssociationMapping &&
             $this->owner &&
             $this->association['orphanRemoval']
         ) {
@@ -336,7 +337,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['type'] & ClassMetadata::TO_MANY &&
+            $this->association instanceof ToManyAssociationMapping &&
             $this->owner &&
             $this->association['orphanRemoval']
         ) {
@@ -475,7 +476,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $uow = $this->getUnitOfWork();
 
         if (
-            $this->association['type'] & ClassMetadata::TO_MANY &&
+            $this->association instanceof ToManyAssociationMapping &&
             $this->association['orphanRemoval'] &&
             $this->owner
         ) {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use RuntimeException;
 
@@ -264,8 +265,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['isOwningSide'] &&
-            $this->association['type'] === ClassMetadata::MANY_TO_MANY &&
+            $this->association instanceof ManyToManyOwningSideMapping &&
             $this->owner &&
             $this->em !== null &&
             $this->em->getClassMetadata($this->owner::class)->isChangeTrackingNotify()
@@ -493,7 +493,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         $this->initialized = true; // direct call, {@link initialize()} is too expensive
 
-        if ($this->association['isOwningSide'] && $this->owner) {
+        if ($this->association->isOwningSide() && $this->owner) {
             $this->changed();
 
             $uow->scheduleCollectionDeletion($this);

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
@@ -24,8 +25,6 @@ use function sprintf;
 
 /**
  * Persister for many-to-many collections.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ManyToManyPersister extends AbstractCollectionPersister
 {
@@ -276,15 +275,14 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * have to join in the actual entities table leading to additional
      * JOIN.
      *
-     * @param mixed[] $mapping Array containing mapping information.
-     * @psalm-param AssociationMapping $mapping
+     * @param AssociationMapping $mapping Array containing mapping information.
      *
      * @return string[] ordered tuple:
      *                   - JOIN condition to add to the SQL
      *                   - WHERE condition to add to the SQL
      * @psalm-return array{0: string, 1: string}
      */
-    public function getFilterSql(array $mapping): array
+    public function getFilterSql(AssociationMapping $mapping): array
     {
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
         $rootClass   = $this->em->getClassMetadata($targetClass->rootEntityName);
@@ -329,13 +327,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
     /**
      * Generate ON condition
      *
-     * @param mixed[] $mapping
-     * @psalm-param AssociationMapping $mapping
-     *
      * @return string[]
      * @psalm-return list<string>
      */
-    protected function getOnConditionSQL(array $mapping): array
+    protected function getOnConditionSQL(AssociationMapping $mapping): array
     {
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
         $association = ! $mapping['isOwningSide']

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1847,7 +1847,7 @@ class BasicEntityPersister implements EntityPersister
 
         switch (true) {
             case isset($class->fieldMappings[$field]):
-                $types = array_merge($types, [$class->fieldMappings[$field]['type']]);
+                $types = array_merge($types, [$class->fieldMappings[$field]->type]);
                 break;
 
             case isset($class->associationMappings[$field]):

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -628,7 +628,7 @@ class BasicEntityPersister implements EntityPersister
             $assoc = $this->class->associationMappings[$field];
 
             // Only owning side of x-1 associations can have a FK column.
-            if (! $assoc['isOwningSide'] || ! ($assoc instanceof ToOneAssociationMapping)) {
+            if (! $assoc->isToOneOwningSide()) {
                 continue;
             }
 
@@ -1285,7 +1285,7 @@ class BasicEntityPersister implements EntityPersister
         ClassMetadata $class,
         string $alias = 'r',
     ): string {
-        if (! ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping)) {
+        if (! $assoc->isToOneOwningSide()) {
             return '';
         }
 
@@ -1402,7 +1402,7 @@ class BasicEntityPersister implements EntityPersister
             if (isset($this->class->associationMappings[$name])) {
                 $assoc = $this->class->associationMappings[$name];
 
-                if ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping) {
+                if ($assoc->isToOneOwningSide()) {
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         $columns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
                     }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -23,7 +23,6 @@ use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Mapping\ToManyAssociationMapping;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Exception\CantUseInOperatorOnCompositeKeys;
@@ -1189,7 +1188,7 @@ class BasicEntityPersister implements EntityPersister
                 $columnList[] = $assocColumnSQL;
             }
 
-            $isAssocToOneInverseSide = $assoc instanceof ToOneAssociationMapping && ! $assoc['isOwningSide'];
+            $isAssocToOneInverseSide = $assoc->isToOne() && ! $assoc['isOwningSide'];
             $isAssocFromOneEager     = ! $assoc instanceof ManyToManyAssociationMapping && $assoc['fetch'] === ClassMetadata::FETCH_EAGER;
 
             if (! ($isAssocFromOneEager || $isAssocToOneInverseSide)) {

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\PersistentCollection;
@@ -16,8 +17,6 @@ use Doctrine\ORM\Query\ResultSetMapping;
 /**
  * Entity persister interface
  * Define the behavior that should be implemented by all entity persisters.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 interface EntityPersister
 {
@@ -47,14 +46,13 @@ interface EntityPersister
      * Gets the SELECT SQL to select one or more entities by a set of field criteria.
      *
      * @param mixed[]|Criteria $criteria
-     * @param mixed[]|null     $assoc
      * @param mixed[]|null     $orderBy
      * @psalm-param AssociationMapping|null $assoc
      * @psalm-param LockMode::*|null $lockMode
      */
     public function getSelectSQL(
         array|Criteria $criteria,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         LockMode|int|null $lockMode = null,
         int|null $limit = null,
         int|null $offset = null,
@@ -84,15 +82,11 @@ interface EntityPersister
      */
     public function expandCriteriaParameters(Criteria $criteria): array;
 
-    /**
-     * Gets the SQL WHERE condition for matching a field with a given value.
-     *
-     * @psalm-param AssociationMapping|null  $assoc
-     */
+    /** Gets the SQL WHERE condition for matching a field with a given value. */
     public function getSelectConditionStatementSQL(
         string $field,
         mixed $value,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         string|null $comparison = null,
     ): string;
 
@@ -158,7 +152,7 @@ interface EntityPersister
      * @param object|null             $entity   The entity to load the data into. If not specified,
      *                                          a new entity is created.
      * @param AssociationMapping|null $assoc    The association that connects the entity
-     *                               to load to another entity, if any.
+     *                                          to load to another entity, if any.
      * @param mixed[]                 $hints    Hints for entity creation.
      * @param LockMode|int|null       $lockMode One of the \Doctrine\DBAL\LockMode::* constants
      *                                          or NULL if no specific lock mode should be used
@@ -177,7 +171,7 @@ interface EntityPersister
     public function load(
         array $criteria,
         object|null $entity = null,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         array $hints = [],
         LockMode|int|null $lockMode = null,
         int|null $limit = null,
@@ -200,17 +194,17 @@ interface EntityPersister
      * Loads an entity of this persister's mapped class as part of a single-valued
      * association from another entity.
      *
-     * @param object $sourceEntity The entity that owns the association (not necessarily the "owning side").
+     * @param AssociationMapping $assoc        The association to load.
+     * @param object             $sourceEntity The entity that owns the association (not necessarily the "owning side").
      * @psalm-param array<string, mixed> $identifier The identifier of the entity to load. Must be provided if
      *                                               the association to load represents the owning side, otherwise
      *                                               the identifier is derived from the $sourceEntity.
-     * @psalm-param AssociationMapping $assoc        The association to load.
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
      *
      * @throws MappingException
      */
-    public function loadOneToOneEntity(array $assoc, object $sourceEntity, array $identifier = []): object|null;
+    public function loadOneToOneEntity(AssociationMapping $assoc, object $sourceEntity, array $identifier = []): object|null;
 
     /**
      * Refreshes a managed entity.
@@ -250,12 +244,10 @@ interface EntityPersister
     /**
      * Gets (sliced or full) elements of the given collection.
      *
-     * @psalm-param AssociationMapping $assoc
-     *
      * @return mixed[]
      */
     public function getManyToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         int|null $offset = null,
         int|null $limit = null,
@@ -264,14 +256,14 @@ interface EntityPersister
     /**
      * Loads a collection of entities of a many-to-many association.
      *
+     * @param AssociationMapping   $assoc        The association mapping of the association being loaded.
      * @param object               $sourceEntity The entity that owns the collection.
      * @param PersistentCollection $collection   The collection to fill.
-     * @psalm-param AssociationMapping $assoc The association mapping of the association being loaded.
      *
      * @return mixed[]
      */
     public function loadManyToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         PersistentCollection $collection,
     ): array;
@@ -280,10 +272,9 @@ interface EntityPersister
      * Loads a collection of entities in a one-to-many association.
      *
      * @param PersistentCollection $collection The collection to load/fill.
-     * @psalm-param AssociationMapping $assoc
      */
     public function loadOneToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         PersistentCollection $collection,
     ): mixed;
@@ -299,12 +290,10 @@ interface EntityPersister
     /**
      * Returns an array with (sliced or full list) of elements in the specified collection.
      *
-     * @psalm-param AssociationMapping $assoc
-     *
      * @return mixed[]
      */
     public function getOneToManyCollection(
-        array $assoc,
+        AssociationMapping $assoc,
         object $sourceEntity,
         int|null $offset = null,
         int|null $limit = null,

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -496,7 +496,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add discriminator column if it is the topmost class.
         if ($this->class->name === $this->class->rootEntityName) {
-            $columns[] = $this->class->getDiscriminatorColumn()['name'];
+            $columns[] = $this->class->getDiscriminatorColumn()->name;
         }
 
         return $columns;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -9,10 +9,12 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\SQLResultCasing;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
+use function assert;
 use function implode;
 
 /**
@@ -236,8 +238,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         return (bool) $this->conn->delete($rootTable, $id, $rootTypes);
     }
 
-    public function getSelectSQL(array|Criteria $criteria, array|null $assoc = null, LockMode|int|null $lockMode = null, int|null $limit = null, int|null $offset = null, array|null $orderBy = null): string
-    {
+    public function getSelectSQL(
+        array|Criteria $criteria,
+        AssociationMapping|null $assoc = null,
+        LockMode|int|null $lockMode = null,
+        int|null $limit = null,
+        int|null $offset = null,
+        array|null $orderBy = null,
+    ): string {
         $this->switchPersisterContext($offset, $limit);
 
         $baseTableAlias = $this->getSQLTableAlias($this->class->name);
@@ -471,8 +479,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             if (isset($this->class->associationMappings[$name])) {
                 $assoc = $this->class->associationMappings[$name];
-                if ($assoc['type'] & ClassMetadata::TO_ONE && $assoc['isOwningSide']) {
-                    foreach ($assoc['targetToSourceKeyColumns'] as $sourceCol) {
+                if ($assoc->type & ClassMetadata::TO_ONE && $assoc['isOwningSide']) {
+                    assert($assoc->targetToSourceKeyColumns !== null);
+                    foreach ($assoc->targetToSourceKeyColumns as $sourceCol) {
                         $columns[] = $sourceCol;
                     }
                 }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -11,8 +11,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
-use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
@@ -389,7 +388,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add foreign key columns
         foreach ($this->class->associationMappings as $mapping) {
-            if (! $mapping['isOwningSide'] || ! ($mapping['type'] & ClassMetadata::TO_ONE)) {
+            if (! $mapping['isOwningSide'] || ! ($mapping instanceof ToOneAssociationMapping)) {
                 continue;
             }
 
@@ -434,7 +433,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             foreach ($subClass->associationMappings as $mapping) {
                 if (
                     ! $mapping['isOwningSide']
-                        || ! ($mapping['type'] & ClassMetadata::TO_ONE)
+                        || ! ($mapping instanceof ToOneAssociationMapping)
                         || isset($mapping['inherited'])
                 ) {
                     continue;
@@ -481,8 +480,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             if (isset($this->class->associationMappings[$name])) {
                 $assoc = $this->class->associationMappings[$name];
-                if ($assoc->type & ClassMetadata::TO_ONE && $assoc['isOwningSide']) {
-                    assert($assoc instanceof OneToOneAssociationMapping || $assoc instanceof ManyToOneAssociationMapping);
+                if ($assoc instanceof ToOneAssociationMapping && $assoc['isOwningSide']) {
                     assert($assoc->targetToSourceKeyColumns !== null);
                     foreach ($assoc->targetToSourceKeyColumns as $sourceCol) {
                         $columns[] = $sourceCol;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
@@ -388,7 +387,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add foreign key columns
         foreach ($this->class->associationMappings as $mapping) {
-            if (! $mapping['isOwningSide'] || ! ($mapping instanceof ToOneAssociationMapping)) {
+            if (! $mapping->isToOneOwningSide()) {
                 continue;
             }
 
@@ -431,11 +430,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Add join columns (foreign keys)
             foreach ($subClass->associationMappings as $mapping) {
-                if (
-                    ! $mapping['isOwningSide']
-                        || ! ($mapping instanceof ToOneAssociationMapping)
-                        || isset($mapping['inherited'])
-                ) {
+                if (! $mapping->isToOneOwningSide() || isset($mapping['inherited'])) {
                     continue;
                 }
 
@@ -480,7 +475,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             if (isset($this->class->associationMappings[$name])) {
                 $assoc = $this->class->associationMappings[$name];
-                if ($assoc instanceof ToOneAssociationMapping && $assoc['isOwningSide']) {
+                if ($assoc->isToOneOwningSide()) {
                     assert($assoc->targetToSourceKeyColumns !== null);
                     foreach ($assoc->targetToSourceKeyColumns as $sourceCol) {
                         $columns[] = $sourceCol;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_combine;
@@ -480,6 +482,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             if (isset($this->class->associationMappings[$name])) {
                 $assoc = $this->class->associationMappings[$name];
                 if ($assoc->type & ClassMetadata::TO_ONE && $assoc['isOwningSide']) {
+                    assert($assoc instanceof OneToOneAssociationMapping || $assoc instanceof ManyToOneAssociationMapping);
                     assert($assoc->targetToSourceKeyColumns !== null);
                     foreach ($assoc->targetToSourceKeyColumns as $sourceCol) {
                         $columns[] = $sourceCol;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_flip;
@@ -67,7 +68,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
             // Foreign key columns
             foreach ($subClass->associationMappings as $assoc) {
-                if (! $assoc['isOwningSide'] || ! ($assoc['type'] & ClassMetadata::TO_ONE) || isset($assoc['inherited'])) {
+                if (! $assoc['isOwningSide'] || ! ($assoc instanceof ToOneAssociationMapping) || isset($assoc['inherited'])) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Internal\SQLResultCasing;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
@@ -109,7 +110,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
     /**
      * {@inheritdoc}
      */
-    protected function getSelectConditionSQL(array $criteria, array|null $assoc = null): string
+    protected function getSelectConditionSQL(array $criteria, AssociationMapping|null $assoc = null): string
     {
         $conditionSql = parent::getSelectConditionSQL($criteria, $assoc);
 

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -97,7 +97,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $columns = parent::getInsertColumnList();
 
         // Add discriminator column to the INSERT SQL
-        $columns[] = $this->class->getDiscriminatorColumn()['name'];
+        $columns[] = $this->class->getDiscriminatorColumn()->name;
 
         return $columns;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_flip;
@@ -68,7 +67,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
             // Foreign key columns
             foreach ($subClass->associationMappings as $assoc) {
-                if (! $assoc['isOwningSide'] || ! ($assoc instanceof ToOneAssociationMapping) || isset($assoc['inherited'])) {
+                if (! $assoc->isToOneOwningSide() || isset($assoc['inherited'])) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -36,7 +36,9 @@ class IdentityFunction extends FunctionNode
         $assocField    = $this->pathExpression->field;
         $assoc         = $sqlWalker->getMetadataForDqlAlias($dqlAlias)->associationMappings[$assocField];
         $targetEntity  = $entityManager->getClassMetadata($assoc['targetEntity']);
-        $joinColumn    = reset($assoc['joinColumns']);
+
+        assert($assoc->joinColumns !== null);
+        $joinColumn = reset($assoc->joinColumns);
 
         if ($this->fieldMapping !== null) {
             if (! isset($targetEntity->fieldMappings[$this->fieldMapping])) {

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -37,7 +37,7 @@ class IdentityFunction extends FunctionNode
         $assoc         = $sqlWalker->getMetadataForDqlAlias($dqlAlias)->associationMappings[$assocField];
         $targetEntity  = $entityManager->getClassMetadata($assoc['targetEntity']);
 
-        assert($assoc->joinColumns !== null);
+        assert($assoc->isToOneOwningSide());
         $joinColumn = reset($assoc->joinColumns);
 
         if ($this->fieldMapping !== null) {

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -64,7 +64,7 @@ class SizeFunction extends FunctionNode
         } else { // many-to-many
             $targetClass = $entityManager->getClassMetadata($assoc['targetEntity']);
 
-            $owningAssoc = $assoc['isOwningSide'] ? $assoc : $targetClass->associationMappings[$assoc['mappedBy']];
+            $owningAssoc = $assoc->isOwningSide() ? $assoc : $targetClass->associationMappings[$assoc['mappedBy']];
             $joinTable   = $owningAssoc['joinTable'];
 
             // SQL table aliases
@@ -74,7 +74,7 @@ class SizeFunction extends FunctionNode
             // join to target table
             $sql .= $quoteStrategy->getJoinTableName($owningAssoc, $targetClass, $platform) . ' ' . $joinTableAlias . ' WHERE ';
 
-            $joinColumns = $assoc['isOwningSide']
+            $joinColumns = $assoc->isOwningSide()
                 ? $joinTable['joinColumns']
                 : $joinTable['inverseJoinColumns'];
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Query;
 use Doctrine\Common\Lexer\Token;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions;
@@ -34,7 +35,6 @@ use function substr;
  * An LL(*) recursive-descent parser for the context-free grammar of the Doctrine Query Language.
  * Parses a DQL query, reports any errors in it, and generates an AST.
  *
- * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-type DqlToken = Token<TokenType, string>
  * @psalm-type QueryComponent = array{
  *                 metadata?: ClassMetadata<object>,

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -626,8 +626,7 @@ final class Parser
 
                 if (
                     isset($class->associationMappings[$field]) &&
-                    $class->associationMappings[$field]['isOwningSide'] &&
-                    $class->associationMappings[$field] instanceof ToOneAssociationMapping
+                    $class->associationMappings[$field]->isToOneOwningSide()
                 ) {
                     continue;
                 }

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -9,7 +9,6 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions;
 use LogicException;
@@ -718,7 +717,7 @@ final class Parser
             if (isset($class->associationMappings[$field])) {
                 $assoc = $class->associationMappings[$field];
 
-                $fieldType = $assoc instanceof ToOneAssociationMapping
+                $fieldType = $assoc->isToOne()
                     ? AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION
                     : AST\PathExpression::TYPE_COLLECTION_VALUED_ASSOCIATION;
             }

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -9,6 +9,7 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions;
 use LogicException;
@@ -626,7 +627,7 @@ final class Parser
                 if (
                     isset($class->associationMappings[$field]) &&
                     $class->associationMappings[$field]['isOwningSide'] &&
-                    $class->associationMappings[$field]['type'] & ClassMetadata::TO_ONE
+                    $class->associationMappings[$field] instanceof ToOneAssociationMapping
                 ) {
                     continue;
                 }
@@ -718,7 +719,7 @@ final class Parser
             if (isset($class->associationMappings[$field])) {
                 $assoc = $class->associationMappings[$field];
 
-                $fieldType = $assoc['type'] & ClassMetadata::TO_ONE
+                $fieldType = $assoc instanceof ToOneAssociationMapping
                     ? AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION
                     : AST\PathExpression::TYPE_COLLECTION_VALUED_ASSOCIATION;
             }

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Exception\ORMException;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Exception;
 use Stringable;
 use Throwable;
 
-/** @psalm-import-type AssociationMapping from ClassMetadata */
 class QueryException extends Exception implements ORMException
 {
     public static function dqlError(string $dql): self
@@ -81,11 +80,7 @@ class QueryException extends Exception implements ORMException
         return new self("Invalid literal '" . $literal . "'");
     }
 
-    /**
-     * @param string[] $assoc
-     * @psalm-param AssociationMapping $assoc
-     */
-    public static function iterateWithFetchJoinCollectionNotAllowed(array $assoc): self
+    public static function iterateWithFetchJoinCollectionNotAllowed(AssociationMapping $assoc): self
     {
         return new self(
             'Invalid query operation: Not allowed to iterate over fetch join collections ' .
@@ -123,11 +118,7 @@ class QueryException extends Exception implements ORMException
         );
     }
 
-    /**
-     * @param string[] $assoc
-     * @psalm-param AssociationMapping $assoc
-     */
-    public static function iterateWithFetchJoinNotAllowed(array $assoc): self
+    public static function iterateWithFetchJoinNotAllowed(AssociationMapping $assoc): self
     {
         return new self(
             'Iterate with fetch join in class ' . $assoc['sourceEntity'] .

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 use InvalidArgumentException;
 use Stringable;
@@ -136,7 +137,7 @@ class ResultSetMappingBuilder extends ResultSetMapping implements Stringable
         }
 
         foreach ($classMetadata->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadata::TO_ONE) {
+            if ($associationMapping['isOwningSide'] && $associationMapping instanceof ToOneAssociationMapping) {
                 $targetClass  = $this->em->getClassMetadata($associationMapping['targetEntity']);
                 $isIdentifier = isset($associationMapping['id']) && $associationMapping['id'] === true;
 
@@ -216,7 +217,7 @@ class ResultSetMappingBuilder extends ResultSetMapping implements Stringable
         }
 
         foreach ($class->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping['type'] & ClassMetadata::TO_ONE) {
+            if ($associationMapping['isOwningSide'] && $associationMapping instanceof ToOneAssociationMapping) {
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     $columnName               = $joinColumn['name'];
                     $columnAlias[$columnName] = $this->getColumnAlias($columnName, $mode, $customRenameColumns);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 use InvalidArgumentException;
 use Stringable;
@@ -137,7 +136,7 @@ class ResultSetMappingBuilder extends ResultSetMapping implements Stringable
         }
 
         foreach ($classMetadata->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping instanceof ToOneAssociationMapping) {
+            if ($associationMapping->isToOneOwningSide()) {
                 $targetClass  = $this->em->getClassMetadata($associationMapping['targetEntity']);
                 $isIdentifier = isset($associationMapping['id']) && $associationMapping['id'] === true;
 
@@ -217,7 +216,7 @@ class ResultSetMappingBuilder extends ResultSetMapping implements Stringable
         }
 
         foreach ($class->associationMappings as $associationMapping) {
-            if ($associationMapping['isOwningSide'] && $associationMapping instanceof ToOneAssociationMapping) {
+            if ($associationMapping->isToOneOwningSide()) {
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     $columnName               = $joinColumn['name'];
                     $columnAlias[$columnName] = $this->getColumnAlias($columnName, $mode, $customRenameColumns);

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
@@ -684,7 +685,7 @@ class SqlWalker
             // Add foreign key columns of class and also parent classes
             foreach ($class->associationMappings as $assoc) {
                 if (
-                    ! ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE)
+                    ! ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping)
                     || ( ! $addMetaColumns && ! isset($assoc['id']))
                 ) {
                     continue;
@@ -723,7 +724,7 @@ class SqlWalker
                         continue;
                     }
 
-                    if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {
+                    if ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping) {
                         $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
                         foreach ($assoc['joinColumns'] as $joinColumn) {
@@ -911,7 +912,7 @@ class SqlWalker
         // be the owning side and previously we ensured that $assoc is always the owning side of the associations.
         // The owning side is necessary at this point because only it contains the JoinColumn information.
         switch (true) {
-            case $assoc['type'] & ClassMetadata::TO_ONE:
+            case $assoc instanceof ToOneAssociationMapping:
                 $conditions = [];
 
                 foreach ($assoc['joinColumns'] as $joinColumn) {
@@ -1645,7 +1646,7 @@ class SqlWalker
         }
 
         foreach ($this->getMetadataForDqlAlias($groupByItem)->associationMappings as $mapping) {
-            if ($mapping['isOwningSide'] && $mapping['type'] & ClassMetadata::TO_ONE) {
+            if ($mapping['isOwningSide'] && $mapping instanceof ToOneAssociationMapping) {
                 $item       = new AST\PathExpression(AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $groupByItem, $mapping['fieldName']);
                 $item->type = AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -602,7 +602,7 @@ class SqlWalker
                 $assoc = $class->associationMappings[$fieldName];
                 assert($assoc instanceof OneToOneAssociationMapping || $assoc instanceof ManyToOneAssociationMapping);
 
-                if (! $assoc['isOwningSide']) {
+                if (! $assoc->isOwningSide()) {
                     throw QueryException::associationPathInverseSideNotSupported($pathExpr);
                 }
 
@@ -685,7 +685,7 @@ class SqlWalker
             // Add foreign key columns of class and also parent classes
             foreach ($class->associationMappings as $assoc) {
                 if (
-                    ! ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping)
+                    ! $assoc->isToOneOwningSide()
                     || ( ! $addMetaColumns && ! isset($assoc['id']))
                 ) {
                     continue;
@@ -724,7 +724,7 @@ class SqlWalker
                         continue;
                     }
 
-                    if ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping) {
+                    if ($assoc->isToOneOwningSide()) {
                         $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
                         foreach ($assoc['joinColumns'] as $joinColumn) {
@@ -804,7 +804,7 @@ class SqlWalker
                 $association = $class->associationMappings[$fieldName];
                 assert($association instanceof OneToOneAssociationMapping || $association instanceof ManyToOneAssociationMapping);
 
-                if (! $association['isOwningSide']) {
+                if (! $association->isOwningSide()) {
                     throw QueryException::associationPathInverseSideNotSupported($pathExpression);
                 }
 
@@ -1646,7 +1646,7 @@ class SqlWalker
         }
 
         foreach ($this->getMetadataForDqlAlias($groupByItem)->associationMappings as $mapping) {
-            if ($mapping['isOwningSide'] && $mapping instanceof ToOneAssociationMapping) {
+            if ($mapping->isToOneOwningSide()) {
                 $item       = new AST\PathExpression(AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $groupByItem, $mapping['fieldName']);
                 $item->type = AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -611,7 +611,8 @@ class SqlWalker
                     $sql .= $this->getSQLTableAlias($class->getTableName(), $dqlAlias) . '.';
                 }
 
-                $sql .= reset($assoc['targetToSourceKeyColumns']);
+                assert($assoc->targetToSourceKeyColumns !== null);
+                $sql .= reset($assoc->targetToSourceKeyColumns);
                 break;
 
             default:
@@ -806,7 +807,8 @@ class SqlWalker
                     throw QueryException::associationPathCompositeKeyNotSupported();
                 }
 
-                $field = reset($association['targetToSourceKeyColumns']);
+                assert($association->targetToSourceKeyColumns !== null);
+                $field = reset($association->targetToSourceKeyColumns);
                 break;
 
             default:

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Mapping\QuoteStrategy;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
@@ -912,7 +911,7 @@ class SqlWalker
         // be the owning side and previously we ensured that $assoc is always the owning side of the associations.
         // The owning side is necessary at this point because only it contains the JoinColumn information.
         switch (true) {
-            case $assoc instanceof ToOneAssociationMapping:
+            case $assoc->isToOne():
                 $conditions = [];
 
                 foreach ($assoc['joinColumns'] as $joinColumn) {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
@@ -597,6 +599,7 @@ class SqlWalker
                 }
 
                 $assoc = $class->associationMappings[$fieldName];
+                assert($assoc instanceof OneToOneAssociationMapping || $assoc instanceof ManyToOneAssociationMapping);
 
                 if (! $assoc['isOwningSide']) {
                     throw QueryException::associationPathInverseSideNotSupported($pathExpr);
@@ -798,6 +801,7 @@ class SqlWalker
                 }
 
                 $association = $class->associationMappings[$fieldName];
+                assert($association instanceof OneToOneAssociationMapping || $association instanceof ManyToOneAssociationMapping);
 
                 if (! $association['isOwningSide']) {
                     throw QueryException::associationPathInverseSideNotSupported($pathExpression);

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -42,7 +43,6 @@ use const JSON_UNESCAPED_UNICODE;
  * @link    www.doctrine-project.org
  *
  * @psalm-import-type AssociationMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  */
 final class MappingDescribeCommand extends AbstractEntityManagerCommand
 {
@@ -257,7 +257,7 @@ EOT);
         foreach ($propertyMappings as $propertyName => $mapping) {
             $output[] = $this->formatField(sprintf('  %s', $propertyName), '');
 
-            foreach ($mapping as $field => $value) {
+            foreach ((array) $mapping as $field => $value) {
                 $output[] = $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
             }
         }

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Mapping\MappingException;
@@ -41,8 +42,6 @@ use const JSON_UNESCAPED_UNICODE;
  * Show information about mapped entities.
  *
  * @link    www.doctrine-project.org
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 final class MappingDescribeCommand extends AbstractEntityManagerCommand
 {

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -6,7 +6,7 @@ namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Proxy;
@@ -71,7 +71,7 @@ class DebugUnitOfWorkListener
                     fwrite($fh, '   ' . $field . ' ');
                     $value = $cm->getFieldValue($entity, $field);
 
-                    if ($assoc['type'] & ClassMetadata::TO_ONE) {
+                    if ($assoc instanceof ToOneAssociationMapping) {
                         if ($value === null) {
                             fwrite($fh, " NULL\n");
                         } else {

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Proxy;
@@ -71,7 +70,7 @@ class DebugUnitOfWorkListener
                     fwrite($fh, '   ' . $field . ' ');
                     $value = $cm->getFieldValue($entity, $field);
 
-                    if ($assoc instanceof ToOneAssociationMapping) {
+                    if ($assoc->isToOne()) {
                         if ($value === null) {
                             fwrite($fh, " NULL\n");
                         } else {

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
 use Doctrine\ORM\Query\AST\Node;
@@ -125,7 +125,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                     if (
                         isset($queryComponent['parent'])
                         && isset($queryComponent['relation'])
-                        && $queryComponent['relation']['type'] & ClassMetadata::TO_MANY
+                        && $queryComponent['relation'] instanceof ToManyAssociationMapping
                     ) {
                         throw new RuntimeException('Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.');
                     }

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 use function array_key_exists;
@@ -19,8 +20,6 @@ use function ltrim;
  *
  * Mechanism to overwrite interfaces or classes specified as association
  * targets.
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ResolveTargetEntityListener implements EventSubscriber
 {
@@ -89,11 +88,13 @@ class ResolveTargetEntityListener implements EventSubscriber
         }
     }
 
-    /** @param AssociationMapping $mapping */
-    private function remapAssociation(ClassMetadata $classMetadata, array $mapping): void
+    private function remapAssociation(ClassMetadata $classMetadata, AssociationMapping $mapping): void
     {
         $newMapping              = $this->resolveTargetEntities[$mapping['targetEntity']];
-        $newMapping              = array_replace_recursive($mapping, $newMapping);
+        $newMapping              = array_replace_recursive(
+            $mapping->toArray(),
+            $newMapping,
+        );
         $newMapping['fieldName'] = $mapping['fieldName'];
 
         unset($classMetadata->associationMappings[$mapping['fieldName']]);

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -14,8 +14,10 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Mapping\JoinColumnData;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -29,14 +31,12 @@ use function array_diff_key;
 use function array_filter;
 use function array_flip;
 use function array_intersect_key;
-use function assert;
 use function class_exists;
 use function count;
 use function current;
 use function func_num_args;
 use function implode;
 use function in_array;
-use function is_array;
 use function is_numeric;
 use function method_exists;
 use function strtolower;
@@ -46,9 +46,6 @@ use function strtolower;
  * <tt>ClassMetadata</tt> class descriptors.
  *
  * @link    www.doctrine-project.org
- *
- * @psalm-import-type AssociationMapping from ClassMetadata
- * @psalm-import-type JoinColumnData from ClassMetadata
  */
 class SchemaTool
 {
@@ -299,7 +296,6 @@ class SchemaTool
                     $pkColumns[] = $this->quoteStrategy->getColumnName($identifierField, $class, $this->platform);
                 } elseif (isset($class->associationMappings[$identifierField])) {
                     $assoc = $class->associationMappings[$identifierField];
-                    assert(is_array($assoc));
 
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         $pkColumns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
@@ -639,8 +635,7 @@ class SchemaTool
     /**
      * Gathers columns and fk constraints that are required for one part of relationship.
      *
-     * @psalm-param array<string, JoinColumnData>    $joinColumns
-     * @psalm-param AssociationMapping               $mapping
+     * @psalm-param array<string, JoinColumnData>             $joinColumns
      * @psalm-param list<string>                     $primaryKeyColumns
      * @psalm-param array<string, array{
      *                  foreignTableName: string,
@@ -654,7 +649,7 @@ class SchemaTool
         array $joinColumns,
         Table $theJoinTable,
         ClassMetadata $class,
-        array $mapping,
+        AssociationMapping $mapping,
         array &$primaryKeyColumns,
         array &$addedFks,
         array &$blacklistedFks,
@@ -770,11 +765,11 @@ class SchemaTool
     }
 
     /**
-     * @psalm-param JoinColumnData|FieldMapping $mapping
+     * @param JoinColumnData|FieldMapping|mixed[] $mapping
      *
      * @return mixed[]
      */
-    private function gatherColumnOptions(FieldMapping|array $mapping): array
+    private function gatherColumnOptions(JoinColumnData|FieldMapping|array $mapping): array
     {
         $mappingOptions = $mapping['options'] ?? [];
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
-use Doctrine\ORM\Mapping\JoinColumnData;
+use Doctrine\ORM\Mapping\JoinColumnMapping;
 use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
@@ -639,7 +639,7 @@ class SchemaTool
     /**
      * Gathers columns and fk constraints that are required for one part of relationship.
      *
-     * @psalm-param array<string, JoinColumnData>             $joinColumns
+     * @psalm-param array<string, JoinColumnMapping>             $joinColumns
      * @psalm-param list<string>                     $primaryKeyColumns
      * @psalm-param array<string, array{
      *                  foreignTableName: string,
@@ -769,11 +769,11 @@ class SchemaTool
     }
 
     /**
-     * @param JoinColumnData|FieldMapping|mixed[] $mapping
+     * @param JoinColumnMapping|FieldMapping|mixed[] $mapping
      *
      * @return mixed[]
      */
-    private function gatherColumnOptions(JoinColumnData|FieldMapping|array $mapping): array
+    private function gatherColumnOptions(JoinColumnMapping|FieldMapping|array $mapping): array
     {
         $mappingOptions = $mapping['options'] ?? [];
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -18,9 +18,10 @@ use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\JoinColumnData;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\ORM\Mapping\QuoteStrategy;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Exception\MissingColumnException;
@@ -540,7 +541,7 @@ class SchemaTool
 
             $foreignClass = $this->em->getClassMetadata($mapping['targetEntity']);
 
-            if ($mapping instanceof ToOneAssociationMapping && $mapping['isOwningSide']) {
+            if ($mapping->isToOneOwningSide()) {
                 $primaryKeyColumns = []; // PK is unnecessary for this relation-type
 
                 $this->gatherRelationJoinColumns(
@@ -552,10 +553,10 @@ class SchemaTool
                     $addedFks,
                     $blacklistedFks,
                 );
-            } elseif ($mapping['type'] === ClassMetadata::ONE_TO_MANY && $mapping['isOwningSide']) {
+            } elseif ($mapping instanceof OneToManyAssociationMapping && $mapping->isOwningSide()) {
                 //... create join table, one-many through join table supported later
                 throw NotSupported::create();
-            } elseif ($mapping['type'] === ClassMetadata::MANY_TO_MANY && $mapping['isOwningSide']) {
+            } elseif ($mapping instanceof ManyToManyOwningSideMapping) {
                 // create join table
                 $joinTable = $mapping['joinTable'];
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -768,12 +768,8 @@ class SchemaTool
         }
     }
 
-    /**
-     * @param JoinColumnMapping|FieldMapping|mixed[] $mapping
-     *
-     * @return mixed[]
-     */
-    private function gatherColumnOptions(JoinColumnMapping|FieldMapping|array $mapping): array
+    /** @return mixed[] */
+    private function gatherColumnOptions(JoinColumnMapping|FieldMapping $mapping): array
     {
         $mappingOptions = $mapping['options'] ?? [];
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\JoinColumnData;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Exception\MissingColumnException;
@@ -539,7 +540,7 @@ class SchemaTool
 
             $foreignClass = $this->em->getClassMetadata($mapping['targetEntity']);
 
-            if ($mapping['type'] & ClassMetadata::TO_ONE && $mapping['isOwningSide']) {
+            if ($mapping instanceof ToOneAssociationMapping && $mapping['isOwningSide']) {
                 $primaryKeyColumns = []; // PK is unnecessary for this relation-type
 
                 $this->gatherRelationJoinColumns(

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -31,6 +31,7 @@ use function array_diff_key;
 use function array_filter;
 use function array_flip;
 use function array_intersect_key;
+use function assert;
 use function class_exists;
 use function count;
 use function current;
@@ -401,6 +402,7 @@ class SchemaTool
     private function addDiscriminatorColumnDefinition(ClassMetadata $class, Table $table): void
     {
         $discrColumn = $class->discriminatorColumn;
+        assert($discrColumn !== null);
 
         if (
             ! isset($discrColumn['type']) ||

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -47,7 +48,6 @@ use function strtolower;
  * @link    www.doctrine-project.org
  *
  * @psalm-import-type AssociationMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  * @psalm-import-type JoinColumnData from ClassMetadata
  */
 class SchemaTool
@@ -455,7 +455,7 @@ class SchemaTool
      */
     private function gatherColumn(
         ClassMetadata $class,
-        array $mapping,
+        FieldMapping $mapping,
         Table $table,
     ): void {
         $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
@@ -774,7 +774,7 @@ class SchemaTool
      *
      * @return mixed[]
      */
-    private function gatherColumnOptions(array $mapping): array
+    private function gatherColumnOptions(FieldMapping|array $mapping): array
     {
         $mappingOptions = $mapping['options'] ?? [];
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -156,7 +156,7 @@ class SchemaValidator
                 }
             }
 
-            if ($assoc['isOwningSide']) {
+            if ($assoc->isOwningSide()) {
                 if ($assoc['type'] === ClassMetadata::MANY_TO_MANY) {
                     $identifierColumns = $class->getIdentifierColumnNames();
                     foreach ($assoc['joinTable']['joinColumns'] as $joinColumn) {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Tools;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 
 use function array_diff;
 use function array_key_exists;
@@ -189,7 +188,7 @@ class SchemaValidator
                                 "however '" . implode(', ', array_diff($class->getIdentifierColumnNames(), array_values($assoc['relationToSourceKeyColumns']))) .
                                 "' are missing.";
                     }
-                } elseif ($assoc instanceof ToOneAssociationMapping) {
+                } elseif ($assoc->isToOne()) {
                     $identifierColumns = $targetMetadata->getIdentifierColumnNames();
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         if (! in_array($joinColumn['referencedColumnName'], $identifierColumns, true)) {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Tools;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 
 use function array_diff;
 use function array_key_exists;
@@ -188,7 +189,7 @@ class SchemaValidator
                                 "however '" . implode(', ', array_diff($class->getIdentifierColumnNames(), array_values($assoc['relationToSourceKeyColumns']))) .
                                 "' are missing.";
                     }
-                } elseif ($assoc['type'] & ClassMetadata::TO_ONE) {
+                } elseif ($assoc instanceof ToOneAssociationMapping) {
                     $identifierColumns = $targetMetadata->getIdentifierColumnNames();
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         if (! in_array($joinColumn['referencedColumnName'], $identifierColumns, true)) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1197,7 +1197,6 @@ class UnitOfWork implements PropertyChangedListener
                     $newNodes[] = $targetClass;
                 }
 
-                assert($assoc->joinColumns !== null);
                 $joinColumns = reset($assoc->joinColumns);
 
                 $calc->addDependency($targetClass->name, $class->name, (int) empty($joinColumns['nullable']));

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\Mapping\ToManyAssociationMapping;
-use Doctrine\ORM\Mapping\ToOneAssociationMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
 use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
@@ -702,7 +701,7 @@ class UnitOfWork implements PropertyChangedListener
                     continue;
                 }
 
-                if ($assoc instanceof ToOneAssociationMapping) {
+                if ($assoc->isToOne()) {
                     if ($assoc['isOwningSide']) {
                         $changeSet[$propName] = [$orgValue, $actualValue];
                     }
@@ -808,7 +807,7 @@ class UnitOfWork implements PropertyChangedListener
         // Look through the entities, and in any of their associations,
         // for transient (new) entities, recursively. ("Persistence by reachability")
         // Unwrap. Uninitialized collections will simply be empty.
-        $unwrappedValue = $assoc instanceof ToOneAssociationMapping ? [$value] : $value->unwrap();
+        $unwrappedValue = $assoc->isToOne() ? [$value] : $value->unwrap();
         $targetClass    = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($unwrappedValue as $key => $entry) {
@@ -2286,7 +2285,7 @@ class UnitOfWork implements PropertyChangedListener
             $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
             switch (true) {
-                case $assoc instanceof ToOneAssociationMapping:
+                case $assoc->isToOne():
                     if (! $assoc['isOwningSide']) {
                         // use the given entity association
                         if (isset($data[$field]) && is_object($data[$field]) && isset($this->entityStates[spl_object_id($data[$field])])) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -615,7 +615,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $assoc = $class->associationMappings[$propName];
 
-                if ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping) {
+                if ($assoc->isToOneOwningSide()) {
                     $changeSet[$propName] = [null, $actualValue];
                 }
             }
@@ -732,8 +732,7 @@ class UnitOfWork implements PropertyChangedListener
 
             if (
                 ! isset($this->entityChangeSets[$oid]) &&
-                $assoc['isOwningSide'] &&
-                $assoc['type'] === ClassMetadata::MANY_TO_MANY &&
+                $assoc->isManyToManyOwningSide() &&
                 $val instanceof PersistentCollection &&
                 $val->isDirty()
             ) {
@@ -1187,7 +1186,7 @@ class UnitOfWork implements PropertyChangedListener
         // Calculate dependencies for new nodes
         while ($class = array_pop($newNodes)) {
             foreach ($class->associationMappings as $assoc) {
-                if (! ($assoc['isOwningSide'] && $assoc instanceof ToOneAssociationMapping)) {
+                if (! $assoc->isToOneOwningSide()) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -70,7 +70,7 @@ class PersisterHelper
 
         // iterate over to-one association mappings
         foreach ($class->associationMappings as $assoc) {
-            if (! isset($assoc['joinColumns'])) {
+            if ($assoc['joinColumns'] === []) {
                 continue;
             }
 
@@ -86,7 +86,7 @@ class PersisterHelper
 
         // iterate over to-many association mappings
         foreach ($class->associationMappings as $assoc) {
-            if (! (isset($assoc['joinTable']) && isset($assoc['joinTable']['joinColumns']))) {
+            if (! (isset($assoc['joinTable']) && $assoc['joinTable']['joinColumns'] !== [])) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -27,7 +27,7 @@ class PersisterHelper
     public static function getTypeOfField(string $fieldName, ClassMetadata $class, EntityManagerInterface $em): array
     {
         if (isset($class->fieldMappings[$fieldName])) {
-            return [$class->fieldMappings[$fieldName]['type']];
+            return [$class->fieldMappings[$fieldName]->type];
         }
 
         if (! isset($class->associationMappings[$fieldName])) {

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -37,7 +37,7 @@ class PersisterHelper
 
         $assoc = $class->associationMappings[$fieldName];
 
-        if (! $assoc['isOwningSide']) {
+        if (! $assoc->isOwningSide()) {
             return self::getTypeOfField($assoc['mappedBy'], $em->getClassMetadata($assoc['targetEntity']), $em);
         }
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Utility;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
 use Doctrine\ORM\Query\QueryException;
 use RuntimeException;
 
@@ -40,7 +41,7 @@ class PersisterHelper
             return self::getTypeOfField($assoc['mappedBy'], $em->getClassMetadata($assoc['targetEntity']), $em);
         }
 
-        if ($assoc['type'] & ClassMetadata::MANY_TO_MANY) {
+        if ($assoc instanceof ManyToManyAssociationMapping) {
             $joinData = $assoc['joinTable'];
         } else {
             $joinData = $assoc;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,11 +131,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadata.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadata.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 2
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,10 @@ parameters:
             message: '~^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getArrayBindingType\(\) never returns .* so it can be removed from the return type\.$~'
             path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
 
+        -
+            message: '~^Unreachable statement \- code above always terminates\.$~'
+            path: lib/Doctrine/ORM/Mapping/AssociationMapping.php
+
         # https://github.com/phpstan/phpstan/issues/8904
         -
             message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\:\\:\\$joinColumns\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,7 +30,7 @@ parameters:
             path: lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
 
         -
-            message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\:\\:fromMappingArrayAndName\\(\\) should return Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneAssociationMapping but returns Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\.$#"
+            message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\:\\:fromMappingArrayAndName\\(\\) should return Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneAssociationMapping but returns static\\(Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\)\\.$#"
             path: lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
 
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,20 @@ parameters:
         -
             message: '~^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getArrayBindingType\(\) never returns .* so it can be removed from the return type\.$~'
             path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+
+        # https://github.com/phpstan/phpstan/issues/8904
+        -
+            message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\:\\:\\$joinColumns\\.$#"
+            path: lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+
+        -
+            message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\:\\:fromMappingArrayAndName\\(\\) should return Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneAssociationMapping but returns Doctrine\\\\ORM\\\\Mapping\\\\ToOneAssociationMapping\\.$#"
+            path: lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php
+
+        -
+            message: "#^Property Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\<T of object\\>\\:\\:\\$associationMappings \\(array\\<string, Doctrine\\\\ORM\\\\Mapping\\\\ManyToManyAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToManyAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneAssociationMapping\\>\\) does not accept array\\<int\\|string, Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping\\>\\.$#"
+            path: lib/Doctrine/ORM/Mapping/ClassMetadata.php
+
+        -
+            message: "#^Property Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\<T of object\\>\\:\\:\\$associationMappings \\(array\\<string, Doctrine\\\\ORM\\\\Mapping\\\\ManyToManyAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToManyAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneAssociationMapping\\>\\) does not accept array\\<string, Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping\\>\\.$#"
+            path: lib/Doctrine/ORM/Mapping/ClassMetadata.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -624,8 +624,11 @@
     <PropertyNotSetInConstructor>
       <code>$joinTable</code>
     </PropertyNotSetInConstructor>
+    <RedundantCondition>
+      <code><![CDATA[$mapping->joinTable]]></code>
+    </RedundantCondition>
     <TypeDoesNotContainType>
-      <code><![CDATA[isset($mapping->joinTable)]]></code>
+      <code>new JoinTableMapping()</code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -280,6 +280,14 @@
       <code><![CDATA[$newObject['args']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/AssociationMapping.php">
+    <LessSpecificReturnStatement>
+      <code>$mapping</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>static</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php">
     <ArgumentTypeCoercion>
       <code>$repositoryClassName</code>
@@ -349,6 +357,7 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$mapping['isOwningSide']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$table['name']]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -364,9 +373,23 @@
     <RedundantFunctionCall>
       <code>array_values</code>
     </RedundantFunctionCall>
+    <RedundantPropertyInitializationCheck>
+      <code><![CDATA[$this->table]]></code>
+      <code>null</code>
+    </RedundantPropertyInitializationCheck>
+    <TypeDoesNotContainType>
+      <code><![CDATA[OneToOneAssociationMapping::fromMappingArrayAndName(
+                        $mapping,
+                        $this->namingStrategy,
+                        $this->name,
+                        $this->table,
+                        $this->isInheritanceTypeSingleTable(),
+                    )]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
     <ArgumentTypeCoercion>
+      <code>$targetEntity</code>
       <code><![CDATA[new $definition['class']()]]></code>
     </ArgumentTypeCoercion>
     <InvalidArrayOffset>
@@ -583,6 +606,33 @@
       <code><![CDATA[$xmlRoot->getName() === 'mapped-superclass']]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php">
+    <ArgumentTypeCoercion>
+      <code>$mappingArray</code>
+    </ArgumentTypeCoercion>
+    <LessSpecificReturnStatement>
+      <code>$mapping</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>static</code>
+    </MoreSpecificReturnType>
+    <UndefinedMethod>
+      <code>assertMappingOrderBy</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php">
+    <PropertyNotSetInConstructor>
+      <code>$joinTable</code>
+    </PropertyNotSetInConstructor>
+    <TypeDoesNotContainType>
+      <code><![CDATA[isset($mapping->joinTable)]]></code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php">
+    <ArgumentTypeCoercion>
+      <code>$mappingArray</code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php">
     <MethodSignatureMismatch>
       <code>$object</code>
@@ -606,6 +656,16 @@
       <code>ReflectionReadonlyProperty</code>
       <code>ReflectionReadonlyProperty</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ToOneAssociationMapping.php">
+    <LessSpecificReturnStatement>
+      <code>$instance</code>
+      <code>$mapping</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>OneToOneAssociationMapping|ManyToOneAssociationMapping</code>
+      <code>static</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php">
     <PossiblyFalseOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -39,14 +39,6 @@
     </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php">
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClassMetadata->associationMappings]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumnFieldNames']]]></code>
-      <code><![CDATA[$assoc['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$owningAssociation['targetToSourceKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <UndefinedInterfaceMethod>
       <code>getCacheRegion</code>
     </UndefinedInterfaceMethod>
@@ -236,10 +228,6 @@
     </RedundantCondition>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$class->associationMappings[$fieldName]['joinColumns']]]></code>
-      <code><![CDATA[$class->associationMappings[$fieldName]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <ReferenceConstraintViolation>
       <code>return $rowData;</code>
       <code>return $rowData;</code>
@@ -283,12 +271,6 @@
       <code>$parentObject</code>
       <code>$parentObject</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$relation['mappedBy']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClass->reflFields]]></code>
-    </PossiblyNullArrayOffset>
     <PossiblyNullReference>
       <code>getValue</code>
       <code>getValue</code>
@@ -298,14 +280,7 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$class->associationMappings[$class->identifier[0]]['joinColumns']]]></code>
-      <code><![CDATA[$class->associationMappings[$fieldName]['joinColumns']]]></code>
       <code><![CDATA[$newObject['args']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$association['joinTable']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php">
@@ -325,9 +300,6 @@
       <code><![CDATA[$this->columnNames]]></code>
       <code><![CDATA[$this->columnNames]]></code>
     </DeprecatedProperty>
-    <DocblockTypeContradiction>
-      <code><![CDATA[! class_exists($mapping['targetEntity'])]]></code>
-    </DocblockTypeContradiction>
     <InvalidArgument>
       <code>$mapping</code>
       <code>$mapping</code>
@@ -336,19 +308,12 @@
     </InvalidArgument>
     <InvalidNullableReturnType>
       <code>ReflectionClass|null</code>
-      <code>string</code>
     </InvalidNullableReturnType>
     <InvalidPropertyAssignmentValue>
       <code>$definition</code>
       <code><![CDATA[$this->identifier]]></code>
       <code><![CDATA[$this->subClasses]]></code>
     </InvalidPropertyAssignmentValue>
-    <InvalidReturnStatement>
-      <code>$mapping</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>AssociationMapping</code>
-    </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code>$cache</code>
       <code>$className</code>
@@ -362,7 +327,6 @@
       <code><![CDATA[list<string>]]></code>
     </MoreSpecificReturnType>
     <NullableReturnStatement>
-      <code><![CDATA[$this->associationMappings[$assocName]['mappedBy']]]></code>
       <code><![CDATA[$this->reflClass]]></code>
     </NullableReturnStatement>
     <ParamNameMismatch>
@@ -390,10 +354,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$table['name']]]></code>
-      <code>$this-&gt;associationMappings[$assocName]['joinColumns']</code>
-      <code>$this-&gt;associationMappings[$fieldName]['joinColumns']</code>
-      <code>$this-&gt;associationMappings[$fieldName]['joinColumns']</code>
-      <code>$this-&gt;associationMappings[$idProperty]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
     <PropertyNotSetInConstructor>
       <code>$idGenerator</code>
@@ -464,10 +424,6 @@
     <MoreSpecificReturnType>
       <code>array</code>
     </MoreSpecificReturnType>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$class->associationMappings[$fieldName]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php">
     <InvalidReturnStatement>
@@ -690,48 +646,18 @@
       <code>$value</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association['targetEntity']]]></code>
       <code><![CDATA[$this->backRefFieldName]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['isOwningSide']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['targetEntity']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullReference>
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <UndefinedMethod>
       <code><![CDATA[[$this->unwrap(), 'add']]]></code>
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
-    <ArgumentTypeCoercion>
-      <code>$mapping</code>
-    </ArgumentTypeCoercion>
-    <InvalidArrayOffset>
-      <code><![CDATA[[$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index]]]></code>
-    </InvalidArrayOffset>
     <PossiblyNullArgument>
-      <code>$association</code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
@@ -739,160 +665,14 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code>$column</code>
-      <code>$filterMapping</code>
-      <code>$filterMapping</code>
-      <code>$indexBy</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
       <code>$owner</code>
-      <code>$targetColumn</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$association['joinTable']['joinColumns']]]></code>
-      <code>$mapping[$sourceRelationMode]</code>
-      <code>$mapping[$targetRelationMode]</code>
-      <code>$mapping[$targetRelationMode][$joinTableColumn]</code>
-      <code><![CDATA[$mapping['indexBy']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$associationSourceClass->associationMappings]]></code>
-      <code><![CDATA[$sourceClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyNullIterator>
-      <code>$joinColumns</code>
-      <code>$joinColumns</code>
-      <code>$mapping[$sourceRelationMode]</code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-    </PossiblyNullIterator>
     <PossiblyNullReference>
       <code>getFieldForColumn</code>
       <code>getFieldForColumn</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code>$mapping[$sourceRelationMode]</code>
-      <code>$mapping[$targetRelationMode]</code>
-      <code><![CDATA[$mapping['indexBy']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
-    <InvalidArrayOffset>
-      <code><![CDATA[[
-                $mapping['mappedBy'] => $collection->getOwner(),
-                $mapping['indexBy']  => $index,
-            ]]]></code>
-    </InvalidArrayOffset>
     <InvalidReturnStatement>
       <code>$numDeleted</code>
       <code><![CDATA[$this->conn->executeStatement($statement, $parameters)]]></code>
@@ -905,51 +685,13 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code>$mapping</code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['orphanRemoval']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$mapping['orphanRemoval']]]></code>
-      <code><![CDATA[$targetClass->associationMappings[$mapping['mappedBy']]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
-    <ArgumentTypeCoercion>
-      <code>$association</code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code>$value === null</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
-      <code>$assoc</code>
       <code>$hints</code>
       <code>$hints</code>
       <code><![CDATA[[Query::HINT_REFRESH => true]]]></code>
@@ -969,27 +711,8 @@
       <code><![CDATA[list<mixed>]]></code>
     </MoreSpecificReturnType>
     <PossiblyNullArgument>
-      <code><![CDATA[$assoc['mappedBy']]]></code>
-      <code><![CDATA[$assoc['mappedBy']]]></code>
-      <code><![CDATA[$assoc['mappedBy']]]></code>
       <code>$association</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$assoc['isOwningSide']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$association['joinTable']['joinColumns']]]></code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$class->associationMappings]]></code>
-      <code><![CDATA[$class->associationMappings]]></code>
-      <code><![CDATA[$targetEntity->associationMappings]]></code>
-      <code><![CDATA[$this->class->associationMappings]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyNullIterator>
-      <code>$joinColumns</code>
-    </PossiblyNullIterator>
     <PossiblyNullReference>
       <code>getValue</code>
       <code>getValue</code>
@@ -999,28 +722,6 @@
       <code>getValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['relationToTargetKeyColumns']]]></code>
-      <code><![CDATA[$assoc['sourceToTargetKeyColumns']]]></code>
-      <code><![CDATA[$association['joinColumns']]]></code>
-      <code><![CDATA[$association['joinColumns']]]></code>
-      <code><![CDATA[$association['joinColumns']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$owningAssoc['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$owningAssoc['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$this->class->associationMappings[$fieldName]['joinColumns']]]></code>
-      <code><![CDATA[$this->class->associationMappings[$idField]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->currentPersisterContext->sqlTableAliases]]></code>
     </PropertyTypeCoercion>
@@ -1037,16 +738,6 @@
     <MoreSpecificReturnType>
       <code>array</code>
     </MoreSpecificReturnType>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
     <ArgumentTypeCoercion>
@@ -1133,25 +824,10 @@
       <code>$sqlWalker</code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
     <PossiblyInvalidArgument>
       <code><![CDATA[$this->simpleArithmeticExpression]]></code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php">
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$owningAssoc['joinTable']]]></code>
-      <code><![CDATA[$owningAssoc['targetToSourceKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod>
@@ -1347,12 +1023,6 @@
       <code>Comparison::EQ</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$associationMapping['joinColumns']]]></code>
-      <code><![CDATA[$associationMapping['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
     <DocblockTypeContradiction>
       <code><![CDATA[$this->conn->quote((string) $newValue)]]></code>
@@ -1373,27 +1043,12 @@
       <code><![CDATA[$simpleCaseExpression->elseScalarExpression]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
-      <code><![CDATA[$targetClass->associationMappings]]></code>
       <code><![CDATA[$this->scalarResultAliasMap]]></code>
       <code><![CDATA[$this->scalarResultAliasMap]]></code>
     </PossiblyNullArrayOffset>
     <PossiblyNullReference>
       <code>dispatch</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinTable']]]></code>
-      <code><![CDATA[$assoc['sourceToTargetKeyColumns']]]></code>
-      <code><![CDATA[$assoc['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$association['sourceToTargetKeyColumns']]]></code>
-      <code><![CDATA[$association['targetToSourceKeyColumns']]]></code>
-      <code><![CDATA[$owningAssoc['joinTable']]]></code>
-      <code><![CDATA[$owningAssoc['targetToSourceKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/QueryBuilder.php">
     <ArgumentTypeCoercion>
@@ -1523,11 +1178,6 @@
       <code>$state === UnitOfWork::STATE_DETACHED</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$rootClass->associationMappings[$property]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php">
     <PossiblyFalseArgument>
       <code><![CDATA[strrpos($orderByItemString, ' ')]]></code>
@@ -1541,9 +1191,6 @@
     <PossiblyNullPropertyFetch>
       <code><![CDATA[$orderByClause->orderByItems]]></code>
     </PossiblyNullPropertyFetch>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$rootClass->associationMappings[$property]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/Paginator.php">
     <ArgumentTypeCoercion>
@@ -1574,45 +1221,18 @@
     <ArgumentTypeCoercion>
       <code>$classes</code>
     </ArgumentTypeCoercion>
-    <InvalidArrayOffset>
-      <code>$mapping['enumType']</code>
-      <code>$mapping['options']</code>
-    </InvalidArrayOffset>
     <MissingClosureParamType>
       <code>$asset</code>
     </MissingClosureParamType>
     <PossiblyNullArgument>
       <code>$referencedFieldName</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$class->getAssociationMapping($fieldName)['joinColumns']]]></code>
-      <code><![CDATA[$idMapping['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <RedundantCondition>
       <code>is_numeric($indexName)</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code>assert(is_array($assoc))</code>
-      <code>is_array($assoc)</code>
-    </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
       <code>$indexName</code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="lib/Doctrine/ORM/Tools/SchemaValidator.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['joinTable']]]></code>
-      <code><![CDATA[$assoc['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$assoc['relationToTargetKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$assoc['orderBy'] !== null]]></code>
-      <code><![CDATA[isset($assoc['orderBy']) && $assoc['orderBy'] !== null]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/UnitOfWork.php">
     <InvalidArgument>
@@ -1634,23 +1254,11 @@
       <code><![CDATA[$this->identityMap[$rootClassName]]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
-      <code>$assoc</code>
-      <code>$assoc</code>
-      <code><![CDATA[$assoc['targetEntity']]]></code>
       <code><![CDATA[$class->getTypeOfField($class->getSingleIdentifierFieldName())]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code><![CDATA[$collectionToDelete->getMapping()]]></code>
-      <code><![CDATA[$collectionToUpdate->getMapping()]]></code>
       <code>$owner</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$assoc['targetEntity']]]></code>
-      <code><![CDATA[$assoc['type']]]></code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$targetClass->reflFields]]></code>
-    </PossiblyNullArrayOffset>
     <PossiblyNullReference>
       <code>buildCachedCollectionPersister</code>
       <code>buildCachedEntityPersister</code>
@@ -1678,11 +1286,6 @@
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
-      <code><![CDATA[$assoc['orphanRemoval']]]></code>
-      <code><![CDATA[$assoc['targetToSourceKeyColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <PossiblyUndefinedMethod>
       <code>unwrap</code>
       <code>unwrap</code>
@@ -1701,18 +1304,5 @@
       <code><![CDATA[$rootClassMetadata->name]]></code>
       <code><![CDATA[$rootClassMetadata->subClasses]]></code>
     </NoInterfaceProperties>
-  </file>
-  <file src="lib/Doctrine/ORM/Utility/IdentifierFlattener.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$class->associationMappings[$field]['joinColumns']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="lib/Doctrine/ORM/Utility/PersisterHelper.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$assoc['mappedBy']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinTable']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -606,21 +606,10 @@
       <code><![CDATA[$xmlRoot->getName() === 'mapped-superclass']]></code>
     </TypeDoesNotContainType>
   </file>
-  <file src="lib/Doctrine/ORM/Mapping/ManyToManyAssociationMapping.php">
+  <file src="lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php">
     <ArgumentTypeCoercion>
       <code>$mappingArray</code>
     </ArgumentTypeCoercion>
-    <LessSpecificReturnStatement>
-      <code>$mapping</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code>static</code>
-    </MoreSpecificReturnType>
-    <UndefinedMethod>
-      <code>assertMappingOrderBy</code>
-    </UndefinedMethod>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php">
     <PropertyNotSetInConstructor>
       <code>$joinTable</code>
     </PropertyNotSetInConstructor>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -364,12 +364,6 @@
     <RedundantFunctionCall>
       <code>array_values</code>
     </RedundantFunctionCall>
-    <TypeDoesNotContainType>
-      <code><![CDATA[! $mapping['isOwningSide']]]></code>
-      <code><![CDATA[! $this->table]]></code>
-      <code><![CDATA[$this->table]]></code>
-      <code><![CDATA[isset($mapping['id']) && $mapping['id'] === true && ! $mapping['isOwningSide']]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
     <ArgumentTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -26,9 +26,6 @@
     </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCache.php">
-    <InvalidOperand>
-      <code><![CDATA[! $association['type']]]></code>
-    </InvalidOperand>
     <PossiblyNullPropertyAssignmentValue>
       <code><![CDATA[$em->getConfiguration()
             ->getSecondLevelCacheConfiguration()

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -331,6 +331,7 @@
     <InvalidArgument>
       <code>$mapping</code>
       <code>$mapping</code>
+      <code>$mapping</code>
       <code>$overrideMapping</code>
     </InvalidArgument>
     <InvalidNullableReturnType>
@@ -344,11 +345,9 @@
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$mapping</code>
-      <code>$mapping</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>AssociationMapping</code>
-      <code>FieldMapping</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code>$cache</code>
@@ -389,15 +388,12 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$mapping['fieldName']]]></code>
-      <code><![CDATA[$mapping['originalClass']]]></code>
-      <code><![CDATA[$mapping['originalField']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$table['name']]]></code>
-      <code><![CDATA[$this->associationMappings[$assocName]['joinColumns']]]></code>
-      <code><![CDATA[$this->associationMappings[$fieldName]['joinColumns']]]></code>
-      <code><![CDATA[$this->associationMappings[$fieldName]['joinColumns']]]></code>
-      <code><![CDATA[$this->associationMappings[$idProperty]['joinColumns']]]></code>
+      <code>$this-&gt;associationMappings[$assocName]['joinColumns']</code>
+      <code>$this-&gt;associationMappings[$fieldName]['joinColumns']</code>
+      <code>$this-&gt;associationMappings[$fieldName]['joinColumns']</code>
+      <code>$this-&gt;associationMappings[$idProperty]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
     <PropertyNotSetInConstructor>
       <code>$idGenerator</code>
@@ -1578,6 +1574,10 @@
     <ArgumentTypeCoercion>
       <code>$classes</code>
     </ArgumentTypeCoercion>
+    <InvalidArrayOffset>
+      <code>$mapping['enumType']</code>
+      <code>$mapping['options']</code>
+    </InvalidArrayOffset>
     <MissingClosureParamType>
       <code>$asset</code>
     </MissingClosureParamType>
@@ -1587,8 +1587,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$assoc['joinColumns']]]></code>
       <code><![CDATA[$class->getAssociationMapping($fieldName)['joinColumns']]]></code>
-      <code><![CDATA[$fieldMapping['precision']]]></code>
-      <code><![CDATA[$fieldMapping['scale']]]></code>
       <code><![CDATA[$idMapping['joinColumns']]]></code>
       <code><![CDATA[$mapping['joinColumns']]]></code>
       <code><![CDATA[$mapping['joinTable']]]></code>

--- a/tests/Doctrine/Performance/Mock/NonLoadingPersister.php
+++ b/tests/Doctrine/Performance/Mock/NonLoadingPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Performance\Mock;
 
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 
 /**
@@ -22,7 +23,7 @@ class NonLoadingPersister extends BasicEntityPersister
     public function load(
         array $criteria,
         object|null $entity = null,
-        array|null $assoc = null,
+        AssociationMapping|null $assoc = null,
         array $hints = [],
         LockMode|int|null $lockMode = null,
         int|null $limit = null,

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
@@ -35,10 +35,10 @@ class DDC964Admin extends DDC964User
                 'joinTable' => [
                     'name'      => 'ddc964_users_admingroups',
                     'joinColumns' => [
-                        ['name' => 'adminuser_id'],
+                        ['name' => 'adminuser_id', 'referencedColumnName' => 'id'],
                     ],
                     'inverseJoinColumns' => [
-                        ['name' => 'admingroup_id'],
+                        ['name' => 'admingroup_id', 'referencedColumnName' => 'id'],
                     ],
                 ],
             ],

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -111,7 +111,7 @@ class DDC964User
                 'fieldName'      => 'address',
                 'targetEntity'   => 'DDC964Address',
                 'cascade'        => ['persist','merge'],
-                'joinColumns'    => [['name' => 'address_id', 'referencedColumnMame' => 'id']],
+                'joinColumns'    => [['name' => 'address_id', 'referencedColumnName' => 'id']],
             ],
         );
 

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -109,7 +109,7 @@ class UserTyped
                 'joinColumns' =>
                     [
                         0 =>
-                            [],
+                            ['referencedColumnName' => 'id'],
                     ],
                 'orphanRemoval' => true,
             ],

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -127,7 +127,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $persister = new OneToManyPersister($em);
         $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCache()));
 
-        $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_READ_ONLY;
+        $mapping->cache['usage'] = ClassMetadata::CACHE_USAGE_READ_ONLY;
 
         $this->factory->expects(self::once())
             ->method('getRegion')
@@ -148,7 +148,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $persister = new OneToManyPersister($em);
         $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCache()));
 
-        $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_READ_WRITE;
+        $mapping->cache['usage'] = ClassMetadata::CACHE_USAGE_READ_WRITE;
 
         $this->factory->expects(self::once())
             ->method('getRegion')
@@ -169,7 +169,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $persister = new OneToManyPersister($em);
         $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCache()));
 
-        $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE;
+        $mapping->cache['usage'] = ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE;
 
         $this->factory->expects(self::once())
             ->method('getRegion')
@@ -241,7 +241,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $mapping   = $metadata->associationMappings['cities'];
         $persister = new OneToManyPersister($em);
 
-        $mapping['cache']['usage'] = -1;
+        $mapping->cache['usage'] = -1;
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unrecognized access strategy type [-1]');

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/CollectionPersisterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/CollectionPersisterTestCase.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -25,7 +26,12 @@ abstract class CollectionPersisterTestCase extends OrmTestCase
     protected CollectionPersister&MockObject $collectionPersister;
     protected EntityManagerMock $em;
 
-    abstract protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister;
+    abstract protected function createPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        Region $region,
+        AssociationMapping $mapping,
+    ): AbstractCollectionPersister;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
@@ -8,14 +8,19 @@ use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('DDC-2183')]
 class NonStrictReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
-    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
-    {
+    protected function createPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        Region $region,
+        AssociationMapping $mapping,
+    ): AbstractCollectionPersister {
         return new NonStrictReadWriteCachedCollectionPersister($persister, $region, $em, $mapping);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
@@ -8,14 +8,19 @@ use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('DDC-2183')]
 class ReadOnlyCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
-    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
-    {
+    protected function createPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        Region $region,
+        AssociationMapping $mapping,
+    ): AbstractCollectionPersister {
         return new ReadOnlyCachedCollectionPersister($persister, $region, $em, $mapping);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\Tests\Models\Cache\State;
 use PHPUnit\Framework\Attributes\Group;
@@ -20,8 +21,12 @@ use ReflectionProperty;
 #[Group('DDC-2183')]
 class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
 {
-    protected function createPersister(EntityManagerInterface $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister
-    {
+    protected function createPersister(
+        EntityManagerInterface $em,
+        CollectionPersister $persister,
+        Region $region,
+        AssociationMapping $mapping,
+    ): AbstractCollectionPersister {
         return new ReadWriteCachedCollectionPersister($persister, $region, $em, $mapping);
     }
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
@@ -90,7 +90,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
     {
         $persister = $this->createPersisterDefault();
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('getSelectSQL')
@@ -154,7 +154,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
     {
         $persister = $this->createPersisterDefault();
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('getSelectConditionStatementSQL')
@@ -225,7 +225,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $persister = $this->createPersisterDefault();
         $entity    = new Country('Foo');
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('load')
@@ -285,7 +285,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $entity    = new Country('Foo');
         $owner     = (object) [];
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('loadOneToOneEntity')
@@ -336,7 +336,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $entity    = new Country('Foo');
         $owner     = (object) [];
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('getManyToManyCollection')
@@ -352,7 +352,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $entity    = new Country('Foo');
         $owner     = (object) [];
 
-        $associationMapping = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToOneAssociationMapping('foo', 'bar', 'baz');
 
         $this->entityPersister->expects(self::once())
             ->method('getOneToManyCollection')
@@ -365,7 +365,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
     public function testInvokeLoadManyToManyCollection(): void
     {
         $mapping   = $this->em->getClassMetadata(Country::class);
-        $assoc     = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $assoc     = new OneToOneAssociationMapping('foo', 'bar', 'baz');
         $coll      = new PersistentCollection($this->em, $mapping, new ArrayCollection());
         $persister = $this->createPersisterDefault();
         $entity    = new Country('Foo');
@@ -382,7 +382,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
     public function testInvokeLoadOneToManyCollection(): void
     {
         $mapping   = $this->em->getClassMetadata(Country::class);
-        $assoc     = new AssociationMapping(1, 'foo', 'bar', 'baz');
+        $assoc     = new OneToOneAssociationMapping('foo', 'bar', 'baz');
         $coll      = new PersistentCollection($this->em, $mapping, new ArrayCollection());
         $persister = $this->createPersisterDefault();
         $entity    = new Country('Foo');

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Models\CMS\CmsGroup;
@@ -265,7 +266,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
                              ->setParameter(1, $user->getId())
                              ->getSingleResult();
         self::assertCount(0, $newUser->groups);
-        self::assertIsArray($newUser->groups->getMapping());
+        self::assertInstanceOf(AssociationMapping::class, $newUser->groups->getMapping());
 
         $newUser->addGroup($group);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AnsiQuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnsiQuoteStrategyTest.php
@@ -104,7 +104,7 @@ class AnsiQuoteStrategyTest extends OrmTestCase
                 'fieldName'     => 'article',
                 'targetEntity'  => DDC117Article::class,
                 'joinColumns'    => [
-                    ['name' => 'article'],
+                    ['name' => 'article', 'referencedColumnName' => 'id'],
                 ],
             ],
         );
@@ -123,7 +123,7 @@ class AnsiQuoteStrategyTest extends OrmTestCase
                 'fieldName'     => 'article',
                 'targetEntity'  => DDC117Article::class,
                 'joinColumns'    => [
-                    ['name' => 'article'],
+                    ['name' => 'article', 'referencedColumnName' => 'id'],
                 ],
             ],
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
@@ -30,11 +30,6 @@ final class AssociationMappingTest extends TestCase
         $mapping->declared             = self::class;
         $mapping->cache                = ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY];
         $mapping->id                   = true;
-        $mapping->isCascadeRemove      = true;
-        $mapping->isCascadePersist     = true;
-        $mapping->isCascadeRefresh     = true;
-        $mapping->isCascadeMerge       = true;
-        $mapping->isCascadeDetach      = true;
         $mapping->isOnDeleteCascade    = true;
         $mapping->joinColumnFieldNames = ['foo' => 'bar'];
         $mapping->joinTableColumns     = ['foo', 'bar'];
@@ -54,11 +49,6 @@ final class AssociationMappingTest extends TestCase
         self::assertSame($resurrectedMapping->declared, self::class);
         self::assertSame($resurrectedMapping->cache, ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY]);
         self::assertSame($resurrectedMapping->id, true);
-        self::assertSame($resurrectedMapping->isCascadeRemove, true);
-        self::assertSame($resurrectedMapping->isCascadePersist, true);
-        self::assertSame($resurrectedMapping->isCascadeRefresh, true);
-        self::assertSame($resurrectedMapping->isCascadeMerge, true);
-        self::assertSame($resurrectedMapping->isCascadeDetach, true);
         self::assertSame($resurrectedMapping->isOnDeleteCascade, true);
         self::assertSame($resurrectedMapping->joinColumnFieldNames, ['foo' => 'bar']);
         self::assertSame($resurrectedMapping->joinTableColumns, ['foo', 'bar']);

--- a/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class AssociationMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new MyAssociationMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->mappedBy             = 'foo';
+        $mapping->inversedBy           = 'bar';
+        $mapping->cascade              = ['persist'];
+        $mapping->fetch                = ClassMetadata::FETCH_EAGER;
+        $mapping->inherited            = self::class;
+        $mapping->declared             = self::class;
+        $mapping->cache                = ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY];
+        $mapping->id                   = true;
+        $mapping->isCascadeRemove      = true;
+        $mapping->isCascadePersist     = true;
+        $mapping->isCascadeRefresh     = true;
+        $mapping->isCascadeMerge       = true;
+        $mapping->isCascadeDetach      = true;
+        $mapping->isOnDeleteCascade    = true;
+        $mapping->joinColumnFieldNames = ['foo' => 'bar'];
+        $mapping->joinTableColumns     = ['foo', 'bar'];
+        $mapping->originalClass        = self::class;
+        $mapping->originalField        = 'foo';
+        $mapping->orphanRemoval        = true;
+        $mapping->unique               = true;
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof AssociationMapping);
+
+        self::assertSame($resurrectedMapping->mappedBy, 'foo');
+        self::assertSame($resurrectedMapping->inversedBy, 'bar');
+        self::assertSame($resurrectedMapping->cascade, ['persist']);
+        self::assertSame($resurrectedMapping->fetch, ClassMetadata::FETCH_EAGER);
+        self::assertSame($resurrectedMapping->inherited, self::class);
+        self::assertSame($resurrectedMapping->declared, self::class);
+        self::assertSame($resurrectedMapping->cache, ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY]);
+        self::assertSame($resurrectedMapping->id, true);
+        self::assertSame($resurrectedMapping->isCascadeRemove, true);
+        self::assertSame($resurrectedMapping->isCascadePersist, true);
+        self::assertSame($resurrectedMapping->isCascadeRefresh, true);
+        self::assertSame($resurrectedMapping->isCascadeMerge, true);
+        self::assertSame($resurrectedMapping->isCascadeDetach, true);
+        self::assertSame($resurrectedMapping->isOnDeleteCascade, true);
+        self::assertSame($resurrectedMapping->joinColumnFieldNames, ['foo' => 'bar']);
+        self::assertSame($resurrectedMapping->joinTableColumns, ['foo', 'bar']);
+        self::assertSame($resurrectedMapping->originalClass, self::class);
+        self::assertSame($resurrectedMapping->originalField, 'foo');
+        self::assertSame($resurrectedMapping->orphanRemoval, true);
+        self::assertSame($resurrectedMapping->unique, true);
+    }
+}
+
+class MyAssociationMapping extends AssociationMapping
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\EmbeddedBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
@@ -12,7 +11,11 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -298,7 +301,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => ManyToOneAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -358,7 +361,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => ManyToOneAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -416,7 +419,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => OneToOneAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -476,7 +479,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => OneToOneAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -550,7 +553,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                AssociationMapping::fromMappingArray([
+                ManyToManyAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' =>
@@ -644,7 +647,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                AssociationMapping::fromMappingArray([
+                OneToManyAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'mappedBy' => 'test',
@@ -692,7 +695,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => OneToOneAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],
@@ -744,7 +747,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                AssociationMapping::fromMappingArray([
+                OneToManyAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'mappedBy' => 'test',
@@ -787,7 +790,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => AssociationMapping::fromMappingArray([
+                'groups' => ManyToManyAssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Builder\EmbeddedBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
@@ -52,12 +53,12 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'name' => [
+                'name' => EmbeddedClassMapping::fromMappingArray([
                     'class' => Name::class,
                     'columnPrefix' => null,
                     'declaredField' => null,
                     'originalField' => null,
-                ],
+                ]),
             ],
             $this->cm->embeddedClasses,
         );
@@ -75,12 +76,12 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'name' => [
+                'name' => EmbeddedClassMapping::fromMappingArray([
                     'class' => Name::class,
                     'columnPrefix' => 'nm_',
                     'declaredField' => null,
                     'originalField' => null,
-                ],
+                ]),
             ],
             $this->cm->embeddedClasses,
         );
@@ -95,12 +96,12 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         $this->assertIsFluent($embeddedBuilder->build());
         self::assertEquals(
-            [
+            EmbeddedClassMapping::fromMappingArray([
                 'class' => Name::class,
                 'columnPrefix' => null,
                 'declaredField' => null,
                 'originalField' => null,
-            ],
+            ]),
             $this->cm->embeddedClasses['name'],
         );
     }
@@ -114,12 +115,12 @@ class ClassMetadataBuilderTest extends OrmTestCase
         $this->assertIsFluent($embeddedBuilder->build());
 
         self::assertEquals(
-            [
+            EmbeddedClassMapping::fromMappingArray([
                 'class' => Name::class,
                 'columnPrefix' => 'nm_',
                 'declaredField' => null,
                 'originalField' => null,
-            ],
+            ]),
             $this->cm->embeddedClasses['name'],
         );
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -11,11 +11,11 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
-use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
-use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -419,7 +419,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => OneToOneAssociationMapping::fromMappingArray([
+                'groups' => OneToOneOwningSideMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -479,7 +479,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => OneToOneAssociationMapping::fromMappingArray([
+                'groups' => OneToOneOwningSideMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -553,7 +553,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                ManyToManyAssociationMapping::fromMappingArray([
+                ManyToManyOwningSideMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' =>
@@ -695,7 +695,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => OneToOneAssociationMapping::fromMappingArray([
+                'groups' => OneToOneOwningSideMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],
@@ -790,7 +790,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => ManyToManyAssociationMapping::fromMappingArray([
+                'groups' => ManyToManyOwningSideMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\EmbeddedBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
@@ -184,7 +185,14 @@ class ClassMetadataBuilderTest extends OrmTestCase
     public function testSetDiscriminatorColumn(): void
     {
         $this->assertIsFluent($this->builder->setDiscriminatorColumn('discr', 'string', 124, null, null));
-        self::assertEquals(['fieldName' => 'discr', 'name' => 'discr', 'type' => 'string', 'length' => '124', 'columnDefinition' => null, 'enumType' => null], $this->cm->discriminatorColumn);
+        self::assertEquals(DiscriminatorColumnMapping::fromMappingArray([
+            'fieldName' => 'discr',
+            'name' => 'discr',
+            'type' => 'string',
+            'length' => 124,
+            'columnDefinition' => null,
+            'enumType' => null,
+        ]), $this->cm->discriminatorColumn);
     }
 
     public function testAddDiscriminatorMapClass(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -328,11 +328,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => true,
-                    'isCascadeRefresh' => true,
-                    'isCascadeMerge' => true,
-                    'isCascadeDetach' => true,
                     'sourceToTargetKeyColumns' =>
                     ['group_id' => 'id'],
                     'joinColumnFieldNames' =>
@@ -388,11 +383,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => true,
-                    'isCascadeRefresh' => true,
-                    'isCascadeMerge' => true,
-                    'isCascadeDetach' => true,
                     'sourceToTargetKeyColumns' =>
                         ['group_id' => 'id'],
                     'joinColumnFieldNames' =>
@@ -446,11 +436,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => true,
-                    'isCascadeRefresh' => true,
-                    'isCascadeMerge' => true,
-                    'isCascadeDetach' => true,
                     'sourceToTargetKeyColumns' =>
                     ['group_id' => 'id'],
                     'joinColumnFieldNames' =>
@@ -507,11 +492,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => true,
-                    'isCascadeRefresh' => true,
-                    'isCascadeMerge' => true,
-                    'isCascadeDetach' => true,
                     'sourceToTargetKeyColumns' =>
                         ['group_id' => 'id'],
                     'joinColumnFieldNames' =>
@@ -597,13 +577,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'mappedBy' => null,
                     'inversedBy' => null,
                     'isOwningSide' => true,
-                    'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => true,
-                    'isCascadeRefresh' => true,
-                    'isCascadeMerge' => true,
-                    'isCascadeDetach' => true,
                     'isOnDeleteCascade' => true,
+                    'sourceEntity' => CmsUser::class,
                     'relationToSourceKeyColumns' =>
                     ['group_id' => 'id'],
                     'joinTableColumns' =>
@@ -659,11 +634,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'sourceEntity' => CmsUser::class,
                     'fetch' => 2,
                     'cascade' => [],
-                    'isCascadeRemove' => false,
-                    'isCascadePersist' => false,
-                    'isCascadeRefresh' => false,
-                    'isCascadeMerge' => false,
-                    'isCascadeDetach' => false,
                     'orphanRemoval' => false,
                 ]),
             ],
@@ -716,11 +686,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => false,
-                    'isCascadeRefresh' => false,
-                    'isCascadeMerge' => false,
-                    'isCascadeDetach' => false,
                     'sourceToTargetKeyColumns' =>
                     ['group_id' => 'id'],
                     'joinColumnFieldNames' =>
@@ -757,11 +722,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'sourceEntity' => CmsUser::class,
                     'fetch' => 2,
                     'cascade' => [],
-                    'isCascadeRemove' => true,
-                    'isCascadePersist' => false,
-                    'isCascadeRefresh' => false,
-                    'isCascadeMerge' => false,
-                    'isCascadeDetach' => false,
                     'orphanRemoval' => true,
                 ]),
             ],
@@ -820,11 +780,6 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'inversedBy' => null,
                     'isOwningSide' => true,
                     'sourceEntity' => CmsUser::class,
-                    'isCascadeRemove' => false,
-                    'isCascadePersist' => false,
-                    'isCascadeRefresh' => false,
-                    'isCascadeMerge' => false,
-                    'isCascadeDetach' => false,
                     'isOnDeleteCascade' => true,
                     'relationToSourceKeyColumns' => ['group_id' => 'id'],
                     'joinTableColumns' => [

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\EmbeddedBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
@@ -288,7 +289,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -327,7 +328,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'targetToSourceKeyColumns' =>
                     ['id' => 'group_id'],
                     'orphanRemoval' => false,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -348,7 +349,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -388,7 +389,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                         ['id' => 'group_id'],
                     'orphanRemoval' => false,
                     'id' => true,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -406,7 +407,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -445,7 +446,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'targetToSourceKeyColumns' =>
                     ['id' => 'group_id'],
                     'orphanRemoval' => false,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -466,7 +467,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [
@@ -506,7 +507,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'targetToSourceKeyColumns' =>
                         ['id' => 'group_id'],
                     'orphanRemoval' => false,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -540,7 +541,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                [
+                AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' =>
@@ -601,7 +602,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'relationToTargetKeyColumns' =>
                     ['user_id' => 'id'],
                     'orphanRemoval' => false,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -634,27 +635,25 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                [
+                AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'mappedBy' => 'test',
-                    'orderBy' =>
-                [0 => 'test'],
+                    'orderBy' => [0 => 'test'],
                     'indexBy' => 'test',
                     'type' => 4,
                     'inversedBy' => null,
                     'isOwningSide' => false,
                     'sourceEntity' => CmsUser::class,
                     'fetch' => 2,
-                    'cascade' =>
-                [],
+                    'cascade' => [],
                     'isCascadeRemove' => false,
                     'isCascadePersist' => false,
                     'isCascadeRefresh' => false,
                     'isCascadeMerge' => false,
                     'isCascadeDetach' => false,
                     'orphanRemoval' => false,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -684,7 +683,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],
@@ -717,7 +716,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'targetToSourceKeyColumns' =>
                     ['id' => 'group_id'],
                     'orphanRemoval' => true,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -736,7 +735,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertEquals(
             [
                 'groups' =>
-                [
+                AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'mappedBy' => 'test',
@@ -752,7 +751,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     'isCascadeMerge' => false,
                     'isCascadeDetach' => false,
                     'orphanRemoval' => true,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );
@@ -779,7 +778,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
         self::assertEquals(
             [
-                'groups' => [
+                'groups' => AssociationMapping::fromMappingArray([
                     'fieldName' => 'groups',
                     'targetEntity' => CmsGroup::class,
                     'cascade' => [],
@@ -822,7 +821,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                     ],
                     'relationToTargetKeyColumns' => ['cmsgroup_id' => 'id'],
                     'orphanRemoval' => true,
-                ],
+                ]),
             ],
             $this->cm->associationMappings,
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\JoinTableMapping;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
@@ -104,7 +105,11 @@ class ClassMetadataTest extends OrmTestCase
         self::assertEquals([One::class, Two::class, Three::class], $cm->subClasses);
         self::assertEquals(['UserParent'], $cm->parentClasses);
         self::assertEquals(UserRepository::class, $cm->customRepositoryClassName);
-        self::assertEquals(['name' => 'disc', 'type' => 'integer', 'fieldName' => 'disc'], $cm->discriminatorColumn);
+        self::assertEquals(DiscriminatorColumnMapping::fromMappingArray([
+            'name' => 'disc',
+            'type' => 'integer',
+            'fieldName' => 'disc',
+        ]), $cm->discriminatorColumn);
         self::assertTrue($cm->associationMappings['phonenumbers']['type'] === ClassMetadata::ONE_TO_ONE);
         self::assertEquals(1, count($cm->associationMappings));
         $oneOneMapping = $cm->getAssociationMapping('phonenumbers');

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use ArrayObject;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Events;
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
@@ -15,6 +14,7 @@ use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\JoinTableMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
@@ -356,16 +356,14 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $a1 = AssociationMapping::fromMappingArray([
+        $a1 = ManyToOneAssociationMapping::fromMappingArray([
             'fieldName' => 'foo',
-            'type' => ClassMetadata::MANY_TO_ONE,
             'sourceEntity' => stdClass::class,
             'targetEntity' => stdClass::class,
             'mappedBy' => 'foo',
         ]);
-        $a2 = AssociationMapping::fromMappingArray([
+        $a2 = ManyToOneAssociationMapping::fromMappingArray([
             'fieldName' => 'foo',
-            'type' => ClassMetadata::MANY_TO_ONE,
             'sourceEntity' => stdClass::class,
             'targetEntity' => stdClass::class,
             'mappedBy' => 'foo',

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -143,7 +143,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(UserTyped::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
+        $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [['name' => 'email_id', 'referencedColumnName' => 'id']]]);
         self::assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
 
         $cm->mapManyToOne(['fieldName' => 'mainEmail']);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -7,11 +7,13 @@ namespace Doctrine\Tests\ORM\Mapping;
 use ArrayObject;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\ORM\Mapping\JoinTableMapping;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
@@ -259,11 +261,11 @@ class ClassMetadataTest extends OrmTestCase
 
         $assoc = $cm->associationMappings['groups'];
         self::assertEquals(
-            [
+            JoinTableMapping::fromMappingArray([
                 'name' => 'cmsuser_cmsgroup',
                 'joinColumns' => [['name' => 'cmsuser_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
                 'inverseJoinColumns' => [['name' => 'cmsgroup_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
-            ],
+            ]),
             $assoc['joinTable'],
         );
         self::assertTrue($assoc['isOnDeleteCascade']);
@@ -349,8 +351,20 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $a1 = ['fieldName' => 'foo', 'sourceEntity' => stdClass::class, 'targetEntity' => stdClass::class, 'mappedBy' => 'foo'];
-        $a2 = ['fieldName' => 'foo', 'sourceEntity' => stdClass::class, 'targetEntity' => stdClass::class, 'mappedBy' => 'foo'];
+        $a1 = AssociationMapping::fromMappingArray([
+            'fieldName' => 'foo',
+            'type' => ClassMetadata::MANY_TO_ONE,
+            'sourceEntity' => stdClass::class,
+            'targetEntity' => stdClass::class,
+            'mappedBy' => 'foo',
+        ]);
+        $a2 = AssociationMapping::fromMappingArray([
+            'fieldName' => 'foo',
+            'type' => ClassMetadata::MANY_TO_ONE,
+            'sourceEntity' => stdClass::class,
+            'targetEntity' => stdClass::class,
+            'mappedBy' => 'foo',
+        ]);
 
         $cm->addInheritedAssociationMapping($a1);
         $this->expectException(MappingException::class);
@@ -853,11 +867,11 @@ class ClassMetadataTest extends OrmTestCase
         );
 
         self::assertEquals(
-            [
+            JoinTableMapping::fromMappingArray([
                 'name' => 'customtypeparent_customtypeparent',
                 'joinColumns' => [['name' => 'customtypeparent_source', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
                 'inverseJoinColumns' => [['name' => 'customtypeparent_target', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
-            ],
+            ]),
             $cm->associationMappings['friendsWithMe']['joinTable'],
         );
         self::assertEquals(['customtypeparent_source', 'customtypeparent_target'], $cm->associationMappings['friendsWithMe']['joinTableColumns']);

--- a/tests/Doctrine/Tests/ORM/Mapping/DiscriminatorColumnMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/DiscriminatorColumnMappingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class DiscriminatorColumnMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new DiscriminatorColumnMapping(
+            type: 'string',
+            fieldName: 'discr',
+            name: 'discr',
+        );
+
+        $mapping->length           = 255;
+        $mapping->columnDefinition = 'VARCHAR(255)';
+        $mapping->enumType         = 'MyEnum';
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof DiscriminatorColumnMapping);
+
+        self::assertSame($resurrectedMapping->length, 255);
+        self::assertSame($resurrectedMapping->columnDefinition, 'VARCHAR(255)');
+        self::assertSame($resurrectedMapping->enumType, 'MyEnum');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/EmbeddedClassMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/EmbeddedClassMappingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class EmbeddedClassMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping                = new EmbeddedClassMapping(self::class);
+        $mapping->columnPrefix  = 'these';
+        $mapping->declaredField = 'values';
+        $mapping->originalField = 'make';
+        $mapping->inherited     = self::class; // no
+        $mapping->declared      = self::class; // sense
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof EmbeddedClassMapping);
+
+        self::assertSame($resurrectedMapping->columnPrefix, 'these');
+        self::assertSame($resurrectedMapping->declaredField, 'values');
+        self::assertSame($resurrectedMapping->originalField, 'make');
+        self::assertSame($resurrectedMapping->inherited, self::class);
+        self::assertSame($resurrectedMapping->declared, self::class);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldMappingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class FieldMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new FieldMapping(
+            type: 'string',
+            fieldName: 'id',
+            columnName: 'id',
+        );
+
+        $mapping->length           = 255;
+        $mapping->id               = true;
+        $mapping->nullable         = true;
+        $mapping->notInsertable    = true;
+        $mapping->notUpdatable     = true;
+        $mapping->columnDefinition = 'VARCHAR(255)';
+        $mapping->generated        = ClassMetadata::GENERATOR_TYPE_AUTO;
+        $mapping->enumType         = 'MyEnum';
+        $mapping->precision        = 10;
+        $mapping->scale            = 2;
+        $mapping->unique           = true;
+        $mapping->inherited        = self::class;
+        $mapping->originalClass    = self::class;
+        $mapping->originalField    = 'id';
+        $mapping->quoted           = true;
+        $mapping->declared         = self::class;
+        $mapping->declaredField    = 'id';
+        $mapping->options          = ['foo' => 'bar'];
+        $mapping->version          = true;
+        $mapping->default          = 'foo';
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof FieldMapping);
+
+        self::assertSame($resurrectedMapping->length, 255);
+        self::assertTrue($resurrectedMapping->id);
+        self::assertTrue($resurrectedMapping->nullable);
+        self::assertTrue($resurrectedMapping->notInsertable);
+        self::assertTrue($resurrectedMapping->notUpdatable);
+        self::assertSame($resurrectedMapping->columnDefinition, 'VARCHAR(255)');
+        self::assertSame($resurrectedMapping->generated, ClassMetadata::GENERATOR_TYPE_AUTO);
+        self::assertSame($resurrectedMapping->enumType, 'MyEnum');
+        self::assertSame($resurrectedMapping->precision, 10);
+        self::assertSame($resurrectedMapping->scale, 2);
+        self::assertTrue($resurrectedMapping->unique);
+        self::assertSame($resurrectedMapping->inherited, self::class);
+        self::assertSame($resurrectedMapping->originalClass, self::class);
+        self::assertSame($resurrectedMapping->originalField, 'id');
+        self::assertTrue($resurrectedMapping->quoted);
+        self::assertSame($resurrectedMapping->declared, self::class);
+        self::assertSame($resurrectedMapping->declaredField, 'id');
+        self::assertSame($resurrectedMapping->options, ['foo' => 'bar']);
+        self::assertTrue($resurrectedMapping->version);
+        self::assertSame($resurrectedMapping->default, 'foo');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
@@ -15,7 +15,7 @@ final class JoinColumnMappingTest extends TestCase
 {
     public function testItSurvivesSerialization(): void
     {
-        $mapping = new JoinColumnMapping();
+        $mapping = new JoinColumnMapping('id');
 
         $mapping->name                 = 'foo';
         $mapping->unique               = true;

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\JoinColumnMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class JoinColumnMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new JoinColumnMapping();
+
+        $mapping->name                 = 'foo';
+        $mapping->unique               = true;
+        $mapping->quoted               = true;
+        $mapping->fieldName            = 'bar';
+        $mapping->onDelete             = 'CASCADE';
+        $mapping->columnDefinition     = 'VARCHAR(255)';
+        $mapping->nullable             = true;
+        $mapping->referencedColumnName = 'baz';
+        $mapping->options              = ['foo' => 'bar'];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof JoinColumnMapping);
+
+        self::assertSame($resurrectedMapping->name, 'foo');
+        self::assertTrue($resurrectedMapping->unique);
+        self::assertTrue($resurrectedMapping->quoted);
+        self::assertSame($resurrectedMapping->fieldName, 'bar');
+        self::assertSame($resurrectedMapping->onDelete, 'CASCADE');
+        self::assertSame($resurrectedMapping->columnDefinition, 'VARCHAR(255)');
+        self::assertTrue($resurrectedMapping->nullable);
+        self::assertSame($resurrectedMapping->referencedColumnName, 'baz');
+        self::assertSame($resurrectedMapping->options, ['foo' => 'bar']);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\JoinColumnMapping;
+use Doctrine\ORM\Mapping\JoinTableMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class JoinTableMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new JoinTableMapping();
+
+        $mapping->quoted             = true;
+        $mapping->joinColumns        = [new JoinColumnMapping()];
+        $mapping->inverseJoinColumns = [new JoinColumnMapping()];
+        $mapping->schema             = 'foo';
+        $mapping->name               = 'bar';
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof JoinTableMapping);
+
+        self::assertTrue($resurrectedMapping->quoted);
+        self::assertCount(1, $resurrectedMapping->joinColumns);
+        self::assertCount(1, $resurrectedMapping->inverseJoinColumns);
+        self::assertSame($resurrectedMapping->schema, 'foo');
+        self::assertSame($resurrectedMapping->name, 'bar');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
@@ -19,8 +19,8 @@ final class JoinTableMappingTest extends TestCase
         $mapping = new JoinTableMapping();
 
         $mapping->quoted             = true;
-        $mapping->joinColumns        = [new JoinColumnMapping()];
-        $mapping->inverseJoinColumns = [new JoinColumnMapping()];
+        $mapping->joinColumns        = [new JoinColumnMapping('id')];
+        $mapping->inverseJoinColumns = [new JoinColumnMapping('id')];
         $mapping->schema             = 'foo';
         $mapping->name               = 'bar';
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToManyAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToManyAssociationMappingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class ManyToManyAssociationMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new ManyToManyAssociationMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->relationToSourceKeyColumns = ['foo' => 'bar'];
+        $mapping->relationToTargetKeyColumns = ['bar' => 'baz'];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof ManyToManyAssociationMapping);
+
+        self::assertSame($resurrectedMapping->relationToSourceKeyColumns, ['foo' => 'bar']);
+        self::assertSame($resurrectedMapping->relationToTargetKeyColumns, ['bar' => 'baz']);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\JoinTableMapping;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class ManyToManyOwningSideMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new ManyToManyOwningSideMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->joinTable       = new JoinTableMapping();
+        $mapping->joinTable->name = 'bar';
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof ManyToManyOwningSideMapping);
+
+        self::assertSame($resurrectedMapping->joinTable->name, 'bar');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\JoinColumnMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class ManyToOneAssociationMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new ManyToOneAssociationMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->joinColumns = [new JoinColumnMapping()];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof ManyToOneAssociationMapping);
+
+        self::assertCount(1, $resurrectedMapping->joinColumns);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
@@ -22,7 +22,7 @@ final class ManyToOneAssociationMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->joinColumns = [new JoinColumnMapping()];
+        $mapping->joinColumns = [new JoinColumnMapping('id')];
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof ManyToOneAssociationMapping);

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -457,7 +458,14 @@ abstract class MappingDriverTestCase extends OrmTestCase
         $class = $this->createClassMetadata(Animal::class);
 
         self::assertEquals(
-            ['name' => 'discr', 'type' => 'string', 'length' => 32, 'fieldName' => 'discr', 'columnDefinition' => null, 'enumType' => null],
+            DiscriminatorColumnMapping::fromMappingArray([
+                'name' => 'discr',
+                'type' => 'string',
+                'length' => 32,
+                'fieldName' => 'discr',
+                'columnDefinition' => null,
+                'enumType' => null,
+            ]),
             $class->discriminatorColumn,
         );
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
@@ -22,7 +22,7 @@ final class OneToOneOwningSideMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->joinColumns = [new JoinColumnMapping()];
+        $mapping->joinColumns = [new JoinColumnMapping('id')];
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof OneToOneOwningSideMapping);

--- a/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\JoinColumnMapping;
+use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class OneToOneOwningSideMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new OneToOneOwningSideMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->joinColumns = [new JoinColumnMapping()];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof OneToOneOwningSideMapping);
+
+        self::assertCount(1, $resurrectedMapping->joinColumns);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
@@ -147,7 +147,7 @@ class QuoteStrategyTest extends OrmTestCase
                 'fieldName'     => 'article',
                 'targetEntity'  => DDC117Article::class,
                 'joinColumns'    => [
-                    ['name' => '`article`'],
+                    ['name' => '`article`', 'referencedColumnName' => 'article'],
                 ],
             ],
         );
@@ -165,7 +165,7 @@ class QuoteStrategyTest extends OrmTestCase
                 'fieldName'     => 'article',
                 'targetEntity'  => DDC117Article::class,
                 'joinColumns'    => [
-                    ['name' => '`article`'],
+                    ['name' => '`article`', 'referencedColumnName' => 'article'],
                 ],
             ],
         );
@@ -184,7 +184,7 @@ class QuoteStrategyTest extends OrmTestCase
                 'fieldName'     => 'article',
                 'targetEntity'  => DDC117Article::class,
                 'joinColumns'    => [
-                    ['name' => '`article`'],
+                    ['name' => '`article`', 'referencedColumnName' => 'id'],
                 ],
             ],
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/ToManyAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ToManyAssociationMappingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class ToManyAssociationMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new MyToManyAssociationMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->indexBy = 'foo';
+        $mapping->orderBy = ['foo' => 'asc'];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof ToManyAssociationMapping);
+
+        self::assertSame($resurrectedMapping->indexBy, 'foo');
+        self::assertSame($resurrectedMapping->orderBy, ['foo' => 'asc']);
+    }
+}
+
+class MyToManyAssociationMapping extends ToManyAssociationMapping
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ToOneAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ToOneAssociationMappingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\ToOneAssociationMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class ToOneAssociationMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new MyToOneAssociationMapping(
+            fieldName: 'foo',
+            sourceEntity: self::class,
+            targetEntity: self::class,
+        );
+
+        $mapping->sourceToTargetKeyColumns = ['foo' => 'bar'];
+        $mapping->targetToSourceKeyColumns = ['bar' => 'foo'];
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof ToOneAssociationMapping);
+
+        self::assertSame(['foo' => 'bar'], $resurrectedMapping->sourceToTargetKeyColumns);
+        self::assertSame(['bar' => 'foo'], $resurrectedMapping->targetToSourceKeyColumns);
+    }
+}
+
+class MyToOneAssociationMapping extends ToOneAssociationMapping
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
@@ -136,12 +137,12 @@ class XmlMappingDriverTest extends MappingDriverTestCase
 
         self::assertEquals(
             [
-                'name' => [
+                'name' => EmbeddedClassMapping::fromMappingArray([
                     'class' => Name::class,
                     'columnPrefix' => 'nm_',
                     'declaredField' => null,
                     'originalField' => null,
-                ],
+                ]),
             ],
             $class->embeddedClasses,
         );

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM;
 
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -48,23 +47,20 @@ class ORMInvalidArgumentExceptionTest extends TestCase
                 return 'ThisIsAStringRepresentationOfEntity3';
             }
         };
-        $association1 = AssociationMapping::fromMappingArray([
+        $association1 = OneToManyAssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
             'targetEntity' => 'baz1',
-            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
-        $association2 = AssociationMapping::fromMappingArray([
+        $association2 = OneToManyAssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo2',
             'fieldName'    => 'bar2',
             'targetEntity' => 'baz2',
-            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
-        $association3 = AssociationMapping::fromMappingArray([
+        $association3 = OneToManyAssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo3',
             'fieldName'    => 'bar3',
             'targetEntity' => 'baz3',
-            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
 
         return [

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM;
 
 use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -51,16 +52,19 @@ class ORMInvalidArgumentExceptionTest extends TestCase
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
             'targetEntity' => 'baz1',
+            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
         $association2 = AssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo2',
             'fieldName'    => 'bar2',
             'targetEntity' => 'baz2',
+            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
         $association3 = AssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo3',
             'fieldName'    => 'bar3',
             'targetEntity' => 'baz3',
+            'type' => ClassMetadata::ONE_TO_MANY,
         ]);
 
         return [

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM;
 
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -46,21 +47,21 @@ class ORMInvalidArgumentExceptionTest extends TestCase
                 return 'ThisIsAStringRepresentationOfEntity3';
             }
         };
-        $association1 = [
+        $association1 = AssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
             'targetEntity' => 'baz1',
-        ];
-        $association2 = [
+        ]);
+        $association2 = AssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo2',
             'fieldName'    => 'bar2',
             'targetEntity' => 'baz2',
-        ];
-        $association3 = [
+        ]);
+        $association3 = AssociationMapping::fromMappingArray([
             'sourceEntity' => 'foo3',
             'fieldName'    => 'bar3',
             'targetEntity' => 'baz3',
-        ];
+        ]);
 
         return [
             'one entity found' => [

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Persisters\Exception\CantUseInOperatorOnCompositeKeys;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -15,36 +17,43 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
 {
     protected BasicEntityPersister $persister;
     protected EntityManagerMock $entityManager;
+    private AssociationMapping $associationMapping;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->entityManager = $this->getTestEntityManager();
-        $this->persister     = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(Admin1AlternateName::class));
+        $this->entityManager      = $this->getTestEntityManager();
+        $this->persister          = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(Admin1AlternateName::class));
+        $this->associationMapping = new AssociationMapping(
+            type: ClassMetadata::MANY_TO_ONE,
+            fieldName: 'admin1',
+            sourceEntity: WhoCares::class,
+            targetEntity: Admin1AlternateName::class,
+        );
     }
 
     public function testSelectConditionStatementEq(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('admin1', 1, [], Comparison::EQ);
+        $statement = $this->persister->getSelectConditionStatementSQL('admin1', 1, $this->associationMapping, Comparison::EQ);
         self::assertEquals('t0.admin1 = ? AND t0.country = ?', $statement);
     }
 
     public function testSelectConditionStatementEqNull(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('admin1', null, [], Comparison::IS);
+        $statement = $this->persister->getSelectConditionStatementSQL('admin1', null, $this->associationMapping, Comparison::IS);
         self::assertEquals('t0.admin1 IS NULL AND t0.country IS NULL', $statement);
     }
 
     public function testSelectConditionStatementNeqNull(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('admin1', null, [], Comparison::NEQ);
+        $statement = $this->persister->getSelectConditionStatementSQL('admin1', null, $this->associationMapping, Comparison::NEQ);
         self::assertEquals('t0.admin1 IS NOT NULL AND t0.country IS NOT NULL', $statement);
     }
 
     public function testSelectConditionStatementIn(): void
     {
         $this->expectException(CantUseInOperatorOnCompositeKeys::class);
-        $this->persister->getSelectConditionStatementSQL('admin1', [], [], Comparison::IN);
+        $this->persister->getSelectConditionStatementSQL('admin1', [], $this->associationMapping, Comparison::IN);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Persisters\Exception\CantUseInOperatorOnCompositeKeys;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -25,8 +25,7 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
 
         $this->entityManager      = $this->getTestEntityManager();
         $this->persister          = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(Admin1AlternateName::class));
-        $this->associationMapping = new AssociationMapping(
-            type: ClassMetadata::MANY_TO_ONE,
+        $this->associationMapping = new ManyToOneAssociationMapping(
             fieldName: 'admin1',
             sourceEntity: WhoCares::class,
             targetEntity: Admin1AlternateName::class,

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
 use Doctrine\Tests\DbalTypes\UpperCaseStringType;
@@ -119,19 +121,27 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     #[Group('DDC-2073')]
     public function testSelectConditionStatementIsNull(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('test', null, [], Comparison::IS);
+        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $statement          = $this->persister->getSelectConditionStatementSQL('test', null, $associationMapping, Comparison::IS);
         self::assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementEqNull(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('test', null, [], Comparison::EQ);
+        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $statement          = $this->persister->getSelectConditionStatementSQL('test', null, $associationMapping, Comparison::EQ);
         self::assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementNeqNull(): void
     {
-        $statement = $this->persister->getSelectConditionStatementSQL('test', null, [], Comparison::NEQ);
+        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $statement          = $this->persister->getSelectConditionStatementSQL(
+            'test',
+            null,
+            $associationMapping,
+            Comparison::NEQ,
+        );
         self::assertEquals('test IS NOT NULL', $statement);
     }
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -10,8 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DBALType;
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
 use Doctrine\Tests\DbalTypes\UpperCaseStringType;
@@ -121,21 +120,21 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     #[Group('DDC-2073')]
     public function testSelectConditionStatementIsNull(): void
     {
-        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToManyAssociationMapping('foo', 'bar', 'baz');
         $statement          = $this->persister->getSelectConditionStatementSQL('test', null, $associationMapping, Comparison::IS);
         self::assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementEqNull(): void
     {
-        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToManyAssociationMapping('foo', 'bar', 'baz');
         $statement          = $this->persister->getSelectConditionStatementSQL('test', null, $associationMapping, Comparison::EQ);
         self::assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementNeqNull(): void
     {
-        $associationMapping = new AssociationMapping(ClassMetadata::ONE_TO_MANY, 'foo', 'bar', 'baz');
+        $associationMapping = new OneToManyAssociationMapping('foo', 'bar', 'baz');
         $statement          = $this->persister->getSelectConditionStatementSQL(
             'test',
             null,


### PR DESCRIPTION
An experiment, not sure if I will manage to do it, but at least it will allow us to port some changes to 2.x:
- for instance, everywhere `FieldMapping` the DTO is used, `FieldMapping` the array-shape should be used
- we can add missing fields to `FieldMapping` (for instance, `version`, or `default`)

## Todo

- [x] field mapping
- [x] association mapping
- [x] embedded classes mapping
- [x] discriminator column mapping
- [x] avoid repetition (array access implementation,  common fields)
- [x] use different DTOs for different association types
- [x] use different DTOs for different sides of the association
- [x] make classes that should never be instantiated abstract
- [x] Fix Psalm issues
- [x] Fix PHPStan issues
- [x] Implement `__sleep()`
- [x] Avoid redundant `isCascade*` properties