### PR TITLE
Fix #9095 by re-applying #9096

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -253,7 +253,12 @@ class SchemaValidator
             }
         }
 
-        if (! $class->isInheritanceTypeNone() && ! $class->isRootEntity() && ! $class->isMappedSuperclass && array_search($class->name, $class->discriminatorMap, true) === false) {
+        if (
+            ! $class->isInheritanceTypeNone()
+            && ! $class->isRootEntity()
+            && ! $class->isMappedSuperclass
+            && array_search($class->name, $class->discriminatorMap, true) === false
+        ) {
             $ce[] = "Entity class '" . $class->name . "' is part of inheritance hierarchy, but is " .
                 "not mapped in the root entity '" . $class->rootEntityName . "' discriminator map. " .
                 'All subclasses must be listed in the discriminator map.';

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -256,6 +256,7 @@ class SchemaValidator
         if (
             ! $class->isInheritanceTypeNone()
             && ! $class->isRootEntity()
+            && ($class->reflClass !== null && ! $class->reflClass->isAbstract())
             && ! $class->isMappedSuperclass
             && array_search($class->name, $class->discriminatorMap, true) === false
         ) {

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -221,6 +221,14 @@ class SchemaValidatorTest extends OrmTestCase
 
         $this->assertEquals([], $ce);
     }
+
+    public function testAbstractChildClassNotPresentInDiscriminator(): void
+    {
+        $class1 = $this->em->getClassMetadata(Issue9095AbstractChild::class);
+        $ce     = $this->validator->validateClass($class1);
+
+        self::assertEmpty($ce);
+    }
 }
 
 /** @MappedSuperclass */
@@ -642,4 +650,29 @@ class EmbeddableWithAssociation
      * @OneToOne(targetEntity="Doctrine\Tests\Models\ECommerce\ECommerceCart")
      */
     private $cart;
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({"child" = Issue9095Child::class})
+ */
+abstract class Issue9095Parent
+{
+    /**
+     * @var mixed
+     * @Id
+     * @Column
+     */
+    protected $key;
+}
+
+/** @Entity */
+abstract class Issue9095AbstractChild extends Issue9095Parent
+{
+}
+
+/** @Entity */
+class Issue9095Child extends Issue9095AbstractChild
+{
 }


### PR DESCRIPTION
Since #10411 has been merged, no more need to specify all intermediate abstract entity classes.

Thus, we can relax the schema validator check as requested in #9095. The reasons given in #9142 to keep it no longer apply.

Fixes #9095.
