### PR TITLE
MetadataFilter: remove useless default value

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -25,7 +25,7 @@ use function sprintf;
 class MetadataFilter extends FilterIterator implements Countable
 {
     /** @var mixed[] */
-    private $filter = [];
+    private $filter;
 
     /**
      * Filter Metadatas by one or more filter options.


### PR DESCRIPTION
Value is always overwritten in constructor.

Detected by: https://github.com/shipmonk-rnd/phpstan-rules#uselessprivatepropertydefaultvalue