### PR TITLE
Enabled lazy-loading for subclasses.

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -298,9 +298,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         self::assertInstanceOf(CompanyOrganization::class, $result[0]);
 
         $mainEvent = $result[0]->getMainEvent();
-        // mainEvent should have been loaded because it can't be lazy
         self::assertInstanceOf(CompanyAuction::class, $mainEvent);
-        self::assertNotInstanceOf(Proxy::class, $mainEvent);
+        self::assertInstanceOf(Proxy::class, $mainEvent);
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -417,6 +417,7 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
                               ->setParameter(1, $this->fix->getId())
                               ->getSingleResult();
 
-        self::assertNotInstanceOf(Proxy::class, $contract->getSalesPerson());
+        self::assertInstanceOf(Proxy::class, $contract->getSalesPerson());
+        self::assertTrue($contract->getSalesPerson()->__isInitialized());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -43,10 +43,8 @@ class DDC531Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $item3 = $this->_em->find(DDC531Item::class, $item2->id); // Load child item first (id 2)
-        // parent will already be loaded, cannot be lazy because it has mapped subclasses and we would not
-        // know which proxy type to put in.
         self::assertInstanceOf(DDC531Item::class, $item3->parent);
-        self::assertNotInstanceOf(Proxy::class, $item3->parent);
+        self::assertInstanceOf(Proxy::class, $item3->parent);
         $item4 = $this->_em->find(DDC531Item::class, $item1->id); // Load parent item (id 1)
         self::assertNull($item4->parent);
         self::assertNotNull($item4->getChildren());


### PR DESCRIPTION
This enables lazy-loading of classes that have subclasses by using 
the discriminator column to get the right subtype for the Proxy.

This also changes a few tests since lazy-loading subclasses 
would now be possible and fetched classes are expected to be 
an instance of the Proxy class.