### PR TITLE
Slight docblock improvements for `CM::parentClasses`

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -394,7 +394,8 @@ class ClassMetadataInfo implements ClassMetadata
     public $isEmbeddedClass = false;
 
     /**
-     * READ-ONLY: The names of the parent classes (ancestors).
+     * READ-ONLY: The names of the parent <em>entity</em> classes (ancestors), starting with the
+     * nearest one and ending with the root entity class.
      *
      * @psalm-var list<class-string>
      */
@@ -2543,7 +2544,8 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
-     * Sets the parent class names.
+     * Sets the parent class names. Only <em>entity</em> classes may be given.
+     *
      * Assumes that the class names in the passed array are in the order:
      * directParent -> directParentParent -> directParentParentParent ... -> root.
      *


### PR DESCRIPTION
This explains a bit more precisely that `parentClasses` is about _entities_ only, and in what order to expect the classes to be listed.

I fear the trouble that comes with a full re-name to a more suitable name.