### PR TITLE
Make missing inheritance declaration a failure

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.0
 
+## BC BREAK: Undeclared entity inheritance now throws a `MappingException`
+
+As soon as an entity class inherits from another entity class, inheritance has to
+be declared by adding the appropriate configuration for the root entity.
+
 ## Removed `getEntityManager()` in `Doctrine\ORM\Event\OnClearEventArgs` and `Doctrine\ORM\Event\*FlushEventArgs`
 
 Use `getObjectManager()` instead.

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -137,13 +137,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         if (! $class->isMappedSuperclass) {
             if ($rootEntityFound && $class->isInheritanceTypeNone()) {
-                Deprecation::trigger(
-                    'doctrine/orm',
-                    'https://github.com/doctrine/orm/pull/10431',
-                    "Entity class '%s' is a subclass of the root entity class '%s', but no inheritance mapping type was declared. This is a misconfiguration and will be an error in Doctrine ORM 3.0.",
-                    $class->name,
-                    end($nonSuperclassParents),
-                );
+                throw MappingException::missingInheritanceTypeDeclaration(end($nonSuperclassParents), $class->name);
             }
 
             foreach ($class->embeddedClasses as $property => $embeddableClass) {

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -34,6 +34,7 @@ use Generator;
 
 use function assert;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 class BasicInheritanceMappingTest extends OrmTestCase
@@ -225,7 +226,12 @@ class BasicInheritanceMappingTest extends OrmTestCase
     /** @dataProvider invalidHierarchyDeclarationClasses */
     public function testUndeclaredHierarchyRejection(string $rootEntity, string $childClass): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10431');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(sprintf(
+            "Entity class '%s' is a subclass of the root entity class '%s', but no inheritance mapping type was declared.",
+            $childClass,
+            $rootEntity,
+        ));
 
         $this->cmf->getMetadataFor($childClass);
     }


### PR DESCRIPTION
This follows up on #10431: This kind of misconfiguration triggered a deprecation warning since 2.15.x. Now let's make it an exception.
