### PR TITLE
Remove concrete table inheritance

### DIFF
--- a/docs/en/reference/php-mapping.rst
+++ b/docs/en/reference/php-mapping.rst
@@ -194,7 +194,6 @@ Inheritance Getters
 -  ``isInheritanceTypeNone()``
 -  ``isInheritanceTypeJoined()``
 -  ``isInheritanceTypeSingleTable()``
--  ``isInheritanceTypeTablePerClass()``
 -  ``isInheritedField($fieldName)``
 -  ``isInheritedAssociation($fieldName)``
 

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -206,7 +206,6 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="SINGLE_TABLE"/>
       <xs:enumeration value="JOINED"/>
-      <xs:enumeration value="TABLE_PER_CLASS"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -164,12 +164,6 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      */
     public const INHERITANCE_TYPE_SINGLE_TABLE = 3;
 
-    /**
-     * TABLE_PER_CLASS means the class will be persisted according to the rules
-     * of <tt>Concrete Table Inheritance</tt>.
-     */
-    public const INHERITANCE_TYPE_TABLE_PER_CLASS = 4;
-
     /* The Id generator types. */
     /**
      * AUTO means the generator type will depend on what the used platform prefers.
@@ -1989,17 +1983,6 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     }
 
     /**
-     * Checks whether the mapped class uses the TABLE_PER_CLASS inheritance mapping strategy.
-     *
-     * @return bool TRUE if the class participates in a TABLE_PER_CLASS inheritance mapping,
-     * FALSE otherwise.
-     */
-    public function isInheritanceTypeTablePerClass(): bool
-    {
-        return $this->inheritanceType === self::INHERITANCE_TYPE_TABLE_PER_CLASS;
-    }
-
-    /**
      * Checks whether the class uses an identity column for the Id generation.
      */
     public function isIdGeneratorIdentity(): bool
@@ -2309,8 +2292,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     {
         return $type === self::INHERITANCE_TYPE_NONE ||
                 $type === self::INHERITANCE_TYPE_SINGLE_TABLE ||
-                $type === self::INHERITANCE_TYPE_JOINED ||
-                $type === self::INHERITANCE_TYPE_TABLE_PER_CLASS;
+                $type === self::INHERITANCE_TYPE_JOINED;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -9,7 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class InheritanceType implements MappingAttribute
 {
-    /** @psalm-param 'NONE'|'JOINED'|'SINGLE_TABLE'|'TABLE_PER_CLASS' $value */
+    /** @psalm-param 'NONE'|'JOINED'|'SINGLE_TABLE' $value */
     public function __construct(
         public readonly string $value,
     ) {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -283,8 +283,6 @@ class SchemaTool
                         $table->setPrimaryKey($pkColumns);
                     }
                 }
-            } elseif ($class->isInheritanceTypeTablePerClass()) {
-                throw NotSupported::create();
             } else {
                 $this->gatherColumns($class, $table);
                 $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);


### PR DESCRIPTION
This seems to be a leftover from early days, but never actually implemented or documented.

#10423 adds the deprecation notices in 2.14.

Closes #7371, references #10217, closes #10220.