### PR TITLE
Allow multiple criterias on the same property.

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Value;
 use RuntimeException;
 
+use function array_merge;
 use function count;
 use function str_replace;
 use function str_starts_with;
@@ -37,11 +38,18 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /** @var list<mixed> */
     private $parameters = [];
 
-    /** @param mixed[] $queryAliases */
-    public function __construct($queryAliases)
+    /** @var list<mixed> */
+    private array $existingParameters;
+
+    /**
+     * @param mixed[] $queryAliases
+     * @param mixed[] $existingParameters
+     */
+    public function __construct($queryAliases, array $existingParameters = [])
     {
-        $this->queryAliases = $queryAliases;
-        $this->expr         = new Expr();
+        $this->queryAliases       = $queryAliases;
+        $this->expr               = new Expr();
+        $this->existingParameters = $existingParameters;
     }
 
     /**
@@ -120,9 +128,11 @@ class QueryExpressionVisitor extends ExpressionVisitor
 
         $parameterName = str_replace('.', '_', $comparison->getField());
 
-        foreach ($this->parameters as $parameter) {
+        $parameters = array_merge($this->parameters, $this->existingParameters);
+
+        foreach ($parameters as $parameter) {
             if ($parameter->getName() === $parameterName) {
-                $parameterName .= '_' . count($this->parameters);
+                $parameterName .= '_' . count($parameters);
                 break;
             }
         }

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1360,7 +1360,7 @@ class QueryBuilder
             throw new Query\QueryException('No aliases are set before invoking addCriteria().');
         }
 
-        $visitor = new QueryExpressionVisitor($this->getAllAliases());
+        $visitor = new QueryExpressionVisitor($this->getAllAliases(), $this->getParameters()->toArray());
 
         $whereExpression = $criteria->getWhereExpression();
         if ($whereExpression) {

--- a/tests/Doctrine/Tests/Models/ReadonlyProperties/Book.php
+++ b/tests/Doctrine/Tests/Models/ReadonlyProperties/Book.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\ReadonlyProperties;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC8702Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC8702Test.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function assert;
+
+class DDC8702Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(DDC8702Article::class);
+    }
+
+    public function testIssue(): void
+    {
+        //setup
+        $article1 = new DDC8702Article();
+        $article2 = new DDC8702Article();
+        $article3 = new DDC8702Article();
+        $article4 = new DDC8702Article();
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($article4);
+
+        $this->_em->flush();
+        $this->_em->clear();
+        //end setup
+
+        $qb = $this->_em->getRepository(DDC8702Article::class)->createQueryBuilder('a');
+
+        assert($qb instanceof QueryBuilder);
+
+        $qb->addCriteria(Criteria::create()->andWhere(Criteria::expr()->lte('created', new DateTimeImmutable('tomorrow'))));
+        $qb->addCriteria(Criteria::create()->andWhere(Criteria::expr()->lte('created', new DateTimeImmutable('-2 hours'))));
+        $qb->addCriteria(Criteria::create()->andWhere(Criteria::expr()->gte('created', new DateTimeImmutable('yesterday'))));
+
+        $result = $qb->getQuery()->toIterable();
+        self::assertCount(4, $result, 'invalid number of articles');
+
+        $this->_em->clear();
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="article")
+ */
+class DDC8702Article
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var DateTimeInterface
+     * @Column(type="datetime_immutable")
+     */
+    private $created;
+
+    public function __construct()
+    {
+        $this->created = new DateTimeImmutable('now');
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getCreated(): DateTimeImmutable
+    {
+        return $this->created;
+    }
+}


### PR DESCRIPTION
When adding multiple criteria referencing the same field, the query builder returnes an error.
The fix is passing existing parameters from previous parameters to every new insteance of QueryExpressionVisitor.
Fixes [#8702](https://github.com/doctrine/orm/issues/8702)

Ensure unique test entity name, and sync criteria field name with entity property.