### PR TITLE
Failing test: Re-configured protected property not rejected

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10454Test.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Tests\OrmTestCase;
+use Generator;
+
+class GH10454Test extends OrmTestCase
+{
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider classesThatOverrideFieldNames
+     */
+    public function testProtectedPropertyMustNotBeInheritedAndReconfigured(string $className): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessageMatches('/Property "field" .* was already declared, but it must be declared only once/');
+
+        $em->getClassMetadata($className);
+    }
+
+    public function classesThatOverrideFieldNames(): Generator
+    {
+        yield 'Entity class that redeclares a protected field inherited from a base entity' => [GH10454EntityChildProtected::class];
+        yield 'Entity class that redeclares a protected field inherited from a mapped superclass' => [GH10454MappedSuperclassChildProtected::class];
+    }
+
+    /**
+     * Override for BC with PHPUnit <8
+     */
+    public function expectExceptionMessageMatches(string $regularExpression): void
+    {
+        if (method_exists(get_parent_class($this), 'expectExceptionMessageMatches')) {
+            parent::expectExceptionMessageMatches($regularExpression);
+        } else {
+            parent::expectExceptionMessageRegExp($regularExpression);
+        }
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({ "base": "GH10454BaseEntityProtected", "child": "GH10454EntityChildProtected" })
+ * @ORM\DiscriminatorColumn(name="type")
+ */
+class GH10454BaseEntityProtected
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="text", name="base")
+     *
+     * @var string
+     */
+    protected $field;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10454EntityChildProtected extends GH10454BaseEntityProtected
+{
+    /**
+     * @ORM\Column(type="text", name="child")
+     *
+     * @var string
+     */
+    protected $field;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH10454BaseMappedSuperclassProtected
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="text", name="base")
+     *
+     * @var string
+     */
+    protected $field;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10454MappedSuperclassChildProtected extends GH10454BaseMappedSuperclassProtected
+{
+    /**
+     * @ORM\Column(type="text", name="child")
+     *
+     * @var string
+     */
+    protected $field;
+}


### PR DESCRIPTION
This has been merged through #10455.

<hr>

This test case demonstrates two situations where an entity inherits from another entity or a mapped superclass. Both (parent and child) classes have a protected property named `field`. In other words, the child class overwrites the property and re-configures the mapping information.

The `ClassMetadataFactory` and other components were not designed to work with such a configuration. Just imagine a situation where an entity base class configures this field on one way, and a subclass in different way – let's say the subclass uses another `name` for the database column. How should the ORM work with this configuration when using STI or JTI, when querying entities through the root or a leaf class?

The exception rejecting this kind of configuration has been present since the early days:

https://github.com/doctrine/orm/blame/70477d81e96c0044ad6fd8c13c37b2270d082792/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2724

However, due to quirks in the mapping drivers (see #10417), the duplicated field was never reported to the `ClassMetadataFactory`, and due to a missing test case for the mis-configuration, this was never noticed.