### PR TITLE
Move psalm types to ClassMetadata

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -4,12 +4,101 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use BackedEnum;
+
 /**
  * {@inheritDoc}
  *
  * @todo remove or rename ClassMetadataInfo to ClassMetadata
  * @template-covariant T of object
  * @template-extends ClassMetadataInfo<T>
+ * @psalm-type FieldMapping = array{
+ *      type: string,
+ *      fieldName: string,
+ *      columnName: string,
+ *      length?: int,
+ *      id?: bool,
+ *      nullable?: bool,
+ *      notInsertable?: bool,
+ *      notUpdatable?: bool,
+ *      generated?: int,
+ *      enumType?: class-string<BackedEnum>,
+ *      columnDefinition?: string,
+ *      precision?: int,
+ *      scale?: int,
+ *      unique?: bool,
+ *      inherited?: class-string,
+ *      originalClass?: class-string,
+ *      originalField?: string,
+ *      quoted?: bool,
+ *      requireSQLConversion?: bool,
+ *      declared?: class-string,
+ *      declaredField?: string,
+ *      options?: array<string, mixed>,
+ *      version?: string,
+ *      default?: string|int,
+ * }
+ * @psalm-type JoinColumnData = array{
+ *     name: string,
+ *     referencedColumnName: string,
+ *     unique?: bool,
+ *     quoted?: bool,
+ *     fieldName?: string,
+ *     onDelete?: string,
+ *     columnDefinition?: string,
+ *     nullable?: bool,
+ * }
+ * @psalm-type AssociationMapping = array{
+ *     cache?: array,
+ *     cascade: array<string>,
+ *     declared?: class-string,
+ *     fetch: mixed,
+ *     fieldName: string,
+ *     id?: bool,
+ *     inherited?: class-string,
+ *     indexBy?: string,
+ *     inversedBy: string|null,
+ *     isCascadeRemove: bool,
+ *     isCascadePersist: bool,
+ *     isCascadeRefresh: bool,
+ *     isCascadeMerge: bool,
+ *     isCascadeDetach: bool,
+ *     isOnDeleteCascade?: bool,
+ *     isOwningSide: bool,
+ *     joinColumns?: array<JoinColumnData>,
+ *     joinColumnFieldNames?: array<string, string>,
+ *     joinTable?: array,
+ *     joinTableColumns?: list<mixed>,
+ *     mappedBy: string|null,
+ *     orderBy?: array,
+ *     originalClass?: class-string,
+ *     originalField?: string,
+ *     orphanRemoval?: bool,
+ *     relationToSourceKeyColumns?: array,
+ *     relationToTargetKeyColumns?: array,
+ *     sourceEntity: class-string,
+ *     sourceToTargetKeyColumns?: array<string, string>,
+ *     targetEntity: class-string,
+ *     targetToSourceKeyColumns?: array<string, string>,
+ *     type: int,
+ *     unique?: bool,
+ * }
+ * @psalm-type DiscriminatorColumnMapping = array{
+ *     name: string,
+ *     fieldName: string,
+ *     type: string,
+ *     length?: int,
+ *     columnDefinition?: string|null,
+ *     enumType?: class-string<BackedEnum>|null,
+ * }
+ * @psalm-type EmbeddedClassMapping = array{
+ *    class: class-string,
+ *    columnPrefix: string|null,
+ *    declaredField: string|null,
+ *    originalField: string|null,
+ *    inherited?: class-string,
+ *    declared?: class-string,
+ * }
  */
 class ClassMetadata extends ClassMetadataInfo
 {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -47,9 +47,9 @@ use function substr;
  * to a relational database.
  *
  * @extends AbstractClassMetadataFactory<ClassMetadata>
- * @psalm-import-type AssociationMapping from ClassMetadataInfo
- * @psalm-import-type EmbeddedClassMapping from ClassMetadataInfo
- * @psalm-import-type FieldMapping from ClassMetadataInfo
+ * @psalm-import-type AssociationMapping from ClassMetadata
+ * @psalm-import-type EmbeddedClassMapping from ClassMetadata
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -68,93 +68,11 @@ use const PHP_VERSION_ID;
  *
  * @template-covariant T of object
  * @template-implements ClassMetadata<T>
- * @psalm-type FieldMapping = array{
- *      type: string,
- *      fieldName: string,
- *      columnName: string,
- *      length?: int,
- *      id?: bool,
- *      nullable?: bool,
- *      notInsertable?: bool,
- *      notUpdatable?: bool,
- *      generated?: int,
- *      enumType?: class-string<BackedEnum>,
- *      columnDefinition?: string,
- *      precision?: int,
- *      scale?: int,
- *      unique?: bool,
- *      inherited?: class-string,
- *      originalClass?: class-string,
- *      originalField?: string,
- *      quoted?: bool,
- *      requireSQLConversion?: bool,
- *      declared?: class-string,
- *      declaredField?: string,
- *      options?: array<string, mixed>,
- *      version?: string,
- *      default?: string|int,
- * }
- * @psalm-type JoinColumnData = array{
- *     name: string,
- *     referencedColumnName: string,
- *     unique?: bool,
- *     quoted?: bool,
- *     fieldName?: string,
- *     onDelete?: string,
- *     columnDefinition?: string,
- *     nullable?: bool,
- * }
- * @psalm-type AssociationMapping = array{
- *     cache?: array,
- *     cascade: array<string>,
- *     declared?: class-string,
- *     fetch: mixed,
- *     fieldName: string,
- *     id?: bool,
- *     inherited?: class-string,
- *     indexBy?: string,
- *     inversedBy: string|null,
- *     isCascadeRemove: bool,
- *     isCascadePersist: bool,
- *     isCascadeRefresh: bool,
- *     isCascadeMerge: bool,
- *     isCascadeDetach: bool,
- *     isOnDeleteCascade?: bool,
- *     isOwningSide: bool,
- *     joinColumns?: array<JoinColumnData>,
- *     joinColumnFieldNames?: array<string, string>,
- *     joinTable?: array,
- *     joinTableColumns?: list<mixed>,
- *     mappedBy: string|null,
- *     orderBy?: array,
- *     originalClass?: class-string,
- *     originalField?: string,
- *     orphanRemoval?: bool,
- *     relationToSourceKeyColumns?: array,
- *     relationToTargetKeyColumns?: array,
- *     sourceEntity: class-string,
- *     sourceToTargetKeyColumns?: array<string, string>,
- *     targetEntity: class-string,
- *     targetToSourceKeyColumns?: array<string, string>,
- *     type: int,
- *     unique?: bool,
- * }
- * @psalm-type DiscriminatorColumnMapping = array{
- *     name: string,
- *     fieldName: string,
- *     type: string,
- *     length?: int,
- *     columnDefinition?: string|null,
- *     enumType?: class-string<BackedEnum>|null,
- * }
- * @psalm-type EmbeddedClassMapping = array{
- *    class: class-string,
- *    columnPrefix: string|null,
- *    declaredField: string|null,
- *    originalField: string|null,
- *    inherited?: class-string,
- *    declared?: class-string,
- * }
+ * @psalm-import-type AssociationMapping from \Doctrine\ORM\Mapping\ClassMetadata
+ * @psalm-import-type FieldMapping from \Doctrine\ORM\Mapping\ClassMetadata
+ * @psalm-import-type EmbeddedClassMapping from \Doctrine\ORM\Mapping\ClassMetadata
+ * @psalm-import-type JoinColumnData from \Doctrine\ORM\Mapping\ClassMetadata
+ * @psalm-import-type DiscriminatorColumnMapping from \Doctrine\ORM\Mapping\ClassMetadata
  */
 class ClassMetadataInfo implements ClassMetadata
 {

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM;
 
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use InvalidArgumentException;
 
 use function array_map;
@@ -24,7 +23,7 @@ use function sprintf;
 /**
  * Contains exception messages for all invalid lifecycle state exceptions inside UnitOfWork
  *
- * @psalm-import-type AssociationMapping from ClassMetadataInfo
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ORMInvalidArgumentException extends InvalidArgumentException
 {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -48,7 +47,7 @@ use function strtolower;
  *
  * @link    www.doctrine-project.org
  *
- * @psalm-import-type FieldMapping from ClassMetadataInfo
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 class SchemaTool
 {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -29,7 +29,6 @@ use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\Reflection\ReflectionPropertiesGetter;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
@@ -83,7 +82,7 @@ use function sprintf;
  *
  * Internal note: This class contains highly performance-sensitive code.
  *
- * @psalm-import-type AssociationMapping from ClassMetadataInfo
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class UnitOfWork implements PropertyChangedListener
 {


### PR DESCRIPTION
This spares us from referencing `ClassMetadataInfo` from other classes, which is a good thing since it is deprecated. It also means merging up is easier.

This prepares a change where I plan to use array shapes a lot more, based on the learnings from https://github.com/doctrine/orm/pull/10405