### PR TITLE
Field mapping DTO

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ArrayAccessImplementation.php
+++ b/lib/Doctrine/ORM/Mapping/ArrayAccessImplementation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use InvalidArgumentException;
+
+use function property_exists;
+
+/** @internal */
+trait ArrayAccessImplementation
+{
+    /** @param string $offset */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    /** @param string $offset */
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (! property_exists($this, $offset)) {
+            throw new InvalidArgumentException('Undefined property: ' . $offset);
+        }
+
+        return $this->$offset;
+    }
+
+    /** @param string $offset */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /** @param string $offset */
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->$offset = null;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -40,6 +40,7 @@ use function gettype;
 use function in_array;
 use function interface_exists;
 use function is_array;
+use function is_string;
 use function is_subclass_of;
 use function ltrim;
 use function method_exists;
@@ -66,32 +67,6 @@ use function trim;
  *
  * @template-covariant T of object
  * @template-implements PersistenceClassMetadata<T>
- * @psalm-type FieldMapping = array{
- *      type: string,
- *      fieldName: string,
- *      columnName: string,
- *      length?: int,
- *      id?: bool,
- *      nullable?: bool,
- *      notInsertable?: bool,
- *      notUpdatable?: bool,
- *      generated?: int,
- *      enumType?: class-string<BackedEnum>,
- *      columnDefinition?: string,
- *      precision?: int,
- *      scale?: int,
- *      unique?: bool,
- *      inherited?: class-string,
- *      originalClass?: class-string,
- *      originalField?: string,
- *      quoted?: bool,
- *      requireSQLConversion?: bool,
- *      declared?: class-string,
- *      declaredField?: string,
- *      options?: array<string, mixed>,
- *      version?: string,
- *      default?: string|int,
- * }
  * @psalm-type JoinColumnData = array{
  *     name: string,
  *     referencedColumnName: string,
@@ -442,65 +417,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
     /**
      * READ-ONLY: The field mappings of the class.
-     * Keys are field names and values are mapping definitions.
+     * Keys are field names and values are FieldMapping instances
      *
-     * The mapping definition array has the following values:
-     *
-     * - <b>fieldName</b> (string)
-     * The name of the field in the Entity.
-     *
-     * - <b>type</b> (string)
-     * The type name of the mapped field. Can be one of Doctrine's mapping types
-     * or a custom mapping type.
-     *
-     * - <b>columnName</b> (string, optional)
-     * The column name. Optional. Defaults to the field name.
-     *
-     * - <b>length</b> (integer, optional)
-     * The database length of the column. Optional. Default value taken from
-     * the type.
-     *
-     * - <b>id</b> (boolean, optional)
-     * Marks the field as the primary key of the entity. Multiple fields of an
-     * entity can have the id attribute, forming a composite key.
-     *
-     * - <b>nullable</b> (boolean, optional)
-     * Whether the column is nullable. Defaults to FALSE.
-     *
-     * - <b>'notInsertable'</b> (boolean, optional)
-     * Whether the column is not insertable. Optional. Is only set if value is TRUE.
-     *
-     * - <b>'notUpdatable'</b> (boolean, optional)
-     * Whether the column is updatable. Optional. Is only set if value is TRUE.
-     *
-     * - <b>columnDefinition</b> (string, optional, schema-only)
-     * The SQL fragment that is used when generating the DDL for the column.
-     *
-     * - <b>precision</b> (integer, optional, schema-only)
-     * The precision of a decimal column. Only valid if the column type is decimal.
-     *
-     * - <b>scale</b> (integer, optional, schema-only)
-     * The scale of a decimal column. Only valid if the column type is decimal.
-     *
-     * - <b>'unique'</b> (boolean, optional, schema-only)
-     * Whether a unique constraint should be generated for the column.
-     *
-     * - <b>'inherited'</b> (string, optional)
-     * This is set when the field is inherited by this class from another (inheritance) parent
-     * <em>entity</em> class. The value is the FQCN of the topmost entity class that contains
-     * mapping information for this field. (If there are transient classes in the
-     * class hierarchy, these are ignored, so the class property may in fact come
-     * from a class further up in the PHP class hierarchy.)
-     * Fields initially declared in mapped superclasses are
-     * <em>not</em> considered 'inherited' in the nearest entity subclasses.
-     *
-     * - <b>'declared'</b> (string, optional)
-     * This is set when the field does not appear for the first time in this class, but is originally
-     * declared in another parent <em>entity or mapped superclass</em>. The value is the FQCN
-     * of the topmost non-transient class that contains mapping information for this field.
-     *
-     * @var mixed[]
-     * @psalm-var array<string, FieldMapping>
+     * @var array<string, FieldMapping>
      */
     public array $fieldMappings = [];
 
@@ -1283,12 +1202,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * Gets the mapping of a (regular) field that holds some data but not a
      * reference to another object.
      *
-     * @return mixed[] The field mapping.
-     * @psalm-return FieldMapping
-     *
      * @throws MappingException
      */
-    public function getFieldMapping(string $fieldName): array
+    public function getFieldMapping(string $fieldName): FieldMapping
     {
         if (! isset($this->fieldMappings[$fieldName])) {
             throw MappingException::mappingNotFound($this->name, $fieldName);
@@ -1403,7 +1319,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @throws MappingException
      */
-    protected function validateAndCompleteFieldMapping(array $mapping): array
+    protected function validateAndCompleteFieldMapping(array $mapping): FieldMapping
     {
         // Check mandatory fields
         if (! isset($mapping['fieldName']) || ! $mapping['fieldName']) {
@@ -1423,6 +1339,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         if (! isset($mapping['columnName'])) {
             $mapping['columnName'] = $this->namingStrategy->propertyToColumnName($mapping['fieldName'], $this->name);
         }
+
+        $mapping = FieldMapping::fromMappingArray($mapping);
 
         if ($mapping['columnName'][0] === '`') {
             $mapping['columnName'] = trim($mapping['columnName'], '`');
@@ -1535,6 +1453,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                     );
                 }
 
+                assert(is_string($mapping['fieldName']));
                 $this->identifier[]              = $mapping['fieldName'];
                 $this->containsForeignIdentifier = true;
             }
@@ -2338,10 +2257,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * INTERNAL:
      * Adds a field mapping without completing/validating it.
      * This is mainly used to add inherited field mappings to derived classes.
-     *
-     * @psalm-param FieldMapping $fieldMapping
      */
-    public function addInheritedFieldMapping(array $fieldMapping): void
+    public function addInheritedFieldMapping(FieldMapping $fieldMapping): void
     {
         $this->fieldMappings[$fieldMapping['fieldName']] = $fieldMapping;
         $this->columnNames[$fieldMapping['fieldName']]   = $fieldMapping['columnName'];
@@ -2942,7 +2859,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      */
     public function inlineEmbeddable(string $property, ClassMetadata $embeddable): void
     {
-        foreach ($embeddable->fieldMappings as $fieldMapping) {
+        foreach ($embeddable->fieldMappings as $originalFieldMapping) {
+            $fieldMapping                    = (array) $originalFieldMapping;
             $fieldMapping['originalClass'] ??= $embeddable->name;
             $fieldMapping['declaredField']   = isset($fieldMapping['declaredField'])
                 ? $property . '.' . $fieldMapping['declaredField']

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -47,7 +47,6 @@ use function substr;
  * @extends AbstractClassMetadataFactory<ClassMetadata>
  * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-import-type EmbeddedClassMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {
@@ -388,7 +387,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      *
      * @param AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping
      */
-    private function addMappingInheritanceInformation(array &$mapping, ClassMetadata $parentClass): void
+    private function addMappingInheritanceInformation(array|FieldMapping &$mapping, ClassMetadata $parentClass): void
     {
         if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
             $mapping['inherited'] = $parentClass->name;
@@ -405,8 +404,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->fieldMappings as $mapping) {
-            $this->addMappingInheritanceInformation($mapping, $parentClass);
-            $subClass->addInheritedFieldMapping($mapping);
+            $subClassMapping = clone $mapping;
+            $this->addMappingInheritanceInformation($subClassMapping, $parentClass);
+            $subClass->addInheritedFieldMapping($subClassMapping);
         }
 
         foreach ($parentClass->reflFields as $name => $field) {

--- a/lib/Doctrine/ORM/Mapping/FieldMapping.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMapping.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+use BackedEnum;
+
+use function in_array;
+use function property_exists;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class FieldMapping implements ArrayAccess
+{
+    use ArrayAccessImplementation;
+
+    /** The database length of the column. Optional. Default value taken from the type. */
+    public int|null $length = null;
+    /**
+     * Marks the field as the primary key of the entity. Multiple
+     * fields of an entity can have the id attribute, forming a composite key.
+     */
+    public bool|null $id                 = null;
+    public bool|null $nullable           = null;
+    public bool|null $notInsertable      = null;
+    public bool|null $notUpdatable       = null;
+    public string|null $columnDefinition = null;
+    /** @psalm-var ClassMetadata::GENERATED_* */
+    public int|null $generated = null;
+    /** @var class-string<BackedEnum>|null */
+    public string|null $enumType = null;
+    /**
+     * The precision of a decimal column.
+     * Only valid if the column type is decimal
+     */
+    public int|null $precision = null;
+    /**
+     * The scale of a decimal column.
+     * Only valid if the column type is decimal
+     */
+    public int|null $scale = null;
+    /** Whether a unique constraint should be generated for the column. */
+    public bool|null $unique = null;
+    /**
+     * @var class-string|null This is set when the field is inherited by this
+     * class from another (inheritance) parent <em>entity</em> class. The value
+     * is the FQCN of the topmost entity class that contains mapping information
+     * for this field. (If there are transient classes in the class hierarchy,
+     * these are ignored, so the class property may in fact come from a class
+     * further up in the PHP class hierarchy.)
+     * Fields initially declared in mapped superclasses are
+     * <em>not</em> considered 'inherited' in the nearest entity subclasses.
+     */
+    public string|null $inherited = null;
+
+    public string|null $originalClass = null;
+    public string|null $originalField = null;
+    public bool|null $quoted          = null;
+    /**
+     * @var class-string|null This is set when the field does not appear for
+     * the first time in this class, but is originally declared in another
+     * parent <em>entity or mapped superclass</em>. The value is the FQCN of
+     * the topmost non-transient class that contains mapping information for
+     * this field.
+     */
+    public string|null $declared      = null;
+    public string|null $declaredField = null;
+    public array|null $options        = null;
+    public bool|null $version         = null;
+    public string|int|null $default   = null;
+
+    /**
+     * @param string $type       The type name of the mapped field. Can be one of
+     *                           Doctrine's mapping types or a custom mapping type.
+     * @param string $fieldName  The name of the field in the Entity.
+     * @param string $columnName The column name. Optional. Defaults to the field name.
+     */
+    public function __construct(
+        public string $type,
+        public string $fieldName,
+        public string $columnName,
+    ) {
+    }
+
+    /** @param array{type: string, fieldName: string, columnName: string} $mappingArray */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $mapping = new self(
+            $mappingArray['type'],
+            $mappingArray['fieldName'],
+            $mappingArray['columnName'],
+        );
+        foreach ($mappingArray as $key => $value) {
+            if (in_array($key, ['type', 'fieldName', 'columnName'])) {
+                continue;
+            }
+
+            if (property_exists($mapping, $key)) {
+                $mapping->$key = $value;
+            }
+        }
+
+        return $mapping;
+    }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        $serialized = ['type', 'fieldName', 'columnName'];
+
+        foreach (['nullable', 'notInsertable', 'notUpdatable', 'id', 'unique', 'version', 'quoted'] as $boolKey) {
+            if ($this->$boolKey) {
+                $serialized[] = $boolKey;
+            }
+        }
+
+        foreach (
+            [
+                'length',
+                'columnDefinition',
+                'generated',
+                'enumType',
+                'precision',
+                'scale',
+                'inherited',
+                'originalClass',
+                'originalField',
+                'declared',
+                'declaredField',
+                'options',
+                'default',
+            ] as $key
+        ) {
+            if ($this->$key !== null) {
+                $serialized[] = $key;
+            }
+        }
+
+        return $serialized;
+    }
+}

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1847,7 +1847,7 @@ class BasicEntityPersister implements EntityPersister
 
         switch (true) {
             case isset($class->fieldMappings[$field]):
-                $types = array_merge($types, [$class->fieldMappings[$field]['type']]);
+                $types = array_merge($types, [$class->fieldMappings[$field]->type]);
                 break;
 
             case isset($class->associationMappings[$field]):

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -42,7 +43,6 @@ use const JSON_UNESCAPED_UNICODE;
  * @link    www.doctrine-project.org
  *
  * @psalm-import-type AssociationMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  */
 final class MappingDescribeCommand extends AbstractEntityManagerCommand
 {
@@ -257,7 +257,7 @@ EOT);
         foreach ($propertyMappings as $propertyName => $mapping) {
             $output[] = $this->formatField(sprintf('  %s', $propertyName), '');
 
-            foreach ($mapping as $field => $value) {
+            foreach ((array) $mapping as $field => $value) {
                 $output[] = $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
             }
         }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -48,7 +49,6 @@ use function strtolower;
  *
  * @psalm-import-type AssociationMapping from ClassMetadata
  * @psalm-import-type DiscriminatorColumnMapping from ClassMetadata
- * @psalm-import-type FieldMapping from ClassMetadata
  * @psalm-import-type JoinColumnData from ClassMetadata
  */
 class SchemaTool
@@ -457,7 +457,7 @@ class SchemaTool
      */
     private function gatherColumn(
         ClassMetadata $class,
-        array $mapping,
+        FieldMapping $mapping,
         Table $table,
     ): void {
         $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
@@ -776,7 +776,7 @@ class SchemaTool
      *
      * @return mixed[]
      */
-    private function gatherColumnOptions(array $mapping): array
+    private function gatherColumnOptions(FieldMapping|array $mapping): array
     {
         $mappingOptions = $mapping['options'] ?? [];
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -27,7 +27,7 @@ class PersisterHelper
     public static function getTypeOfField(string $fieldName, ClassMetadata $class, EntityManagerInterface $em): array
     {
         if (isset($class->fieldMappings[$fieldName])) {
-            return [$class->fieldMappings[$fieldName]['type']];
+            return [$class->fieldMappings[$fieldName]->type];
         }
 
         if (! isset($class->associationMappings[$fieldName])) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -331,6 +331,7 @@
     <InvalidArgument>
       <code>$mapping</code>
       <code>$mapping</code>
+      <code>$mapping</code>
       <code>$overrideMapping</code>
     </InvalidArgument>
     <InvalidNullableReturnType>
@@ -343,11 +344,9 @@
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$mapping</code>
-      <code>$mapping</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>AssociationMapping</code>
-      <code>FieldMapping</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code>$cache</code>
@@ -388,9 +387,6 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$mapping['fieldName']]]></code>
-      <code><![CDATA[$mapping['originalClass']]]></code>
-      <code><![CDATA[$mapping['originalField']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$table['name']]]></code>
       <code><![CDATA[$this->associationMappings[$assocName]['joinColumns']]]></code>
@@ -1579,8 +1575,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$assoc['joinColumns']]]></code>
       <code><![CDATA[$class->getAssociationMapping($fieldName)['joinColumns']]]></code>
-      <code><![CDATA[$fieldMapping['precision']]]></code>
-      <code><![CDATA[$fieldMapping['scale']]]></code>
       <code><![CDATA[$idMapping['joinColumns']]]></code>
       <code><![CDATA[$mapping['joinColumns']]]></code>
       <code><![CDATA[$mapping['joinTable']]]></code>

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldMappingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+final class FieldMappingTest extends TestCase
+{
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping = new FieldMapping(
+            type: 'string',
+            fieldName: 'id',
+            columnName: 'id',
+        );
+
+        $mapping->length           = 255;
+        $mapping->id               = true;
+        $mapping->nullable         = true;
+        $mapping->notInsertable    = true;
+        $mapping->notUpdatable     = true;
+        $mapping->columnDefinition = 'VARCHAR(255)';
+        $mapping->generated        = ClassMetadata::GENERATOR_TYPE_AUTO;
+        $mapping->enumType         = 'MyEnum';
+        $mapping->precision        = 10;
+        $mapping->scale            = 2;
+        $mapping->unique           = true;
+        $mapping->inherited        = self::class;
+        $mapping->originalClass    = self::class;
+        $mapping->originalField    = 'id';
+        $mapping->quoted           = true;
+        $mapping->declared         = self::class;
+        $mapping->declaredField    = 'id';
+        $mapping->options          = ['foo' => 'bar'];
+        $mapping->version          = true;
+        $mapping->default          = 'foo';
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+        assert($resurrectedMapping instanceof FieldMapping);
+
+        self::assertSame($resurrectedMapping->length, 255);
+        self::assertTrue($resurrectedMapping->id);
+        self::assertTrue($resurrectedMapping->nullable);
+        self::assertTrue($resurrectedMapping->notInsertable);
+        self::assertTrue($resurrectedMapping->notUpdatable);
+        self::assertSame($resurrectedMapping->columnDefinition, 'VARCHAR(255)');
+        self::assertSame($resurrectedMapping->generated, ClassMetadata::GENERATOR_TYPE_AUTO);
+        self::assertSame($resurrectedMapping->enumType, 'MyEnum');
+        self::assertSame($resurrectedMapping->precision, 10);
+        self::assertSame($resurrectedMapping->scale, 2);
+        self::assertTrue($resurrectedMapping->unique);
+        self::assertSame($resurrectedMapping->inherited, self::class);
+        self::assertSame($resurrectedMapping->originalClass, self::class);
+        self::assertSame($resurrectedMapping->originalField, 'id');
+        self::assertTrue($resurrectedMapping->quoted);
+        self::assertSame($resurrectedMapping->declared, self::class);
+        self::assertSame($resurrectedMapping->declaredField, 'id');
+        self::assertSame($resurrectedMapping->options, ['foo' => 'bar']);
+        self::assertTrue($resurrectedMapping->version);
+        self::assertSame($resurrectedMapping->default, 'foo');
+    }
+}


### PR DESCRIPTION
In the past, it has been decided to use arrays for this out of
legitimate performance concerns. But PHP has evolved, and now, it is
more performant and memory efficient to use objects.