### PR TITLE
Reject colliding field mapping in STI (need advice)

### DIFF
--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -634,6 +634,11 @@ class MappingException extends ORMException
         return new self("Duplicate definition of column '" . $columnName . "' on entity '" . $className . "' in a field or discriminator column mapping.");
     }
 
+    public static function columnAlreadyExists(string $table, string $columnName, string $className, string $field): self
+    {
+        return new self(sprintf('The column %s in table %s is already defined and cannot be reused for the %s#%s field. Define a separate column name for this field.', $columnName, $table, $className, $field));
+    }
+
     /**
      * @param string $className
      * @param string $field

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -520,9 +520,7 @@ class SchemaTool
         }
 
         if ($table->hasColumn($columnName)) {
-            $method = method_exists($table, 'modifyColumn') ? 'modifyColumn' : 'changeColumn';
-            // required in some inheritance scenarios
-            $table->$method($columnName, $options);
+            throw MappingException::columnAlreadyExists($table->getName(), $columnName, $class->name, $mapping['fieldName']);
         } else {
             $table->addColumn($columnName, $columnType, $options);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10488Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10488Test.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH10488Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH10488Root::class,
+            GH10488A::class,
+            GH10488B::class
+        );
+    }
+
+    public function testTwoSubclassesWithCollidingColumnDefinitions(): void
+    {
+        $entityA        = new GH10488A();
+        $entityA->value = 42;
+        $this->_em->persist($entityA);
+
+        $entityB        = new GH10488B();
+        $entityB->value = 'test';
+        $this->_em->persist($entityB);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $loadedEntityA = $this->_em->find(GH10488A::class, $entityA->id);
+        $loadedEntityB = $this->_em->find(GH10488B::class, $entityB->id);
+
+        self::assertSame($entityA->value, $loadedEntityA->value);
+        self::assertSame($entityB->value, $loadedEntityB->value);
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="root")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "A": "GH10488A", "B": "GH10488B" })
+ */
+abstract class GH10488Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10488A extends GH10488Root
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $value;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10488B extends GH10488Root
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $value;
+}


### PR DESCRIPTION
When using Single Table Inheritance and two sibling classes declare fields with the same name, but different column definitions (say, one is `int`, the other one `string`), the resulting conflict is not raised as a problem.

#### Current situation

The database schema will be created based on one of the two definitions. In the current example, we actually end up with an `INT` column. Values can not be persisted correctly, are implicitly cast/converted or lost.

#### Expected behaviour

* The ORM should at least refuse this configuration, clearly pointing out what the problem is, an possibly suggest to use `name="..."` declarations to make sure different columns for the different fields can co-exist in the database.
* The naming strategy (or whatever mechanism) might try to use pre/suffixes automatically to resolve the situation, albeit that would probably be a larger BC break and would cause old schemas to not work anymore.
* We might consider to check if the column definitions actually differ and use a single column for two fields in two classes if the definitions match. In the long run, that might be hard to maintain – for example, what should happen once one of the two definitions changes?

Probably the first one is the only feasible solution. 

#### Additional information

* Seems to work well for JTI, since different fields end up in different tables and each one gets the right column definition. 
* Regarding the Schema Tool, ba01175700e1f0caf79cef642531fcfdb40478a6 made it possible to re-process a column with a name already taken, but changing/removing that line at least does not break any tests. So, I could not figure out why this was needed (at that time).

#### TODO

- [ ] Can we throw the exception from a better, more central place like the runtime validation in CMF? Or is the check too expensive and can only be in the Schema Validator?
- [ ] When checking somewhere where we don't know about the final, resulting schema, the check is more involved. We also need to think about potential conflicts from associations and embeddables.