### PR TITLE
Failing test: Duplicate private fields not detected

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10450Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10450Test.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Tests\OrmTestCase;
+use Generator;
+
+class GH10450Test extends OrmTestCase
+{
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider classesThatOverrideFieldNames
+     */
+    public function testDuplicatePrivateFieldsShallBeRejected(string $className): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $this->expectException(MappingException::class);
+
+        $em->getClassMetadata($className);
+    }
+
+    public function classesThatOverrideFieldNames(): Generator
+    {
+        yield 'Entity class that redeclares a private field inherited from a base entity' => [GH10450EntityChild::class];
+        yield 'Entity class that redeclares a private field inherited from a mapped superclass' => [GH10450MappedSuperclassChild::class];
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({ "base": "GH10450BaseEntity", "child": "GH10450EntityChild" })
+ * @ORM\DiscriminatorColumn(name="type")
+ */
+class GH10450BaseEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="text", name="base")
+     *
+     * @var string
+     */
+    private $field;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10450EntityChild extends GH10450BaseEntity
+{
+    /**
+     * @ORM\Column(type="text", name="child")
+     *
+     * @var string
+     */
+    private $field;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH10450BaseMappedSuperclass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="text", name="base")
+     *
+     * @var string
+     */
+    private $field;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10450MappedSuperclassChild extends GH10450BaseMappedSuperclass
+{
+    /**
+     * @ORM\Column(type="text", name="child")
+     *
+     * @var string
+     */
+    private $field;
+}


### PR DESCRIPTION
This has been merged through #10455.

<hr>

This test case demonstrates two situations where an entity inherits from another entity or a mapped superclass. Both (parent and child) classes have a private property named `field`.

Technically, that's two properties on two separate classes. Also, the mapping configuration given suggests to put both properties into separate database columns.

However, the ORM was not designed to make this distinction. For example, `ClassMetadata::$fieldMappings` is indexed by "field name" – there is no room for juggling with duplicate private fields being declared in different classes. This design limitation that would be very hard to change, should be documented as a limitation and be rejected when it is noticed. The same applies to association mappings and embeddables.

Due to a quirk in the way the annotation and attribute drivers report fields (see #10417), the property will be skipped on the subclass. So, the property and mapping configuration will be picked up from the first (parent) class, and mapping configuration for `GH10450ChildClass::$field` will never be considered. The property will silently remain unmapped.