### PR TITLE
Support not Insertable/Updateable columns for entities with `JOINED` inheritance type

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2764,6 +2764,10 @@ class ClassMetadataInfo implements ClassMetadata
         $this->fieldMappings[$fieldMapping['fieldName']] = $fieldMapping;
         $this->columnNames[$fieldMapping['fieldName']]   = $fieldMapping['columnName'];
         $this->fieldNames[$fieldMapping['columnName']]   = $fieldMapping['fieldName'];
+
+        if (isset($fieldMapping['generated'])) {
+            $this->requiresFetchAfterChange = true;
+        }
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -183,7 +183,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @var IdentifierFlattener
      */
-    final protected $identifierFlattener;
+    protected $identifierFlattener;
 
     /** @var CachedPersisterContext */
     protected $currentPersisterContext;

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -183,7 +183,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @var IdentifierFlattener
      */
-    private $identifierFlattener;
+    protected $identifierFlattener;
 
     /** @var CachedPersisterContext */
     protected $currentPersisterContext;
@@ -379,7 +379,7 @@ class BasicEntityPersister implements EntityPersister
      * @return int[]|null[]|string[]
      * @psalm-return list<int|string|null>
      */
-    private function extractIdentifierTypes(array $id, ClassMetadata $versionedClass): array
+    protected function extractIdentifierTypes(array $id, ClassMetadata $versionedClass): array
     {
         $types = [];
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -183,7 +183,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @var IdentifierFlattener
      */
-    protected $identifierFlattener;
+    final protected $identifierFlattener;
 
     /** @var CachedPersisterContext */
     protected $currentPersisterContext;
@@ -379,7 +379,7 @@ class BasicEntityPersister implements EntityPersister
      * @return int[]|null[]|string[]
      * @psalm-return list<int|string|null>
      */
-    protected function extractIdentifierTypes(array $id, ClassMetadata $versionedClass): array
+    final protected function extractIdentifierTypes(array $id, ClassMetadata $versionedClass): array
     {
         $types = [];
 

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -165,10 +165,6 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
             }
 
-            if ($this->class->requiresFetchAfterChange) {
-                $this->assignDefaultVersionAndUpsertableValues($entity, $id);
-            }
-
             // Execute inserts on subtables.
             // The order doesn't matter because all child tables link to the root table via FK.
             foreach ($subTableStmts as $tableName => $stmt) {
@@ -188,6 +184,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 }
 
                 $stmt->executeStatement();
+            }
+
+            if ($this->class->requiresFetchAfterChange) {
+                $this->assignDefaultVersionAndUpsertableValues($entity, $id);
             }
         }
 
@@ -510,6 +510,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     || isset($this->class->associationMappings[$name]['inherited'])
                     || ($this->class->isVersioned && $this->class->versionField === $name)
                     || isset($this->class->embeddedClasses[$name])
+                    || isset($this->class->fieldMappings[$name]['notInsertable'])
             ) {
                 continue;
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/GH9467Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/GH9467Test.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH9467Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            JoinedInheritanceRoot::class,
+            JoinedInheritanceWritableColumn::class,
+            JoinedInheritanceNonWritableColumn::class,
+            JoinedInheritanceNonInsertableColumn::class,
+            JoinedInheritanceNonUpdatableColumn::class
+        );
+    }
+
+    public function testChildWritableColumnInsert(): int
+    {
+        $entity                  = new JoinedInheritanceWritableColumn();
+        $entity->writableContent = 'foo';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check INSERT query doesn't change insertable entity property
+        self::assertEquals('foo', $entity->writableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceWritableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceWritableColumn::class, $entity);
+        self::assertEquals('foo', $entity->writableContent);
+
+        return $entity->id;
+    }
+
+    /** @depends testChildWritableColumnInsert */
+    public function testChildWritableColumnUpdate(int $entityId): void
+    {
+        $entity = $this->_em->find(JoinedInheritanceWritableColumn::class, $entityId);
+        self::assertInstanceOf(JoinedInheritanceWritableColumn::class, $entity);
+
+        // update exist entity
+        $entity->writableContent = 'bar';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check UPDATE query doesn't change updatable entity property
+        self::assertEquals('bar', $entity->writableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceWritableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceWritableColumn::class, $entity);
+        self::assertEquals('bar', $entity->writableContent);
+    }
+
+    public function testChildNonWritableColumnInsert(): int
+    {
+        $entity                     = new JoinedInheritanceNonWritableColumn();
+        $entity->nonWritableContent = 'foo';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check INSERT query cause set database value into non-insertable entity property
+        self::assertEquals('dbDefault', $entity->nonWritableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonWritableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonWritableColumn::class, $entity);
+        self::assertEquals('dbDefault', $entity->nonWritableContent);
+
+        return $entity->id;
+    }
+
+    /** @depends testChildNonWritableColumnInsert */
+    public function testChildNonWritableColumnUpdate(int $entityId): void
+    {
+        $entity = $this->_em->find(JoinedInheritanceNonWritableColumn::class, $entityId);
+        self::assertInstanceOf(JoinedInheritanceNonWritableColumn::class, $entity);
+
+        // update exist entity
+        $entity->nonWritableContent = 'bar';
+        // change some property to ensure UPDATE query will be done
+        self::assertNotEquals('bar', $entity->rootField);
+        $entity->rootField = 'bar';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check UPDATE query cause set database value into non-updatable entity property
+        self::assertEquals('dbDefault', $entity->nonWritableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonWritableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonWritableColumn::class, $entity);
+        self::assertEquals('bar', $entity->rootField); // check that UPDATE query done
+        self::assertEquals('dbDefault', $entity->nonWritableContent);
+    }
+
+    public function testChildNonInsertableColumnInsert(): int
+    {
+        $entity                       = new JoinedInheritanceNonInsertableColumn();
+        $entity->nonInsertableContent = 'foo';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check INSERT query cause set database value into non-insertable entity property
+        self::assertEquals('dbDefault', $entity->nonInsertableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonInsertableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonInsertableColumn::class, $entity);
+        self::assertEquals('dbDefault', $entity->nonInsertableContent);
+
+        return $entity->id;
+    }
+
+    /** @depends testChildNonInsertableColumnInsert */
+    public function testChildNonInsertableColumnUpdate(int $entityId): void
+    {
+        $entity = $this->_em->find(JoinedInheritanceNonInsertableColumn::class, $entityId);
+        self::assertInstanceOf(JoinedInheritanceNonInsertableColumn::class, $entity);
+
+        // update exist entity
+        $entity->nonInsertableContent = 'bar';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check UPDATE query doesn't change updatable entity property
+        self::assertEquals('bar', $entity->nonInsertableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonInsertableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonInsertableColumn::class, $entity);
+        self::assertEquals('bar', $entity->nonInsertableContent);
+    }
+
+    public function testChildNonUpdatableColumnInsert(): int
+    {
+        $entity                      = new JoinedInheritanceNonUpdatableColumn();
+        $entity->nonUpdatableContent = 'foo';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check INSERT query doesn't change insertable entity property
+        self::assertEquals('foo', $entity->nonUpdatableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonUpdatableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonUpdatableColumn::class, $entity);
+        self::assertEquals('foo', $entity->nonUpdatableContent);
+
+        return $entity->id;
+    }
+
+    /** @depends testChildNonUpdatableColumnInsert */
+    public function testChildNonUpdatableColumnUpdate(int $entityId): void
+    {
+        $entity = $this->_em->find(JoinedInheritanceNonUpdatableColumn::class, $entityId);
+        self::assertInstanceOf(JoinedInheritanceNonUpdatableColumn::class, $entity);
+        self::assertEquals('foo', $entity->nonUpdatableContent);
+
+        // update exist entity
+        $entity->nonUpdatableContent = 'bar';
+        // change some property to ensure UPDATE query will be done
+        self::assertNotEquals('bar', $entity->rootField);
+        $entity->rootField = 'bar';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // check UPDATE query cause set database value into non-updatable entity property
+        self::assertEquals('foo', $entity->nonUpdatableContent);
+
+        // check other process get same state
+        $this->_em->clear();
+        $entity = $this->_em->find(JoinedInheritanceNonUpdatableColumn::class, $entity->id);
+        self::assertInstanceOf(JoinedInheritanceNonUpdatableColumn::class, $entity);
+        self::assertEquals('bar', $entity->rootField); // check that UPDATE query done
+        self::assertEquals('foo', $entity->nonUpdatableContent);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceChild.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceChild.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_child")
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_child')]
+class JoinedInheritanceChild extends JoinedInheritanceRoot
+{
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonInsertableColumn.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonInsertableColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_non_insertable_column")
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_non_insertable_column')]
+class JoinedInheritanceNonInsertableColumn extends JoinedInheritanceRoot
+{
+    /**
+     * @var string
+     * @Column(type="string", insertable=false, updatable=true, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: false, updatable: true, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $nonInsertableContent;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonUpdatableColumn.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonUpdatableColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_non_updatable_column")
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_non_updatable_column')]
+class JoinedInheritanceNonUpdatableColumn extends JoinedInheritanceRoot
+{
+    /**
+     * @var string
+     * @Column(type="string", insertable=true, updatable=false, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: true, updatable: false, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $nonUpdatableContent;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonWritableColumn.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceNonWritableColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_non_writable_column")
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_non_writable_column')]
+class JoinedInheritanceNonWritableColumn extends JoinedInheritanceRoot
+{
+    /**
+     * @var string
+     * @Column(type="string", insertable=false, updatable=false, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: false, updatable: false, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $nonWritableContent;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceRoot.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceRoot.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Mapping\Table;
  * @InheritanceType("JOINED")
  * @DiscriminatorColumn(name="discr", type="string")
  * @DiscriminatorMap({
+ *      "child" = "JoinedInheritanceChild",
  *      "writable" = "JoinedInheritanceWritableColumn",
  *      "nonWritable" = "JoinedInheritanceNonWritableColumn",
  *      "nonInsertable" = "JoinedInheritanceNonInsertableColumn",
@@ -29,7 +30,7 @@ use Doctrine\ORM\Mapping\Table;
 #[Table(name: 'joined_inheritance_root')]
 #[InheritanceType('JOINED')]
 #[DiscriminatorColumn(name: 'discr', type: 'string')]
-#[DiscriminatorMap(['writable' => JoinedInheritanceWritableColumn::class, 'nonWritable' => JoinedInheritanceNonWritableColumn::class, 'nonInsertable' => JoinedInheritanceNonInsertableColumn::class, 'nonUpdatable' => JoinedInheritanceNonUpdatableColumn::class])]
+#[DiscriminatorMap(['child' => JoinedInheritanceChild::class, 'writable' => JoinedInheritanceWritableColumn::class, 'nonWritable' => JoinedInheritanceNonWritableColumn::class, 'nonInsertable' => JoinedInheritanceNonInsertableColumn::class, 'nonUpdatable' => JoinedInheritanceNonUpdatableColumn::class])]
 class JoinedInheritanceRoot
 {
     /**
@@ -49,4 +50,32 @@ class JoinedInheritanceRoot
      */
     #[Column(type: 'string')]
     public $rootField = '';
+
+    /**
+     * @var string
+     * @Column(type="string", insertable=true, updatable=true, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: true, updatable: true, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $rootWritableContent = '';
+
+    /**
+     * @var string
+     * @Column(type="string", insertable=false, updatable=false, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: false, updatable: false, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $rootNonWritableContent;
+
+    /**
+     * @var string
+     * @Column(type="string", insertable=false, updatable=true, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: false, updatable: true, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $rootNonInsertableContent;
+
+    /**
+     * @var string
+     * @Column(type="string", insertable=true, updatable=false, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: true, updatable: false, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $rootNonUpdatableContent = '';
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceRoot.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceRoot.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_root")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "writable" = "JoinedInheritanceWritableColumn",
+ *      "nonWritable" = "JoinedInheritanceNonWritableColumn",
+ *      "nonInsertable" = "JoinedInheritanceNonInsertableColumn",
+ *      "nonUpdatable" = "JoinedInheritanceNonUpdatableColumn"
+ * })
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_root')]
+#[InheritanceType('JOINED')]
+#[DiscriminatorColumn(name: 'discr', type: 'string')]
+#[DiscriminatorMap(['writable' => JoinedInheritanceWritableColumn::class, 'nonWritable' => JoinedInheritanceNonWritableColumn::class, 'nonInsertable' => JoinedInheritanceNonInsertableColumn::class, 'nonUpdatable' => JoinedInheritanceNonUpdatableColumn::class])]
+class JoinedInheritanceRoot
+{
+    /**
+     * @var int
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    #[Column(type: 'string')]
+    public $rootField = '';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceWritableColumn.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH9467/JoinedInheritanceWritableColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9467;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="joined_inheritance_writable_column")
+ */
+#[Entity]
+#[Table(name: 'joined_inheritance_writable_column')]
+class JoinedInheritanceWritableColumn extends JoinedInheritanceRoot
+{
+    /**
+     * @var string
+     * @Column(type="string", insertable=true, updatable=true, options={"default": "dbDefault"}, generated="ALWAYS")
+     */
+    #[Column(type: 'string', insertable: true, updatable: true, options: ['default' => 'dbDefault'], generated: 'ALWAYS')]
+    public $writableContent;
+}


### PR DESCRIPTION
Fix for https://github.com/doctrine/orm/issues/9467 when insert and update entity with `joined` inheritance + update values from database


1. Entities with `#[InheritanceType('JOINED')]` attribute process by `JoinedSubclassPersister`, according to `UnitOfWork::getEntityPersister()`:
    https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/UnitOfWork.php#L3227-L3228
1. The persister override `getInsertColumnList()` without excluding `notInsertable` columns like parent do:
    https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php#L1478
  so when it use prepared sql-statement with parameters prepared by parent (`AbstractEntityInheritancePersister::prepareInsertData()` reuse `BasicEntityPersister::prepareInsertData()` reuse `BasicEntityPersister::prepareUpdateData()` with `$isInsert` mode):
    https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php#L640-L659
  we get error from database, e.g. postgresql:
    ```
    DOException: SQLSTATE[08P01]: <<Unknown error>>: 7 ERROR:  bind message supplies 4 parameters, but prepared statement "" requires 6
    ```
   So fixed `JoinedSubclassPersister::getInsertColumnList()`. There is no such error for update queries, because parent methods used in `JoinedSubclassPersister::update()`: `BasicEntityPersister::prepareUpdateData()` and `BasicEntityPersister::updateTable()`.
1. There were problems with logic to update entity properties with database values in generated columns (`notInsertable`|`notUpdatable`|`version`) after flush - `JoinedSubclassPersister::assignDefaultVersionAndUpsertableValues()`:
    https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php#L548-L555
    - flag which activates it (`ClassMetadataInfo::$requiresFetchAfterChange`) in both cases ([executeInserts()](https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php#L170-L171) and [update()](https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php#L224-L235)) doesnt inherited from entity parent-class. This fixed by tracking of parent mappings in `ClassMetadataInfo::addInheritedFieldMapping()` like it done for child entity in `mapField()` (may be add setter for [factory](https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L105-L108)):
    https://github.com/doctrine/orm/blob/da9b9de5906802cab1c71f59ffd9fba53ed4011d/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2814-L2820
    - it use parent select query to get generated columns, while it could be in both tables (child and parent), so override query builder in persister - `JoinedSubclassPersister::fetchVersionAndNotUpsertableValues()` - where added join (reuse `JoinedSubclassPersister::getJoinSql()`) and column aliases. Make parent `extractIdentifierTypes()` and `$identifierFlattener` make them protected.
    - because generated column may be in child tables logic should be after insert into child tables in persister `insert()` method to avoid `LengthException('Unexpected empty result for database query.')`.
1. For functional tests added `JoinedInheritanceRoot` entity, with children for each case and `JoinedInheritanceChild` to test root entity columns. Declare database default column values to avoid platform-specific `columnDefinition`. Use `generated: 'ALWAYS'` in hope to obtain error from `update()` method