### PR TITLE
Fix forgotten exception throws

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -227,7 +227,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
                 $alias
             );
         } else {
-            NotSupported::createForPersistence3(sprintf(
+            throw NotSupported::createForPersistence3(sprintf(
                 'Using short namespace alias "%s" by calling %s',
                 $alias,
                 __METHOD__

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -814,7 +814,7 @@ class EntityManager implements EntityManagerInterface
                     $entityName
                 );
             } else {
-                NotSupported::createForPersistence3(sprintf(
+                throw NotSupported::createForPersistence3(sprintf(
                     'Using short namespace alias "%s" when calling %s',
                     $entityName,
                     __METHOD__

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\Exception\MetadataCacheNotConfigured;
@@ -17,6 +18,7 @@ use Doctrine\ORM\Cache\Exception\QueryCacheUsesNonPersistentCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
+use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\ProxyClassesAlwaysRegenerating;
 use Doctrine\ORM\Mapping as AnnotationNamespace;
@@ -128,7 +130,11 @@ class ConfigurationTest extends DoctrineTestCase
 
     public function testSetGetEntityNamespace(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
+        if (class_exists(PersistentObject::class)) {
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
+        } else {
+            $this->expectException(NotSupported::class);
+        }
 
         $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__);
         self::assertSame(__NAMESPACE__, $this->configuration->getEntityNamespace('TestNamespace'));

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsAddressDTO;
@@ -13,6 +14,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsUserDTO;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function class_exists;
 use function count;
 
 /** @group DDC-1574 */
@@ -208,6 +210,10 @@ class NewOperatorTest extends OrmFunctionalTestCase
 
     public function testShouldSupportFromEntityNamespaceAlias(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         $dql = '
             SELECT
                 new CmsUserDTO(u.name, e.email, a.city)
@@ -235,6 +241,10 @@ class NewOperatorTest extends OrmFunctionalTestCase
 
     public function testShouldSupportValueObjectNamespaceAlias(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         $dql = '
             SELECT
                 new cms:CmsUserDTO(u.name, e.email, a.city)

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\DBAL\Logging\Middleware as LoggingMiddleware;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\NonUniqueResultException;
@@ -557,6 +558,10 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testSupportsQueriesWithEntityNamespaces(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         $this->_em->getConfiguration()->addEntityNamespace('CMS', 'Doctrine\Tests\Models\CMS');
 
         try {

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
@@ -11,6 +12,8 @@ use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 use stdClass;
+
+use function class_exists;
 
 class ParserTest extends OrmTestCase
 {
@@ -53,6 +56,10 @@ class ParserTest extends OrmTestCase
      */
     public function testAbstractSchemaNameSupportsNamespaceAlias(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         $parser = $this->createParser('CMS:CmsUser');
 
         $parser->getEntityManager()->getConfiguration()->addEntityNamespace('CMS', 'Doctrine\Tests\Models\CMS');
@@ -66,6 +73,10 @@ class ParserTest extends OrmTestCase
      */
     public function testAbstractSchemaNameSupportsNamespaceAliasWithRelativeClassname(): void
     {
+        if (! class_exists(PersistentObject::class)) {
+            self::markTestSkipped('This test requires doctrine/persistence 2');
+        }
+
         $parser = $this->createParser('Model:CMS\CmsUser');
 
         $parser->getEntityManager()->getConfiguration()->addEntityNamespace('Model', 'Doctrine\Tests\Models');


### PR DESCRIPTION
I believe those exceptions are meant to be thrown, right? Otherwise, this code is useles.

Detected by https://github.com/shipmonk-rnd/phpstan-rules#forbidunusedexception