### PR TITLE
Deprecate overriding fields/associations inherited from other entities

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 2.15
 
+## Deprecated overriding fields or associations not declared in mapped superclasses
+
+As stated in the documentation, fields and associations may only be overridden when being inherited
+from mapped superclasses. Overriding them for parent entity classes now triggers a deprecation notice
+and will be an error in 3.0.
+
 ## Deprecated undeclared entity inheritance
 
 As soon as an entity class inherits from another entity class, inheritance has to 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2693,10 +2693,17 @@ class ClassMetadataInfo implements ClassMetadata
 
         $mapping = $this->fieldMappings[$fieldName];
 
-        //if (isset($mapping['inherited'])) {
-            // TODO: Enable this exception in 2.8
+        if (isset($mapping['inherited'])) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10470',
+                'Overrides are only allowed for fields or associations declared in mapped superclasses or traits. This is not the case for %s::%s, which was inherited from %s. This is a misconfiguration and will be an error in Doctrine ORM 3.0.',
+                $this->name,
+                $fieldName,
+                $mapping['inherited']
+            );
             //throw MappingException::illegalOverrideOfInheritedProperty($this->name, $fieldName);
-        //}
+        }
 
         if (isset($mapping['id'])) {
             $overrideMapping['id'] = $mapping['id'];

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -908,8 +908,7 @@ class MappingException extends ORMException
     {
         return new self(
             sprintf(
-                'Override for %s::%s is only allowed for attributes/associations ' .
-                'declared on a mapped superclass or a trait.',
+                'Overrides are only allowed for fields or associations declared in mapped superclasses or traits, which is not the case for %s::%s.',
                 $className,
                 $propertyName
             )

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -25,6 +25,7 @@ use Doctrine\ORM\Mapping\SequenceGenerator;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\DDC869\DDC869ChequePayment;
 use Doctrine\Tests\Models\DDC869\DDC869CreditCardPayment;
 use Doctrine\Tests\Models\DDC869\DDC869Payment;
@@ -249,6 +250,16 @@ class BasicInheritanceMappingTest extends OrmTestCase
 
         yield 'complex example (Entity Root -> Mapped Superclass -> transient class -> Entity)'
             => [InvalidComplexRoot::class, InvalidComplexEntity::class];
+    }
+
+    /** @group DDC-964 */
+    public function testInvalidOverrideFieldInheritedFromEntity(): void
+    {
+        $cm = $this->cmf->getMetadataFor(CompanyFixContract::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10470');
+
+        $cm->setAttributeOverride('completed', ['name' => 'other_column_name']);
     }
 }
 


### PR DESCRIPTION
This was brought up in https://github.com/doctrine/orm/pull/8348, but seemingly forgotten to be implemented in later versions.

Exact reference:
https://github.com/doctrine/orm/pull/8348/files#diff-732e324167dd49e48b221477c3e0f6d7934f3eb5ec0970dbf1c06f6c7df15398R2261-R2264

Probably never really worked, because a subclass entity cannot have its fields mapped to other columns than the parent entity (just think about what that would mean for STI/JTI, for example).

Closes https://github.com/doctrine/orm/issues/10289.

**Update** #10519 adds the check for associations.