### PR TITLE
Ignore the cache dir of PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ vendor/
 /tests/Doctrine/Performance/history.db
 /.phpcs-cache
 composer.lock
+.phpunit.cache
 .phpunit.result.cache
 /*.phpunit.xml


### PR DESCRIPTION
This will make switching between branches easier once we've merged #10492.