### PR TITLE
Fix some tests that were missed in #10431

### DIFF
--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
@@ -42,6 +42,8 @@ class DDC5934BaseContract
 
     public static function loadMetadata(ClassMetadata $metadata): void
     {
+        $metadata->isMappedSuperclass = true;
+
         $metadata->mapField([
             'id'         => true,
             'fieldName'  => 'id',

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 
+$metadata->isMappedSuperclass = true;
+
 $metadata->mapField([
     'id'         => true,
     'fieldName'  => 'id',

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.xml
@@ -4,12 +4,12 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Doctrine\Tests\Models\DDC5934\DDC5934BaseContract">
+    <mapped-superclass name="Doctrine\Tests\Models\DDC5934\DDC5934BaseContract">
         <id name="id" type="integer">
             <generator strategy="AUTO" />
         </id>
 
         <many-to-many target-entity="DDC5934Member" inversed-by="contract" fetch="LAZY" field="members" />
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
In #10431, some invalid inheritance declarations in our test base were fixed. However, the change missed to update XML, PHP and static PHP mapping configurations as well.

Apparently, this did not raise any flags because the misconfiguration only caused a deprecation notice in 2.15.x. Running the tests against 3.0 (where the misconfiguration will be an error) unveiled the mistake.

Reviewers: Compare to https://github.com/doctrine/orm/pull/10431/files#diff-3acd7a05f18efb0e3cb41d042f0699ff8f97ce91c3964f9ee588cb876304449b, this PR here does the same change for the other mapping types.