### PR TITLE
Remove commented-out code sections

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -156,8 +156,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $class->name,
                     end($nonSuperclassParents)
                 );
-                // enable this in 3.0
-                // throw MappingException::missingInheritanceTypeDeclaration(end($nonSuperclassParents), $class->name);
             }
 
             foreach ($class->embeddedClasses as $property => $embeddableClass) {

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -540,19 +540,6 @@ class MappingException extends ORMException
     }
 
     /**
-     * @param class-string $rootEntityClass
-     * @param class-string $childEntityClass
-     */
-    //public static function missingInheritanceTypeDeclaration(string $rootEntityClass, string $childEntityClass): self
-    //{
-    //    return new self(sprintf(
-    //        "Entity class '%s' is a subclass of the root entity class '%s', but no inheritance mapping type was declared.",
-    //        $childEntityClass,
-    //        $rootEntityClass
-    //    ));
-    //}
-
-    /**
      * @param string $className
      *
      * @return MappingException

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -230,15 +230,7 @@ class BasicInheritanceMappingTest extends OrmTestCase
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10431');
 
-        /* on 3.0, use this instead: */
-        // self::expectException(MappingException::class);
-        // self::expectExceptionMessage(\sprintf(
-        //     "Entity class '%s' is a subclass of the root entity class '%s', but no inheritance mapping type was declared.",
-        //     $childClass,
-        //     $rootEntity
-        // ));
-
-         $this->cmf->getMetadataFor($childClass);
+        $this->cmf->getMetadataFor($childClass);
     }
 
     public function invalidHierarchyDeclarationClasses(): Generator


### PR DESCRIPTION
This removes comments added in #10431 on the 2.15.x branch, as suggested in https://github.com/doctrine/orm/pull/10460#issuecomment-1404889903.
