### PR TITLE
Skip test instead of commenting it out

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -573,12 +573,11 @@ class LanguageRecognitionTest extends OrmTestCase
         $this->assertValidDQL('SELECT g FROM ' . __NAMESPACE__ . '\DQLKeywordsModelGroup g WHERE g.from=0');
     }
 
-    /* The exception is currently thrown in the SQLWalker, not earlier.
-    public function testInverseSideSingleValuedAssociationPathNotAllowed()
+    public function testInverseSideSingleValuedAssociationPathNotAllowed(): void
     {
+        self::markTestSkipped('The exception is currently thrown in the SQLWalker, not earlier.');
         $this->assertInvalidDQL('SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.address = ?1');
     }
-    */
 
     /** @group DDC-617 */
     public function testSelectOnlyNonRootEntityAlias(): void


### PR DESCRIPTION
Skipping makes the test more discoverable.

Follow-up of #10560