### PR TITLE
Remove calls to `withConsecutive()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -181,16 +181,10 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $driver = $this->createMock(MappingDriver::class);
         $driver->expects(self::exactly(2))
             ->method('isTransient')
-            ->withConsecutive(
-                [CmsUser::class],
-                [CmsArticle::class]
-            )
-            ->willReturnMap(
-                [
-                    [CmsUser::class, true],
-                    [CmsArticle::class, false],
-                ]
-            );
+            ->willReturnMap([
+                [CmsUser::class, true],
+                [CmsArticle::class, false],
+            ]);
 
         $em = $this->createEntityManager($driver);
 


### PR DESCRIPTION
This method has been removed in PHPUnit 10. Let's stop using it.

Cherry-picked from #10492