### PR TITLE
Correct use of PHP attribute

### DIFF
--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -21,7 +21,7 @@ these comparisons are always made **BY REFERENCE**. That means the following cha
     #[Entity]
     class Article
     {
-        #[Column(type='datetime')]
+        #[Column(type: 'datetime')]
         private DateTime $updated;
 
         public function setUpdated(): void


### PR DESCRIPTION
Incorrect syntax used in php 8 attribute. This should be key: value, rather than key=value