### PR TITLE
fix: Fixes LengthException when persisting versioned entity using class table inheritance

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -167,10 +167,6 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
             }
 
-            if ($this->class->requiresFetchAfterChange) {
-                $this->assignDefaultVersionAndUpsertableValues($entity, $id);
-            }
-
             // Execute inserts on subtables.
             // The order doesn't matter because all child tables link to the root table via FK.
             foreach ($subTableStmts as $tableName => $stmt) {
@@ -190,6 +186,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 }
 
                 $stmt->executeStatement();
+            }
+            
+            if ($this->class->requiresFetchAfterChange) {
+                $this->assignDefaultVersionAndUpsertableValues($entity, $id);
             }
         }
 

--- a/tests/Doctrine/Tests/Models/GH9378/GH9378Employee.php
+++ b/tests/Doctrine/Tests/Models/GH9378/GH9378Employee.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH9378;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="doctrine_employee")
+ */
+final class GH9378Employee extends GH9378Person
+{
+    /**
+     * @ORM\Column(type="string", length=64, nullable=false)
+     */
+    public string $employeeId = '';
+    
+    /**
+     * @ORM\Version()
+     * @ORM\Column(type="integer")
+     */
+    private int $version;
+}

--- a/tests/Doctrine/Tests/Models/GH9378/GH9378Person.php
+++ b/tests/Doctrine/Tests/Models/GH9378/GH9378Person.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH9378;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(
+ *      name="doctrine_person",
+ * )
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ * 		"employee" = "Doctrine\Tests\Models\GH9378\GH9378Employee",
+ * })
+ */
+abstract class GH9378Person
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=64, nullable=false)
+     */
+    public string $firstName = '';
+
+    /**
+     * @ORM\Column(type="string", length=64, nullable=false)
+     */
+    public string $lastName = '';
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9378Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9378Test.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH9378\GH9378Employee;
+use Doctrine\Tests\Models\GH9378\GH9378Person;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @requires PHP 7.4
+ */
+final class GH9378Test extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH9378Employee::class,
+            GH9378Person::class,
+        );
+    }
+
+    public function testCanPersistVersionedEntityWithClassTableInheritance(): void
+    {
+        $firstName          = 'Max';
+        $lastName           = 'MusterMann';
+        $employeeId         = 'ABC123';
+        
+        $entity             = new GH9378Employee();
+        $entity->firstName  = $firstName;
+        $entity->lastName   = $lastName;
+        $entity->employeeId = $employeeId;
+
+        $this->_em->persist($entity);
+        
+        /*
+         * Wthout the fix in Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister
+         * the flush would cause a
+         * 
+         * "LengthException: Unexpected empty result for database query."
+         * 
+         * as fetching generated columns and version column will take place
+         * before the actual INSERT statement has been executed.
+         * 
+         * As we cannot test no exception, we simply test, that the entity's
+         * properties have been persisted as expected.
+         */
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(GH9378Employee::class, 1);
+
+        $this->assertSame($firstName, $entity->firstName);
+        $this->assertSame($lastName, $entity->lastName);
+        $this->assertSame($employeeId, $entity->employeeId);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9378Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9378Test.php
@@ -37,7 +37,7 @@ final class GH9378Test extends OrmFunctionalTestCase
         $this->_em->persist($entity);
         
         /*
-         * Wthout the fix in Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister
+         * Without the fix in Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister
          * the flush would cause a
          * 
          * "LengthException: Unexpected empty result for database query."


### PR DESCRIPTION
This is a fix for #9378 and a replacement for #9379.

Now there is a fix and a test case as well. I'm sorry that I took that long.