### PR TITLE
Add embedded class mapping array shape

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -47,6 +47,9 @@ use function substr;
  * to a relational database.
  *
  * @extends AbstractClassMetadataFactory<ClassMetadata>
+ * @psalm-import-type AssociationMapping from ClassMetadataInfo
+ * @psalm-import-type EmbeddedClassMapping from ClassMetadataInfo
+ * @psalm-import-type FieldMapping from ClassMetadataInfo
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {
@@ -148,10 +151,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             foreach ($class->embeddedClasses as $property => $embeddableClass) {
                 if (isset($embeddableClass['inherited'])) {
                     continue;
-                }
-
-                if (! (isset($embeddableClass['class']) && $embeddableClass['class'])) {
-                    throw MappingException::missingEmbeddedClass($property);
                 }
 
                 if (isset($this->embeddablesActiveNesting[$embeddableClass['class']])) {
@@ -415,7 +414,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * Puts the `inherited` and `declared` values into mapping information for fields, associations
      * and embedded classes.
      *
-     * @param mixed[] $mapping
+     * @param AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping
      */
     private function addMappingInheritanceInformation(array &$mapping, ClassMetadata $parentClass): void
     {

--- a/psalm.xml
+++ b/psalm.xml
@@ -121,6 +121,18 @@
                 <referencedFunction name="Doctrine\ORM\Mapping\ClassMetadata::addInheritedAssociationMapping"/>
             </errorLevel>
         </InvalidArgument>
+        <InvalidArrayAccess>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/9160 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            </errorLevel>
+        </InvalidArrayAccess>
+        <InvalidArrayAssignment>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/9160 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            </errorLevel>
+        </InvalidArrayAssignment>
         <InvalidClass>
             <errorLevel type="suppress">
                 <!-- Class name changes in DBAL 3. -->
@@ -133,6 +145,12 @@
                 <file name="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php"/>
             </errorLevel>
         </InvalidParamDefault>
+        <InvalidPropertyAssignmentValue>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/9155 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            </errorLevel>
+        </InvalidPropertyAssignmentValue>
         <MethodSignatureMismatch>
             <errorLevel type="suppress">
                 <!-- See https://github.com/vimeo/psalm/issues/7357 -->
@@ -162,6 +180,12 @@
                 <file name="lib/Doctrine/ORM/Query/AST/InSubselectExpression.php"/>
             </errorLevel>
         </NonInvariantDocblockPropertyType>
+        <PossiblyInvalidArgument>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/9155 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            </errorLevel>
+        </PossiblyInvalidArgument>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <!-- Remove on 3.0.x -->
@@ -171,6 +195,11 @@
                 <directory name="lib/Doctrine/ORM/Query/AST" />
             </errorLevel>
         </PropertyNotSetInConstructor>
+        <PropertyTypeCoercion>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
+            </errorLevel>
+        </PropertyTypeCoercion>
         <RedundantCastGivenDocblockType>
             <errorLevel type="suppress">
                 <!-- Can be removed once the "getMaxResults" methods of those classes have native parameter types -->
@@ -184,6 +213,12 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
             </errorLevel>
         </RedundantCondition>
+        <ReferenceConstraintViolation>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/9155 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
+            </errorLevel>
+        </ReferenceConstraintViolation>
         <TooManyArguments>
             <errorLevel type="suppress">
                 <!-- Symfony cache supports passing a key prefix to the clear method. -->

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -464,29 +464,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertSame($entityManager, $property->getValue($classMetadataFactory));
     }
 
-    /** @group DDC-3305 */
-    public function testRejectsEmbeddableWithoutValidClassName(): void
-    {
-        $metadata = $this->createValidClassMetadata();
-
-        $metadata->mapEmbedded(
-            [
-                'fieldName'    => 'embedded',
-                'class'        => '',
-                'columnPrefix' => false,
-            ]
-        );
-
-        $cmf = $this->createTestFactory();
-
-        $cmf->setMetadataForClass($metadata->name, $metadata);
-
-        $this->expectException(MappingException::class);
-        $this->expectExceptionMessage('The embed mapping \'embedded\' misses the \'class\' attribute.');
-
-        $cmf->getMetadataFor($metadata->name);
-    }
-
     /** @group DDC-4006 */
     public function testInheritsIdGeneratorMappingFromEmbeddable(): void
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1339,6 +1339,20 @@ class ClassMetadataTest extends OrmTestCase
 
         self::assertTrue($classMetadata->hasField('test'));
     }
+
+    /** @group DDC-3305 */
+    public function testRejectsEmbeddableWithoutValidClassName(): void
+    {
+        $metadata = new ClassMetadata(TestEntity1::class);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The embed mapping \'embedded\' misses the \'class\' attribute.');
+        $metadata->mapEmbedded([
+            'fieldName'    => 'embedded',
+            'class'        => '',
+            'columnPrefix' => false,
+        ]);
+    }
 }
 
 /** @MappedSuperclass */


### PR DESCRIPTION
This should be replaced with a DTO in the next major. To be able to have something usable, I had to move the validation of the DTO (checking that it has a "class" attribute) to mapEmbedded, which happens earlier than doLoadMetadata(). It is unclear to me why it was not put here in the first place in https://github.com/doctrine/orm/pull/1133


Cc @mpdude 