### PR TITLE
Add QueryBuilder::when method

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1209,6 +1209,27 @@ class QueryBuilder
     }
 
     /**
+     * Adds restriction defined by the callback to the query results if a condition is true.
+     * Otherwise it apply the default if defined.
+     *
+     * @param bool                    $condition
+     * @param callable(QueryBuilder): $this|null $callback
+     * @param callable(QueryBuilder): $this|null $default
+     *
+     * @return $this
+     */
+    public function when($condition, $callback, $default = null)
+    {
+        if ($condition) {
+            return $callback($this) ?? $this;
+        } elseif ($default) {
+            return $default($this) ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Specifies a grouping over the results of the query.
      * Replaces any previously specified groupings, if any.
      *

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -379,6 +379,51 @@ class QueryBuilderTest extends OrmTestCase
         $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid OR u.id NOT IN(1, 2, 3)');
     }
 
+    public function testWhenWithValidCondition(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u');
+
+        $qb->when(true, static function (QueryBuilder $qb): QueryBuilder {
+            return $qb->andWhere('u.id = :uid');
+        });
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid');
+    }
+
+    public function testWhenWithIvalidCondition(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u');
+
+        $qb->when(false, static function (QueryBuilder $qb): QueryBuilder {
+            return $qb->andWhere('u.id = :uid');
+        });
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    public function testWhenWithCallback(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u');
+
+        $qb->when(
+            false,
+            static function (QueryBuilder $qb): QueryBuilder {
+                return $qb->andWhere('u.id = :uid');
+            },
+            static function (QueryBuilder $qb): QueryBuilder {
+                return $qb->andWhere('u.id != :uid');
+            }
+        );
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id != :uid');
+    }
+
     public function testGroupBy(): void
     {
         $qb = $this->entityManager->createQueryBuilder()


### PR DESCRIPTION
Add a `when` helper method that allow to limit `if-else` condition in our code.

For exemple:

```php
$qb = $this->createQueryBuilder();
$qb->when($isEnabled === true, static fn (QueryBuilder $q) => $q->andWhere('c.enabled = true'));
```

If the condition is `false`, it's possible to add a default query expression, otherwise it will do nothing.
