### PR TITLE
Enabled lazy-loading for subclasses to improve performance when loading entities with a to-one association

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2893,19 +2893,52 @@ class UnitOfWork implements PropertyChangedListener
 
                             break;
 
-                        case $targetClass->subClasses:
-                            // If it might be a subtype, it can not be lazy. There isn't even
-                            // a way to solve this with deferred eager loading, which means putting
-                            // an entity with subclasses at a *-to-one location is really bad! (performance-wise)
-                            $newValue = $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity, $associatedId);
-                            break;
-
                         default:
                             $normalizedAssociatedId = $this->normalizeIdentifier($targetClass, $associatedId);
 
                             switch (true) {
                                 // We are negating the condition here. Other cases will assume it is valid!
                                 case $hints['fetchMode'][$class->name][$field] !== ClassMetadata::FETCH_EAGER:
+                                    if ($targetClass->subClasses) {
+                                        if (! $targetClass->isInheritanceTypeNone() && isset($targetClass->discriminatorColumn)) {
+                                            $connection = $this->em->getConnection();
+
+                                            $discriminatorColumnName = $targetClass->discriminatorColumn['name'];
+                                            $selectClause            = $connection->quoteIdentifier($discriminatorColumnName);
+                                            $fromClause              = $connection->quoteIdentifier($this->em->getClassMetadata(
+                                                $targetClass->rootEntityName
+                                            )->getTableName());
+
+                                            $whereClauses = [];
+                                            $whereValues  = [];
+                                            foreach ($targetClass->getIdentifierColumnNames() as $pkName) {
+                                                $whereClauses[] = $connection->quoteIdentifier($pkName) . ' = ?';
+                                                $whereValues[]  = $associatedId[$targetClass->fieldNames[$pkName]];
+                                            }
+
+                                            $whereClause = implode(' AND ', $whereClauses);
+
+                                            $query = 'SELECT ' . $selectClause . ' FROM ' . $fromClause . ' WHERE ' . $whereClause;
+                                            $stmt  = $this->em->getConnection()->prepare($query);
+
+                                            $index = 1;
+                                            foreach ($whereValues as $whereValue) {
+                                                $stmt->bindValue($index, $whereValue);
+                                                $index++;
+                                            }
+
+                                            $result     = $stmt->executeQuery();
+                                            $fieldValue = $result->fetchFirstColumn()[0];
+
+                                            $targetSubClass = $targetClass->discriminatorMap[$fieldValue];
+                                            $newValue       = $this->em->getProxyFactory()->getProxy($targetSubClass, $associatedId);
+                                            break;
+                                        }
+
+                                        $newValue = $this->em->getProxyFactory()->getProxy($assoc['targetEntity'], $associatedId);
+                                        break;
+                                    }
+
                                     $newValue = $this->em->getProxyFactory()->getProxy($assoc['targetEntity'], $normalizedAssociatedId);
                                     break;
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -29,7 +29,6 @@ use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\Reflection\ReflectionPropertiesGetter;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
@@ -75,6 +74,7 @@ use function method_exists;
 use function reset;
 use function spl_object_id;
 use function sprintf;
+use function strtolower;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
@@ -2905,9 +2905,9 @@ class UnitOfWork implements PropertyChangedListener
 
                                             $discriminatorColumnName = $targetClass->discriminatorColumn['name'];
                                             $selectClause            = $connection->quoteIdentifier($discriminatorColumnName);
-                                            $fromClause              = $connection->quoteIdentifier($this->em->getClassMetadata(
+                                            $fromClause              = $this->em->getClassMetadata(
                                                 $targetClass->rootEntityName
-                                            )->getTableName());
+                                            )->getTableName();
 
                                             $whereClauses = [];
                                             $whereValues  = [];

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -298,9 +298,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         self::assertInstanceOf(CompanyOrganization::class, $result[0]);
 
         $mainEvent = $result[0]->getMainEvent();
-        // mainEvent should have been loaded because it can't be lazy
         self::assertInstanceOf(CompanyAuction::class, $mainEvent);
-        self::assertNotInstanceOf(Proxy::class, $mainEvent);
+        self::assertInstanceOf(Proxy::class, $mainEvent);
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -417,6 +417,7 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
                               ->setParameter(1, $this->fix->getId())
                               ->getSingleResult();
 
-        self::assertNotInstanceOf(Proxy::class, $contract->getSalesPerson());
+        self::assertInstanceOf(Proxy::class, $contract->getSalesPerson());
+        self::assertTrue($contract->getSalesPerson()->__isInitialized());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC531Test extends OrmFunctionalTestCase
@@ -43,10 +42,7 @@ class DDC531Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $item3 = $this->_em->find(DDC531Item::class, $item2->id); // Load child item first (id 2)
-        // parent will already be loaded, cannot be lazy because it has mapped subclasses and we would not
-        // know which proxy type to put in.
         self::assertInstanceOf(DDC531Item::class, $item3->parent);
-        self::assertNotInstanceOf(Proxy::class, $item3->parent);
         $item4 = $this->_em->find(DDC531Item::class, $item1->id); // Load parent item (id 1)
         self::assertNull($item4->parent);
         self::assertNotNull($item4->getChildren());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10466Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10466Test.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\Persistence\Proxy;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function getenv;
+
+class GH10466Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH10466Item::class,
+            GH10466SubItem::class
+        );
+    }
+
+    public function testIssue(): void
+    {
+        $item1         = new GH10466Item();
+        $item2         = new GH10466Item();
+        $item2->parent = $item1;
+        $this->_em->persist($item1);
+        $this->_em->persist($item2);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $item3 = $this->_em->find(GH10466Item::class, $item2->id);
+        self::assertInstanceOf(GH10466Item::class, $item3->parent);
+
+        if (! getenv('ENABLE_SECOND_LEVEL_CACHE')) {
+            self::assertInstanceOf(Proxy::class, $item3->parent);
+        }
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="type", type="integer")
+ * @DiscriminatorMap({"0" = "GH10466Item", "1" = "GH10466SubItem"})
+ */
+class GH10466Item
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var GH10466Item
+     * @ManyToOne(targetEntity="GH10466Item", inversedBy="children")
+     * @JoinColumn(name="parentId", referencedColumnName="id")
+     */
+    public $parent;
+
+    public function __construct()
+    {
+    }
+}
+
+/** @Entity */
+class GH10466SubItem extends GH10466Item
+{
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10466Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10466Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -13,6 +14,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 


### PR DESCRIPTION
This PR is a continuation of the closed PR [#10466](https://github.com/doctrine/orm/pull/10466) (which cannot be reopend).

We encountered a performance problem regarding entity instances that point to parent entity instances, when the entity class was involved in entity inheritance. When the chain of parent instances was long (42) it would cause one of the following:

* When XDebug was enabled, error: `Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '256' frames`
* When XDebug was not enabled, error: `Allowed memory size of .... bytes exhausted`

The reason for this was because when loading a related entity instance of a class that has subclasses (when the association was many-to-one or one-to-one), it would fully load the related entity, regardless of whether that entity was needed. It would then also fully load that entity's parent, all the way until there is no parent anymore.

Before this change, the relevant code in UnitOfWork was:

```
case ($targetClass->subClasses):
    // If it might be a subtype, it can not be lazy. There isn't even
    // a way to solve this with deferred eager loading, which means putting
    // an entity with subclasses at a *-to-one location is really bad! (performance-wise)
    $newValue = $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity, $associatedId);
    break;
```

This PR changes the behavior so that the related entity will not be fully loaded, but instead will be a Proxy class that will only load extra data when it is required.
Doing this causes the loading to stop at 1 parent instead of loading every single parent up until there is no parent anymore.

It does this by doing the following:

1. Find the identifier column for this entity.
2. Find the discriminator column for this entity that is used to determine the subclass of the entity.
3. Find the discriminator column's value for the entity using the identifier by executing a query on the database.
4. Create a Proxy class for the correct subclass of the entity using the discriminatorMap.

The documentation about the limitation [linked](https://github.com/doctrine/orm/pull/10466#issuecomment-1405418619) by @mpdude is indeed relevant to the PR, but the limitation not only affects single table inheritance, because in our case we are using joined inheritance.

I created a test which simulates the scenario for single table inheritance. It defines 2 entities, and one of the entities inherits the other. We create 2 instances of the superclass, and let instance 2 point to instance 1 via a parent field. When we load instance 2, the test asserts that the parent of instance 2 is a Proxy instead of the fully loaded instance 1.