### PR TITLE
docs: Remove incorrect @SequenceGenerator info

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -534,8 +534,6 @@ the above example with ``allocationSize=100`` Doctrine ORM would only
 need to access the sequence once to generate the identifiers for
 100 new entities.
 
-*The default allocationSize for a @SequenceGenerator is currently 10.*
-
 .. caution::
 
     The allocationSize is detected by SchemaTool and


### PR DESCRIPTION
### Improvement

docs: Remove incorrect @SequenceGenerator info

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

#### Summary

The default allocationSize for @SequenceGenerator has actually been set to 1 ever since 434325e (back in 2010!)
This was done to remove confusion, but the docs were never updated to reflect the change