### PR TITLE
Use array shapes where appropriate

### DIFF
--- a/lib/Doctrine/ORM/Cache/CacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/CacheFactory.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 /**
  * Contract for building second level cache regions components.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 interface CacheFactory
 {
@@ -31,7 +33,7 @@ interface CacheFactory
     /**
      * Build a collection persister for the given relation mapping.
      *
-     * @param mixed[] $mapping The association mapping.
+     * @param AssociationMapping $mapping The association mapping.
      *
      * @return CachedCollectionPersister
      */

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -138,6 +138,7 @@ class DefaultCacheFactory implements CacheFactory
      */
     public function buildCachedCollectionPersister(EntityManagerInterface $em, CollectionPersister $persister, array $mapping)
     {
+        assert(isset($mapping['cache']));
         $usage  = $mapping['cache']['usage'];
         $region = $this->getRegion($mapping['cache']);
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -29,6 +29,8 @@ use function reset;
 
 /**
  * Default query cache implementation.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class DefaultQueryCache implements QueryCache
 {
@@ -326,8 +328,8 @@ class DefaultQueryCache implements QueryCache
     }
 
     /**
-     * @param array<string,mixed> $assoc
-     * @param mixed               $assocValue
+     * @param AssociationMapping $assoc
+     * @param mixed              $assocValue
      *
      * @return mixed[]|null
      * @psalm-return array{targetEntity: class-string, type: mixed, list?: array[], identifier?: array}|null

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -25,6 +25,7 @@ use function array_values;
 use function assert;
 use function count;
 
+/** @psalm-import-type AssociationMapping from ClassMetadata */
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
     /** @var UnitOfWork */
@@ -64,7 +65,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      * @param CollectionPersister    $persister   The collection persister that will be cached.
      * @param Region                 $region      The collection region.
      * @param EntityManagerInterface $em          The entity manager.
-     * @param mixed[]                $association The association mapping.
+     * @param AssociationMapping     $association The association mapping.
      */
     public function __construct(CollectionPersister $persister, Region $region, EntityManagerInterface $em, array $association)
     {

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -7,14 +7,16 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
 use function spl_object_id;
 
+/** @psalm-import-type AssociationMapping from ClassMetadata */
 class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {
-    /** @param mixed[] $association The association mapping. */
+    /** @param AssociationMapping $association The association mapping. */
     public function __construct(CollectionPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, array $association)
     {
         parent::__construct($persister, $region, $em, $association);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1855,30 +1855,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      *
      * @return mixed[] The validated & completed mapping.
-     * @psalm-return array{
-     *      mappedBy: mixed|null,
-     *      inversedBy: mixed|null,
-     *      isOwningSide: bool,
-     *      sourceEntity: class-string,
-     *      targetEntity: string,
-     *      fieldName: mixed,
-     *      fetch: mixed,
-     *      cascade: array<string>,
-     *      isCascadeRemove: bool,
-     *      isCascadePersist: bool,
-     *      isCascadeRefresh: bool,
-     *      isCascadeMerge: bool,
-     *      isCascadeDetach: bool,
-     *      type: int,
-     *      originalField: string,
-     *      originalClass: class-string,
-     *      joinColumns?: array{0: array{name: string, referencedColumnName: string}}|mixed,
-     *      id?: mixed,
-     *      sourceToTargetKeyColumns?: array<string, string>,
-     *      joinColumnFieldNames?: array<string, string>,
-     *      targetToSourceKeyColumns?: array<string, string>,
-     *      orphanRemoval: bool
-     * }
+     * @psalm-return AssociationMapping
      *
      * @throws RuntimeException
      * @throws MappingException
@@ -1968,22 +1945,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @psalm-param array<string, mixed> $mapping The mapping to validate and complete.
      *
      * @return mixed[] The validated and completed mapping.
-     * @psalm-return array{
-     *                   mappedBy: mixed,
-     *                   inversedBy: mixed,
-     *                   isOwningSide: bool,
-     *                   sourceEntity: string,
-     *                   targetEntity: string,
-     *                   fieldName: mixed,
-     *                   fetch: int|mixed,
-     *                   cascade: array<array-key,string>,
-     *                   isCascadeRemove: bool,
-     *                   isCascadePersist: bool,
-     *                   isCascadeRefresh: bool,
-     *                   isCascadeMerge: bool,
-     *                   isCascadeDetach: bool,
-     *                   orphanRemoval: bool
-     *               }
+     * @psalm-return AssociationMapping
      *
      * @throws MappingException
      * @throws InvalidArgumentException
@@ -2011,30 +1973,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
      *
      * @return mixed[] The validated & completed mapping.
-     * @psalm-return array{
-     *      mappedBy: mixed,
-     *      inversedBy: mixed,
-     *      isOwningSide: bool,
-     *      sourceEntity: class-string,
-     *      targetEntity: string,
-     *      fieldName: mixed,
-     *      fetch: mixed,
-     *      cascade: array<string>,
-     *      isCascadeRemove: bool,
-     *      isCascadePersist: bool,
-     *      isCascadeRefresh: bool,
-     *      isCascadeMerge: bool,
-     *      isCascadeDetach: bool,
-     *      type: int,
-     *      originalField: string,
-     *      originalClass: class-string,
-     *      joinTable?: array{inverseJoinColumns: mixed}|mixed,
-     *      joinTableColumns?: list<mixed>,
-     *      isOnDeleteCascade?: true,
-     *      relationToSourceKeyColumns?: array,
-     *      relationToTargetKeyColumns?: array,
-     *      orphanRemoval: bool
-     * }
+     * @psalm-return AssociationMapping
      *
      * @throws InvalidArgumentException
      */
@@ -3033,7 +2972,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Stores the association mapping.
      *
-     * @psalm-param array<string, mixed> $assocMapping
+     * @psalm-param AssociationMapping $assocMapping
      *
      * @return void
      *
@@ -3185,7 +3124,7 @@ class ClassMetadataInfo implements ClassMetadata
      * @see getDiscriminatorColumn()
      *
      * @param mixed[]|null $columnDef
-     * @psalm-param array{name: string|null, fieldName?: string, type?: string, length?: int, columnDefinition?: string|null, enumType?: class-string<BackedEnum>|null}|null $columnDef
+     * @psalm-param DiscriminatorColumnMapping|array{name: string|null, fieldName?: string, type?: string, length?: int, columnDefinition?: string|null, enumType?: class-string<BackedEnum>|null}|null $columnDef
      *
      * @return void
      *
@@ -3891,7 +3830,7 @@ class ClassMetadataInfo implements ClassMetadata
         return $sequencePrefix;
     }
 
-    /** @psalm-param array<string, mixed> $mapping */
+    /** @psalm-param AssociationMapping $mapping */
     private function assertMappingOrderBy(array $mapping): void
     {
         if (isset($mapping['orderBy']) && ! is_array($mapping['orderBy'])) {

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -8,6 +8,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * A set of rules for determining the column, alias and table quotes.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
+ * @psalm-import-type JoinColumnData from ClassMetadata
  */
 interface QuoteStrategy
 {
@@ -39,7 +42,7 @@ interface QuoteStrategy
     /**
      * Gets the (possibly quoted) name of the join table.
      *
-     * @param mixed[] $association
+     * @param AssociationMapping $association
      *
      * @return string
      */
@@ -48,7 +51,7 @@ interface QuoteStrategy
     /**
      * Gets the (possibly quoted) join column name.
      *
-     * @param mixed[] $joinColumn
+     * @param JoinColumnData $joinColumn
      *
      * @return string
      */
@@ -57,7 +60,7 @@ interface QuoteStrategy
     /**
      * Gets the (possibly quoted) join column name.
      *
-     * @param mixed[] $joinColumn
+     * @param JoinColumnData $joinColumn
      *
      * @return string
      */

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -82,8 +82,8 @@ class ORMInvalidArgumentException extends InvalidArgumentException
     }
 
     /**
-     * @param array[][]|object[][] $newEntitiesWithAssociations non-empty an array
-     *                                                              of [array $associationMapping, object $entity] pairs
+     * @psalm-param non-empty-list<array{AssociationMapping, object}> $newEntitiesWithAssociations non-empty an array
+     *                                                                of [array $associationMapping, object $entity] pairs
      *
      * @return ORMInvalidArgumentException
      */
@@ -122,7 +122,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
 
     /**
      * @param object $entry
-     * @psalm-param array<string, string> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return ORMInvalidArgumentException
      */
@@ -222,8 +222,8 @@ EXCEPTION
     }
 
     /**
-     * @param mixed[] $assoc
-     * @param mixed   $actualValue
+     * @param AssociationMapping $assoc
+     * @param mixed              $actualValue
      *
      * @return self
      */

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -36,6 +36,7 @@ use function spl_object_id;
  * @psalm-template T
  * @template-extends AbstractLazyCollection<TKey,T>
  * @template-implements Selectable<TKey,T>
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 final class PersistentCollection extends AbstractLazyCollection implements Selectable
 {
@@ -58,7 +59,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * The association mapping the collection belongs to.
      * This is currently either a OneToManyMapping or a ManyToManyMapping.
      *
-     * @psalm-var array<string, mixed>|null
+     * @psalm-var AssociationMapping|null
      */
     private $association;
 
@@ -113,7 +114,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * describes the association between the owner and the elements of the collection.
      *
      * @param object $entity
-     * @psalm-param array<string, mixed> $assoc
+     * @psalm-param AssociationMapping $assoc
      */
     public function setOwner($entity, array $assoc): void
     {
@@ -271,7 +272,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @psalm-return array<string, mixed>|null
+     * @psalm-return AssociationMapping|null
      */
     public function getMapping(): ?array
     {

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -24,6 +24,8 @@ use function sprintf;
 
 /**
  * Persister for many-to-many collections.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ManyToManyPersister extends AbstractCollectionPersister
 {
@@ -286,7 +288,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * JOIN.
      *
      * @param mixed[] $mapping Array containing mapping information.
-     * @psalm-param array<string, mixed> $mapping
+     * @psalm-param AssociationMapping $mapping
      *
      * @return string[] ordered tuple:
      *                   - JOIN condition to add to the SQL
@@ -339,7 +341,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * Generate ON condition
      *
      * @param mixed[] $mapping
-     * @psalm-param array<string, mixed> $mapping
+     * @psalm-param AssociationMapping $mapping
      *
      * @return string[]
      * @psalm-return list<string>

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -87,6 +87,8 @@ use function trim;
  *
  * Subclasses can be created to provide custom persisting and querying strategies,
  * i.e. spanning multiple tables.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class BasicEntityPersister implements EntityPersister
 {
@@ -1332,9 +1334,9 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Gets the SQL join fragment used when selecting entities from an association.
      *
-     * @param string  $field
-     * @param mixed[] $assoc
-     * @param string  $alias
+     * @param string             $field
+     * @param AssociationMapping $assoc
+     * @param string             $alias
      *
      * @return string
      */
@@ -1366,7 +1368,7 @@ class BasicEntityPersister implements EntityPersister
      * Gets the SQL join fragment used when selecting entities from a
      * many-to-many association.
      *
-     * @psalm-param array<string, mixed> $manyToMany
+     * @psalm-param AssociationMapping $manyToMany
      *
      * @return string
      */
@@ -1694,7 +1696,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Builds the left-hand-side of a where condition statement.
      *
-     * @psalm-param array<string, mixed>|null $assoc
+     * @psalm-param AssociationMapping|null $assoc
      *
      * @return string[]
      * @psalm-return list<string>
@@ -1767,7 +1769,7 @@ class BasicEntityPersister implements EntityPersister
      * Subclasses are supposed to override this method if they intend to change
      * or alter the criteria by which entities are selected.
      *
-     * @param mixed[]|null $assoc
+     * @param AssociationMapping|null $assoc
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, mixed>|null $assoc
      *
@@ -1810,7 +1812,7 @@ class BasicEntityPersister implements EntityPersister
      * Builds criteria and execute SQL statement to fetch the one to many entities from.
      *
      * @param object $sourceEntity
-     * @psalm-param array<string, mixed> $assoc
+     * @psalm-param AssociationMapping $assoc
      */
     private function getOneToManyStatement(
         array $assoc,

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Query\ResultSetMapping;
 /**
  * Entity persister interface
  * Define the behavior that should be implemented by all entity persisters.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 interface EntityPersister
 {
@@ -48,11 +50,11 @@ interface EntityPersister
      * Gets the SELECT SQL to select one or more entities by a set of field criteria.
      *
      * @param mixed[]|Criteria $criteria
-     * @param mixed[]|null     $assoc
      * @param int|null         $lockMode
      * @param int|null         $limit
      * @param int|null         $offset
      * @param mixed[]|null     $orderBy
+     * @psalm-param AssociationMapping|null $assoc
      * @psalm-param LockMode::*|null $lockMode
      *
      * @return string
@@ -87,11 +89,10 @@ interface EntityPersister
     /**
      * Gets the SQL WHERE condition for matching a field with a given value.
      *
-     * @param string       $field
-     * @param mixed        $value
-     * @param mixed[]|null $assoc
-     * @param string|null  $comparison
-     * @psalm-param array<string, mixed>|null  $assoc
+     * @param string                  $field
+     * @param mixed                   $value
+     * @param AssociationMapping|null $assoc
+     * @param string|null             $comparison
      *
      * @return string
      */
@@ -171,19 +172,18 @@ interface EntityPersister
     /**
      * Loads an entity by a list of field criteria.
      *
-     * @param mixed[]       $criteria The criteria by which to load the entity.
-     * @param object|null   $entity   The entity to load the data into. If not specified,
-     *                                a new entity is created.
-     * @param mixed[]|null  $assoc    The association that connects the entity
-     *                                to load to another entity, if any.
-     * @param mixed[]       $hints    Hints for entity creation.
-     * @param int|null      $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                                or NULL if no specific lock mode should be used
-     *                                for loading the entity.
-     * @param int|null      $limit    Limit number of results.
-     * @param string[]|null $orderBy  Criteria to order by.
+     * @param mixed[]                 $criteria The criteria by which to load the entity.
+     * @param object|null             $entity   The entity to load the data into. If not specified,
+     *                                          a new entity is created.
+     * @param AssociationMapping|null $assoc    The association that connects the entity
+     *                               to load to another entity, if any.
+     * @param mixed[]                 $hints    Hints for entity creation.
+     * @param int|null                $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                                          or NULL if no specific lock mode should be used
+     *                                          for loading the entity.
+     * @param int|null                $limit    Limit number of results.
+     * @param string[]|null           $orderBy  Criteria to order by.
      * @psalm-param array<string, mixed>       $criteria
-     * @psalm-param array<string, mixed>|null  $assoc
      * @psalm-param array<string, mixed>       $hints
      * @psalm-param LockMode::*|null           $lockMode
      * @psalm-param array<string, string>|null $orderBy
@@ -222,7 +222,7 @@ interface EntityPersister
      * @psalm-param array<string, mixed> $identifier The identifier of the entity to load. Must be provided if
      *                                               the association to load represents the owning side, otherwise
      *                                               the identifier is derived from the $sourceEntity.
-     * @psalm-param array<string, mixed> $assoc        The association to load.
+     * @psalm-param AssociationMapping $assoc        The association to load.
      *
      * @return object The loaded and managed entity instance or NULL if the entity can not be found.
      *
@@ -269,7 +269,7 @@ interface EntityPersister
      * @param object   $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
-     * @psalm-param array<string, mixed> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return mixed[]
      */
@@ -280,7 +280,7 @@ interface EntityPersister
      *
      * @param object               $sourceEntity The entity that owns the collection.
      * @param PersistentCollection $collection   The collection to fill.
-     * @psalm-param array<string, mixed> $assoc The association mapping of the association being loaded.
+     * @psalm-param AssociationMapping $assoc The association mapping of the association being loaded.
      *
      * @return mixed[]
      */
@@ -291,7 +291,7 @@ interface EntityPersister
      *
      * @param object               $sourceEntity
      * @param PersistentCollection $collection   The collection to load/fill.
-     * @psalm-param array<string, mixed> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return mixed
      */
@@ -314,7 +314,7 @@ interface EntityPersister
      * @param object   $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
-     * @psalm-param array<string, mixed> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return mixed[]
      */

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -35,11 +35,12 @@ use function substr;
  * An LL(*) recursive-descent parser for the context-free grammar of the Doctrine Query Language.
  * Parses a DQL query, reports any errors in it, and generates an AST.
  *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-type DqlToken = Token<Lexer::T_*, string>
  * @psalm-type QueryComponent = array{
  *                 metadata?: ClassMetadata<object>,
  *                 parent?: string|null,
- *                 relation?: mixed[]|null,
+ *                 relation?: AssociationMapping|null,
  *                 map?: string|null,
  *                 resultVariable?: AST\Node|string,
  *                 nestingLevel: int,

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Exception;
 use Stringable;
 
+/** @psalm-import-type AssociationMapping from ClassMetadata */
 class QueryException extends ORMException
 {
     /**
@@ -142,7 +144,7 @@ class QueryException extends ORMException
 
     /**
      * @param string[] $assoc
-     * @psalm-param array<string, string> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return QueryException
      */
@@ -190,7 +192,7 @@ class QueryException extends ORMException
 
     /**
      * @param string[] $assoc
-     * @psalm-param array<string, string> $assoc
+     * @psalm-param AssociationMapping $assoc
      *
      * @return QueryException
      */

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -39,6 +39,9 @@ use const JSON_UNESCAPED_UNICODE;
  * Show information about mapped entities.
  *
  * @link    www.doctrine-project.org
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 final class MappingDescribeCommand extends AbstractEntityManagerCommand
 {
@@ -246,7 +249,7 @@ EOT
     /**
      * Format the association mappings
      *
-     * @psalm-param array<string, array<string, mixed>> $propertyMappings
+     * @psalm-param array<string, FieldMapping|AssociationMapping> $propertyMappings
      *
      * @return string[][]
      * @psalm-return list<array{0: string, 1: string}>

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -19,6 +19,8 @@ use function ltrim;
  *
  * Mechanism to overwrite interfaces or classes specified as association
  * targets.
+ *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  */
 class ResolveTargetEntityListener implements EventSubscriber
 {
@@ -97,7 +99,7 @@ class ResolveTargetEntityListener implements EventSubscriber
         }
     }
 
-    /** @param mixed[] $mapping */
+    /** @param AssociationMapping $mapping */
     private function remapAssociation(ClassMetadata $classMetadata, array $mapping): void
     {
         $newMapping              = $this->resolveTargetEntities[$mapping['targetEntity']];

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -47,7 +47,9 @@ use function strtolower;
  *
  * @link    www.doctrine-project.org
  *
+ * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-import-type FieldMapping from ClassMetadata
+ * @psalm-import-type JoinColumnData from ClassMetadata
  */
 class SchemaTool
 {
@@ -659,8 +661,8 @@ class SchemaTool
     /**
      * Gathers columns and fk constraints that are required for one part of relationship.
      *
-     * @psalm-param array<string, mixed>             $joinColumns
-     * @psalm-param array<string, mixed>             $mapping
+     * @psalm-param array<string, JoinColumnData>    $joinColumns
+     * @psalm-param AssociationMapping               $mapping
      * @psalm-param list<string>                     $primaryKeyColumns
      * @psalm-param array<string, array{
      *                  foreignTableName: string,
@@ -790,7 +792,7 @@ class SchemaTool
     }
 
     /**
-     * @param mixed[] $mapping
+     * @psalm-param JoinColumnData|FieldMapping $mapping
      *
      * @return mixed[]
      */

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -213,7 +213,7 @@ class UnitOfWork implements PropertyChangedListener
      * Keys are OIDs, payload is a two-item array describing the association
      * and the entity.
      *
-     * @var object[][]|array[][] indexed by respective object spl_object_id()
+     * @var array<int, array{AssociationMapping, object}> indexed by respective object spl_object_id()
      */
     private $nonCascadedNewDetectedEntities = [];
 
@@ -257,7 +257,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * The collection persister instances used to persist collections.
      *
-     * @psalm-var array<string, CollectionPersister>
+     * @psalm-var array<array-key, CollectionPersister>
      */
     private $collectionPersisters = [];
 
@@ -905,7 +905,7 @@ class UnitOfWork implements PropertyChangedListener
      * Computes the changes of an association.
      *
      * @param mixed $value The value of the association.
-     * @psalm-param array<string, mixed> $assoc The association mapping.
+     * @psalm-param AssociationMapping $assoc The association mapping.
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
@@ -3246,7 +3246,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Gets a collection persister for a collection-valued association.
      *
-     * @psalm-param array<string, mixed> $association
+     * @psalm-param AssociationMapping $association
      *
      * @return CollectionPersister
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,11 +171,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\:\\:_validateAndCompleteManyToManyMapping\\(\\) should return array\\{mappedBy\\: mixed, inversedBy\\: mixed, isOwningSide\\: bool, sourceEntity\\: class\\-string, targetEntity\\: string, fieldName\\: mixed, fetch\\: mixed, cascade\\: array\\<string\\>, \\.\\.\\.\\} but returns array\\{cache\\?\\: array, cascade\\: array\\<string\\>, declared\\?\\: class\\-string, fetch\\: mixed, fieldName\\: string, id\\?\\: bool, inherited\\?\\: class\\-string, indexBy\\?\\: string, \\.\\.\\.\\}\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\:\\:fullyQualifiedClassName\\(\\) should return class\\-string\\|null but returns string\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -495,6 +495,11 @@
       <code>$class</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php">
+    <PossiblyUndefinedArrayOffset>
+      <code>$association['joinTable']</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php">
     <ArgumentTypeCoercion>
       <code>$repositoryClassName</code>
@@ -585,6 +590,7 @@
       <code>! $this-&gt;table</code>
       <code>! class_exists($mapping['targetEntity'])</code>
       <code>$this-&gt;table</code>
+      <code>isset($mapping['orderBy']) &amp;&amp; ! is_array($mapping['orderBy'])</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code>$mapping</code>
@@ -605,53 +611,11 @@
     <InvalidReturnStatement>
       <code>$mapping</code>
       <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
       <code>$this-&gt;reflClass</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>AssociationMapping</code>
       <code>FieldMapping</code>
-      <code>array{
-     *                   mappedBy: mixed,
-     *                   inversedBy: mixed,
-     *                   isOwningSide: bool,
-     *                   sourceEntity: string,
-     *                   targetEntity: string,
-     *                   fieldName: mixed,
-     *                   fetch: int|mixed,
-     *                   cascade: array&lt;array-key,string&gt;,
-     *                   isCascadeRemove: bool,
-     *                   isCascadePersist: bool,
-     *                   isCascadeRefresh: bool,
-     *                   isCascadeMerge: bool,
-     *                   isCascadeDetach: bool,
-     *                   orphanRemoval: bool
-     *               }</code>
-      <code>array{
-     *      mappedBy: mixed|null,
-     *      inversedBy: mixed|null,
-     *      isOwningSide: bool,
-     *      sourceEntity: class-string,
-     *      targetEntity: string,
-     *      fieldName: mixed,
-     *      fetch: mixed,
-     *      cascade: array&lt;string&gt;,
-     *      isCascadeRemove: bool,
-     *      isCascadePersist: bool,
-     *      isCascadeRefresh: bool,
-     *      isCascadeMerge: bool,
-     *      isCascadeDetach: bool,
-     *      type: int,
-     *      originalField: string,
-     *      originalClass: class-string,
-     *      joinColumns?: array{0: array{name: string, referencedColumnName: string}}|mixed,
-     *      id?: mixed,
-     *      sourceToTargetKeyColumns?: array&lt;string, string&gt;,
-     *      joinColumnFieldNames?: array&lt;string, string&gt;,
-     *      targetToSourceKeyColumns?: array&lt;string, string&gt;,
-     *      orphanRemoval: bool
-     * }</code>
       <code>getReflectionClass</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
@@ -659,7 +623,6 @@
       <code>$className</code>
       <code>$className</code>
       <code>$columnNames</code>
-      <code>$mapping</code>
       <code>$quotedColumnNames</code>
       <code>$this-&gt;namespace . '\\' . $className</code>
     </LessSpecificReturnStatement>
@@ -667,30 +630,6 @@
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
     <MoreSpecificReturnType>
-      <code>array{
-     *      mappedBy: mixed,
-     *      inversedBy: mixed,
-     *      isOwningSide: bool,
-     *      sourceEntity: class-string,
-     *      targetEntity: string,
-     *      fieldName: mixed,
-     *      fetch: mixed,
-     *      cascade: array&lt;string&gt;,
-     *      isCascadeRemove: bool,
-     *      isCascadePersist: bool,
-     *      isCascadeRefresh: bool,
-     *      isCascadeMerge: bool,
-     *      isCascadeDetach: bool,
-     *      type: int,
-     *      originalField: string,
-     *      originalClass: class-string,
-     *      joinTable?: array{inverseJoinColumns: mixed}|mixed,
-     *      joinTableColumns?: list&lt;mixed&gt;,
-     *      isOnDeleteCascade?: true,
-     *      relationToSourceKeyColumns?: array,
-     *      relationToTargetKeyColumns?: array,
-     *      orphanRemoval: bool
-     * }</code>
       <code>array{usage: int, region: string|null}</code>
       <code>class-string|null</code>
       <code>list&lt;string&gt;</code>
@@ -795,6 +734,7 @@
       <code>getIdentifierColumnNames</code>
     </MoreSpecificReturnType>
     <PossiblyUndefinedArrayOffset>
+      <code>$association['joinTable']</code>
       <code>$class-&gt;associationMappings[$fieldName]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
   </file>
@@ -1219,11 +1159,6 @@
       <code>$sql</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="lib/Doctrine/ORM/ORMInvalidArgumentException.php">
-    <PossiblyInvalidArgument>
-      <code>$entity</code>
-    </PossiblyInvalidArgument>
-  </file>
   <file src="lib/Doctrine/ORM/PersistentCollection.php">
     <ImplementedReturnTypeMismatch>
       <code>Collection&lt;TKey, T&gt;</code>
@@ -1274,11 +1209,22 @@
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code>$this-&gt;association['orphanRemoval']</code>
+      <code>$this-&gt;association['orphanRemoval']</code>
+      <code>$this-&gt;association['orphanRemoval']</code>
+    </PossiblyUndefinedArrayOffset>
     <UndefinedMethod>
       <code>[$this-&gt;unwrap(), 'add']</code>
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
+    <ArgumentTypeCoercion>
+      <code>$mapping</code>
+    </ArgumentTypeCoercion>
+    <InvalidArrayOffset>
+      <code>[$mappedKey =&gt; $collection-&gt;getOwner(), $mapping['indexBy'] =&gt; $index]</code>
+    </InvalidArrayOffset>
     <PossiblyNullArgument>
       <code>$association</code>
       <code>$collection-&gt;getOwner()</code>
@@ -1290,9 +1236,11 @@
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
+      <code>$column</code>
       <code>$filterMapping</code>
       <code>$filterMapping</code>
       <code>$indexBy</code>
+      <code>$mapping</code>
       <code>$mapping</code>
       <code>$mapping</code>
       <code>$mapping</code>
@@ -1324,14 +1272,24 @@
       <code>$mapping['targetEntity']</code>
       <code>$mapping['targetEntity']</code>
       <code>$owner</code>
+      <code>$targetColumn</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']['inverseJoinColumns']</code>
+      <code>$association['joinTable']['joinColumns']</code>
+      <code>$mapping[$sourceRelationMode]</code>
+      <code>$mapping[$targetRelationMode]</code>
+      <code>$mapping[$targetRelationMode][$joinTableColumn]</code>
       <code>$mapping['indexBy']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
@@ -1339,16 +1297,22 @@
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns'][$joinTableColumn]</code>
       <code>$mapping['relationToSourceKeyColumns'][$joinTableColumn]</code>
       <code>$mapping['relationToTargetKeyColumns']</code>
       <code>$mapping['relationToTargetKeyColumns'][$joinTableColumn]</code>
@@ -1373,14 +1337,21 @@
       <code>$associationSourceClass-&gt;associationMappings</code>
       <code>$sourceClass-&gt;associationMappings</code>
       <code>$targetClass-&gt;associationMappings</code>
+      <code>$targetClass-&gt;associationMappings</code>
+      <code>$targetClass-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>
     <PossiblyNullIterator>
       <code>$joinColumns</code>
+      <code>$joinColumns</code>
+      <code>$mapping[$sourceRelationMode]</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
     </PossiblyNullIterator>
@@ -1395,16 +1366,33 @@
       <code>$association['joinTable']</code>
       <code>$mapping[$sourceRelationMode]</code>
       <code>$mapping[$targetRelationMode]</code>
+      <code>$mapping['indexBy']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToTargetKeyColumns']</code>
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
     <ImplementedReturnTypeMismatch>
       <code>int|null</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidArrayOffset>
+      <code>[
+                $mapping['mappedBy'] =&gt; $collection-&gt;getOwner(),
+                $mapping['indexBy']  =&gt; $index,
+            ]</code>
+    </InvalidArrayOffset>
     <InvalidReturnStatement>
       <code>$numDeleted</code>
       <code>$this-&gt;conn-&gt;executeStatement($statement, $parameters)</code>
@@ -1418,6 +1406,7 @@
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$mapping</code>
+      <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['sourceEntity']</code>
@@ -1448,14 +1437,20 @@
       <code>$targetClass-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>
     <PossiblyUndefinedArrayOffset>
+      <code>$mapping['orphanRemoval']</code>
       <code>$targetClass-&gt;associationMappings[$mapping['mappedBy']]['joinColumns']</code>
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
+    <ArgumentTypeCoercion>
+      <code>$assoc</code>
+      <code>$association</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code>$value === null</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
+      <code>$assoc</code>
       <code>$em-&gt;getMetadataFactory()</code>
       <code>$hints</code>
       <code>$hints</code>
@@ -1487,16 +1482,27 @@
     </NullableReturnStatement>
     <PossiblyNullArgument>
       <code>$assoc['mappedBy']</code>
+      <code>$assoc['mappedBy']</code>
+      <code>$assoc['mappedBy']</code>
       <code>$association</code>
       <code>$type</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
       <code>$assoc['isOwningSide']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']['inverseJoinColumns']</code>
+      <code>$association['joinTable']['joinColumns']</code>
     </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code>$class-&gt;associationMappings</code>
       <code>$class-&gt;associationMappings</code>
+      <code>$targetEntity-&gt;associationMappings</code>
+      <code>$this-&gt;class-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>
+    <PossiblyNullIterator>
+      <code>$joinColumns</code>
+    </PossiblyNullIterator>
     <PossiblyNullReference>
       <code>getValue</code>
       <code>getValue</code>
@@ -1507,7 +1513,7 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code>$assoc['inversedBy']</code>
+      <code>$assoc['joinColumns']</code>
       <code>$assoc['joinColumns']</code>
       <code>$assoc['joinColumns']</code>
       <code>$assoc['relationToTargetKeyColumns']</code>
@@ -1515,6 +1521,10 @@
       <code>$association['joinColumns']</code>
       <code>$association['joinColumns']</code>
       <code>$association['joinColumns']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']</code>
+      <code>$association['joinTable']</code>
       <code>$association['joinTable']</code>
       <code>$association['joinTable']</code>
       <code>$association['joinTable']</code>
@@ -2352,7 +2362,6 @@
       <code>$expr</code>
     </ImplicitToStringCast>
     <InvalidArgument>
-      <code>$assoc</code>
       <code>$condExpr</code>
       <code>$condTerm</code>
       <code>$factor</code>
@@ -2380,6 +2389,7 @@
     <PossiblyNullArrayOffset>
       <code>$targetClass-&gt;associationMappings</code>
       <code>$targetClass-&gt;associationMappings</code>
+      <code>$targetClass-&gt;associationMappings</code>
       <code>$this-&gt;scalarResultAliasMap</code>
       <code>$this-&gt;scalarResultAliasMap</code>
     </PossiblyNullArrayOffset>
@@ -2393,8 +2403,6 @@
       <code>$assoc['joinTable']</code>
       <code>$assoc['sourceToTargetKeyColumns']</code>
       <code>$assoc['targetToSourceKeyColumns']</code>
-      <code>$assoc['type']</code>
-      <code>$assoc['type']</code>
       <code>$association['sourceToTargetKeyColumns']</code>
       <code>$association['targetToSourceKeyColumns']</code>
       <code>$owningAssoc['joinTable']</code>
@@ -3089,6 +3097,9 @@
       <code>unwrap</code>
       <code>unwrap</code>
     </PossiblyUndefinedMethod>
+    <PropertyTypeCoercion>
+      <code>$this-&gt;nonCascadedNewDetectedEntities</code>
+    </PropertyTypeCoercion>
     <RedundantCondition>
       <code>$i &gt;= 0 &amp;&amp; $this-&gt;entityDeletions</code>
       <code>$this-&gt;entityDeletions</code>


### PR DESCRIPTION
Working on converting these array shapes to DTO allowed me to find every signature where they are supposed to be used.

The Psalm baseline gets worse because it considers accessing an array key differently depending on whether it is defined vaguely, as `array<string, mixed>`, or precisely, as `array{my-key?: string}`.

See https://psalm.dev/r/5940ba233e