### PR TITLE
Make all data providers static

### DIFF
--- a/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
@@ -83,7 +83,7 @@ final class AbstractQueryTest extends TestCase
     }
 
     /** @return array<string, array{string}> */
-    public function provideSettersWithDeprecatedDefault(): array
+    public static function provideSettersWithDeprecatedDefault(): array
     {
         return [
             'setHydrationCacheProfile' => ['setHydrationCacheProfile'],

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -46,7 +46,7 @@ class EntityManagerDecoratorTest extends TestCase
     }
 
     /** @psalm-return Generator<string, mixed[]> */
-    public function getMethodParameters(): Generator
+    public static function getMethodParameters(): Generator
     {
         $class = new ReflectionClass(EntityManagerInterface::class);
 
@@ -55,12 +55,12 @@ class EntityManagerDecoratorTest extends TestCase
                 continue;
             }
 
-            yield $method->getName() => $this->getParameters($method);
+            yield $method->getName() => self::getParameters($method);
         }
     }
 
     /** @return mixed[] */
-    private function getParameters(ReflectionMethod $method): array
+    private static function getParameters(ReflectionMethod $method): array
     {
         /** Special case EntityManager::createNativeQuery() */
         if ($method->getName() === 'createNativeQuery') {

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -198,7 +198,7 @@ class EntityManagerTest extends OrmTestCase
     }
 
     /** @return Generator<array{mixed}> */
-    public function dataToBeReturnedByWrapInTransaction(): Generator
+    public static function dataToBeReturnedByWrapInTransaction(): Generator
     {
         yield [[]];
         yield [[1]];

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -384,7 +384,7 @@ EXCEPTION
     }
 
     /** @return array<string, array{class-string}> */
-    public function provideCardClasses(): array
+    public static function provideCardClasses(): array
     {
         return [
             Card::class => [Card::class],

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -33,7 +33,7 @@ class NewOperatorTest extends OrmFunctionalTestCase
     }
 
     /** @psalm-return list<array{int}> */
-    public function provideDataForHydrationMode(): array
+    public static function provideDataForHydrationMode(): array
     {
         return [
             [Query::HYDRATE_ARRAY],

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -736,8 +736,17 @@ SQL
         $this->_em->flush();
     }
 
-    /** @psalm-return list<array{bool, bool}> */
-    public function useOutputWalkers(): array
+    /** @psalm-return list<array{bool}> */
+    public static function useOutputWalkers(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /** @psalm-return list<array{bool}> */
+    public static function fetchJoinCollection(): array
     {
         return [
             [true],
@@ -746,16 +755,7 @@ SQL
     }
 
     /** @psalm-return list<array{bool, bool}> */
-    public function fetchJoinCollection(): array
-    {
-        return [
-            [true],
-            [false],
-        ];
-    }
-
-    /** @psalm-return list<array{bool, bool}> */
-    public function useOutputWalkersAndFetchJoinCollection(): array
+    public static function useOutputWalkersAndFetchJoinCollection(): array
     {
         return [
             [true, false],

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -364,7 +364,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         );
     }
 
-    public function dateAddSubProvider(): array
+    public static function dateAddSubProvider(): array
     {
         $secondsInDay = 86400;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -77,7 +77,7 @@ class DDC2825Test extends OrmFunctionalTestCase
      *
      * @return string[][]
      */
-    public function getTestedClasses(): array
+    public static function getTestedClasses(): array
     {
         return [
             [ExplicitSchemaAndTable::class, 'explicit_schema', 'explicit_table'],

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10387Test.php
@@ -32,7 +32,7 @@ class GH10387Test extends OrmTestCase
         self::assertNotNull($schema->getTable('root')->getColumn('leaf_class_field'));
     }
 
-    public function classHierachies(): Generator
+    public static function classHierachies(): Generator
     {
         yield 'hierarchy with Entity classes only' => [[GH10387EntitiesOnlyRoot::class, GH10387EntitiesOnlyMiddle::class, GH10387EntitiesOnlyLeaf::class]];
         yield 'MappedSuperclass in the middle of the hierarchy' => [[GH10387MappedSuperclassRoot::class, GH10387MappedSuperclassMiddle::class, GH10387MappedSuperclassLeaf::class]];

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
@@ -75,7 +75,7 @@ final class GH7875Test extends OrmFunctionalTestCase
     }
 
     /** @return array<array<string|callable|null>> */
-    public function provideUpdateSchemaSqlWithSchemaAssetFilter(): array
+    public static function provideUpdateSchemaSqlWithSchemaAssetFilter(): array
     {
         return [
             ['/^(?!my_enti)/', null],

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8127Test.php
@@ -41,7 +41,7 @@ class GH8127Test extends OrmFunctionalTestCase
         self::assertSame('leaf', $loadedEntity->leaf);
     }
 
-    public function queryClasses(): array
+    public static function queryClasses(): array
     {
         return [
             'query via root entity' => [GH8127Root::class],

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9230Test.php
@@ -37,7 +37,7 @@ class GH9230Test extends OrmFunctionalTestCase
     /**
      * This does not work before the fix in PR#9663, but is does work after the fix is applied
      */
-    public function failingValuesBeforeFix(): array
+    public static function failingValuesBeforeFix(): array
     {
         return [
             'string=""' => ['name', '', 'test name'],
@@ -66,7 +66,7 @@ class GH9230Test extends OrmFunctionalTestCase
     /**
      * This already works before the fix in PR#9663 is applied because none of these are falsy values in php
      */
-    public function succeedingValuesBeforeFix(): array
+    public static function succeedingValuesBeforeFix(): array
     {
         return [
             'string="test"' => ['name', 'test', 'test2'],

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -345,7 +345,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
     }
 
     /** @psalm-return list<array{string, string}> */
-    public function getInfiniteEmbeddableNestingData(): array
+    public static function getInfiniteEmbeddableNestingData(): array
     {
         return [
             ['DDCInfiniteNestingEmbeddable', 'DDCInfiniteNestingEmbeddable'],

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -17,7 +17,7 @@ use Doctrine\Tests\Models\Forum\ForumCategory;
 class ArrayHydratorTest extends HydrationTestCase
 {
     /** @psalm-return list<array{mixed}> */
-    public function provideDataForUserEntityResult(): array
+    public static function provideDataForUserEntityResult(): array
     {
         return [
             [0],

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -35,7 +35,7 @@ class ObjectHydratorTest extends HydrationTestCase
     use MockBuilderCompatibilityTools;
 
     /** @psalm-return list<array{mixed}> */
-    public function provideDataForUserEntityResult(): array
+    public static function provideDataForUserEntityResult(): array
     {
         return [
             [0],
@@ -44,7 +44,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /** @psalm-return list<array{mixed, mixed}> */
-    public function provideDataForMultipleRootEntityResult(): array
+    public static function provideDataForMultipleRootEntityResult(): array
     {
         return [
             [0, 0],
@@ -55,7 +55,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /** @psalm-return list<array{mixed}> */
-    public function provideDataForProductEntityResult(): array
+    public static function provideDataForProductEntityResult(): array
     {
         return [
             [0],

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -37,7 +37,7 @@ class AssignedGeneratorTest extends OrmTestCase
         $this->assignedGen->generateId($this->entityManager, $entity);
     }
 
-    public function entitiesWithoutId(): array
+    public static function entitiesWithoutId(): array
     {
         return [
             'single'    => [new AssignedSingleIdEntity()],

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -154,7 +154,7 @@ class HydrationCompleteHandlerTest extends TestCase
     }
 
     /** @psalm-return list<array{int}> */
-    public function invocationFlagProvider(): array
+    public static function invocationFlagProvider(): array
     {
         return [
             [ListenersInvoker::INVOKE_LISTENERS],

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -276,7 +276,7 @@ class AnnotationDriverTest extends MappingDriverTestCase
         self::assertSame($expectedLength, $metadata->discriminatorColumn['length']);
     }
 
-    public function provideDiscriminatorColumnTestcases(): Generator
+    public static function provideDiscriminatorColumnTestcases(): Generator
     {
         yield [DiscriminatorColumnWithNullLength::class, 255];
         yield [DiscriminatorColumnWithNoLength::class, 255];

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -69,49 +69,47 @@ class ReflectionEmbeddedPropertyTest extends TestCase
     }
 
     /**
-     * Data provider
-     *
      * @return ReflectionProperty[][]|string[][]
      */
-    public function getTestedReflectionProperties(): array
+    public static function getTestedReflectionProperties(): array
     {
         return [
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
+                self::getReflectionProperty(BooleanModel::class, 'id'),
+                self::getReflectionProperty(BooleanModel::class, 'id'),
                 BooleanModel::class,
             ],
             // reflection on embeddables that have properties defined in abstract ancestors:
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(AbstractEmbeddable::class, 'propertyInAbstractClass'),
+                self::getReflectionProperty(BooleanModel::class, 'id'),
+                self::getReflectionProperty(AbstractEmbeddable::class, 'propertyInAbstractClass'),
                 ConcreteEmbeddable::class,
             ],
             [
-                $this->getReflectionProperty(BooleanModel::class, 'id'),
-                $this->getReflectionProperty(ConcreteEmbeddable::class, 'propertyInConcreteClass'),
+                self::getReflectionProperty(BooleanModel::class, 'id'),
+                self::getReflectionProperty(ConcreteEmbeddable::class, 'propertyInConcreteClass'),
                 ConcreteEmbeddable::class,
             ],
             // reflection on classes extending internal PHP classes:
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'privateProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'privateProperty'),
                 ArrayObjectExtendingClass::class,
             ],
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'protectedProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'protectedProperty'),
                 ArrayObjectExtendingClass::class,
             ],
             [
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
-                $this->getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
+                self::getReflectionProperty(ArrayObjectExtendingClass::class, 'publicProperty'),
                 ArrayObjectExtendingClass::class,
             ],
         ];
     }
 
-    private function getReflectionProperty(string $className, string $propertyName): ReflectionProperty
+    private static function getReflectionProperty(string $className, string $propertyName): ReflectionProperty
     {
         $reflectionProperty = new ReflectionProperty($className, $propertyName);
 

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -7,10 +7,8 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Stringable;
 
 use function spl_object_id;
-use function uniqid;
 
 /** @covers \Doctrine\ORM\ORMInvalidArgumentException */
 class ORMInvalidArgumentExceptionTest extends TestCase
@@ -29,7 +27,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
     }
 
     /** @psalm-return list<array{mixed, string}> */
-    public function invalidEntityNames(): array
+    public static function invalidEntityNames(): array
     {
         return [
             [null, 'Entity name must be a string, null given'],
@@ -49,29 +47,31 @@ class ORMInvalidArgumentExceptionTest extends TestCase
         self::assertSame($expectedMessage, $exception->getMessage());
     }
 
-    public function newEntitiesFoundThroughRelationshipsErrorMessages(): array
+    public static function newEntitiesFoundThroughRelationshipsErrorMessages(): array
     {
-        $stringEntity3 = uniqid('entity3', true);
-        $entity1       = new stdClass();
-        $entity2       = new stdClass();
-        $entity3       = $this->createMock(Stringable::class);
-        $association1  = [
+        $entity1      = new stdClass();
+        $entity2      = new stdClass();
+        $entity3      = new class {
+            public function __toString(): string
+            {
+                return 'ThisIsAStringRepresentationOfEntity3';
+            }
+        };
+        $association1 = [
             'sourceEntity' => 'foo1',
             'fieldName'    => 'bar1',
             'targetEntity' => 'baz1',
         ];
-        $association2  = [
+        $association2 = [
             'sourceEntity' => 'foo2',
             'fieldName'    => 'bar2',
             'targetEntity' => 'baz2',
         ];
-        $association3  = [
+        $association3 = [
             'sourceEntity' => 'foo3',
             'fieldName'    => 'bar3',
             'targetEntity' => 'baz3',
         ];
-
-        $entity3->method('__toString')->willReturn($stringEntity3);
 
         return [
             'one entity found' => [
@@ -121,7 +121,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
                     ],
                 ],
                 'A new entity was found through the relationship \'foo3#bar3\' that was not configured to cascade '
-                . 'persist operations for entity: ' . $stringEntity3
+                . 'persist operations for entity: ThisIsAStringRepresentationOfEntity3'
                 . '. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity '
                 . 'or configure cascade persist this association in the mapping for example '
                 . '@ManyToOne(..,cascade={"persist"}).',

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -278,7 +278,7 @@ class ExprTest extends OrmTestCase
         self::assertEquals(':groupId MEMBER OF u.groups', (string) $this->expr->isMemberOf(':groupId', 'u.groups'));
     }
 
-    public function provideIterableValue(): Generator
+    public static function provideIterableValue(): Generator
     {
         $gen = static function () {
             yield from [1, 2, 3];
@@ -288,7 +288,7 @@ class ExprTest extends OrmTestCase
         yield 'generator' => [$gen()];
     }
 
-    public function provideLiteralIterableValue(): Generator
+    public static function provideLiteralIterableValue(): Generator
     {
         $gen = static function () {
             yield from ['foo', 'bar'];

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -88,7 +88,7 @@ class LanguageRecognitionTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{string}> */
-    public function invalidDQL(): array
+    public static function invalidDQL(): array
     {
         return [
 

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -226,7 +226,7 @@ class LexerTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{int, string}> */
-    public function provideTokens(): array
+    public static function provideTokens(): array
     {
         return [
             [Lexer::T_IDENTIFIER, 'u'], // one char

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -21,7 +21,7 @@ use const PHP_VERSION_ID;
 class ParameterTypeInfererTest extends OrmTestCase
 {
     /** @psalm-return Generator<string, array{mixed, (int|string)}> */
-    public function providerParameterTypeInferer(): Generator
+    public static function providerParameterTypeInferer(): Generator
     {
         yield 'integer' => [1, Types::INTEGER];
         yield 'string' => ['bar', ParameterType::STRING];

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -113,7 +113,7 @@ class ParserTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{int, string}> */
-    public function validMatches()
+    public static function validMatches(): array
     {
         /*
          * This only covers the special case handling in the Parser that some
@@ -134,7 +134,7 @@ class ParserTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{int, string}> */
-    public function invalidMatches(): array
+    public static function invalidMatches(): array
     {
         return [
             [Lexer::T_DOT, 'ALL'], // ALL is a terminal string (reserved keyword) and also possibly an identifier

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -46,7 +46,7 @@ class QueryExpressionVisitorTest extends TestCase
      *                   2?: Parameter,
      *               }>
      */
-    public function comparisonData(): array
+    public static function comparisonData(): array
     {
         $cb = new CriteriaBuilder();
         $qb = new QueryBuilder();

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -252,7 +252,7 @@ class QueryTest extends OrmTestCase
     }
 
     /** @psalm-return Generator<string, array{iterable}> */
-    public function provideProcessParameterValueIterable(): Generator
+    public static function provideProcessParameterValueIterable(): Generator
     {
         $baseArray = [
             0 => 'Paris',

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2190,7 +2190,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{string}> */
-    public function mathematicOperatorsProvider(): array
+    public static function mathematicOperatorsProvider(): array
     {
         return [['+'], ['-'], ['*'], ['/']];
     }

--- a/tests/Doctrine/Tests/ORM/Query/SqlWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SqlWalkerTest.php
@@ -44,7 +44,7 @@ class SqlWalkerTest extends OrmTestCase
      *
      * @private data provider
      */
-    public function getColumnNamesAndSqlAliases(): array
+    public static function getColumnNamesAndSqlAliases(): array
     {
         return [
             ['aaaaa', 'a0_'],

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/SchemaTool/UpdateCommandTest.php
@@ -34,7 +34,7 @@ class UpdateCommandTest extends CommandTestCase
         self::assertStringContainsString($expectedMessage, $tester->getErrorOutput());
     }
 
-    public function getCasesForWarningMessageFromCompleteOption(): iterable
+    public static function getCasesForWarningMessageFromCompleteOption(): iterable
     {
         yield 'default_name' => [
             null,

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1019,7 +1019,7 @@ class EntityGeneratorTest extends OrmTestCase
      *     value: mixed
      * }>
      */
-    public function getEntityTypeAliasDataProvider(): array
+    public static function getEntityTypeAliasDataProvider(): array
     {
         return [
             [
@@ -1114,7 +1114,7 @@ class EntityGeneratorTest extends OrmTestCase
     }
 
     /** @psalm-return list<array{string, array{string}}> */
-    public function getParseTokensInEntityFileData(): array
+    public static function getParseTokensInEntityFileData(): array
     {
         return [
             [
@@ -1206,7 +1206,7 @@ class
         self::assertStringContainsString($expectedAnnotation, $docComment);
     }
 
-    public function columnOptionsProvider(): array
+    public static function columnOptionsProvider(): array
     {
         return [
             'string-default'   => [

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -51,7 +51,7 @@ class SchemaValidatorTest extends OrmTestCase
         self::assertEmpty($this->validator->validateMapping());
     }
 
-    public function modelSetProvider(): array
+    public static function modelSetProvider(): array
     {
         return [
             'cms'        => [__DIR__ . '/../../Models/CMS'],

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -490,7 +490,7 @@ class UnitOfWorkTest extends OrmTestCase
      *
      * @return mixed[][]
      */
-    public function invalidAssociationValuesDataProvider(): array
+    public static function invalidAssociationValuesDataProvider(): array
     {
         return [
             ['foo'],
@@ -516,7 +516,7 @@ class UnitOfWorkTest extends OrmTestCase
     }
 
     /** @psalm-return array<string, array{object, string}> */
-    public function entitiesWithValidIdentifiersProvider()
+    public static function entitiesWithValidIdentifiersProvider(): array
     {
         $emptyString = new EntityWithStringIdentifier();
 
@@ -575,7 +575,7 @@ class UnitOfWorkTest extends OrmTestCase
     }
 
     /** @psalm-return array<string, array{object, array<string, mixed>}> */
-    public function entitiesWithInvalidIdentifiersProvider(): array
+    public static function entitiesWithInvalidIdentifiersProvider(): array
     {
         $firstNullString = new EntityWithCompositeStringIdentifier();
 


### PR DESCRIPTION
Cherry-picked from #10492.

PHPUnit 10 triggers a deprecation warning for non-static data providers. This PR switches all (I hope 🤞🏻) data providers to `static`.