### PR TITLE
Allow to-many associations on mapped superclasses w/ ResolveTargetEntityListener

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -39,7 +39,7 @@ have to be used.
     to replace references to a mapped superclass with an entity class at runtime.
     As long as there is only one entity subclass inheriting from the mapped
     superclass and all references to the mapped superclass are resolved to that
-    entity class at runtime, the mapped superclass _can_ use One-To-Many associations
+    entity class at runtime, the mapped superclass *can* use One-To-Many associations
     and be named as the ``targetEntity`` on the owning sides.
 
 .. note::

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -15,22 +15,32 @@ is common to multiple entity classes.
 
 Mapped superclasses, just as regular, non-mapped classes, can
 appear in the middle of an otherwise mapped inheritance hierarchy
-(through Single Table Inheritance or Class Table Inheritance).
+(through Single Table Inheritance or Class Table Inheritance). They
+are not query-able, and need not have an ``#[Id]`` property.
 
 No database table will be created for a mapped superclass itself,
-only for entity classes inheriting from it. Also, a mapped superclass
-need not have an ``#[Id]`` property.
+only for entity classes inheriting from it. That  implies that a
+mapped superclass cannot be the ``targetEntity`` in associations.
+
+In other words, a mapped superclass can use unidirectional One-To-One
+and Many-To-One associations where it is the owning side.
+Many-To-Many associations are only possible if the mapped
+superclass is only used in exactly one entity at the moment. For further
+support of inheritance, the single or joined table inheritance features
+have to be used.
 
 .. note::
 
-    A mapped superclass cannot be an entity, it is not query-able and
-    persistent relationships defined by a mapped superclass must be
-    unidirectional (with an owning side only). This means that One-To-Many
-    associations are not possible on a mapped superclass at all.
-    Furthermore Many-To-Many associations are only possible if the
-    mapped superclass is only used in exactly one entity at the moment.
-    For further support of inheritance, the single or
-    joined table inheritance features have to be used.
+    One-To-Many associations are not generally possible on a mapped
+    superclass, since they require the "many" side to hold the foreign
+    key.
+
+    It is, however, possible to use the :doc:```ResolveTargetEntityListener`` <cookbook/resolve-target-entity-listener>`
+    to replace references to a mapped superclass with an entity class at runtime.
+    As long as there is only one entity subclass inheriting from the mapped
+    superclass and all references to the mapped superclass are resolved to that
+    entity class at runtime, the mapped superclass _can_ use One-To-Many associations
+    and be named as the ``targetEntity`` on the owning sides.
 
 .. note::
 

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -848,6 +848,15 @@ class MappingException extends ORMException
     }
 
     /**
+     * @param class-string $targetEntity
+     * @param class-string $sourceEntity
+     */
+    public static function associationTargetIsNotAnEntity(string $targetEntity, string $sourceEntity, string $associationName): self
+    {
+        return new self(sprintf('The target entity class %s specified for %s::$%s is not an entity class.', $targetEntity, $sourceEntity, $associationName));
+    }
+
+    /**
      * @param string[] $cascades
      * @param string   $className
      * @param string   $propertyName

--- a/tests/Doctrine/Tests/Models/Cache/Attraction.php
+++ b/tests/Doctrine/Tests/Models/Cache/Attraction.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Models\Cache;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Entity;
@@ -29,6 +30,7 @@ use Doctrine\ORM\Mapping\Table;
  *  3  = "Bar"
  * })
  */
+#[Entity]
 abstract class Attraction
 {
     /**
@@ -108,5 +110,9 @@ abstract class Attraction
         if (! $this->infos->contains($info)) {
             $this->infos->add($info);
         }
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/Cache/State.php
+++ b/tests/Doctrine/Tests/Models/Cache/State.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Models\Cache;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -21,6 +22,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Table("cache_state")
  * @Cache("NONSTRICT_READ_WRITE")
  */
+#[Entity]
 class State
 {
     /**
@@ -104,5 +106,9 @@ class State
     public function addCity(City $city): void
     {
         $this->cities[] = $city;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/Cache/Travel.php
+++ b/tests/Doctrine/Tests/Models/Cache/Travel.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -23,6 +24,7 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity
  * @Table("cache_travel")
  */
+#[Entity]
 class Travel
 {
     /**
@@ -103,5 +105,9 @@ class Travel
     public function getCreatedAt(): DateTime
     {
         return $this->createdAt;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Models\DDC3579;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -66,5 +67,9 @@ class DDC3579Group
     public function getAdmins(): Collection
     {
         return $this->admins;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934Member.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934Member.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Models\DDC5934;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 /** @ORM\Entity() */
 #[ORM\Entity]
@@ -22,5 +23,9 @@ class DDC5934Member
     public function __construct()
     {
         $this->contracts = new ArrayCollection();
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\DDC964;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 
 /** @Entity */
+#[Entity]
 class DDC964Address
 {
     /**
@@ -99,5 +101,9 @@ class DDC964Address
     public function setStreet(string $street): void
     {
         $this->street = $street;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -12,6 +13,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToMany;
 
 /** @Entity */
+#[Entity]
 class DDC964Group
 {
     /**
@@ -59,5 +61,9 @@ class DDC964Group
     public function getUsers(): ArrayCollection
     {
         return $this->users;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10473Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10473Test.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\Tests\OrmTestCase;
+
+class GH10473Test extends OrmTestCase
+{
+    public function testMappedSuperclassAssociationsCanBeResolvedToEntities(): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $resolveTargetEntity = new ResolveTargetEntityListener();
+
+        $resolveTargetEntity->addResolveTargetEntity(
+            GH10473BaseUser::class,
+            GH10473UserImplementation::class,
+            []
+        );
+
+        $em->getEventManager()->addEventSubscriber($resolveTargetEntity);
+
+        $userMetadata = $em->getClassMetadata(GH10473UserImplementation::class);
+
+        self::assertFalse($userMetadata->isMappedSuperclass);
+        self::assertTrue($userMetadata->isInheritanceTypeNone());
+
+        $socialMediaAccountsMapping = $userMetadata->getAssociationMapping('socialMediaAccounts');
+        self::assertArrayNotHasKey('inherited', $socialMediaAccountsMapping);
+        self::assertTrue((bool) ($socialMediaAccountsMapping['type'] & ClassMetadata::TO_MANY));
+        self::assertFalse($socialMediaAccountsMapping['isOwningSide']);
+        self::assertSame(GH10473SocialMediaAccount::class, $socialMediaAccountsMapping['targetEntity']);
+        self::assertSame('user', $socialMediaAccountsMapping['mappedBy']);
+
+        $createdByMapping = $userMetadata->getAssociationMapping('createdBy');
+        self::assertArrayNotHasKey('inherited', $createdByMapping);
+        self::assertTrue((bool) ($createdByMapping['type'] & ClassMetadata::TO_ONE));
+        self::assertTrue($createdByMapping['isOwningSide']);
+        self::assertSame(GH10473UserImplementation::class, $createdByMapping['targetEntity']);
+        self::assertSame('createdUsers', $createdByMapping['inversedBy']);
+
+        $createdUsersMapping = $userMetadata->getAssociationMapping('createdUsers');
+        self::assertArrayNotHasKey('inherited', $createdUsersMapping);
+        self::assertTrue((bool) ($createdUsersMapping['type'] & ClassMetadata::TO_MANY));
+        self::assertFalse($createdUsersMapping['isOwningSide']);
+        self::assertSame(GH10473UserImplementation::class, $createdUsersMapping['targetEntity']);
+        self::assertSame('createdBy', $createdUsersMapping['mappedBy']);
+
+        $socialMediaAccountMetadata = $em->getClassMetadata(GH10473SocialMediaAccount::class);
+
+        self::assertFalse($socialMediaAccountMetadata->isMappedSuperclass);
+        self::assertTrue($socialMediaAccountMetadata->isInheritanceTypeNone());
+
+        $userMapping = $socialMediaAccountMetadata->getAssociationMapping('user');
+        self::assertArrayNotHasKey('inherited', $userMapping);
+        self::assertTrue((bool) ($userMapping['type'] & ClassMetadata::TO_ONE));
+        self::assertTrue($userMapping['isOwningSide']);
+        self::assertSame(GH10473UserImplementation::class, $userMapping['targetEntity']);
+        self::assertSame('socialMediaAccounts', $userMapping['inversedBy']);
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+abstract class GH10473BaseUser
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH10473SocialMediaAccount", mappedBy="user")
+     *
+     * @var Collection
+     */
+    private $socialMediaAccounts;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH10473BaseUser", inversedBy="createdUsers")
+     *
+     * @var GH10473BaseUser
+     */
+    private $createdBy;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH10473BaseUser", mappedBy="createdBy")
+     *
+     * @var Collection
+     */
+    private $createdUsers;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10473SocialMediaAccount
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH10473BaseUser", inversedBy="socialMediaAccounts")
+     *
+     * @var GH10473BaseUser
+     */
+    private $user;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10473UserImplementation extends GH10473BaseUser
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -175,11 +175,10 @@ class AnnotationDriverTest extends MappingDriverTestCase
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(
-            'It is illegal to put an inverse side one-to-many or many-to-many association on ' .
-            "mapped superclass 'Doctrine\Tests\ORM\Mapping\InvalidMappedSuperClass#users'"
+            'The target entity class Doctrine\Tests\ORM\Mapping\InvalidMappedSuperClass specified for Doctrine\Tests\ORM\Mapping\InvalidMappedSuperClass::$selfWhatever is not an entity class.'
         );
 
-        $factory->getMetadataFor(UsingInvalidMappedSuperClass::class);
+        $factory->getMetadataFor(InvalidMappedSuperClass::class);
     }
 
     /** @group DDC-1050 */
@@ -309,22 +308,10 @@ class ColumnWithoutType
 class InvalidMappedSuperClass
 {
     /**
-     * @psalm-var Collection<int, CmsUser>
-     * @ManyToMany(targetEntity="Doctrine\Tests\Models\CMS\CmsUser", mappedBy="invalid")
+     * @psalm-var Collection<int, self>
+     * @ManyToMany(targetEntity="InvalidMappedSuperClass", mappedBy="invalid")
      */
-    private $users;
-}
-
-/** @Entity */
-class UsingInvalidMappedSuperClass extends InvalidMappedSuperClass
-{
-    /**
-     * @var int
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
-     */
-    private $id;
+    private $selfWhatever;
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -304,6 +304,7 @@ class MappedSuperclassBase
     private $transient;
 }
 
+/** @Entity */
 class MappedSuperclassRelated1
 {
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.Attraction.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.Attraction.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.State.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.State.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.Travel.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.Travel.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579Group.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579Group.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934Member.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934Member.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Address.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Address.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Group.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Group.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.Attraction.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.Attraction.dcm.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Doctrine\Tests\Models\Cache\Attraction" />
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.State.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.State.dcm.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Doctrine\Tests\Models\Cache\State" />
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.Travel.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Cache.Travel.dcm.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Doctrine\Tests\Models\Cache\Travel" />
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC117.DDC117Article.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC117.DDC117Article.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC117\DDC117Article"/>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC117.DDC117Editor.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC117.DDC117Editor.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC117\DDC117Editor" />
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3579.DDC3579Group.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3579.DDC3579Group.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC3579\DDC3579Group" />
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934Member.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934Member.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC5934\DDC5934Member" />
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Address.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Address.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC964\DDC964Address" />
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Group.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC964.DDC964Group.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC964\DDC964Group" />
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.Attraction.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.Attraction.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\Cache\Attraction:
+    type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.State.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.State.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\Cache\State:
+    type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.Travel.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Cache.Travel.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\Cache\Travel:
+    type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC3579.DDC3579Group.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC3579.DDC3579Group.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\DDC3579\DDC3579Group:
+  type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934Member.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934Member.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\DDC5934\DDC5934Member:
+  type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Address.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Address.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\DDC964\DDC964Address:
+  type: entity

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Group.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC964.DDC964Group.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\Models\DDC964\DDC964Group:
+  type: entity

--- a/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
@@ -25,8 +26,9 @@ use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\TestUtil;
 use Symfony\Component\Yaml\Parser;
 
+use function array_filter;
+use function array_values;
 use function count;
-use function current;
 use function file_get_contents;
 use function glob;
 use function is_array;
@@ -106,7 +108,9 @@ abstract class ClassMetadataExporterTestCase extends OrmTestCase
         $metadataDriver = $this->createMetadataDriver($type, __DIR__ . '/' . $type);
         $em             = $this->createEntityManager($metadataDriver);
         $cmf            = $this->createClassMetadataFactory($em, $type);
-        $metadata       = $cmf->getAllMetadata();
+        $metadata       = array_values(array_filter($cmf->getAllMetadata(), static function (ClassMetadata $class): bool {
+            return $class->name === User::class;
+        }));
 
         $metadata[0]->name = ExportedUser::class;
 
@@ -142,15 +146,15 @@ abstract class ClassMetadataExporterTestCase extends OrmTestCase
         $metadataDriver = $this->createMetadataDriver($type, __DIR__ . '/export/' . $type);
         $em             = $this->createEntityManager($metadataDriver);
         $cmf            = $this->createClassMetadataFactory($em, $type);
-        $metadata       = $cmf->getAllMetadata();
+        $metadatas      = $cmf->getAllMetadata();
 
-        self::assertCount(1, $metadata);
+        foreach ($metadatas as $metadata) {
+            if ($metadata->name === ExportedUser::class) {
+                return $metadata;
+            }
+        }
 
-        $class = current($metadata);
-
-        self::assertEquals(ExportedUser::class, $class->name);
-
-        return $class;
+        $this->fail('Expected metadata not found');
     }
 
     /** @depends testExportedMetadataCanBeReadBackIn */
@@ -388,12 +392,11 @@ abstract class ClassMetadataExporterTestCase extends OrmTestCase
     }
 }
 
-class Address
-{
-}
+/** @Entity */
 class Phonenumber
 {
 }
+/** @Entity */
 class Group
 {
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.Address.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.Address.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Export;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class Address
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.Address.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.Address.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.Address.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.Address.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Tools\Export\Address"/>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.Address.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.Address.dcm.yml
@@ -1,0 +1,2 @@
+Doctrine\Tests\ORM\Tools\Export\Address:
+  type: entity


### PR DESCRIPTION
Allow to-many associations to be used on mapped superclasses when the owning (inverse) side does not refer back to the mapped superclass, thanks to `ResolveTargetEntityListener`.

#### Current situation

The [documentation states](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html):

> No database table will be created for a mapped superclass itself

> [...] persistent relationships defined by a mapped superclass must be unidirectional (with an owning side only). This means that One-To-Many associations are not possible on a mapped superclass at all.

That's a though limitation. 

~Obviously~ ~apparently~ Probably the limitation comes from the fact that in a to-many association the "many" side has to hold a foreign key. Since the mapped superclass does not have a database table (it's not an entity), no such backreference can be established.

Currently, to-many associations trigger an exception as soon as they are seen on a mapped superclass:

https://github.com/doctrine/orm/blob/d6c0031d44f04e04bbc0cd57a3ed7e05c7ea8b40/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L459-L461

#### `ResolveTargetEntityListener`

The `ResolveTargetEntityListener` can be used to substitute interface or class names in mapping configuration at runtime, during the metadata load phase.

When this gimmick is used to replace _all_ references to the mapped superclass with an entity class in time, it should be possible to have to-many associations on the inheriting entity classes.

#### Suggested solution

Instead of rejecting to-many associations on mapped superclasses right away, validate that at the end of the day (after the `loadClassMetadata` event has been processed) no association may target at a non-entity class. That includes mapped superclasses as well as transient classes.

#### Motivating example

Consider a library that comes with a `User` base class. This class is `abstract` and has to be subclassed/filled when the library is used.

By making this a mapped superclass, library users have the freedom to either have a simple user entity class or a user class hierarchy, but we do not impose any requirements on them. (NB we also don't want to have a root entity in the library, because that would have to declare the entire class hierarchy, including library users' classes.)

The actual user class to be used will be configured through the `ResolveTargetEntityListener`.

The library also includes a `SocialMediaAccount` entity. A `User` can have multiple of these accounts, and we want to be able to navigate the accounts from the user side.

To make the example even more fancy, there is a self-referencing association on the `User`: A `User` has been created by another user, and holds a collection of all other `User`s it created.

The test case contained in this PR contains this example and validates that all association mappings look just as if the final user class had been written as an entity directly, without the superclass.

#### Potential review talking points

- Am I missing other reasons why to-many is not feasible?
- We now reject association mappings with `targetEntity`s that are not entities; relevant BC break? (IMHO: no.)

#### Review tip

Review commit by commit, not all files at once. The last commit adds a lot of entity declarations that were previously missed in tests and now raised exceptions; that's a lot of clutter in the PR.

#### Relationship to #10455 

This PR here does not make any changes to the inner workings of the ORM (!).

In fact, the example given can be run with current versions/releases of the ORM with no issues. That is possible because the one config validation rule that would stop it is in fact not effective, since the annotations/attribute mapping drivers do not report the potentially problematic association mapping in the first place.

This would change with #10455. Once that is merged, the to-many association would be dismissed right away and break the example. 

So we need this PR here to keep examples like the one given working with #10455, by finding a more precise rule why/when to reject invalid configurations.

Other: This closes #10398, since the check no longer exists.