### PR TITLE
Stabilize DBAL version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-ctype": "*",
         "doctrine/collections": "^2.1",
         "doctrine/common": "^3.3",
-        "doctrine/dbal": "^3.6@dev",
+        "doctrine/dbal": "^3.6",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2",
         "doctrine/inflector": "^1.4 || ^2.0",


### PR DESCRIPTION
DBAL 3.6 has been released, so we don't need to require the `@dev` version anymore.