### PR TITLE
Remove calls to `assertObjectHasAttribute()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -29,6 +29,7 @@ use Doctrine\Tests\Models\Hydration\SimpleEntity;
 use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 
 use function count;
+use function property_exists;
 
 class ObjectHydratorTest extends HydrationTestCase
 {
@@ -927,10 +928,10 @@ class ObjectHydratorTest extends HydrationTestCase
         self::assertEquals(1, $result[0]->getId());
         self::assertEquals(2, $result[1]->getId());
 
-        self::assertObjectHasAttribute('boards', $result[0]);
+        self::assertTrue(property_exists($result[0], 'boards'));
         self::assertEquals(3, count($result[0]->boards));
 
-        self::assertObjectHasAttribute('boards', $result[1]);
+        self::assertTrue(property_exists($result[1], 'boards'));
         self::assertEquals(1, count($result[1]->boards));
     }
 


### PR DESCRIPTION
`assertObjectHasAttribute()` has been removed in PHPUnit 10, so let's stop using that method.

Cherry-picked from #10492