### PR TITLE
Deprecate overriding associations not inherited from a mapped superclass

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2526,12 +2526,16 @@ class ClassMetadataInfo implements ClassMetadata
 
         $mapping = $this->associationMappings[$fieldName];
 
-        //if (isset($mapping['inherited']) && (count($overrideMapping) !== 1 || ! isset($overrideMapping['fetch']))) {
-            // TODO: Deprecate overriding the fetch mode via association override for 3.0,
-            // users should do this with a listener and a custom attribute/annotation
-            // TODO: Enable this exception in 2.8
-            //throw MappingException::illegalOverrideOfInheritedProperty($this->name, $fieldName);
-        //}
+        if (isset($mapping['inherited'])) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/10470',
+                'Overrides are only allowed for fields or associations declared in mapped superclasses or traits. This is not the case for %s::%s, which was inherited from %s. This is a misconfiguration and will be an error in Doctrine ORM 3.0.',
+                $this->name,
+                $fieldName,
+                $mapping['inherited']
+            );
+        }
 
         if (isset($overrideMapping['joinColumns'])) {
             $mapping['joinColumns'] = $overrideMapping['joinColumns'];

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -261,6 +261,16 @@ class BasicInheritanceMappingTest extends OrmTestCase
 
         $cm->setAttributeOverride('completed', ['name' => 'other_column_name']);
     }
+
+    /** @group DDC-964 */
+    public function testInvalidOverrideAssociationInheritedFromEntity(): void
+    {
+        $cm = $this->cmf->getMetadataFor(CompanyFixContract::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10470');
+
+        $cm->setAssociationOverride('salesPerson', ['inversedBy' => 'other_inversed_by_name']);
+    }
 }
 
 class TransientBaseClass


### PR DESCRIPTION
This follows up on #10470, this time taking care of the associations.

I use the same UPGRADE notice, deprecation text etc. since it already covered this use case as well.