### PR TITLE
add `$isXsdValidationEnabled` to SimplifiedXmlDriver constructor

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php
@@ -16,10 +16,10 @@ class SimplifiedXmlDriver extends XmlDriver
     /**
      * {@inheritDoc}
      */
-    public function __construct($prefixes, $fileExtension = self::DEFAULT_FILE_EXTENSION)
+    public function __construct($prefixes, $fileExtension = self::DEFAULT_FILE_EXTENSION, bool $isXsdValidationEnabled = false)
     {
         $locator = new SymfonyFileLocator((array) $prefixes, $fileExtension);
 
-        parent::__construct($locator, $fileExtension);
+        parent::__construct($locator, $fileExtension, $isXsdValidationEnabled);
     }
 }


### PR DESCRIPTION
This adds the missing `$isXsdValidationEnabled` argument to the `SimplifiedXmlDriver` constructor.

Will enable us to fix [this](https://github.com/doctrine/DoctrineBundle/pull/1634#issuecomment-1448189266) deprecation on DoctrineBundle.