### PR TITLE
Use recognized array key

### DIFF
--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -134,7 +134,7 @@ class DDC964User
                 'fieldName'      => 'address',
                 'targetEntity'   => 'DDC964Address',
                 'cascade'        => ['persist','merge'],
-                'joinColumn'     => ['name' => 'address_id', 'referencedColumnMame' => 'id'],
+                'joinColumns'    => [['name' => 'address_id', 'referencedColumnMame' => 'id']],
             ]
         );
 


### PR DESCRIPTION
`joinColumn` has no meaning for the static PHP driver. That's because it performs no translation, unlike other drivers: we're using the ClassMetadata API directly.

Before this change, changing the value of the "name" key did not break the test suite. After this change, it does.

Found while working on https://github.com/doctrine/orm/pull/10405