### PR TITLE
Use correct type for FieldMapping#unique

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -82,7 +82,7 @@ use const PHP_VERSION_ID;
  *      columnDefinition?: string,
  *      precision?: int,
  *      scale?: int,
- *      unique?: string,
+ *      unique?: bool,
  *      inherited?: class-string,
  *      originalClass?: class-string,
  *      originalField?: string,
@@ -536,7 +536,7 @@ class ClassMetadataInfo implements ClassMetadata
      * - <b>scale</b> (integer, optional, schema-only)
      * The scale of a decimal column. Only valid if the column type is decimal.
      *
-     * - <b>'unique'</b> (string, optional, schema-only)
+     * - <b>'unique'</b> (boolean, optional, schema-only)
      * Whether a unique constraint should be generated for the column.
      *
      * - <b>'inherited'</b> (string, optional)


### PR DESCRIPTION
Looking at usages in the codebase, it is supposed to be at least `bool|string`, but not `string`.
When dumping the value inside `getFieldMapping`, it is always a boolean.