### PR TITLE
Add deprecations for "table per class" inheritance

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.14
 
+## Deprecated stubs for "concrete table inheritance"
+
+This third way of mapping class inheritance was never implemented. Code stubs are
+now deprecated and will be removed in 3.0.
+
+* `\Doctrine\ORM\Mapping\ClassMetadataInfo::INHERITANCE_TYPE_TABLE_PER_CLASS` constant
+* `\Doctrine\ORM\Mapping\ClassMetadataInfo::isInheritanceTypeTablePerClass()` method
+* Using `TABLE_PER_CLASS` as the value for the `InheritanceType` attribute or annotation
+  or in XML configuration files.
+
 ## Deprecated `Doctrine\ORM\Persisters\Exception\UnrecognizedField::byName($field)` method.
 
 Use `Doctrine\ORM\Persisters\Exception\UnrecognizedField::byFullyQualifiedName($className, $field)` instead.

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -172,6 +172,8 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * TABLE_PER_CLASS means the class will be persisted according to the rules
      * of <tt>Concrete Table Inheritance</tt>.
+     *
+     * @deprecated
      */
     public const INHERITANCE_TYPE_TABLE_PER_CLASS = 4;
 
@@ -2377,11 +2379,19 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Checks whether the mapped class uses the TABLE_PER_CLASS inheritance mapping strategy.
      *
+     * @deprecated
+     *
      * @return bool TRUE if the class participates in a TABLE_PER_CLASS inheritance mapping,
      * FALSE otherwise.
      */
     public function isInheritanceTypeTablePerClass()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10414/',
+            'Concrete table inheritance has never been implemented, and its stubs will be removed in Doctrine ORM 3.0 with no replacement'
+        );
+
         return $this->inheritanceType === self::INHERITANCE_TYPE_TABLE_PER_CLASS;
     }
 
@@ -2798,6 +2808,14 @@ class ClassMetadataInfo implements ClassMetadata
      */
     private function isInheritanceType(int $type): bool
     {
+        if ($type === self::INHERITANCE_TYPE_TABLE_PER_CLASS) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10414/',
+                'Concrete table inheritance has never been implemented, and its stubs will be removed in Doctrine ORM 3.0 with no replacement'
+            );
+        }
+
         return $type === self::INHERITANCE_TYPE_NONE ||
                 $type === self::INHERITANCE_TYPE_SINGLE_TABLE ||
                 $type === self::INHERITANCE_TYPE_JOINED ||

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * @Annotation
@@ -28,6 +29,14 @@ final class InheritanceType implements MappingAttribute
     /** @psalm-param 'NONE'|'JOINED'|'SINGLE_TABLE'|'TABLE_PER_CLASS' $value */
     public function __construct(string $value)
     {
+        if ($value === 'TABLE_PER_CLASS') {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10414/',
+                'Concrete table inheritance has never been implemented, and its stubs will be removed in Doctrine ORM 3.0 with no replacement'
+            );
+        }
+
         $this->value = $value;
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -51,6 +51,10 @@
                 <file name="lib/Doctrine/ORM/Query/Parser.php"/>
                 <file name="lib/Doctrine/ORM/QueryBuilder.php"/>
                 <file name="lib/Doctrine/ORM/Tools/EntityGenerator.php"/>
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php" />
+                <file name="lib/Doctrine/ORM/Tools/EntityGenerator.php" />
+                <file name="lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php" />
+                <file name="lib/Doctrine/ORM/Tools/SchemaTool.php" />
             </errorLevel>
         </DeprecatedConstant>
         <DeprecatedInterface>
@@ -89,6 +93,7 @@
                 <referencedMethod name="Doctrine\ORM\ORMSetup::createDefaultAnnotationDriver"/>
                 <referencedMethod name="Doctrine\ORM\Query\SqlWalker::walkInExpression"/>
                 <referencedMethod name="Doctrine\ORM\Query\TreeWalkerAdapter::_getQueryComponents"/>
+                <referencedMethod name="Doctrine\ORM\Mapping\ClassMetadataInfo::isInheritanceTypeTablePerClass"/>
                 <file name="lib/Doctrine/ORM/Query/TreeWalkerChain.php"/>
             </errorLevel>
         </DeprecatedMethod>


### PR DESCRIPTION
This complements #10414.

I don't see how the `\Doctrine\ORM\Mapping\ClassMetadataInfo::INHERITANCE_TYPE_TABLE_PER_CLASS` constant could be deprecated by itself, but this covers all places where it might reasonably be passed in.