### PR TITLE
Field mapping improvements

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1582,9 +1582,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param  array{fieldName: string, type?: mixed} $mapping The field mapping to validate & complete.
+     * @param  array{fieldName: string, type?: string} $mapping The field mapping to validate & complete.
      *
-     * @return array{fieldName: string, enumType?: string, type?: mixed} The updated mapping.
+     * @return array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
      */
     private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -90,7 +90,9 @@ use const PHP_VERSION_ID;
  *      requireSQLConversion?: bool,
  *      declared?: class-string,
  *      declaredField?: string,
- *      options?: array<string, mixed>
+ *      options?: array<string, mixed>,
+ *      version?: string,
+ *      default?: string|int,
  * }
  * @psalm-type JoinColumnData = array{
  *     name: string,

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1630,7 +1630,7 @@ class ClassMetadataInfo implements ClassMetadata
      *     enumType?: class-string,
      * } $mapping The field mapping to validate & complete.
      *
-     * @return mixed[] The updated mapping.
+     * @return FieldMapping The updated mapping.
      *
      * @throws MappingException
      */

--- a/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use BackedEnum;
 use ReflectionProperty;
 
 interface TypedFieldMapper
@@ -11,9 +12,9 @@ interface TypedFieldMapper
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param array{fieldName: string, enumType?: string, type?: mixed} $mapping The field mapping to validate & complete.
+     * @param array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} $mapping The field mapping to validate & complete.
      *
-     * @return array{fieldName: string, enumType?: string, type?: mixed} The updated mapping.
+     * @return array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
      */
     public function validateAndComplete(array $mapping, ReflectionProperty $field): array;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -576,11 +576,6 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Offset 'version' on array\\{type\\: string, fieldName\\: string, columnName\\: string, length\\?\\: int, id\\?\\: bool, nullable\\?\\: bool, notInsertable\\?\\: bool, notUpdatable\\?\\: bool, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
-
-		-
 			message: "#^Parameter \\#1 \\$policy of method Doctrine\\\\ORM\\\\Tools\\\\Export\\\\Driver\\\\AbstractExporter\\:\\:_getChangeTrackingPolicyString\\(\\) expects 1\\|2\\|3, int given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2694,9 +2694,6 @@
     <DeprecatedClass occurrences="1">
       <code>AbstractExporter</code>
     </DeprecatedClass>
-    <InvalidArrayOffset occurrences="1">
-      <code>$field['version']</code>
-    </InvalidArrayOffset>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$_extension</code>
     </NonInvariantDocblockPropertyType>


### PR DESCRIPTION
It will be hard to finish https://github.com/doctrine/orm/pull/10405, but this should get us closer to it.
Also, I learnt that DTOs shouldn't be used in mapping drivers, because drivers produce incomplete field mappings (they might not have a type), and also produce mapping overrides that might have even fewer fields. DTOs should be used in the class metadata and its consumers.