### PR TITLE
Forbid PHPUnit annotations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -116,6 +116,36 @@
         <exclude-pattern>lib/Doctrine/ORM/Cache/DefaultQueryCache.php</exclude-pattern>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+        <properties>
+            <property name="forbiddenAnnotations" type="array">
+                <!--
+                    From Doctrine Coding Standard:
+                    Forbid useless annotations - Git and LICENCE file provide more accurate information
+                -->
+                <element value="@api"/>
+                <element value="@author"/>
+                <element value="@category"/>
+                <element value="@copyright"/>
+                <element value="@created"/>
+                <element value="@license"/>
+                <element value="@package"/>
+                <element value="@since"/>
+                <element value="@subpackage"/>
+                <element value="@version"/>
+
+                <!-- Additionally forbid oldschool PHPUnit annotations to force the usage of attributes -->
+                <element value="@covers"/>
+                <element value="@depends"/>
+                <element value="@dataProvider"/>
+                <element value="@group"/>
+                <element value="@requires"/>
+                <element value="@test"/>
+                <element value="@testWith"/>
+            </property>
+        </properties>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
         <exclude-pattern>lib/Doctrine/ORM/EntityManagerInterface.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
Following up on #10559, this PR introduces a PHPCS rule that will fail on PHPUnit annotations. This should serve as a constant reminder to switch them to attributes when merging up tests.

I've tested the rule locally by running PHPCS on the commits before and after @chr-hertel's changes.