### PR TITLE
Add regression test for a to-many relationship on a base class & mapped superclass in the hierarchy

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9516Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9516Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH9516Test extends OrmFunctionalTestCase
+{
+    public function testEntityCanHaveInverseOneToManyAssociationWithChildMappedSuperclass(): void
+    {
+        $sportsCarMetadata = $this->_em->getClassMetadata(GH9516SportsCar::class);
+        $this->assertTrue($sportsCarMetadata->hasAssociation('passengers'));
+    }
+}
+
+/** @Entity */
+class GH9516Passenger
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @var int $id
+     */
+    private $id;
+
+    /**
+     * @ManyToOne(targetEntity="GH9516Vehicle", inversedBy="passengers")
+     * @var GH9516Vehicle $vehicle
+     */
+    private $vehicle;
+}
+
+/**
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({ "sports" = "\Doctrine\Tests\ORM\Functional\Ticket\GH9516SportsCar" })
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ *
+ * @Entity
+ */
+abstract class GH9516Vehicle
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @var int $id
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="GH9516Passenger", mappedBy="vehicle")
+     * @var GH9516Passenger[] $passengers
+     */
+    private $passengers;
+}
+
+/**
+ * @MappedSuperclass
+ */
+abstract class GH9516Car extends GH9516Vehicle
+{
+}
+
+/**
+ * @Entity
+ */
+class GH9516SportsCar extends GH9516Car
+{
+}


### PR DESCRIPTION
This picks the test case from #9517 and rebases it onto 2.14.x.

The problem has been covered in #8415, so this PR closes #9517 and fixes #9516.

Co-authored-by: Robert D'Ercole <bobdercole@gmail.com>
