### PR TITLE
Require that inheritance be declared when it is used

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -285,6 +285,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         } elseif ($class->isMappedSuperclass && $class->name === $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
             throw MappingException::noInheritanceOnMappedSuperClass($class->name);
+        } else if ($class->name !== $class->rootEntityName && $class->isInheritanceTypeNone()) {
+            throw MappingException::inheritanceUsedButNotDeclared($class->name, $class->rootEntityName);
         }
     }
 

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -767,6 +767,13 @@ class MappingException extends ORMException
         );
     }
 
+    public static function inheritanceUsedButNotDeclared(string $className, string $rootClassName): self
+    {
+        return new self(
+            "Entity '" . $className . "' inherits from '" . $rootClassName . "', but this root entity does not declare any inheritance mapping type."
+        );
+    }
+
     /**
      * @param string $className
      * @param string $methodName


### PR DESCRIPTION
It seems to be possible to have two `@Entity` classes inherit from each other, but omit the `@InheritanceType` declaration at the root entity. This will lead to mapping information being loaded without complaints and the inheritance type being set to `NONE` for both classes.

At the same time, the subclass will have its field and association mappings set with the `inherited` and `declared` metadata, and also the `rootEntity` in the metadata will correctly point to the parent class.

So, the question is: Is it valid to have two entities inherit from each other without declaring an inheritance type?

The documentation does not explicitly address this.

This PR here adds a runtime validation failure for this case. Let’s see what the testsuites have to say.

Thoughts?