### PR TITLE
Exclude traits from runtime association mappings check

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1297,12 +1297,10 @@ class ClassMetadataInfo implements ClassMetadata
     public function validateAssociations()
     {
         foreach ($this->associationMappings as $mapping) {
-            if (
-                ! class_exists($mapping['targetEntity'])
-                && ! interface_exists($mapping['targetEntity'])
-                && ! trait_exists($mapping['targetEntity'])
-            ) {
-                throw MappingException::invalidTargetEntityClass($mapping['targetEntity'], $this->name, $mapping['fieldName']);
+            /** @var string */
+            $targetEntity = $mapping['targetEntity'];
+            if (! class_exists($targetEntity)) {
+                throw MappingException::invalidTargetEntityClass($targetEntity, $this->name, $mapping['fieldName']);
             }
         }
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -583,7 +583,6 @@
     </DeprecatedProperty>
     <DocblockTypeContradiction>
       <code>! $this-&gt;table</code>
-      <code>! class_exists($mapping['targetEntity'])</code>
       <code>$this-&gt;table</code>
     </DocblockTypeContradiction>
     <InvalidArgument>


### PR DESCRIPTION
When checking at runtime whether an association mapping is valid/correct, do not check for traits.

I don't see how it would make sense to have an association targeting at a trait. Traits never exist on their own, they are only used in classes. So you cannot have an association aim at a trait in any meaningful way?

(I may be wrong and would be happy to learn, though!)