### PR TITLE
Fix invalid phpdocs missing null

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -246,7 +246,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      *
      * @param string            $query
      * @param string[]|Criteria $criteria
-     * @param string[]          $orderBy
+     * @param string[]|null     $orderBy
      * @param int|null          $limit
      * @param int|null          $offset
      *

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -46,9 +46,9 @@ final class Table implements MappingAttribute
     public $options = [];
 
     /**
-     * @param array<Index>            $indexes
-     * @param array<UniqueConstraint> $uniqueConstraints
-     * @param array<string,mixed>     $options
+     * @param array<Index>|null            $indexes
+     * @param array<UniqueConstraint>|null $uniqueConstraints
+     * @param array<string,mixed>          $options
      */
     public function __construct(
         ?string $name = null,

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -40,9 +40,9 @@ final class UniqueConstraint implements MappingAttribute
     public $options;
 
     /**
-     * @param array<string>       $columns
-     * @param array<string>       $fields
-     * @param array<string,mixed> $options
+     * @param array<string>|null       $columns
+     * @param array<string>|null       $fields
+     * @param array<string,mixed>|null $options
      */
     public function __construct(
         ?string $name = null,


### PR DESCRIPTION
To match native type which already contains null.

Detected by https://github.com/shipmonk-rnd/phpstan-rules#forbidphpdocnullabilitymismatchwithnativetypehint