### PR TITLE
Address deprecation of fetchAll()

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1304,14 +1304,13 @@ creating a class which extends ``AbstractHydrator``:
     <?php
     namespace MyProject\Hydrators;
 
-    use Doctrine\DBAL\FetchMode;
     use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 
     class CustomHydrator extends AbstractHydrator
     {
         protected function _hydrateAll()
         {
-            return $this->_stmt->fetchAll(FetchMode::FETCH_ASSOC);
+            return $this->_stmt->fetchAllAssociative();
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
@@ -36,7 +36,7 @@ class AbstractManyToManyAssociationTestCase extends OrmFunctionalTestCase
 
     protected function countForeignKeys($firstId, $secondId): int
     {
-        return count($this->_em->getConnection()->executeQuery(sprintf(
+        return count($this->_em->getConnection()->fetchAllAssociative(sprintf(
             <<<'SQL'
             SELECT %s
               FROM %s
@@ -48,7 +48,7 @@ SQL
             $this->table,
             $this->firstField,
             $this->secondField
-        ), [$firstId, $secondId])->fetchAll());
+        ), [$firstId, $secondId]));
     }
 
     public function assertCollectionEquals(Collection $first, Collection $second): bool


### PR DESCRIPTION
The methods `Connection::fetchAll()` and `Result::fetchAll()` have been deprecated in favor of more their precise counterparts.