### PR TITLE
Test with a stable PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/coding-standard": "^9.0.2 || ^11.0",
         "phpbench/phpbench": "^0.16.10 || ^1.0",
         "phpstan/phpstan": "~1.4.10 || 1.9.8",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5.28@dev",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5.28",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",


### PR DESCRIPTION
PHPUnit has issued a release that is compatible with Instantiator 2. Thus, let's switch back to stable PHPUnit releases.