### PR TITLE
Fix to-many collections left in dirty state after entities are removed by the UoW

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -916,13 +916,6 @@ class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        if ($value instanceof PersistentCollection && $value->isDirty()) {
-            $coid = spl_object_id($value);
-
-            $this->collectionUpdates[$coid]  = $value;
-            $this->visitedCollections[$coid] = $value;
-        }
-
         // Look through the entities, and in any of their associations,
         // for transient (new) entities, recursively. ("Persistence by reachability")
         // Unwrap. Uninitialized collections will simply be empty.
@@ -982,6 +975,13 @@ class UnitOfWork implements PropertyChangedListener
                     // MANAGED associated entities are already taken into account
                     // during changeset calculation anyway, since they are in the identity map.
             }
+        }
+
+        if ($value instanceof PersistentCollection && $value->isDirty()) {
+            $coid = spl_object_id($value);
+
+            $this->collectionUpdates[$coid]  = $value;
+            $this->visitedCollections[$coid] = $value;
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
@@ -28,7 +28,7 @@ class ManyToManyEventTest extends OrmFunctionalTestCase
         $evm->addEventListener(Events::postUpdate, $this->listener);
     }
 
-    public function testListenerShouldBeNotifiedOnlyWhenUpdating(): void
+    public function testListenerShouldBeNotifiedWhenNewCollectionEntryAdded(): void
     {
         $user = $this->createNewValidUser();
         $this->_em->persist($user);
@@ -39,6 +39,23 @@ class ManyToManyEventTest extends OrmFunctionalTestCase
         $group->name = 'admins';
         $user->addGroup($group);
         $this->_em->persist($user);
+        $this->_em->flush();
+
+        self::assertTrue($this->listener->wasNotified);
+    }
+
+    public function testListenerShouldBeNotifiedWhenNewCollectionEntryRemoved(): void
+    {
+        $user        = $this->createNewValidUser();
+        $group       = new CmsGroup();
+        $group->name = 'admins';
+        $user->addGroup($group);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        self::assertFalse($this->listener->wasNotified);
+
+        $this->_em->remove($group);
         $this->_em->flush();
 
         self::assertTrue($this->listener->wasNotified);

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -31,6 +31,7 @@ use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\EntityPersisterMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;
+use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
@@ -865,6 +866,62 @@ class UnitOfWorkTest extends OrmTestCase
     {
         $this->expectException(EntityNotFoundException::class);
         $this->_unitOfWork->getEntityIdentifier(new stdClass());
+    }
+
+    public function testRemovedEntityIsRemovedFromManyToManyCollection(): void
+    {
+        $group       = new CmsGroup();
+        $group->name = 'test';
+        $this->_unitOfWork->persist($group);
+
+        $user       = new CmsUser();
+        $user->name = 'test';
+        $user->groups->add($group);
+        $this->_unitOfWork->persist($user);
+
+        $this->_unitOfWork->commit();
+
+        self::assertFalse($user->groups->isDirty());
+
+        $this->_unitOfWork->remove($group);
+        $this->_unitOfWork->commit();
+
+        // Test that the removed entity has been removed from the many to many collection
+        self::assertEmpty(
+            $user->groups,
+            'the removed entity should have been removed from the many to many collection'
+        );
+
+        // Collection is clean, snapshot has been updated
+        self::assertFalse($user->groups->isDirty());
+        self::assertEmpty($user->groups->getSnapshot());
+    }
+
+    public function testRemovedEntityIsRemovedFromOneToManyCollection(): void
+    {
+        $user       = new CmsUser();
+        $user->name = 'test';
+
+        $phonenumber              = new CmsPhonenumber();
+        $phonenumber->phonenumber = '0800-123456';
+
+        $user->addPhonenumber($phonenumber);
+
+        $this->_unitOfWork->persist($user);
+        $this->_unitOfWork->persist($phonenumber);
+        $this->_unitOfWork->commit();
+
+        self::assertFalse($user->phonenumbers->isDirty());
+
+        $this->_unitOfWork->remove($phonenumber);
+        $this->_unitOfWork->commit();
+
+        // Test that the removed entity has been removed from the one to many collection
+        self::assertEmpty($user->phonenumbers);
+
+        // Collection is clean, snapshot has been updated
+        self::assertFalse($user->phonenumbers->isDirty());
+        self::assertEmpty($user->phonenumbers->getSnapshot());
     }
 }
 


### PR DESCRIPTION
#### Current situation

When an entity is removed from the EM, the UoW updates collections that contain that entity, removing it from the collections as well.

The collections are left in a dirty state afterwards with outdated snapshots, which leads to errors e. g. when the Entity Manager is flushed again (see #10485).

#### Suggested fix

This PR fixes the problem by moving a check further down, so that also collections updated by the UoW itself (by removing the entity in question) are captured as "processed" by the current commit phase.

#### Tests added

It seems tests for this feature were completely missing, so I added them.

Also added a second test case for the feature added in #256 that the event for many-to-many collections is not only generated for added, but also for removed entities.

Closes #10485, fixes #10483, fixes #10060, closes #10061.