### PR TITLE
Failing test: Illegal to-many association on MappedSuperclass not rejected

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10449Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10449Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Tests\OrmTestCase;
+
+use function get_parent_class;
+use function method_exists;
+
+class GH10449Test extends OrmTestCase
+{
+    public function testToManyAssociationOnMappedSuperclassShallBeRejected(): void
+    {
+        $em      = $this->getTestEntityManager();
+        $classes = [GH10449MappedSuperclass::class, GH10449Entity::class, GH10449ToManyAssociationTarget::class];
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessageMatches('/illegal to put an inverse side one-to-many or many-to-many association on mapped superclass/');
+
+        foreach ($classes as $class) {
+            $cm = $em->getClassMetadata($class);
+        }
+    }
+
+    /**
+     * Override for BC with PHPUnit <8
+     */
+    public function expectExceptionMessageMatches(string $regularExpression): void
+    {
+        if (method_exists(get_parent_class($this), 'expectExceptionMessageMatches')) {
+            parent::expectExceptionMessageMatches($regularExpression);
+        } else {
+            parent::expectExceptionMessageRegExp($regularExpression);
+        }
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10449ToManyAssociationTarget
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH10449MappedSuperclass", inversedBy="targets")
+     *
+     * @var GH10449MappedSuperclass
+     */
+    public $base;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH10449MappedSuperclass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH10449ToManyAssociationTarget", mappedBy="base")
+     *
+     * @var Collection
+     */
+    public $targets;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10449Entity extends GH10449MappedSuperclass
+{
+}


### PR DESCRIPTION
**Closing** since this is no longer an error condition we need to check for.

#10473 relaxed the runtime check that mapped superclasses must not use one-to-many associations. It turned the check the other way round, so that no mapped superclass may be used as the targetEntity of an association. (In addition, #10554 also made it a "lazy" (non-runtime) check in the schema validator.)

<hr>

This test case demonstrates a situation where an invalid to-many association on a mapped superclass is not being detected.

Since at least the annotations and attribute drivers currently skip non-private properties from mapped superclasses (see #10417), the `ClassMetadataFactory` is not even aware of the association on the mapped superclass and so cannot reject it.

IMHO, we should bail out as soon as we detect this on the mapped superclass. I don't see how we could proceed at that time and try to rescue/fixup the situation afterwards.

In addition to that, maybe an association with a `target` that is a mapped superclass should be rejected in its own right?

More details on what happens down the road, just for the sake of completeness:

When the mapping driver processes the entity class with the inherited association, PHP reflection will report the association property. Since the association was not reported for the mapped superclass, the driver thinks (see #10417) this is a "new" (non-inherited) field and reports to the `ClassMetadataFactory`.

The association will show up as being from `GH10449Entity` to `GH10449ToManyAssociationTarget`. On `GH10449ToManyAssociationTarget`, it will refer back to `GH10449MappedSuperclass`.