### PR TITLE
Add handling of 'not' composite expression in QueryExpressionVisitor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "ext-ctype": "*",
         "doctrine/cache": "^1.12.1 || ^2.1.1",
-        "doctrine/collections": "^1.5 || ^2.1",
+        "doctrine/collections": "^2.1",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.1 || ^3.2",
         "doctrine/deprecations": "^0.5.3 || ^1",

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -96,6 +96,9 @@ class QueryExpressionVisitor extends ExpressionVisitor
             case CompositeExpression::TYPE_OR:
                 return new Expr\Orx($expressionList);
 
+            case CompositeExpression::TYPE_NOT:
+                return new Expr\Func('NOT', $expressionList);
+
             default:
                 // Multiversion support for `doctrine/collections` before and after v2.1.0
                 if (defined(CompositeExpression::class . '::TYPE_NOT') && $expr->getType() === CompositeExpression::TYPE_NOT) {

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -335,6 +335,15 @@ class ExprTest extends OrmTestCase
         self::assertEquals('(1 = 1 AND 1 < 5) OR 1 = 1', (string) $orExpr);
     }
 
+    public function testAndxNotxExpr(): void
+    {
+        $andExpr = $this->expr->andX();
+        $andExpr->add($this->expr->eq(1, 1));
+        $andExpr->add($this->expr->not($this->expr->lt(1, 5)));
+
+        self::assertEquals('1 = 1 AND NOT(1 < 5)', (string) $andExpr);
+    }
+
     public function testOrxExpr(): void
     {
         $orExpr = $this->expr->orX();


### PR DESCRIPTION
Add handling of ```NOT``` composite expression in ```QueryExpressionVisitor::walkCompositeExpression``` like in ```Expr::not```.

Before, if you ran the following criteria it gave the error ```Unknown composite NOT```:

```php
new Criteria(
    new CompositeExpression(
        CompositeExpression::TYPE_NOT,
        [new Comparison('id', Comparison::EQ, '1')]
    )
);
```

With the introduced changes, a handler for the ```NOT``` expression is found and the query is constructed correctly:

```sql
SELECT * FROM Entity u0_ WHERE NOT (u0_.id = ?)
```