### PR TITLE
Make sure tests from #7837 are actually run

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -71,7 +71,8 @@ class GH7820Test extends OrmFunctionalTestCase
     {
         $query = $this->_em->getRepository(GH7820Line::class)
             ->createQueryBuilder('l')
-            ->orderBy('l.lineNumber', Criteria::ASC);
+            ->orderBy('l.lineNumber', Criteria::ASC)
+            ->setMaxResults(100);
 
         self::assertSame(
             self::SONG,
@@ -90,7 +91,8 @@ class GH7820Test extends OrmFunctionalTestCase
 
         $query = $this->_em->getRepository(GH7820Line::class)
             ->createQueryBuilder('l')
-            ->orderBy('l.lineNumber', Criteria::ASC);
+            ->orderBy('l.lineNumber', Criteria::ASC)
+            ->setMaxResults(100);
 
         self::assertSame(
             self::SONG,
@@ -102,7 +104,8 @@ class GH7820Test extends OrmFunctionalTestCase
 
         $query = $this->_em->getRepository(GH7820Line::class)
             ->createQueryBuilder('l')
-            ->orderBy('l.lineNumber', Criteria::ASC);
+            ->orderBy('l.lineNumber', Criteria::ASC)
+            ->setMaxResults(100);
 
         self::assertSame(
             self::SONG,


### PR DESCRIPTION
I noticed that when I remove this line

https://github.com/Ocramius/doctrine2/blob/98e557b68eeecd7f266f1e4628007aed2714026c/lib/Doctrine/ORM/Tools/Pagination/Paginator.php#L169

added in #7837 the corresponding tests still pass.

This is because the relevant branch in `\Doctrine\ORM\Tools\Pagination\Paginator::getIterator()` is not reached. A new necessary condition was added briefly afterwards in #7863, and that caused the tests to miss the relevant section.

With the change suggested here, removing the line will make the specific test fail again.

