### PR TITLE
Migrate Parser to PHP 8

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
@@ -8,13 +8,10 @@ use Doctrine\ORM\Query\SqlWalker;
 
 class AggregateExpression extends Node
 {
-    /**
-     * @param PathExpression|SimpleArithmeticExpression $pathExpression
-     * @param bool                                      $isDistinct     Some aggregate expressions support distinct, eg COUNT.
-     */
+    /** @param bool $isDistinct Some aggregate expressions support distinct, eg COUNT. */
     public function __construct(
         public string $functionName,
-        public $pathExpression,
+        public Node|string $pathExpression,
         public bool $isDistinct,
     ) {
     }

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
@@ -13,8 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class ArithmeticExpression extends Node
 {
-    /** @var SimpleArithmeticExpression|null */
-    public $simpleArithmeticExpression;
+    public Node|string|null $simpleArithmeticExpression = null;
 
     /** @var Subselect|null */
     public $subselect;

--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
@@ -16,8 +16,7 @@ use Doctrine\ORM\Query\TokenType;
  */
 class AbsFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
-    public $simpleArithmeticExpression;
+    public Node|string $simpleArithmeticExpression;
 
     public function getSql(SqlWalker $sqlWalker): string
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
@@ -17,11 +16,10 @@ use Doctrine\ORM\Query\TokenType;
  */
 class LocateFunction extends FunctionNode
 {
-    public Node $firstStringPrimary;
-    public Node $secondStringPrimary;
+    public Node|string $firstStringPrimary;
+    public Node|string $secondStringPrimary;
 
-    /** @var SimpleArithmeticExpression|bool */
-    public $simpleArithmeticExpression = false;
+    public Node|string|bool $simpleArithmeticExpression = false;
 
     public function getSql(SqlWalker $sqlWalker): string
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
@@ -16,11 +16,8 @@ use Doctrine\ORM\Query\TokenType;
  */
 class ModFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
-    public $firstSimpleArithmeticExpression;
-
-    /** @var SimpleArithmeticExpression */
-    public $secondSimpleArithmeticExpression;
+    public Node|string $firstSimpleArithmeticExpression;
+    public Node|string $secondSimpleArithmeticExpression;
 
     public function getSql(SqlWalker $sqlWalker): string
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
@@ -18,8 +18,7 @@ use function sprintf;
  */
 class SqrtFunction extends FunctionNode
 {
-    /** @var SimpleArithmeticExpression */
-    public $simpleArithmeticExpression;
+    public Node|string $simpleArithmeticExpression;
 
     public function getSql(SqlWalker $sqlWalker): string
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
@@ -19,11 +18,8 @@ class SubstringFunction extends FunctionNode
 {
     public Node $stringPrimary;
 
-    /** @var SimpleArithmeticExpression */
-    public $firstSimpleArithmeticExpression;
-
-    /** @var SimpleArithmeticExpression|null */
-    public $secondSimpleArithmeticExpression = null;
+    public Node|string $firstSimpleArithmeticExpression;
+    public Node|string|null $secondSimpleArithmeticExpression = null;
 
     public function getSql(SqlWalker $sqlWalker): string
     {

--- a/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
@@ -13,9 +13,8 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class NullComparisonExpression extends Node
 {
-    /** @param Node $expression */
     public function __construct(
-        public $expression,
+        public Node|string $expression,
         public bool $not = false,
     ) {
     }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1943,6 +1943,8 @@ class SqlWalker
             return $this->walkInputParameter($expression) . $comparison;
         }
 
+        assert(! is_string($expression));
+
         return $expression->dispatch($this) . $comparison;
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,44 +256,14 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Expr/Select.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\Parser\\:\\:ArithmeticFactor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\AST\\\\ArithmeticFactor but returns Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node\\|string\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\Parser\\:\\:ArithmeticTerm\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\AST\\\\ArithmeticTerm but returns Doctrine\\\\ORM\\\\Query\\\\AST\\\\ArithmeticFactor\\|string\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
-			message: """
-				#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
-				        AST\\\\CollectionMemberExpression\\|
-				        AST\\\\ComparisonExpression\\|
-				        AST\\\\EmptyCollectionComparisonExpression\\|
-				        AST\\\\ExistsExpression\\|
-				        AST\\\\InExpression\\|
-				        AST\\\\InstanceOfExpression\\|
-				        AST\\\\LikeExpression\\|
-				        AST\\\\NullComparisonExpression\\)\\: Unexpected token "\\\\n     \\* ", expected type at offset 344$#
-			"""
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
 			message: "#^Parameter \\#2 \\$stringPattern of class Doctrine\\\\ORM\\\\Query\\\\AST\\\\LikeExpression constructor expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\Functions\\\\FunctionNode\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\InputParameter\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\Literal\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\PathExpression, Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 3
+			count: 2
 			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
-			message: "#^Call to function is_string\\(\\) with Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-
 			message: "#^Match arm is unreachable because previous comparison is always true\\.$#"
@@ -302,11 +272,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$condExpr of method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkJoinAssociationDeclaration\\(\\) expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\ConditionalPrimary\\|null, Doctrine\\\\ORM\\\\Query\\\\AST\\\\ConditionalExpression\\|null given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/SqlWalker.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1099,11 +1099,6 @@
       <code>$parserResult</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-    </PossiblyInvalidPropertyAssignmentValue>
-  </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php">
     <PossiblyInvalidPropertyAssignmentValue>
       <code>$parser-&gt;ArithmeticPrimary()</code>
@@ -1150,15 +1145,6 @@
     <PossiblyInvalidArgument>
       <code>$this-&gt;simpleArithmeticExpression</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-    </PossiblyInvalidPropertyAssignmentValue>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php">
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-    </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php">
     <PossiblyNullArrayOffset>
@@ -1169,17 +1155,6 @@
       <code>$owningAssoc['joinTable']</code>
       <code>$owningAssoc['targetToSourceKeyColumns']</code>
     </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php">
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-    </PossiblyInvalidPropertyAssignmentValue>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-      <code>$parser-&gt;SimpleArithmeticExpression()</code>
-    </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod>
@@ -1328,25 +1303,6 @@
     <InvalidPropertyAssignmentValue>
       <code>$this-&gt;queryComponents</code>
     </InvalidPropertyAssignmentValue>
-    <InvalidReturnStatement>
-      <code>$factors[0]</code>
-      <code>$primary</code>
-      <code>$terms[0]</code>
-      <code>$this-&gt;CollectionMemberExpression()</code>
-      <code>$this-&gt;ComparisonExpression()</code>
-      <code>$this-&gt;EmptyCollectionComparisonExpression()</code>
-      <code>$this-&gt;ExistsExpression()</code>
-      <code>$this-&gt;InExpression()</code>
-      <code>$this-&gt;InstanceOfExpression()</code>
-      <code>$this-&gt;LikeExpression()</code>
-      <code>$this-&gt;NullComparisonExpression()</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>AST\ArithmeticFactor</code>
-      <code>AST\ArithmeticTerm</code>
-      <code>AST\BetweenExpression|</code>
-      <code>AST\SimpleArithmeticExpression|AST\ArithmeticTerm</code>
-    </InvalidReturnType>
     <InvalidStringClass>
       <code>new $functionClass($functionName)</code>
       <code>new $functionClass($functionName)</code>
@@ -1367,7 +1323,6 @@
       <code>$AST</code>
       <code>$conditionalExpression</code>
       <code>$expr</code>
-      <code>$pathExp</code>
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
@@ -1377,7 +1332,6 @@
     <PossiblyInvalidPropertyAssignmentValue>
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
-      <code>$this-&gt;SimpleArithmeticExpression()</code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument>
       <code>$dql</code>
@@ -1391,15 +1345,9 @@
       <code>$token-&gt;value</code>
       <code>$token-&gt;value</code>
     </PossiblyNullPropertyFetch>
-    <PossiblyUndefinedVariable>
-      <code>$args</code>
-    </PossiblyUndefinedVariable>
     <RedundantCondition>
       <code>$token-&gt;value === TokenType::T_IDENTIFIER-&gt;value</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code>$AST instanceof AST\SelectStatement</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/QueryExpressionVisitor.php">
     <InvalidReturnStatement>
@@ -1421,7 +1369,6 @@
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
     <DocblockTypeContradiction>
       <code>$this-&gt;conn-&gt;quote((string) $newValue)</code>
-      <code>is_string($expression)</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code>$assoc</code>


### PR DESCRIPTION
In some cases, I had to widen the documented type, running the test suite showed me it was wrong.