### PR TITLE
Use the right property

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -77,8 +77,8 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
     public function testLazyLoadsObjectsOnTheOwningSide(): void
     {
         $this->createFixture();
-        $metadata                                               = $this->_em->getClassMetadata(ECommerceCart::class);
-        $metadata->associationMappings['customer']['fetchMode'] = ClassMetadata::FETCH_LAZY;
+        $metadata                                           = $this->_em->getClassMetadata(ECommerceCart::class);
+        $metadata->associationMappings['customer']['fetch'] = ClassMetadata::FETCH_LAZY;
 
         $query  = $this->_em->createQuery('select c from Doctrine\Tests\Models\ECommerce\ECommerceCart c');
         $result = $query->getResult();


### PR DESCRIPTION
association mappings do not have a `fetchMode` property, they have a `fetch` property.

Found while working on https://github.com/doctrine/orm/pull/10405