### PR TITLE
Add `--check-sync` option to `UpdateCommand`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -19,4 +19,20 @@ class UpdateCommandTest extends CommandTestCase
 
         self::$sharedConn->executeStatement($tester->getDisplay());
     }
+
+    public function testCheckSyncExitCode(): void
+    {
+        $tester = $this->getCommandTester(UpdateCommand::class);
+        $tester->execute(
+            ['--check-sync' => true],
+            ['capture_stderr_separately' => true]
+        );
+
+        self::assertStringContainsString(
+            '[ERROR] The mapping metadata is not in sync with the current database schema',
+            $tester->getErrorOutput()
+        );
+
+        self::assertSame(1, $tester->getStatusCode());
+    }
 }


### PR DESCRIPTION
I need to check in a CI pipeline if my database schema is in sync with the mapping metadata.
Currently, I can't achieve this in a simpler way without checking the output.