### PR TITLE
Introduce FilterCollection#restore method

### DIFF
--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -92,3 +92,10 @@ object.
     want to refresh or reload an object after having modified a filter or the
     FilterCollection, then you should clear the EntityManager and re-fetch your
     entities, having the new rules for filtering applied.
+
+.. warning::
+    If you enable a previously disabled filter, doctrine will create a new
+    one without keeping any of the previously parameter set with
+    ``SQLFilter#setParameter()`` or ``SQLFilter#getParameterList()``. If you
+    want to restore the previously disabled filter instead, you must use the
+    ``FilterCollection#restore($name)`` method.

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -93,6 +93,30 @@ object.
     FilterCollection, then you should clear the EntityManager and re-fetch your
     entities, having the new rules for filtering applied.
 
+
+Suspending/Restoring Filters
+----------------------------
+When a filter is disabled, the instance is fully deleted and all the filter
+parameters previously set are lost. Then, if you enable it again, a new filter
+is created without the previous filter parameters. If you want to keep a filter
+(in order to use it later) but temporary disable it, you'll need to use the
+``FilterCollection#suspend($name)`` and ``FilterCollection#restore($name)``
+methods instead.
+
+.. code-block:: php
+
+    <?php
+    $filter = $em->getFilters()->enable("locale");
+    $filter->setParameter('locale', 'en');
+
+    // Temporary suspend the filter
+    $filter = $em->getFilters()->suspend("locale");
+
+    // Do things
+
+    // Then restore it, the locale parameter will still be set
+    $filter = $em->getFilters()->restore("locale");
+
 .. warning::
     If you enable a previously disabled filter, doctrine will create a new
     one without keeping any of the previously parameter set with

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -30,15 +30,36 @@ class FilterCollectionTest extends OrmTestCase
 
         self::assertCount(0, $filterCollection->getEnabledFilters());
 
-        $filterCollection->enable('testFilter');
+        $filter1 = $filterCollection->enable('testFilter');
 
         $enabledFilters = $filterCollection->getEnabledFilters();
 
         self::assertCount(1, $enabledFilters);
         self::assertContainsOnly(MyFilter::class, $enabledFilters);
 
-        $filterCollection->disable('testFilter');
+        $filter2 = $filterCollection->disable('testFilter');
         self::assertCount(0, $filterCollection->getEnabledFilters());
+        self::assertSame($filter1, $filter2);
+
+        $filter3 = $filterCollection->enable('testFilter');
+        self::assertNotSame($filter1, $filter3);
+    }
+
+    public function testRestore(): void
+    {
+        $filterCollection = $this->em->getFilters();
+
+        self::assertCount(0, $filterCollection->getEnabledFilters());
+
+        $filter1 = $filterCollection->enable('testFilter');
+        $filterCollection->disable('testFilter');
+
+        $filter3 = $filterCollection->restore('testFilter');
+        self::assertSame($filter1, $filter3);
+
+        $enabledFilters = $filterCollection->getEnabledFilters();
+        self::assertCount(1, $enabledFilters);
+        self::assertContainsOnly(MyFilter::class, $enabledFilters);
     }
 
     public function testHasFilter(): void
@@ -49,7 +70,6 @@ class FilterCollectionTest extends OrmTestCase
         self::assertFalse($filterCollection->has('fakeFilter'));
     }
 
-    /** @depends testEnable */
     public function testIsEnabled(): void
     {
         $filterCollection = $this->em->getFilters();
@@ -59,6 +79,21 @@ class FilterCollectionTest extends OrmTestCase
         $filterCollection->enable('testFilter');
 
         self::assertTrue($filterCollection->isEnabled('testFilter'));
+    }
+
+    public function testIsDisabled(): void
+    {
+        $filterCollection = $this->em->getFilters();
+
+        self::assertFalse($filterCollection->isDisabled('testFilter'));
+
+        $filterCollection->enable('testFilter');
+
+        self::assertFalse($filterCollection->isDisabled('testFilter'));
+
+        $filterCollection->disable('testFilter');
+
+        self::assertTrue($filterCollection->isDisabled('testFilter'));
     }
 
     public function testGetFilterInvalidArgument(): void

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -52,7 +52,7 @@ class FilterCollectionTest extends OrmTestCase
         self::assertCount(0, $filterCollection->getEnabledFilters());
 
         $filter1 = $filterCollection->enable('testFilter');
-        $filterCollection->disable('testFilter');
+        $filterCollection->suspend('testFilter');
 
         $filter3 = $filterCollection->restore('testFilter');
         self::assertSame($filter1, $filter3);
@@ -60,6 +60,14 @@ class FilterCollectionTest extends OrmTestCase
         $enabledFilters = $filterCollection->getEnabledFilters();
         self::assertCount(1, $enabledFilters);
         self::assertContainsOnly(MyFilter::class, $enabledFilters);
+    }
+
+    public function testRestoreFailure(): void
+    {
+        $filterCollection = $this->em->getFilters();
+
+        $this->expectException(InvalidArgumentException::class);
+        $filterCollection->suspend('testFilter');
     }
 
     public function testHasFilter(): void
@@ -81,19 +89,27 @@ class FilterCollectionTest extends OrmTestCase
         self::assertTrue($filterCollection->isEnabled('testFilter'));
     }
 
-    public function testIsDisabled(): void
+    public function testIsSuspended(): void
     {
         $filterCollection = $this->em->getFilters();
 
-        self::assertFalse($filterCollection->isDisabled('testFilter'));
+        self::assertFalse($filterCollection->isSuspended('testFilter'));
 
         $filterCollection->enable('testFilter');
 
-        self::assertFalse($filterCollection->isDisabled('testFilter'));
+        self::assertFalse($filterCollection->isSuspended('testFilter'));
+
+        $filterCollection->suspend('testFilter');
+
+        self::assertTrue($filterCollection->isSuspended('testFilter'));
+
+        $filterCollection->restore('testFilter');
+
+        self::assertFalse($filterCollection->isSuspended('testFilter'));
 
         $filterCollection->disable('testFilter');
 
-        self::assertTrue($filterCollection->isDisabled('testFilter'));
+        self::assertFalse($filterCollection->isSuspended('testFilter'));
     }
 
     public function testGetFilterInvalidArgument(): void


### PR DESCRIPTION
Closes https://github.com/doctrine/orm/issues/10536

I just don't know if it's better to introduce a new method or it should be the default behavior of the `enable` method.