### PR TITLE
Replace hardcoded name with `Command::getName()` in output message from `UpdateCommand`

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -79,7 +79,10 @@ EOT
         $saveMode = ! $input->getOption('complete');
 
         if ($saveMode) {
-            $notificationUi->warning('Not passing the "--complete" option to "orm:schema-tool:update" is deprecated and will not be supported when using doctrine/dbal 4');
+            $notificationUi->warning(sprintf(
+                'Not passing the "--complete" option to "%s" is deprecated and will not be supported when using doctrine/dbal 4',
+                $this->getName() ?? $this->name
+            ));
         }
 
         $sqls = $schemaTool->getUpdateSchemaSql($metadatas, $saveMode);

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CommandTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/CommandTestCase.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 abstract class CommandTestCase extends OrmFunctionalTestCase
 {
     /** @param class-string<AbstractCommand> $commandClass */
-    protected function getCommandTester(string $commandClass): CommandTester
+    protected function getCommandTester(string $commandClass, ?string $commandName = null): CommandTester
     {
         $entityManager = $this->getEntityManager(null, ORMSetup::createDefaultAnnotationDriver([
             __DIR__ . '/Models',
@@ -24,8 +24,14 @@ abstract class CommandTestCase extends OrmFunctionalTestCase
             self::markTestSkipped('We are testing the symfony/console integration');
         }
 
-        return new CommandTester(new $commandClass(
+        $command = new $commandClass(
             new SingleManagerProvider($entityManager)
-        ));
+        );
+
+        if ($commandName !== null) {
+            $command->setName($commandName);
+        }
+
+        return new CommandTester($command);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -19,4 +19,31 @@ class UpdateCommandTest extends CommandTestCase
 
         self::$sharedConn->executeStatement($tester->getDisplay());
     }
+
+    /**
+     * @dataProvider getCasesForWarningMessageFromCompleteOption
+     */
+    public function testWarningMessageFromCompleteOption(?string $name, string $expectedMessage): void
+    {
+        $tester = $this->getCommandTester(UpdateCommand::class, $name);
+        $tester->execute(
+            [],
+            ['capture_stderr_separately' => true]
+        );
+
+        self::assertStringContainsString($expectedMessage, $tester->getErrorOutput());
+    }
+
+    public function getCasesForWarningMessageFromCompleteOption(): iterable
+    {
+        yield 'default_name' => [
+            null,
+            '[WARNING] Not passing the "--complete" option to "orm:schema-tool:update" is deprecated',
+        ];
+
+        yield 'custom_name' => [
+            'doctrine:schema:update',
+            '[WARNING] Not passing the "--complete" option to "doctrine:schema:update" is deprecated',
+        ];
+    }
 }


### PR DESCRIPTION
By instance, "doctrine/doctrine-bundle" defines the name [`doctrine:schema:update`](https://github.com/doctrine/DoctrineBundle/blob/cd7847f52373bb33892e8e505a717c0e44f0f270/Resources/config/orm.xml#L244-L247) for this command, but the hardcoded value here generates a misleading message.
```
$ bin/console doctrine:schema:update --dump-sql

                                                                                                                        
 [WARNING] Not passing the "--complete" option to "orm:schema-tool:update" is deprecated and will not be supported when 
           using doctrine/dbal 4                                                                                        
                                                                                                                        

                                                                                                                        
 [OK] Nothing to update - your database is already in sync with the current entity metadata.                            
```