### PR TITLE
fix(persistent-collection): check association is not nullable before using it as an array

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use ReturnTypeWillChange;
 use RuntimeException;
+use UnexpectedValueException;
 
 use function array_combine;
 use function array_diff_key;
@@ -162,7 +163,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         // If _backRefFieldName is set and its a one-to-many association,
         // we need to set the back reference.
-        if ($this->backRefFieldName && $this->association['type'] === ClassMetadata::ONE_TO_MANY) {
+        if ($this->backRefFieldName && $this->getMapping()['type'] === ClassMetadata::ONE_TO_MANY) {
             assert($this->typeClass !== null);
             // Set back reference to owner
             $this->typeClass->reflFields[$this->backRefFieldName]->setValue(
@@ -191,7 +192,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         // If _backRefFieldName is set, then the association is bidirectional
         // and we need to set the back reference.
-        if ($this->backRefFieldName && $this->association['type'] === ClassMetadata::ONE_TO_MANY) {
+        if ($this->backRefFieldName && $this->getMapping()['type'] === ClassMetadata::ONE_TO_MANY) {
             assert($this->typeClass !== null);
             // Set back reference to owner
             $this->typeClass->reflFields[$this->backRefFieldName]->setValue(
@@ -272,10 +273,14 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @psalm-return AssociationMapping|null
+     * @psalm-return AssociationMapping
      */
-    public function getMapping(): ?array
+    public function getMapping(): array
     {
+        if ($this->association === null) {
+            throw new UnexpectedValueException('The underlying association mapping is null although it should not be');
+        }
+
         return $this->association;
     }
 
@@ -292,8 +297,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['isOwningSide'] &&
-            $this->association['type'] === ClassMetadata::MANY_TO_MANY &&
+            $this->getMapping()['isOwningSide'] &&
+            $this->getMapping()['type'] === ClassMetadata::MANY_TO_MANY &&
             $this->owner &&
             $this->em !== null &&
             $this->em->getClassMetadata(get_class($this->owner))->isChangeTrackingNotify()
@@ -352,9 +357,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['type'] & ClassMetadata::TO_MANY &&
+            $this->getMapping()['type'] & ClassMetadata::TO_MANY &&
             $this->owner &&
-            $this->association['orphanRemoval']
+            $this->getMapping()['orphanRemoval']
         ) {
             $this->getUnitOfWork()->scheduleOrphanRemoval($removed);
         }
@@ -377,9 +382,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if (
             $this->association !== null &&
-            $this->association['type'] & ClassMetadata::TO_MANY &&
+            $this->getMapping()['type'] & ClassMetadata::TO_MANY &&
             $this->owner &&
-            $this->association['orphanRemoval']
+            $this->getMapping()['orphanRemoval']
         ) {
             $this->getUnitOfWork()->scheduleOrphanRemoval($element);
         }
@@ -393,10 +398,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function containsKey($key): bool
     {
         if (
-            ! $this->initialized && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
-            && isset($this->association['indexBy'])
+            ! $this->initialized && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
+            && isset($this->getMapping()['indexBy'])
         ) {
-            $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
+            $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $this->unwrap()->containsKey($key) || $persister->containsKey($this, $key);
         }
@@ -411,8 +416,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function contains($element): bool
     {
-        if (! $this->initialized && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
-            $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
+        if (! $this->initialized && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $this->unwrap()->contains($element) || $persister->contains($this, $element);
         }
@@ -427,16 +432,16 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     {
         if (
             ! $this->initialized
-            && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
-            && isset($this->association['indexBy'])
+            && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
+            && isset($this->getMapping()['indexBy'])
         ) {
             assert($this->em !== null);
             assert($this->typeClass !== null);
-            if (! $this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
+            if (! $this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->getMapping()['indexBy'])) {
                 return $this->em->find($this->typeClass->name, $key);
             }
 
-            return $this->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
+            return $this->getUnitOfWork()->getCollectionPersister($this->getMapping())->get($this, $key);
         }
 
         return parent::get($key);
@@ -444,7 +449,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
     public function count(): int
     {
-        if (! $this->initialized && $this->association !== null && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
+        if (! $this->initialized && $this->association !== null && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
 
             return $persister->count($this) + ($this->isDirty ? $this->unwrap()->count() : 0);
@@ -540,11 +545,12 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             return;
         }
 
-        $uow = $this->getUnitOfWork();
+        $uow         = $this->getUnitOfWork();
+        $association = $this->getMapping();
 
         if (
-            $this->association['type'] & ClassMetadata::TO_MANY &&
-            $this->association['orphanRemoval'] &&
+            $association['type'] & ClassMetadata::TO_MANY &&
+            $association['orphanRemoval'] &&
             $this->owner
         ) {
             // we need to initialize here, as orphan removal acts like implicit cascadeRemove,
@@ -560,7 +566,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         $this->initialized = true; // direct call, {@link initialize()} is too expensive
 
-        if ($this->association['isOwningSide'] && $this->owner) {
+        if ($association['isOwningSide'] && $this->owner) {
             $this->changed();
 
             $uow->scheduleCollectionDeletion($this);
@@ -599,8 +605,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function slice($offset, $length = null): array
     {
-        if (! $this->initialized && ! $this->isDirty && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
-            $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
+        if (! $this->initialized && ! $this->isDirty && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $persister->slice($this, $offset, $length);
         }
@@ -651,8 +657,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             return $this->unwrap()->matching($criteria);
         }
 
-        if ($this->association['type'] === ClassMetadata::MANY_TO_MANY) {
-            $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
+        $association = $this->getMapping();
+        if ($association['type'] === ClassMetadata::MANY_TO_MANY) {
+            $persister = $this->getUnitOfWork()->getCollectionPersister($association);
 
             return new ArrayCollection($persister->loadCriteria($this, $criteria));
         }
@@ -664,11 +671,11 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         $criteria = clone $criteria;
         $criteria->where($expression);
-        $criteria->orderBy($criteria->getOrderings() ?: $this->association['orderBy'] ?? []);
+        $criteria->orderBy($criteria->getOrderings() ?: $association['orderBy'] ?? []);
 
-        $persister = $this->getUnitOfWork()->getEntityPersister($this->association['targetEntity']);
+        $persister = $this->getUnitOfWork()->getEntityPersister($association['targetEntity']);
 
-        return $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
+        return $association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
             ? new LazyCriteriaCollection($persister, $criteria)
             : new ArrayCollection($persister->loadCriteria($criteria));
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1160,7 +1160,7 @@
       <code>object|null</code>
     </ImplementedReturnTypeMismatch>
     <InvalidReturnStatement>
-      <code><![CDATA[$this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
+      <code><![CDATA[$association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
             ? new LazyCriteriaCollection($persister, $criteria)
             : new ArrayCollection($persister->loadCriteria($criteria))]]></code>
       <code><![CDATA[$this->em->find($this->typeClass->name, $key)]]></code>
@@ -1179,48 +1179,27 @@
       <code>$value</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association]]></code>
-      <code><![CDATA[$this->association['targetEntity']]]></code>
       <code><![CDATA[$this->backRefFieldName]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['fetch']]]></code>
-      <code><![CDATA[$this->association['isOwningSide']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['targetEntity']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-      <code><![CDATA[$this->association['type']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullReference>
       <code>setValue</code>
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
-      <code><![CDATA[$this->association['orphanRemoval']]]></code>
+      <code><![CDATA[$association['orphanRemoval']]]></code>
+      <code><![CDATA[$this->getMapping()['indexBy']]]></code>
+      <code><![CDATA[$this->getMapping()['orphanRemoval']]]></code>
+      <code><![CDATA[$this->getMapping()['orphanRemoval']]]></code>
     </PossiblyUndefinedArrayOffset>
     <UndefinedMethod>
       <code><![CDATA[[$this->unwrap(), 'add']]]></code>
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
-    <ArgumentTypeCoercion>
-      <code>$mapping</code>
-    </ArgumentTypeCoercion>
     <InvalidArrayOffset>
       <code><![CDATA[[$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index]]]></code>
     </InvalidArrayOffset>
     <PossiblyNullArgument>
-      <code>$association</code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
@@ -1230,103 +1209,8 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code>$column</code>
-      <code>$filterMapping</code>
-      <code>$filterMapping</code>
-      <code>$indexBy</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code>$mapping</code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
       <code>$owner</code>
-      <code>$targetColumn</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']]]></code>
-      <code><![CDATA[$association['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$association['joinTable']['joinColumns']]]></code>
-      <code>$mapping[$sourceRelationMode]</code>
-      <code>$mapping[$targetRelationMode]</code>
-      <code>$mapping[$targetRelationMode][$joinTableColumn]</code>
-      <code><![CDATA[$mapping['indexBy']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns']]]></code>
-      <code><![CDATA[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$associationSourceClass->associationMappings]]></code>
       <code><![CDATA[$sourceClass->associationMappings]]></code>
@@ -1334,21 +1218,6 @@
       <code><![CDATA[$targetClass->associationMappings]]></code>
       <code><![CDATA[$targetClass->associationMappings]]></code>
     </PossiblyNullArrayOffset>
-    <PossiblyNullIterator>
-      <code>$joinColumns</code>
-      <code>$joinColumns</code>
-      <code>$mapping[$sourceRelationMode]</code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['inverseJoinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTable']['joinColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['joinTableColumns']]]></code>
-      <code><![CDATA[$mapping['relationToSourceKeyColumns']]]></code>
-    </PossiblyNullIterator>
     <PossiblyNullReference>
       <code>getFieldForColumn</code>
       <code>getFieldForColumn</code>
@@ -1399,34 +1268,10 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code>$mapping</code>
       <code><![CDATA[$mapping['mappedBy']]]></code>
       <code><![CDATA[$mapping['mappedBy']]]></code>
       <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['mappedBy']]]></code>
-      <code><![CDATA[$mapping['orphanRemoval']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['sourceEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-      <code><![CDATA[$mapping['targetEntity']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$targetClass->associationMappings]]></code>
     </PossiblyNullArrayOffset>
@@ -2966,20 +2811,11 @@
     <PossiblyNullArgument>
       <code>$assoc</code>
       <code>$assoc</code>
-      <code>$assoc</code>
-      <code>$assoc</code>
-      <code><![CDATA[$assoc['targetEntity']]]></code>
       <code><![CDATA[$class->getTypeOfField($class->getSingleIdentifierFieldName())]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
-      <code><![CDATA[$collectionToDelete->getMapping()]]></code>
-      <code><![CDATA[$collectionToUpdate->getMapping()]]></code>
       <code>$owner</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$assoc['targetEntity']]]></code>
-      <code><![CDATA[$assoc['type']]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$class->reflFields]]></code>
       <code><![CDATA[$targetClass->reflFields]]></code>


### PR DESCRIPTION
Hi,

I've faced the same issue explained here : https://github.com/doctrine/orm/pull/8356 so I decided to retry his commit.

![Warning: Trying to access array offset on value of type null](https://user-images.githubusercontent.com/95275902/228179898-acc170f5-ded7-4955-8785-dc97d1c6269f.jpg)

I only check if `$this->association !== null` like on the linked PR.

Thank you !