### PR TITLE
Add handling of 'not' composite expression in QueryExpressionVisitor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "ext-ctype": "*",
         "doctrine/cache": "^1.12.1 || ^2.1.1",
-        "doctrine/collections": "^1.5 || ^2.0",
+        "doctrine/collections": "^2.1",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.1 || ^3.2",
         "doctrine/deprecations": "^0.5.3 || ^1",

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -21,7 +21,7 @@ these comparisons are always made **BY REFERENCE**. That means the following cha
     #[Entity]
     class Article
     {
-        #[Column(type='datetime')]
+        #[Column(type: 'datetime')]
         private DateTime $updated;
 
         public function setUpdated(): void

--- a/docs/en/reference/faq.rst
+++ b/docs/en/reference/faq.rst
@@ -38,7 +38,7 @@ upon insert:
 
         private string $algorithm = "sha1";
         /** @var self::STATUS_* */
-        private int $status = self:STATUS_DISABLED;
+        private int $status = self::STATUS_DISABLED;
     }
 
 .

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -32,6 +32,19 @@ need not have an ``#[Id]`` property.
     For further support of inheritance, the single or
     joined table inheritance features have to be used.
 
+.. warning::
+
+    At least when using attributes or annotations to specify your mapping,
+    it _seems_ as if you could inherit from a base class that is neither
+    an entity nor a mapped superclass, but has properties with mapping configuration
+    on them that would also be used in the inheriting class.
+
+    This, however, is due to how the corresponding mapping
+    drivers work and what the PHP reflection API reports for inherited fields.
+
+    Such a configuration is explicitly not supported. To give just one example,
+    it will break for ``private`` properties.
+
 .. note::
 
     You may be tempted to use traits to mix mapped fields or relationships

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -95,6 +95,9 @@ class QueryExpressionVisitor extends ExpressionVisitor
             case CompositeExpression::TYPE_OR:
                 return new Expr\Orx($expressionList);
 
+            case CompositeExpression::TYPE_NOT:
+                return new Expr\Func('NOT', $expressionList);
+
             default:
                 throw new RuntimeException('Unknown composite ' . $expr->getType());
         }

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -22,7 +22,6 @@ use function array_key_exists;
 use function array_map;
 use function array_sum;
 use function assert;
-use function count;
 use function is_string;
 
 /**
@@ -160,7 +159,7 @@ class Paginator implements Countable, IteratorAggregate
             $ids          = array_map('current', $foundIdRows);
 
             $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
-            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, count($ids));
+            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
             $whereInQuery->setFirstResult(0)->setMaxResults(null);
             $whereInQuery->setCacheable($this->query->isCacheable());
 

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -28,15 +28,15 @@ use function reset;
  * The parameter namespace (dpid) is defined by
  * the PAGINATOR_ID_ALIAS
  *
- * The total number of parameters is retrieved from
- * the HINT_PAGINATOR_ID_COUNT query hint.
+ * The HINT_PAGINATOR_HAS_IDS query hint indicates whether there are
+ * any ids in the parameter at all.
  */
 class WhereInWalker extends TreeWalkerAdapter
 {
     /**
      * ID Count hint name.
      */
-    public const HINT_PAGINATOR_ID_COUNT = 'doctrine.id.count';
+    public const HINT_PAGINATOR_HAS_IDS = 'doctrine.paginator_has_ids';
 
     /**
      * Primary key alias for query.
@@ -65,9 +65,9 @@ class WhereInWalker extends TreeWalkerAdapter
         $pathExpression       = new PathExpression(PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $rootAlias, $identifierFieldName);
         $pathExpression->type = $pathType;
 
-        $count = $this->_getQuery()->getHint(self::HINT_PAGINATOR_ID_COUNT);
+        $hasIds = $this->_getQuery()->getHint(self::HINT_PAGINATOR_HAS_IDS);
 
-        if ($count > 0) {
+        if ($hasIds) {
             $arithmeticExpression                             = new ArithmeticExpression();
             $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
                 [$pathExpression]

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -97,7 +97,7 @@ class SchemaTool
 
         foreach ($createSchemaSql as $sql) {
             try {
-                $conn->executeQuery($sql);
+                $conn->executeStatement($sql);
             } catch (Throwable $e) {
                 throw ToolsException::schemaToolFailure($sql, $e);
             }
@@ -831,7 +831,7 @@ class SchemaTool
 
         foreach ($dropSchemaSql as $sql) {
             try {
-                $conn->executeQuery($sql);
+                $conn->executeStatement($sql);
             } catch (Throwable $e) {
                 // ignored
             }
@@ -849,7 +849,7 @@ class SchemaTool
         $conn          = $this->em->getConnection();
 
         foreach ($dropSchemaSql as $sql) {
-            $conn->executeQuery($sql);
+            $conn->executeStatement($sql);
         }
     }
 
@@ -939,7 +939,7 @@ class SchemaTool
         $conn            = $this->em->getConnection();
 
         foreach ($updateSchemaSql as $sql) {
-            $conn->executeQuery($sql);
+            $conn->executeStatement($sql);
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -667,6 +667,27 @@ SQL
         self::assertCount(9, $paginator->getIterator());
     }
 
+    public function testDifferentResultLengthsDoNotRequireExtraQueryCacheEntries(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id >= :id';
+        $query = $this->_em->createQuery($dql);
+        $query->setMaxResults(10);
+
+        $query->setParameter('id', 1);
+        $paginator = new Paginator($query);
+        $paginator->getIterator(); // exercise the Paginator
+
+        $initialCount = count(self::$queryCache->getValues());
+
+        $query->setParameter('id', 2);
+        $paginator = new Paginator($query);
+        $paginator->getIterator(); // exercise the Paginator again, with a smaller result set
+
+        $newCount = count(self::$queryCache->getValues());
+
+        self::assertSame($initialCount, $newCount);
+    }
+
     public function populate(): void
     {
         $groups = [];

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -674,18 +674,19 @@ SQL
         $query->setMaxResults(10);
 
         $query->setParameter('id', 1);
-        $paginator = new Paginator($query);
-        $paginator->getIterator(); // exercise the Paginator
+        $paginator     = new Paginator($query);
+        $initialResult = iterator_to_array($paginator->getIterator()); // exercise the Paginator
+        self::assertCount(9, $initialResult);
 
-        $initialCount = count(self::$queryCache->getValues());
+        $initialQueryCount = count(self::$queryCache->getValues());
 
-        $query->setParameter('id', 2);
+        $query->setParameter('id', $initialResult[1]->id); // skip the first result element
         $paginator = new Paginator($query);
-        $paginator->getIterator(); // exercise the Paginator again, with a smaller result set
+        self::assertCount(8, $paginator->getIterator()); // exercise the Paginator again, with a smaller result set
 
         $newCount = count(self::$queryCache->getValues());
 
-        self::assertSame($initialCount, $newCount);
+        self::assertSame($initialQueryCount, $newCount);
     }
 
     public function populate(): void

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -335,6 +335,15 @@ class ExprTest extends OrmTestCase
         self::assertEquals('(1 = 1 AND 1 < 5) OR 1 = 1', (string) $orExpr);
     }
 
+    public function testAndxNotxExpr(): void
+    {
+        $andExpr = $this->expr->andX();
+        $andExpr->add($this->expr->eq(1, 1));
+        $andExpr->add($this->expr->not($this->expr->lt(1, 5)));
+
+        self::assertEquals('1 = 1 AND NOT(1 < 5)', (string) $andExpr);
+    }
+
     public function testOrxExpr(): void
     {
         $orExpr = $this->expr->orX();

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Expr\Comparison as CriteriaComparison;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\ExpressionBuilder as CriteriaBuilder;
 use Doctrine\ORM\Query\Expr as QueryBuilder;
@@ -107,6 +108,20 @@ class QueryExpressionVisitorTest extends TestCase
 
         self::assertInstanceOf(QueryBuilder\Orx::class, $expr);
         self::assertCount(2, $expr->getParts());
+    }
+
+    public function testWalkNotCompositeExpression(): void
+    {
+        $cb = new CriteriaBuilder();
+        $expr = $this->visitor->walkCompositeExpression(
+            $cb->not(
+                $cb->eq('foo', 1)
+            )
+        );
+
+        self::assertInstanceOf(QueryBuilder\Func::class, $expr);
+        self::assertEquals(CompositeExpression::TYPE_NOT, $expr->getName());
+        self::assertCount(1, $expr->getArguments());
     }
 
     public function testWalkValue(): void

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -19,7 +19,7 @@ class WhereInWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery($dql);
         $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [WhereInWalker::class]);
-        $query->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
+        $query->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
 
         $result = (new Parser($query))->parse();
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -74,7 +74,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      *
      * @var CacheItemPoolInterface|null
      */
-    private static $queryCache = null;
+    protected static $queryCache = null;
 
     /**
      * Shared connection when a TestCase is run alone (outside of its functional suite).


### PR DESCRIPTION
Add handling of ```NOT``` composite expression in ```QueryExpressionVisitor::walkCompositeExpression``` like in ```Expr::not```.

Before, if you ran the following criteria it gave the error ```Unknown composite NOT```:

```php
new Criteria(
    new CompositeExpression(
        CompositeExpression::TYPE_NOT,
        [new Comparison('id', Comparison::EQ, '1')]
    )
);
```

With the introduced changes, a handler for the ```NOT``` expression is found and the query is constructed correctly:

```sql
SELECT * FROM Entity u0_ WHERE NOT (u0_.id = ?)
```

