### PR TITLE
Fix id hash of entity with enum as identifier

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -271,6 +271,10 @@ class BasicEntityPersister implements EntityPersister
                 $paramIndex = 1;
 
                 foreach ($insertData[$tableName] as $column => $value) {
+                    if ($value instanceof BackedEnum) {
+                        $value = $value->value;
+                    }
+
                     $stmt->bindValue($paramIndex++, $value, $this->columnTypes[$column]);
                 }
             }

--- a/tests/Doctrine/Tests/Models/GH10334/GH10334Foo.php
+++ b/tests/Doctrine/Tests/Models/GH10334/GH10334Foo.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10334;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+/**
+ * @Entity
+ */
+class GH10334Foo
+{
+    /**
+     * @var GH10334FooCollection
+     * @Id
+     * @ManyToOne(targetEntity="GH10334FooCollection", inversedBy="foos")
+     * @JoinColumn(name="foo_collection_id", referencedColumnName="id", nullable = false)
+     * @GeneratedValue
+     */
+    protected $collection;
+
+    /**
+     * @var GH10334ProductTypeId
+     * @Id
+     * @Column(type="string", enumType="Doctrine\Tests\Models\GH10334\GH10334ProductTypeId")
+     */
+    protected $productTypeId;
+
+    public function __construct(GH10334FooCollection $collection, GH10334ProductTypeId $productTypeId)
+    {
+        $this->collection    = $collection;
+        $this->productTypeId = $productTypeId;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH10334/GH10334FooCollection.php
+++ b/tests/Doctrine/Tests/Models/GH10334/GH10334FooCollection.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10334;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+/**
+ * @Entity
+ */
+class GH10334FooCollection
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    protected $id;
+
+    /**
+     * @OneToMany(targetEntity="GH10334Foo", mappedBy="collection", cascade={"persist", "remove"})
+     * @var Collection<GH10334Foo> $foos
+     */
+    private $foos;
+
+    public function __construct()
+    {
+        $this->foos = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<GH10334Foo>
+     */
+    public function getFoos(): Collection
+    {
+        return $this->foos;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH10334/GH10334Product.php
+++ b/tests/Doctrine/Tests/Models/GH10334/GH10334Product.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10334;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+/**
+ * @Entity
+ */
+class GH10334Product
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(name="product_id", type="integer")
+     * @GeneratedValue()
+     */
+    protected $id;
+
+    /**
+     * @var string
+     * @Column(name="name", type="string")
+     */
+    private $name;
+
+    /**
+     * @var GH10334ProductType $productType
+     * @ManyToOne(targetEntity="GH10334ProductType", inversedBy="products")
+     * @JoinColumn(name="product_type_id", referencedColumnName="id", nullable = false)
+     */
+    private $productType;
+
+    public function __construct(string $name, GH10334ProductType $productType)
+    {
+        $this->name        = $name;
+        $this->productType = $productType;
+    }
+
+    public function getProductType(): GH10334ProductType
+    {
+        return $this->productType;
+    }
+
+    public function setProductType(GH10334ProductType $productType): void
+    {
+        $this->productType = $productType;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH10334/GH10334ProductType.php
+++ b/tests/Doctrine/Tests/Models/GH10334/GH10334ProductType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10334;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+/**
+ * @Entity
+ */
+class GH10334ProductType
+{
+    /**
+     * @var GH10334ProductTypeId
+     * @Id
+     * @Column(type="string", enumType="Doctrine\Tests\Models\GH10334\GH10334ProductTypeId")
+     */
+    protected $id;
+
+    /**
+     * @var float
+     * @Column(type="float")
+     */
+    private $value;
+
+    /**
+     * @OneToMany(targetEntity="GH10334Product", mappedBy="productType", cascade={"persist", "remove"})
+     * @var Collection $products
+     */
+    private $products;
+
+    public function __construct(GH10334ProductTypeId $id, float $value)
+    {
+        $this->id       = $id;
+        $this->value    = $value;
+        $this->products = new ArrayCollection();
+    }
+
+    public function getId(): GH10334ProductTypeId
+    {
+        return $this->id;
+    }
+
+    public function addProduct(GH10334Product $product): void
+    {
+        $product->setProductType($this);
+        $this->products->add($product);
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH10334/GH10334ProductTypeId.php
+++ b/tests/Doctrine/Tests/Models/GH10334/GH10334ProductTypeId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH10334;
+
+enum GH10334ProductTypeId: string
+{
+    case Jean  = 'jean';
+    case Short = 'short';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10334Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10334Test.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH10334\GH10334Foo;
+use Doctrine\Tests\Models\GH10334\GH10334FooCollection;
+use Doctrine\Tests\Models\GH10334\GH10334Product;
+use Doctrine\Tests\Models\GH10334\GH10334ProductType;
+use Doctrine\Tests\Models\GH10334\GH10334ProductTypeId;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH10334Test
+ * @requires PHP 8.1
+ */
+class GH10334Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH10334FooCollection::class, GH10334Foo::class, GH10334ProductType::class, GH10334Product::class]);
+    }
+
+    public function testTicket(): void
+    {
+        $collection = new GH10334FooCollection();
+        $foo        = new GH10334Foo($collection, GH10334ProductTypeId::Jean);
+        $foo2       = new GH10334Foo($collection, GH10334ProductTypeId::Short);
+
+        $this->_em->persist($collection);
+        $this->_em->persist($foo);
+        $this->_em->persist($foo2);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em
+            ->getRepository(GH10334FooCollection::class)
+            ->createQueryBuilder('collection')
+            ->leftJoin('collection.foos', 'foo')->addSelect('foo')
+            ->getQuery()
+            ->getResult();
+
+        $this->_em
+            ->getRepository(GH10334FooCollection::class)
+            ->createQueryBuilder('collection')
+            ->leftJoin('collection.foos', 'foo')->addSelect('foo')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertCount(1, $result);
+        $this->assertCount(2, $result[0]->getFoos());
+    }
+
+    public function testGetChildWithBackedEnumId(): void
+    {
+        $jean    = new GH10334ProductType(GH10334ProductTypeId::Jean, 23.5);
+        $short   = new GH10334ProductType(GH10334ProductTypeId::Short, 45.2);
+        $product = new GH10334Product('Extra Large Blue', $jean);
+
+        $jean->addProduct($product);
+
+        $this->_em->persist($jean);
+        $this->_em->persist($short);
+        $this->_em->persist($product);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(GH10334Product::class, 1);
+
+        self::assertNotNull($entity);
+        self::assertSame($entity->getProductType()->getId(), GH10334ProductTypeId::Jean);
+    }
+}


### PR DESCRIPTION
**Current situation**
When an entity have a backed enum as identifier, Unit Of Work tries to cast to string when generating the hash of the id.

`Error "Object of class MyEnum could not be converted to string"`

**Suggested fix**
This PR fixes the problem by adding function to get id of entity with backed enum check.

**Tests added**
It seems tests for this feature were completely missing, so I added them.

Fixes https://github.com/doctrine/orm/issues/10471 
Fixes https://github.com/doctrine/orm/issues/10334