### PR TITLE
Fill in missing subclasses when loading ClassMetadata

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -115,6 +115,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $class->setVersioned($parent->isVersioned);
             $class->setVersionField($parent->versionField);
             $class->setDiscriminatorMap($parent->discriminatorMap);
+            $class->addSubClasses($parent->subClasses);
             $class->setLifecycleCallbacks($parent->lifecycleCallbacks);
             $class->setChangeTrackingPolicy($parent->changeTrackingPolicy);
 
@@ -219,10 +220,15 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $this->addDefaultDiscriminatorMap($class);
         }
 
+        // During the following event, there may also be updates to the discriminator map as per GH-1257/GH-8402.
+        // So, we must not discover the missing subclasses before that.
+
         if ($this->evm->hasListeners(Events::loadClassMetadata)) {
             $eventArgs = new LoadClassMetadataEventArgs($class, $this->em);
             $this->evm->dispatchEvent(Events::loadClassMetadata, $eventArgs);
         }
+
+        $this->findAbstractEntityClassesNotListedInDiscriminatorMap($class);
 
         if ($class->changeTrackingPolicy === ClassMetadata::CHANGETRACKING_NOTIFY) {
             Deprecation::trigger(
@@ -336,6 +342,58 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         $class->setDiscriminatorMap($map);
+    }
+
+    private function findAbstractEntityClassesNotListedInDiscriminatorMap(ClassMetadata $rootEntityClass): void
+    {
+        // Only root classes in inheritance hierarchies need contain a discriminator map,
+        // so skip for other classes.
+        if (! $rootEntityClass->isRootEntity() || $rootEntityClass->isInheritanceTypeNone()) {
+            return;
+        }
+
+        $processedClasses = [$rootEntityClass->name => true];
+        foreach ($rootEntityClass->subClasses as $knownSubClass) {
+            $processedClasses[$knownSubClass] = true;
+        }
+
+        foreach ($rootEntityClass->discriminatorMap as $declaredClassName) {
+            // This fetches non-transient parent classes only
+            $parentClasses = $this->getParentClasses($declaredClassName);
+
+            foreach ($parentClasses as $parentClass) {
+                if (isset($processedClasses[$parentClass])) {
+                    continue;
+                }
+
+                $processedClasses[$parentClass] = true;
+
+                // All non-abstract entity classes must be listed in the discriminator map, and
+                // this will be validated/enforced at runtime (possibly at a later time, when the
+                // subclass is loaded, but anyways). Also, subclasses is about entity classes only.
+                // That means we can ignore non-abstract classes here. The (expensive) driver
+                // check for mapped superclasses need only be run for abstract candidate classes.
+                if (! (new ReflectionClass($parentClass))->isAbstract() || $this->peekIfIsMappedSuperclass($parentClass)) {
+                    continue;
+                }
+
+                // We have found a non-transient, non-mapped-superclass = an entity class (possibly abstract, but that does not matter)
+                $rootEntityClass->addSubClass($parentClass);
+            }
+        }
+    }
+
+    /** @param class-string $className */
+    private function peekIfIsMappedSuperclass(string $className): bool
+    {
+        // TODO can we shortcut this for classes that have already been loaded? can that be the case at all?
+        $reflService = $this->getReflectionService();
+        $class       = $this->newClassMetadataInstance($className);
+        $this->initializeReflection($class, $reflService);
+
+        $this->driver->loadMetadataForClass($className, $class);
+
+        return $class->isMappedSuperclass;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -386,7 +386,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /** @param class-string $className */
     private function peekIfIsMappedSuperclass(string $className): bool
     {
-        // TODO can we shortcut this for classes that have already been loaded? can that be the case at all?
         $reflService = $this->getReflectionService();
         $class       = $this->newClassMetadataInstance($className);
         $this->initializeReflection($class, $reflService);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -397,7 +397,27 @@ class ClassMetadataInfo implements ClassMetadata
     public $parentClasses = [];
 
     /**
-     * READ-ONLY: The names of all subclasses (descendants).
+     * READ-ONLY: For classes in inheritance mapping hierarchies, this field contains the names of all
+     * <em>entity</em> subclasses of this class. These may also be abstract classes.
+     *
+     * This list is used, for example, to enumerate all necessary tables in JTI when querying for root
+     * or subclass entities, or to gather all fields comprised in an entity inheritance tree.
+     *
+     * For classes that do not use STI/JTI, this list is empty.
+     *
+     * Implementation note:
+     *
+     * In PHP, there is no general way to discover all subclasses of a given class at runtime. For that
+     * reason, the list of classes given in the discriminator map at the root entity is considered
+     * authoritative. The discriminator map must contain all <em>concrete</em> classes that can
+     * appear in the particular inheritance hierarchy tree. Since there can be no instances of abstract
+     * entity classes, users are not required to list such classes with a discriminator value.
+     *
+     * The possibly remaining "gaps" for abstract entity classes are filled after the class metadata for the
+     * root entity has been loaded.
+     *
+     * For subclasses of such root entities, the list can be reused/passed downwards, it only needs to
+     * be filtered accordingly (only keep remaining subclasses)
      *
      * @psalm-var list<class-string>
      */
@@ -3275,6 +3295,21 @@ class ClassMetadataInfo implements ClassMetadata
             throw MappingException::invalidClassInDiscriminatorMap($className, $this->name);
         }
 
+        $this->addSubClass($className);
+    }
+
+    /** @param array<class-string> $classes */
+    public function addSubClasses(array $classes): void
+    {
+        foreach ($classes as $className) {
+            $this->addSubClass($className);
+        }
+    }
+
+    public function addSubClass(string $className): void
+    {
+        // By ignoring classes that are not subclasses of the current class, we simplify inheriting
+        // the subclass list from a parent class at the beginning of \Doctrine\ORM\Mapping\ClassMetadataFactory::doLoadMetadata.
         if (is_subclass_of($className, $this->name) && ! in_array($className, $this->subClasses, true)) {
             $this->subClasses[] = $className;
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6558Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6558Test.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6558
+ */
+class DDC6558Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC6558Person::class),
+            $this->_em->getClassMetadata(DDC6558Employee::class),
+            $this->_em->getClassMetadata(DDC6558Staff::class),
+            $this->_em->getClassMetadata(DDC6558Developer::class),
+            $this->_em->getClassMetadata(DDC6558Manager::class),
+        ]);
+    }
+
+    public function testEmployeeIsPopulated(): void
+    {
+        $developer               = new DDC6558Developer();
+        $developer->phoneNumber  = 1231231231;
+        $developer->emailAddress = 'email@address.com';
+
+        $this->_em->persist($developer);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $persistedDeveloper = $this->_em->find(DDC6558Person::class, $developer->id);
+
+        self::assertNotNull($persistedDeveloper->phoneNumber);
+        self::assertNotNull($persistedDeveloper->emailAddress);
+    }
+}
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="discr", type="string")
+ * @ORM\DiscriminatorMap({"manager" = "DDC6558Manager", "staff" = "DDC6558Staff", "developer" = "DDC6558Developer"})
+ */
+abstract class DDC6558Person
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue()
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/** @ORM\Entity() */
+class DDC6558Manager extends DDC6558Person
+{
+}
+
+/**
+ * @ORM\Entity()
+ */
+abstract class DDC6558Employee extends DDC6558Person
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $phoneNumber;
+}
+
+/** @ORM\Entity() */
+class DDC6558Staff extends DDC6558Employee
+{
+}
+
+/** @ORM\Entity() */
+class DDC6558Developer extends DDC6558Employee
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $emailAddress;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmTestCase;
+use Generator;
+
+use function array_map;
+
+/**
+ * @group GH-10387
+ */
+class GH10387Test extends OrmTestCase
+{
+    /**
+     * @dataProvider classHierachies
+     */
+    public function testSchemaToolCreatesColumnForFieldInTheMiddleClass(array $classes): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $metadata   = array_map(static function (string $class) use ($em) {
+            return $em->getClassMetadata($class);
+        }, $classes);
+        $schema     = $schemaTool->getSchemaFromMetadata([$metadata[0]]);
+
+        self::assertNotNull($schema->getTable('root')->getColumn('middle_class_field'));
+        self::assertNotNull($schema->getTable('root')->getColumn('leaf_class_field'));
+    }
+
+    public function classHierachies(): Generator
+    {
+        yield 'hierarchy with Entity classes only' => [[GH10387EntitiesOnlyRoot::class, GH10387EntitiesOnlyMiddle::class, GH10387EntitiesOnlyLeaf::class]];
+        yield 'MappedSuperclass in the middle of the hierarchy' => [[GH10387MappedSuperclassRoot::class, GH10387MappedSuperclassMiddle::class, GH10387MappedSuperclassLeaf::class]];
+        yield 'abstract entity the the root and in the middle of the hierarchy' => [[GH10387AbstractEntitiesRoot::class, GH10387AbstractEntitiesMiddle::class, GH10387AbstractEntitiesLeaf::class]];
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH10387EntitiesOnlyRoot", "B": "GH10387EntitiesOnlyMiddle", "C": "GH10387EntitiesOnlyLeaf"})
+ */
+class GH10387EntitiesOnlyRoot
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     *
+     * @var string
+     */
+    private $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10387EntitiesOnlyMiddle extends GH10387EntitiesOnlyRoot
+{
+    /**
+     * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
+     */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10387EntitiesOnlyLeaf extends GH10387EntitiesOnlyMiddle
+{
+    /**
+     * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
+     */
+    private $childValue;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH10387MappedSuperclassRoot", "B": "GH10387MappedSuperclassLeaf"})
+ * ^- This DiscriminatorMap contains the Entity classes only, not the Mapped Superclass
+ */
+class GH10387MappedSuperclassRoot
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     *
+     * @var string
+     */
+    private $id;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH10387MappedSuperclassMiddle extends GH10387MappedSuperclassRoot
+{
+    /**
+     * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
+     */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10387MappedSuperclassLeaf extends GH10387MappedSuperclassMiddle
+{
+    /**
+     * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
+     */
+    private $childValue;
+}
+
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH10387AbstractEntitiesLeaf"})
+ * ^- This DiscriminatorMap contains the single non-abstract Entity class only
+ */
+abstract class GH10387AbstractEntitiesRoot
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     *
+     * @var string
+     */
+    private $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+abstract class GH10387AbstractEntitiesMiddle extends GH10387AbstractEntitiesRoot
+{
+    /**
+     * @ORM\Column(name="middle_class_field")
+     *
+     * @var string
+     */
+    private $parentValue;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10387AbstractEntitiesLeaf extends GH10387AbstractEntitiesMiddle
+{
+    /**
+     * @ORM\Column(name="leaf_class_field")
+     *
+     * @var string
+     */
+    private $childValue;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH8127Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH8127Root::class,
+            GH8127Middle::class,
+            GH8127Middle2::class,
+            GH8127Leaf::class
+        );
+    }
+
+    /**
+     * @dataProvider queryClasses
+     */
+    public function testLoadFieldsFromAllClassesInHierarchy(string $queryClass): void
+    {
+        $entity          = new GH8127Leaf();
+        $entity->root    = 'root';
+        $entity->middle  = 'middle';
+        $entity->middle2 = 'middle2';
+        $entity->leaf    = 'leaf';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $loadedEntity = $this->_em->find(GH8127Root::class, $entity->id);
+
+        self::assertSame('root', $loadedEntity->root);
+        self::assertSame('middle', $loadedEntity->middle);
+        self::assertSame('middle2', $loadedEntity->middle2);
+        self::assertSame('leaf', $loadedEntity->leaf);
+    }
+
+    public function queryClasses(): array
+    {
+        return [
+            'query via root entity' => [GH8127Root::class],
+            'query via leaf entity' => [GH8127Leaf::class],
+        ];
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({ "leaf": "GH8127Leaf" })
+ */
+abstract class GH8127Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $root;
+}
+
+/**
+ * @ORM\Entity
+ */
+abstract class GH8127Middle extends GH8127Root
+{
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $middle;
+}
+
+/**
+ * @ORM\Entity
+ */
+abstract class GH8127Middle2 extends GH8127Middle
+{
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $middle2;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8127Leaf extends GH8127Middle2
+{
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $leaf;
+}


### PR DESCRIPTION
This PR suggests that for inheritance hierarchies, `abstract` `@Entity` classes shall be identified automatically, so that they do not have to be declared by users in their `@DiscriminatorMap` configuration.

#### Background

For entities and mapped superclasses that are part of an STI or JTI inheritance hierarchy, `ClassMetadata::$subClasses` contains a list of all entities that are a subclass of the current class. This field is of crucial importance since it is used to enumerate all entity classes and thus tables that need to be dealt with when loading or persisting data, creating the schema etc.

When this list is incomplete, possibly subtle or weird bugs like #9145 or #8127 may occur.

It is not possible in PHP to obtain a list of all existing subclasses for a given class. Also, our mapping drivers cannot provide that list, at least not in a general way and at acceptable cost. For that reason, the discriminator map (DM) at the root entity is used to "discover" all the entity (sub)classes that may need to be persisted in an inheritance tree.

#### Situation before/without this PR

Runtime validation of the discriminator map allows `abstract` `@Entity` classes to be omitted from it. Also, the error message given when a class missing from the DM is detected refers to `abstract` as an alternative:

https://github.com/doctrine/orm/blob/c5e4e41e0517887b7ce5ffd2d825f9c337bc5cd4/lib/Doctrine/ORM/Mapping/MappingException.php#L761-L768

From the users point of view, there is no point in listing abstract entity classes and assigning a discriminator value for them, when no such entities can be created and persisted in practice. When defining the mapping, the primary concern is to specify discriminator values for the entity classes being used, not to declare a full class hierarchy.

I suspect there may be other bugs lurking in the context of the feature from #1257, where an event listener was added to re-map interfaces to classes in the DM at runtime. When the entity class provided at runtime inherits from another abstract entity, this feature falls short as this extra class cannot be provided.

#### Suggested change

After `ClassMetadata` has been loaded for the root entity class in a STI/JTI hierarchy, fill in missing `subClasses` automatically. 

This does not amend, change or autogenerate the DM in any way. It only takes the entity classes given in the DM as starting pointers, works upwards through the class hierarchy from there on and identifies and adds `abstract` `@Entity` classes to the `subClasses` field.

#### Implementation remarks

There's a challenge since we need to identify all classes that are `abstract` and `@Entity` (especially not `@MappedSuperclass`). That would be easy if we had all the class metadata already loaded.

However, metadata loading happens through `doctrine/persistence` and goes from root classes towards child classes. So, we will always need to process "higher up" classes first and do not have child class mapping information available at that time.

It also seems unsafe to update parent class metadata at a later time when child class information has been loaded, given that the `ClassMetadata` is distributed with the `loadClassMetadata` event and is put into the metadata cache.

So, my choice was to put the initialization at the end of `doLoadMetadata`: That way, we can run it at the end of loading metadata for the root entity. 

* No need to update/"fixup" the root entity metadata later on
* Child classes can inherit the `subClass` field data, keeping only the classes relevant for them (→ we need just one "discovery" run for the root class)

The initialization happens _after_ the `loadClassMetadata` event (at the risk of having a possibly incomplete subclass list at the time it is run), to allow the mechanism from #1257 to kick in and provide classes _before_ we do the resolution.

Since we need to exclude mapped superclasses from the `subClass` list, I saw no other option than to make the driver do an extra load request. This, however, only has to happen for classes that we know are `abstract` (remember, non-abstract ones must be specified in the DM), and the resulting information will be cached with the root entity's metadata.

The driver thing maybe can be improved if drivers get a "shortcut" method to identify mapped superclasses, without doing all the other extra loading. Might be possible to add this through an add-on interface implemented by drivers.

#### Tests

For a start, this PR includes test cases that demonstrate #6558, #9145 and #8127 would be fixed _without_ having to provide complete (including `abstract` entities) DMs.

Ideas for other reasonable test cases are welcome!

#### Related issues

Closes #10389, closes #10387, closes #10388, fixes #8127, includes #9145, includes #6578, fixes #6558.

A follow-up fix for an edge case is in #10557.

A warning is given in [this comment](https://github.com/doctrine/orm/issues/10552#issuecomment-1451606300) that there may still be issues when event listeners are used to provide or change mapping information, which is currently not supported in the new `peekIfIsMappedSuperclass()` method.