### PR TITLE
[Documentation] consistency order for docblock in association mapping

### DIFF
--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -1386,6 +1386,14 @@ Is essentially the same as following:
 
 .. configuration-block::
 
+    .. code-block:: attribute
+
+        <?php
+        /** One Product has One Shipment. */
+        #[OneToOne(targetEntity: Shipment::class)]
+        #[JoinColumn(name: 'shipment_id', referencedColumnName: 'id', nullable: false)]
+        private Shipment $shipment;
+
     .. code-block:: annotation
 
         <?php
@@ -1394,14 +1402,6 @@ Is essentially the same as following:
          * @OneToOne(targetEntity="Shipment")
          * @JoinColumn(name="shipment_id", referencedColumnName="id", nullable=false)
          */
-        private Shipment $shipment;
-
-    .. code-block:: attribute
-
-        <?php
-        /** One Product has One Shipment. */
-        #[OneToOne(targetEntity: Shipment::class)]
-        #[JoinColumn(name: 'shipment_id', referencedColumnName: 'id', nullable: false)]
         private Shipment $shipment;
 
     .. code-block:: xml


### PR DESCRIPTION
Small change to have docblock in a consistent order in association mapping documentation