### PR TITLE
Use Rector to migrate to the object API of FieldMapping

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -46,7 +46,7 @@ class DefaultEntityHydrator implements EntityHydrator
             }
 
             foreach ($metadata->fieldMappings as $name => $fieldMapping) {
-                if (isset($fieldMapping['generated'])) {
+                if (isset($fieldMapping->generated)) {
                     $data[$name] = $metadata->getFieldValue($entity, $name);
                 }
             }
@@ -79,7 +79,7 @@ class DefaultEntityHydrator implements EntityHydrator
                     if (isset($targetClassMetadata->fieldMappings[$fieldName])) {
                         $fieldMapping = $targetClassMetadata->fieldMappings[$fieldName];
 
-                        $data[$owningAssociation['targetToSourceKeyColumns'][$fieldMapping['columnName']]] = $fieldValue;
+                        $data[$owningAssociation['targetToSourceKeyColumns'][$fieldMapping->columnName]] = $fieldValue;
 
                         continue;
                     }

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -401,7 +401,7 @@ abstract class AbstractHydrator
                 $columnInfo    = [
                     'isIdentifier' => in_array($fieldName, $classMetadata->identifier, true),
                     'fieldName'    => $fieldName,
-                    'type'         => Type::getType($fieldMapping['type']),
+                    'type'         => Type::getType($fieldMapping->type),
                     'dqlAlias'     => $ownerMap,
                     'enumType'     => $this->rsm->enumMappings[$key] ?? null,
                 ];

--- a/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
@@ -20,7 +20,7 @@ class AnsiQuoteStrategy implements QuoteStrategy
         ClassMetadata $class,
         AbstractPlatform $platform,
     ): string {
-        return $class->fieldMappings[$fieldName]['columnName'];
+        return $class->fieldMappings[$fieldName]->columnName;
     }
 
     public function getTableName(ClassMetadata $class, AbstractPlatform $platform): string

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -387,12 +387,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         AssociationMapping|EmbeddedClassMapping|FieldMapping $mapping,
         ClassMetadata $parentClass,
     ): void {
-        if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
-            $mapping['inherited'] = $parentClass->name;
+        if (! isset($mapping->inherited) && ! $parentClass->isMappedSuperclass) {
+            $mapping->inherited = $parentClass->name;
         }
 
-        if (! isset($mapping['declared'])) {
-            $mapping['declared'] = $parentClass->name;
+        if (! isset($mapping->declared)) {
+            $mapping->declared = $parentClass->name;
         }
     }
 
@@ -519,7 +519,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 $sequenceName = null;
                 $fieldName    = $class->identifier ? $class->getSingleIdentifierFieldName() : null;
 
-                $generator = $fieldName && $class->fieldMappings[$fieldName]['type'] === 'bigint'
+                $generator = $fieldName && $class->fieldMappings[$fieldName]->type === 'bigint'
                     ? new BigIntegerIdentityGenerator()
                     : new IdentityGenerator();
 
@@ -534,7 +534,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 if (! $definition) {
                     $fieldName    = $class->getSingleIdentifierFieldName();
                     $sequenceName = $class->getSequenceName($this->getTargetPlatform());
-                    $quoted       = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
+                    $quoted       = isset($class->fieldMappings[$fieldName]->quoted) || isset($class->table['quoted']);
 
                     $definition = [
                         'sequenceName'      => $this->truncateSequenceName($sequenceName),

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -22,9 +22,9 @@ class DefaultQuoteStrategy implements QuoteStrategy
 
     public function getColumnName(string $fieldName, ClassMetadata $class, AbstractPlatform $platform): string
     {
-        return isset($class->fieldMappings[$fieldName]['quoted'])
-            ? $platform->quoteIdentifier($class->fieldMappings[$fieldName]['columnName'])
-            : $class->fieldMappings[$fieldName]['columnName'];
+        return isset($class->fieldMappings[$fieldName]->quoted)
+            ? $platform->quoteIdentifier($class->fieldMappings[$fieldName]->columnName)
+            : $class->fieldMappings[$fieldName]->columnName;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -40,7 +40,7 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
     {
         $tableAlias   = $alias === 'r' ? '' : $alias;
         $fieldMapping = $class->fieldMappings[$field];
-        $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
+        $columnAlias  = $this->getSQLColumnAlias($fieldMapping->columnName);
         $sql          = sprintf(
             '%s.%s',
             $this->getSQLTableAlias($class->name, $tableAlias),
@@ -49,7 +49,7 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
 
         $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field, $class->name);
 
-        $type = Type::getType($fieldMapping['type']);
+        $type = Type::getType($fieldMapping->type);
         $sql  = $type->convertToPHPValueSQL($sql, $this->platform);
 
         return $sql . ' AS ' . $columnAlias;

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -279,7 +279,7 @@ class BasicEntityPersister implements EntityPersister
         $values = $this->fetchVersionAndNotUpsertableValues($this->class, $id);
 
         foreach ($values as $field => $value) {
-            $value = Type::getType($this->class->fieldMappings[$field]['type'])->convertToPHPValue($value, $this->platform);
+            $value = Type::getType($this->class->fieldMappings[$field]->type)->convertToPHPValue($value, $this->platform);
 
             $this->class->setFieldValue($entity, $field, $value);
         }
@@ -295,7 +295,7 @@ class BasicEntityPersister implements EntityPersister
     {
         $columnNames = [];
         foreach ($this->class->fieldMappings as $key => $column) {
-            if (isset($column['generated']) || ($this->class->isVersioned && $key === $versionedClass->versionField)) {
+            if (isset($column->generated) || ($this->class->isVersioned && $key === $versionedClass->versionField)) {
                 $columnNames[$key] = $this->quoteStrategy->getColumnName($key, $versionedClass, $this->platform);
             }
         }
@@ -428,7 +428,7 @@ class BasicEntityPersister implements EntityPersister
         foreach ($this->class->identifier as $idField) {
             if (! isset($this->class->associationMappings[$idField])) {
                 $params[] = $identifier[$idField];
-                $types[]  = $this->class->fieldMappings[$idField]['type'];
+                $types[]  = $this->class->fieldMappings[$idField]->type;
                 $where[]  = $this->quoteStrategy->getColumnName($idField, $this->class, $this->platform);
 
                 continue;
@@ -454,11 +454,11 @@ class BasicEntityPersister implements EntityPersister
         if ($versioned) {
             $versionField = $this->class->versionField;
             assert($versionField !== null);
-            $versionFieldType = $this->class->fieldMappings[$versionField]['type'];
+            $versionFieldType = $this->class->fieldMappings[$versionField]->type;
             $versionColumn    = $this->quoteStrategy->getColumnName($versionField, $this->class, $this->platform);
 
             $where[]  = $versionColumn;
-            $types[]  = $this->class->fieldMappings[$versionField]['type'];
+            $types[]  = $this->class->fieldMappings[$versionField]->type;
             $params[] = $this->class->reflFields[$versionField]->getValue($entity);
 
             switch ($versionFieldType) {
@@ -605,17 +605,17 @@ class BasicEntityPersister implements EntityPersister
 
             if (! isset($this->class->associationMappings[$field])) {
                 $fieldMapping = $this->class->fieldMappings[$field];
-                $columnName   = $fieldMapping['columnName'];
+                $columnName   = $fieldMapping->columnName;
 
-                if (! $isInsert && isset($fieldMapping['notUpdatable'])) {
+                if (! $isInsert && isset($fieldMapping->notUpdatable)) {
                     continue;
                 }
 
-                if ($isInsert && isset($fieldMapping['notInsertable'])) {
+                if ($isInsert && isset($fieldMapping->notInsertable)) {
                     continue;
                 }
 
-                $this->columnTypes[$columnName] = $fieldMapping['type'];
+                $this->columnTypes[$columnName] = $fieldMapping->type;
 
                 $result[$this->getOwningTable($field)][$columnName] = $newVal;
 
@@ -1120,7 +1120,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if (isset($this->class->fieldMappings[$fieldName])) {
-                $tableAlias = isset($this->class->fieldMappings[$fieldName]['inherited'])
+                $tableAlias = isset($this->class->fieldMappings[$fieldName]->inherited)
                     ? $this->getSQLTableAlias($this->class->fieldMappings[$fieldName]['inherited'])
                     : $baseTableAlias;
 
@@ -1409,12 +1409,12 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if (! $this->class->isIdGeneratorIdentity() || $this->class->identifier[0] !== $name) {
-                if (isset($this->class->fieldMappings[$name]['notInsertable'])) {
+                if (isset($this->class->fieldMappings[$name]->notInsertable)) {
                     continue;
                 }
 
                 $columns[]                = $this->quoteStrategy->getColumnName($name, $this->class, $this->platform);
-                $this->columnTypes[$name] = $this->class->fieldMappings[$name]['type'];
+                $this->columnTypes[$name] = $this->class->fieldMappings[$name]->type;
             }
         }
 
@@ -1433,14 +1433,14 @@ class BasicEntityPersister implements EntityPersister
         $tableAlias   = $this->getSQLTableAlias($class->name, $root);
         $fieldMapping = $class->fieldMappings[$field];
         $sql          = sprintf('%s.%s', $tableAlias, $this->quoteStrategy->getColumnName($field, $class, $this->platform));
-        $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
+        $columnAlias  = $this->getSQLColumnAlias($fieldMapping->columnName);
 
         $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field);
-        if (! empty($fieldMapping['enumType'])) {
-            $this->currentPersisterContext->rsm->addEnumResult($columnAlias, $fieldMapping['enumType']);
+        if (! empty($fieldMapping->enumType)) {
+            $this->currentPersisterContext->rsm->addEnumResult($columnAlias, $fieldMapping->enumType);
         }
 
-        $type = Type::getType($fieldMapping['type']);
+        $type = Type::getType($fieldMapping->type);
         $sql  = $type->convertToPHPValueSQL($sql, $this->platform);
 
         return $sql . ' AS ' . $columnAlias;
@@ -1545,7 +1545,7 @@ class BasicEntityPersister implements EntityPersister
             $placeholder = '?';
 
             if (isset($this->class->fieldMappings[$field])) {
-                $type        = Type::getType($this->class->fieldMappings[$field]['type']);
+                $type        = Type::getType($this->class->fieldMappings[$field]->type);
                 $placeholder = $type->convertToDatabaseValueSQL($placeholder, $this->platform);
             }
 
@@ -1608,7 +1608,7 @@ class BasicEntityPersister implements EntityPersister
         AssociationMapping|null $assoc = null,
     ): array {
         if (isset($this->class->fieldMappings[$field])) {
-            $className = $this->class->fieldMappings[$field]['inherited'] ?? $this->class->name;
+            $className = $this->class->fieldMappings[$field]->inherited ?? $this->class->name;
 
             return [$this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $this->class, $this->platform)];
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -57,8 +57,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      */
     private function getVersionedClassMetadata(): ClassMetadata
     {
-        if (isset($this->class->fieldMappings[$this->class->versionField]['inherited'])) {
-            $definingClassName = $this->class->fieldMappings[$this->class->versionField]['inherited'];
+        if (isset($this->class->fieldMappings[$this->class->versionField]->inherited)) {
+            $definingClassName = $this->class->fieldMappings[$this->class->versionField]->inherited;
 
             return $this->em->getClassMetadata($definingClassName);
         }
@@ -78,8 +78,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $cm = match (true) {
             isset($this->class->associationMappings[$fieldName]['inherited'])
                 => $this->em->getClassMetadata($this->class->associationMappings[$fieldName]['inherited']),
-            isset($this->class->fieldMappings[$fieldName]['inherited'])
-                => $this->em->getClassMetadata($this->class->fieldMappings[$fieldName]['inherited']),
+            isset($this->class->fieldMappings[$fieldName]->inherited)
+                => $this->em->getClassMetadata($this->class->fieldMappings[$fieldName]->inherited),
             default => $this->class,
         };
 
@@ -378,8 +378,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add regular columns
         foreach ($this->class->fieldMappings as $fieldName => $mapping) {
-            $class = isset($mapping['inherited'])
-                ? $this->em->getClassMetadata($mapping['inherited'])
+            $class = isset($mapping->inherited)
+                ? $this->em->getClassMetadata($mapping->inherited)
                 : $this->class;
 
             $columnList[] = $this->getSelectColumnSQL($fieldName, $class);
@@ -421,7 +421,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Add subclass columns
             foreach ($subClass->fieldMappings as $fieldName => $mapping) {
-                if (isset($mapping['inherited'])) {
+                if (isset($mapping->inherited)) {
                     continue;
                 }
 
@@ -464,8 +464,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         foreach ($this->class->reflFields as $name => $field) {
             if (
-                isset($this->class->fieldMappings[$name]['inherited'])
-                    && ! isset($this->class->fieldMappings[$name]['id'])
+                isset($this->class->fieldMappings[$name]->inherited)
+                    && ! isset($this->class->fieldMappings[$name]->id)
                     || isset($this->class->associationMappings[$name]['inherited'])
                     || ($this->class->isVersioned && $this->class->versionField === $name)
                     || isset($this->class->embeddedClasses[$name])
@@ -486,7 +486,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     ! $this->class->isIdGeneratorIdentity() || $this->class->identifier[0] !== $name
             ) {
                 $columns[]                = $this->quoteStrategy->getColumnName($name, $this->class, $this->platform);
-                $this->columnTypes[$name] = $this->class->fieldMappings[$name]['type'];
+                $this->columnTypes[$name] = $this->class->fieldMappings[$name]->type;
             }
         }
 
@@ -506,7 +506,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $values = $this->fetchVersionAndNotUpsertableValues($this->getVersionedClassMetadata(), $id);
 
         foreach ($values as $field => $value) {
-            $value = Type::getType($this->class->fieldMappings[$field]['type'])->convertToPHPValue($value, $this->platform);
+            $value = Type::getType($this->class->fieldMappings[$field]->type)->convertToPHPValue($value, $this->platform);
 
             $this->class->setFieldValue($entity, $field, $value);
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -58,7 +58,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
             // Regular columns
             foreach ($subClass->fieldMappings as $fieldName => $mapping) {
-                if (isset($mapping['inherited'])) {
+                if (isset($mapping->inherited)) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -49,7 +49,7 @@ class IdentityFunction extends FunctionNode
             $joinColumn = null;
 
             foreach ($assoc['joinColumns'] as $mapping) {
-                if ($mapping['referencedColumnName'] === $field['columnName']) {
+                if ($mapping['referencedColumnName'] === $field->columnName) {
                     $joinColumn = $mapping;
 
                     break;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -88,7 +88,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
                 $field = $updateItem->pathExpression->field;
 
                 if (
-                    (isset($class->fieldMappings[$field]) && ! isset($class->fieldMappings[$field]['inherited'])) ||
+                    (isset($class->fieldMappings[$field]) && ! isset($class->fieldMappings[$field]->inherited)) ||
                     (isset($class->associationMappings[$field]) && ! isset($class->associationMappings[$field]['inherited']))
                 ) {
                     $newValue = $updateItem->newValue;

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -251,9 +251,9 @@ class ResultSetMappingBuilder extends ResultSetMapping implements Stringable
                 $class             = $this->em->getClassMetadata($this->declaringClasses[$columnName]);
                 $fieldName         = $this->fieldMappings[$columnName];
                 $classFieldMapping = $class->fieldMappings[$fieldName];
-                $columnSql         = $tableAlias . '.' . $classFieldMapping['columnName'];
+                $columnSql         = $tableAlias . '.' . $classFieldMapping->columnName;
 
-                $type      = Type::getType($classFieldMapping['type']);
+                $type      = Type::getType($classFieldMapping->type);
                 $columnSql = $type->convertToPHPValueSQL($columnSql, $this->em->getConnection()->getDatabasePlatform());
 
                 $sql .= $columnSql;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -556,9 +556,9 @@ class SqlWalker
 
         if (
             $fieldName !== null && $class->isInheritanceTypeJoined() &&
-            isset($class->fieldMappings[$fieldName]['inherited'])
+            isset($class->fieldMappings[$fieldName]->inherited)
         ) {
-            $class = $this->em->getClassMetadata($class->fieldMappings[$fieldName]['inherited']);
+            $class = $this->em->getClassMetadata($class->fieldMappings[$fieldName]->inherited);
         }
 
         return $this->getSQLTableAlias($class->getTableName(), $identificationVariable);
@@ -1237,10 +1237,10 @@ class SqlWalker
                 $sqlTableAlias = $this->getSQLTableAlias($tableName, $dqlAlias);
                 $fieldMapping  = $class->fieldMappings[$fieldName];
                 $columnName    = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
-                $columnAlias   = $this->getSQLColumnAlias($fieldMapping['columnName']);
+                $columnAlias   = $this->getSQLColumnAlias($fieldMapping->columnName);
                 $col           = $sqlTableAlias . '.' . $columnName;
 
-                $type = Type::getType($fieldMapping['type']);
+                $type = Type::getType($fieldMapping->type);
                 $col  = $type->convertToPHPValueSQL($col, $this->conn->getDatabasePlatform());
 
                 $sql .= $col . ' AS ' . $columnAlias;
@@ -1248,11 +1248,11 @@ class SqlWalker
                 $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
 
                 if (! $hidden) {
-                    $this->rsm->addScalarResult($columnAlias, $resultAlias, $fieldMapping['type']);
+                    $this->rsm->addScalarResult($columnAlias, $resultAlias, $fieldMapping->type);
                     $this->scalarFields[$dqlAlias][$fieldName] = $columnAlias;
 
-                    if (! empty($fieldMapping['enumType'])) {
-                        $this->rsm->addEnumResult($columnAlias, $fieldMapping['enumType']);
+                    if (! empty($fieldMapping->enumType)) {
+                        $this->rsm->addEnumResult($columnAlias, $fieldMapping->enumType);
                     }
                 }
 
@@ -1342,17 +1342,17 @@ class SqlWalker
                         continue;
                     }
 
-                    $tableName = isset($mapping['inherited'])
-                        ? $this->em->getClassMetadata($mapping['inherited'])->getTableName()
+                    $tableName = isset($mapping->inherited)
+                        ? $this->em->getClassMetadata($mapping->inherited)->getTableName()
                         : $class->getTableName();
 
                     $sqlTableAlias    = $this->getSQLTableAlias($tableName, $dqlAlias);
-                    $columnAlias      = $this->getSQLColumnAlias($mapping['columnName']);
+                    $columnAlias      = $this->getSQLColumnAlias($mapping->columnName);
                     $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
 
                     $col = $sqlTableAlias . '.' . $quotedColumnName;
 
-                    $type = Type::getType($mapping['type']);
+                    $type = Type::getType($mapping->type);
                     $col  = $type->convertToPHPValueSQL($col, $this->platform);
 
                     $sqlParts[] = $col . ' AS ' . $columnAlias;
@@ -1361,8 +1361,8 @@ class SqlWalker
 
                     $this->rsm->addFieldResult($dqlAlias, $columnAlias, $fieldName, $class->name);
 
-                    if (! empty($mapping['enumType'])) {
-                        $this->rsm->addEnumResult($columnAlias, $mapping['enumType']);
+                    if (! empty($mapping->enumType)) {
+                        $this->rsm->addEnumResult($columnAlias, $mapping->enumType);
                     }
                 }
 
@@ -1376,16 +1376,16 @@ class SqlWalker
                         $sqlTableAlias = $this->getSQLTableAlias($subClass->getTableName(), $dqlAlias);
 
                         foreach ($subClass->fieldMappings as $fieldName => $mapping) {
-                            if (isset($mapping['inherited']) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
+                            if (isset($mapping->inherited) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
                                 continue;
                             }
 
-                            $columnAlias      = $this->getSQLColumnAlias($mapping['columnName']);
+                            $columnAlias      = $this->getSQLColumnAlias($mapping->columnName);
                             $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $subClass, $this->platform);
 
                             $col = $sqlTableAlias . '.' . $quotedColumnName;
 
-                            $type = Type::getType($mapping['type']);
+                            $type = Type::getType($mapping->type);
                             $col  = $type->convertToPHPValueSQL($col, $this->platform);
 
                             $sqlParts[] = $col . ' AS ' . $columnAlias;
@@ -1487,7 +1487,7 @@ class SqlWalker
                     $class        = $this->getMetadataForDqlAlias($dqlAlias);
                     $fieldName    = $e->field;
                     $fieldMapping = $class->fieldMappings[$fieldName];
-                    $fieldType    = $fieldMapping['type'];
+                    $fieldType    = $fieldMapping->type;
                     $col          = trim($e->dispatch($this));
 
                     $type = Type::getType($fieldType);
@@ -1495,8 +1495,8 @@ class SqlWalker
 
                     $sqlSelectExpressions[] = $col . ' AS ' . $columnAlias;
 
-                    if (! empty($fieldMapping['enumType'])) {
-                        $this->rsm->addEnumResult($columnAlias, $fieldMapping['enumType']);
+                    if (! empty($fieldMapping->enumType)) {
+                        $this->rsm->addEnumResult($columnAlias, $fieldMapping->enumType);
                     }
 
                     break;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -413,10 +413,10 @@ class LimitSubqueryOutputWalker extends SqlWalker
             // Get the SQL table alias for the entity and field
             $sqlTableAliasForFieldAlias = $aliasMap[$dqlAliasForFieldAlias];
 
-            if (isset($fieldMapping['declared']) && $fieldMapping['declared'] !== $class->name) {
+            if (isset($fieldMapping->declared) && $fieldMapping->declared !== $class->name) {
                 // Field was declared in a parent class, so we need to get the proper SQL table alias
                 // for the joined parent table.
-                $otherClassMetadata = $this->em->getClassMetadata($fieldMapping['declared']);
+                $otherClassMetadata = $this->em->getClassMetadata($fieldMapping->declared);
 
                 if (! $otherClassMetadata->isMappedSuperclass) {
                     $sqlTableAliasForFieldAlias = $this->getSQLTableAlias($otherClassMetadata->getTableName(), $dqlAliasForFieldAlias);

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -49,7 +49,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
 
         $this->_getQuery()->setHint(
             self::IDENTIFIER_TYPE,
-            Type::getType($rootClass->fieldMappings[$identifier]['type']),
+            Type::getType($rootClass->fieldMappings[$identifier]->type),
         );
 
         $this->_getQuery()->setHint(self::FORCE_DBAL_TYPE_CONVERSION, true);

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -212,7 +212,7 @@ class SchemaTool
             } elseif ($class->isInheritanceTypeJoined()) {
                 // Add all non-inherited fields as columns
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
-                    if (! isset($mapping['inherited'])) {
+                    if (! isset($mapping->inherited)) {
                         $this->gatherColumn($class, $mapping, $table);
                     }
                 }
@@ -228,7 +228,7 @@ class SchemaTool
                     $inheritedKeyColumns = [];
 
                     foreach ($class->identifier as $identifierField) {
-                        if (isset($class->fieldMappings[$identifierField]['inherited'])) {
+                        if (isset($class->fieldMappings[$identifierField]->inherited)) {
                             $idMapping = $class->fieldMappings[$identifierField];
                             $this->gatherColumn($class, $idMapping, $table);
                             $columnName = $this->quoteStrategy->getColumnName(
@@ -436,14 +436,14 @@ class SchemaTool
         $pkColumns = [];
 
         foreach ($class->fieldMappings as $mapping) {
-            if ($class->isInheritanceTypeSingleTable() && isset($mapping['inherited'])) {
+            if ($class->isInheritanceTypeSingleTable() && isset($mapping->inherited)) {
                 continue;
             }
 
             $this->gatherColumn($class, $mapping, $table);
 
-            if ($class->isIdentifier($mapping['fieldName'])) {
-                $pkColumns[] = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
+            if ($class->isIdentifier($mapping->fieldName)) {
+                $pkColumns[] = $this->quoteStrategy->getColumnName($mapping->fieldName, $class, $this->platform);
             }
         }
     }
@@ -459,43 +459,43 @@ class SchemaTool
         FieldMapping $mapping,
         Table $table,
     ): void {
-        $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
-        $columnType = $mapping['type'];
+        $columnName = $this->quoteStrategy->getColumnName($mapping->fieldName, $class, $this->platform);
+        $columnType = $mapping->type;
 
         $options            = [];
-        $options['length']  = $mapping['length'] ?? null;
-        $options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
+        $options['length']  = $mapping->length ?? null;
+        $options['notnull'] = isset($mapping->nullable) ? ! $mapping->nullable : true;
         if ($class->isInheritanceTypeSingleTable() && $class->parentClasses) {
             $options['notnull'] = false;
         }
 
         $options['platformOptions']            = [];
-        $options['platformOptions']['version'] = $class->isVersioned && $class->versionField === $mapping['fieldName'];
+        $options['platformOptions']['version'] = $class->isVersioned && $class->versionField === $mapping->fieldName;
 
         if (strtolower($columnType) === 'string' && $options['length'] === null) {
             $options['length'] = 255;
         }
 
-        if (isset($mapping['precision'])) {
-            $options['precision'] = $mapping['precision'];
+        if (isset($mapping->precision)) {
+            $options['precision'] = $mapping->precision;
         }
 
-        if (isset($mapping['scale'])) {
-            $options['scale'] = $mapping['scale'];
+        if (isset($mapping->scale)) {
+            $options['scale'] = $mapping->scale;
         }
 
-        if (isset($mapping['default'])) {
-            $options['default'] = $mapping['default'];
+        if (isset($mapping->default)) {
+            $options['default'] = $mapping->default;
         }
 
-        if (isset($mapping['columnDefinition'])) {
-            $options['columnDefinition'] = $mapping['columnDefinition'];
+        if (isset($mapping->columnDefinition)) {
+            $options['columnDefinition'] = $mapping->columnDefinition;
         }
 
         // the 'default' option can be overwritten here
         $options = $this->gatherColumnOptions($mapping) + $options;
 
-        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() === [$mapping['fieldName']]) {
+        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() === [$mapping->fieldName]) {
             $options['autoincrement'] = true;
         }
 
@@ -510,7 +510,7 @@ class SchemaTool
             $table->addColumn($columnName, $columnType, $options);
         }
 
-        $isUnique = $mapping['unique'] ?? false;
+        $isUnique = $mapping->unique ?? false;
         if ($isUnique) {
             $table->addUniqueIndex([$columnName]);
         }
@@ -698,8 +698,8 @@ class SchemaTool
 
                 if (isset($joinColumn['columnDefinition'])) {
                     $columnOptions['columnDefinition'] = $joinColumn['columnDefinition'];
-                } elseif (isset($fieldMapping['columnDefinition'])) {
-                    $columnOptions['columnDefinition'] = $fieldMapping['columnDefinition'];
+                } elseif (isset($fieldMapping->columnDefinition)) {
+                    $columnOptions['columnDefinition'] = $fieldMapping->columnDefinition;
                 }
 
                 if (isset($joinColumn['nullable'])) {
@@ -708,18 +708,18 @@ class SchemaTool
 
                 $columnOptions += $this->gatherColumnOptions($fieldMapping);
 
-                if (isset($fieldMapping['length'])) {
-                    $columnOptions['length'] = $fieldMapping['length'];
+                if (isset($fieldMapping->length)) {
+                    $columnOptions['length'] = $fieldMapping->length;
                 }
 
-                if ($fieldMapping['type'] === 'decimal') {
-                    $columnOptions['scale']     = $fieldMapping['scale'];
-                    $columnOptions['precision'] = $fieldMapping['precision'];
+                if ($fieldMapping->type === 'decimal') {
+                    $columnOptions['scale']     = $fieldMapping->scale;
+                    $columnOptions['precision'] = $fieldMapping->precision;
                 }
 
                 $columnOptions = $this->gatherColumnOptions($joinColumn) + $columnOptions;
 
-                $theJoinTable->addColumn($quotedColumnName, $fieldMapping['type'], $columnOptions);
+                $theJoinTable->addColumn($quotedColumnName, $fieldMapping->type, $columnOptions);
             }
 
             if (isset($joinColumn['unique']) && $joinColumn['unique'] === true) {
@@ -769,10 +769,10 @@ class SchemaTool
     /** @return mixed[] */
     private function gatherColumnOptions(JoinColumnMapping|FieldMapping|DiscriminatorColumnMapping $mapping): array
     {
-        $mappingOptions = $mapping['options'] ?? [];
+        $mappingOptions = $mapping->options ?? [];
 
-        if (isset($mapping['enumType'])) {
-            $mappingOptions['enumType'] = $mapping['enumType'];
+        if (isset($mapping->enumType)) {
+            $mappingOptions['enumType'] = $mapping->enumType;
         }
 
         if (($mappingOptions['default'] ?? null) instanceof BackedEnum) {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -69,8 +69,8 @@ class SchemaValidator
         $cmf = $this->em->getMetadataFactory();
 
         foreach ($class->fieldMappings as $fieldName => $mapping) {
-            if (! Type::hasType($mapping['type'])) {
-                $ce[] = "The field '" . $class->name . '#' . $fieldName . "' uses a non-existent type '" . $mapping['type'] . "'.";
+            if (! Type::hasType($mapping->type)) {
+                $ce[] = "The field '" . $class->name . '#' . $fieldName . "' uses a non-existent type '" . $mapping->type . "'.";
             }
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -635,7 +635,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $orgValue = $originalData[$propName];
 
-                if (! empty($class->fieldMappings[$propName]['enumType'])) {
+                if (! empty($class->fieldMappings[$propName]->enumType)) {
                     if (is_array($orgValue)) {
                         foreach ($orgValue as $id => $val) {
                             if ($val instanceof BackedEnum) {

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -63,7 +63,7 @@ class PersisterHelper
             $fieldName = $class->fieldNames[$columnName];
 
             if (isset($class->fieldMappings[$fieldName])) {
-                return $class->fieldMappings[$fieldName]['type'];
+                return $class->fieldMappings[$fieldName]->type;
             }
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -334,7 +334,6 @@
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$parentReflFields[$embeddedClass['declaredField']]]]></code>
-      <code><![CDATA[$parentReflFields[$mapping['declaredField']]]]></code>
     </PossiblyNullArgument>
     <PossiblyNullReference>
       <code>getProperty</code>

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -66,16 +66,16 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $metadata = $metadatas['DbdriverFoo'];
 
         self::assertArrayHasKey('id', $metadata->fieldMappings);
-        self::assertEquals('id', $metadata->fieldMappings['id']['fieldName']);
-        self::assertEquals('id', strtolower($metadata->fieldMappings['id']['columnName']));
-        self::assertEquals('integer', (string) $metadata->fieldMappings['id']['type']);
+        self::assertEquals('id', $metadata->fieldMappings['id']->fieldName);
+        self::assertEquals('id', strtolower($metadata->fieldMappings['id']->columnName));
+        self::assertEquals('integer', (string) $metadata->fieldMappings['id']->type);
 
         self::assertArrayHasKey('bar', $metadata->fieldMappings);
-        self::assertEquals('bar', $metadata->fieldMappings['bar']['fieldName']);
-        self::assertEquals('bar', strtolower($metadata->fieldMappings['bar']['columnName']));
-        self::assertEquals('string', (string) $metadata->fieldMappings['bar']['type']);
-        self::assertEquals(200, $metadata->fieldMappings['bar']['length']);
-        self::assertTrue($metadata->fieldMappings['bar']['nullable']);
+        self::assertEquals('bar', $metadata->fieldMappings['bar']->fieldName);
+        self::assertEquals('bar', strtolower($metadata->fieldMappings['bar']->columnName));
+        self::assertEquals('string', (string) $metadata->fieldMappings['bar']->type);
+        self::assertEquals(200, $metadata->fieldMappings['bar']->length);
+        self::assertTrue($metadata->fieldMappings['bar']->nullable);
     }
 
     public function testLoadMetadataWithForeignKeyFromDatabase(): void
@@ -172,24 +172,24 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $metadata = $metadatas['DbdriverFoo'];
 
         self::assertArrayHasKey('id', $metadata->fieldMappings);
-        self::assertEquals('id', $metadata->fieldMappings['id']['fieldName']);
-        self::assertEquals('id', strtolower($metadata->fieldMappings['id']['columnName']));
-        self::assertEquals('integer', (string) $metadata->fieldMappings['id']['type']);
+        self::assertEquals('id', $metadata->fieldMappings['id']->fieldName);
+        self::assertEquals('id', strtolower($metadata->fieldMappings['id']->columnName));
+        self::assertEquals('integer', (string) $metadata->fieldMappings['id']->type);
 
         if (self::supportsUnsignedInteger($this->_em->getConnection()->getDatabasePlatform())) {
             self::assertArrayHasKey('columnUnsigned', $metadata->fieldMappings);
-            self::assertTrue($metadata->fieldMappings['columnUnsigned']['options']['unsigned']);
+            self::assertTrue($metadata->fieldMappings['columnUnsigned']->options['unsigned']);
         }
 
         self::assertArrayHasKey('columnComment', $metadata->fieldMappings);
-        self::assertEquals('test_comment', $metadata->fieldMappings['columnComment']['options']['comment']);
+        self::assertEquals('test_comment', $metadata->fieldMappings['columnComment']->options['comment']);
 
         self::assertArrayHasKey('columnDefault', $metadata->fieldMappings);
-        self::assertEquals('test_default', $metadata->fieldMappings['columnDefault']['options']['default']);
+        self::assertEquals('test_default', $metadata->fieldMappings['columnDefault']->options['default']);
 
         self::assertArrayHasKey('columnDecimal', $metadata->fieldMappings);
-        self::assertEquals(4, $metadata->fieldMappings['columnDecimal']['precision']);
-        self::assertEquals(3, $metadata->fieldMappings['columnDecimal']['scale']);
+        self::assertEquals(4, $metadata->fieldMappings['columnDecimal']->precision);
+        self::assertEquals(3, $metadata->fieldMappings['columnDecimal']->scale);
 
         self::assertNotEmpty($metadata->table['indexes']['index1']['columns']);
         self::assertEquals(

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -359,8 +359,8 @@ class EnumTest extends OrmFunctionalTestCase
         $metadata = $this->_em->getClassMetadata($cardClass);
         $this->_em->getConnection()->update(
             $metadata->table['name'],
-            [$metadata->fieldMappings['suit']['columnName'] => 'invalid'],
-            [$metadata->fieldMappings['id']['columnName'] => $card->id],
+            [$metadata->fieldMappings['suit']->columnName => 'invalid'],
+            [$metadata->fieldMappings['id']->columnName => $card->id],
         );
 
         $this->expectException(MappingException::class);

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -82,8 +82,8 @@ class BasicInheritanceMappingTest extends OrmTestCase
         self::assertArrayHasKey('id', $class->fieldMappings);
         self::assertArrayHasKey('name', $class->fieldMappings);
 
-        self::assertArrayNotHasKey('inherited', $class->fieldMappings['mapped1']);
-        self::assertArrayNotHasKey('inherited', $class->fieldMappings['mapped2']);
+        self::assertNull($class->fieldMappings['mapped1']->inherited);
+        self::assertNull($class->fieldMappings['mapped2']->inherited);
         self::assertArrayNotHasKey('transient', $class->fieldMappings);
 
         self::assertArrayHasKey('mappedRelated1', $class->associationMappings);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -228,9 +228,9 @@ class ClassMetadataBuilderTest extends OrmTestCase
     {
         $this->assertIsFluent($this->builder->addField('name', 'string'));
         $mapping = $this->cm->getFieldMapping('name');
-        self::assertSame('name', $mapping['fieldName']);
-        self::assertSame('name', $mapping['columnName']);
-        self::assertSame('string', $mapping['type']);
+        self::assertSame('name', $mapping->fieldName);
+        self::assertSame('name', $mapping->columnName);
+        self::assertSame('string', $mapping->type);
     }
 
     public function testCreateField(): void
@@ -241,9 +241,9 @@ class ClassMetadataBuilderTest extends OrmTestCase
         self::assertFalse(isset($this->cm->fieldMappings['name']));
         $this->assertIsFluent($fieldBuilder->build());
         $mapping = $this->cm->getFieldMapping('name');
-        self::assertSame('name', $mapping['fieldName']);
-        self::assertSame('name', $mapping['columnName']);
-        self::assertSame('string', $mapping['type']);
+        self::assertSame('name', $mapping->fieldName);
+        self::assertSame('name', $mapping->columnName);
+        self::assertSame('string', $mapping->type);
     }
 
     public function testCreateVersionedField(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -300,8 +300,8 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $addressMetadata = $cmf->getMetadataFor(Address::class);
 
         // Phone Class Metadata
-        self::assertTrue($phoneMetadata->fieldMappings['number']['quoted']);
-        self::assertEquals('phone-number', $phoneMetadata->fieldMappings['number']['columnName']);
+        self::assertTrue($phoneMetadata->fieldMappings['number']->quoted);
+        self::assertEquals('phone-number', $phoneMetadata->fieldMappings['number']->columnName);
 
         $user = $phoneMetadata->associationMappings['user'];
         self::assertTrue($user['joinColumns'][0]['quoted']);
@@ -309,11 +309,11 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertEquals('user-id', $user['joinColumns'][0]['referencedColumnName']);
 
         // User Group Metadata
-        self::assertTrue($groupMetadata->fieldMappings['id']['quoted']);
-        self::assertTrue($groupMetadata->fieldMappings['name']['quoted']);
+        self::assertTrue($groupMetadata->fieldMappings['id']->quoted);
+        self::assertTrue($groupMetadata->fieldMappings['name']->quoted);
 
-        self::assertEquals('user-id', $userMetadata->fieldMappings['id']['columnName']);
-        self::assertEquals('user-name', $userMetadata->fieldMappings['name']['columnName']);
+        self::assertEquals('user-id', $userMetadata->fieldMappings['id']->columnName);
+        self::assertEquals('user-name', $userMetadata->fieldMappings['name']->columnName);
 
         $user = $groupMetadata->associationMappings['parent'];
         self::assertTrue($user['joinColumns'][0]['quoted']);
@@ -321,11 +321,11 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertEquals('group-id', $user['joinColumns'][0]['referencedColumnName']);
 
         // Address Class Metadata
-        self::assertTrue($addressMetadata->fieldMappings['id']['quoted']);
-        self::assertTrue($addressMetadata->fieldMappings['zip']['quoted']);
+        self::assertTrue($addressMetadata->fieldMappings['id']->quoted);
+        self::assertTrue($addressMetadata->fieldMappings['zip']->quoted);
 
-        self::assertEquals('address-id', $addressMetadata->fieldMappings['id']['columnName']);
-        self::assertEquals('address-zip', $addressMetadata->fieldMappings['zip']['columnName']);
+        self::assertEquals('address-id', $addressMetadata->fieldMappings['id']->columnName);
+        self::assertEquals('address-zip', $addressMetadata->fieldMappings['zip']->columnName);
 
         $user = $addressMetadata->associationMappings['user'];
         self::assertTrue($user['joinColumns'][0]['quoted']);
@@ -333,11 +333,11 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertEquals('user-id', $user['joinColumns'][0]['referencedColumnName']);
 
         // User Class Metadata
-        self::assertTrue($userMetadata->fieldMappings['id']['quoted']);
-        self::assertTrue($userMetadata->fieldMappings['name']['quoted']);
+        self::assertTrue($userMetadata->fieldMappings['id']->quoted);
+        self::assertTrue($userMetadata->fieldMappings['name']->quoted);
 
-        self::assertEquals('user-id', $userMetadata->fieldMappings['id']['columnName']);
-        self::assertEquals('user-name', $userMetadata->fieldMappings['name']['columnName']);
+        self::assertEquals('user-id', $userMetadata->fieldMappings['id']->columnName);
+        self::assertEquals('user-name', $userMetadata->fieldMappings['name']->columnName);
 
         $address = $userMetadata->associationMappings['address'];
         self::assertTrue($address['joinColumns'][0]['quoted']);

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -242,15 +242,15 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertTrue($class->isVersioned);
         self::assertEquals('version', $class->versionField);
 
-        self::assertFalse(isset($class->fieldMappings['version']['version']));
+        self::assertFalse(isset($class->fieldMappings['version']->version));
     }
 
     #[Depends('testEntityTableNameAndInheritance')]
     public function testFieldMappingsColumnNames(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals('id', $class->fieldMappings['id']['columnName']);
-        self::assertEquals('name', $class->fieldMappings['name']['columnName']);
-        self::assertEquals('user_email', $class->fieldMappings['email']['columnName']);
+        self::assertEquals('id', $class->fieldMappings['id']->columnName);
+        self::assertEquals('name', $class->fieldMappings['name']->columnName);
+        self::assertEquals('user_email', $class->fieldMappings['email']->columnName);
 
         return $class;
     }
@@ -258,10 +258,10 @@ abstract class MappingDriverTestCase extends OrmTestCase
     #[Depends('testEntityTableNameAndInheritance')]
     public function testStringFieldMappings(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals('string', $class->fieldMappings['name']['type']);
-        self::assertEquals(50, $class->fieldMappings['name']['length']);
-        self::assertTrue($class->fieldMappings['name']['nullable']);
-        self::assertTrue($class->fieldMappings['name']['unique']);
+        self::assertEquals('string', $class->fieldMappings['name']->type);
+        self::assertEquals(50, $class->fieldMappings['name']->length);
+        self::assertTrue($class->fieldMappings['name']->nullable);
+        self::assertTrue($class->fieldMappings['name']->unique);
 
         return $class;
     }
@@ -306,7 +306,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     public function testFieldOptions(ClassMetadata $class): ClassMetadata
     {
         $expected = ['foo' => 'bar', 'baz' => ['key' => 'val'], 'fixed' => false];
-        self::assertEquals($expected, $class->fieldMappings['name']['options']);
+        self::assertEquals($expected, $class->fieldMappings['name']->options);
 
         return $class;
     }
@@ -314,7 +314,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     #[Depends('testEntityTableNameAndInheritance')]
     public function testIdFieldOptions(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals(['foo' => 'bar', 'unsigned' => false], $class->fieldMappings['id']['options']);
+        self::assertEquals(['foo' => 'bar', 'unsigned' => false], $class->fieldMappings['id']->options);
 
         return $class;
     }
@@ -323,7 +323,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     public function testIdentifier(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals(['id'], $class->identifier);
-        self::assertEquals('integer', $class->fieldMappings['id']['type']);
+        self::assertEquals('integer', $class->fieldMappings['id']->type);
         self::assertEquals(ClassMetadata::GENERATOR_TYPE_AUTO, $class->generatorType, 'ID-Generator is not ClassMetadata::GENERATOR_TYPE_AUTO');
 
         return $class;
@@ -334,11 +334,11 @@ abstract class MappingDriverTestCase extends OrmTestCase
     {
         $class = $this->createClassMetadata(User::class);
 
-        self::assertIsBool($class->fieldMappings['id']['options']['unsigned']);
-        self::assertFalse($class->fieldMappings['id']['options']['unsigned']);
+        self::assertIsBool($class->fieldMappings['id']->options['unsigned']);
+        self::assertFalse($class->fieldMappings['id']->options['unsigned']);
 
-        self::assertIsBool($class->fieldMappings['name']['options']['fixed']);
-        self::assertFalse($class->fieldMappings['name']['options']['fixed']);
+        self::assertIsBool($class->fieldMappings['name']->options['fixed']);
+        self::assertFalse($class->fieldMappings['name']->options['fixed']);
 
         return $class;
     }
@@ -434,7 +434,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     #[Depends('testJoinColumnUniqueAndNullable')]
     public function testColumnDefinition(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals('CHAR(32) NOT NULL', $class->fieldMappings['email']['columnDefinition']);
+        self::assertEquals('CHAR(32) NOT NULL', $class->fieldMappings['email']->columnDefinition);
         self::assertEquals('INT NULL', $class->associationMappings['groups']['joinTable']['inverseJoinColumns'][0]['columnDefinition']);
 
         return $class;
@@ -504,23 +504,14 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertArrayHasKey('id', $class->fieldMappings);
         self::assertArrayHasKey('name', $class->fieldMappings);
 
-        self::assertArrayHasKey('type', $class->fieldMappings['id']);
-        self::assertArrayHasKey('type', $class->fieldMappings['name']);
+        self::assertEquals('string', $class->fieldMappings['id']->type);
+        self::assertEquals('string', $class->fieldMappings['name']->type);
 
-        self::assertEquals('string', $class->fieldMappings['id']['type']);
-        self::assertEquals('string', $class->fieldMappings['name']['type']);
+        self::assertEquals('id', $class->fieldMappings['id']->fieldName);
+        self::assertEquals('name', $class->fieldMappings['name']->fieldName);
 
-        self::assertArrayHasKey('fieldName', $class->fieldMappings['id']);
-        self::assertArrayHasKey('fieldName', $class->fieldMappings['name']);
-
-        self::assertEquals('id', $class->fieldMappings['id']['fieldName']);
-        self::assertEquals('name', $class->fieldMappings['name']['fieldName']);
-
-        self::assertArrayHasKey('columnName', $class->fieldMappings['id']);
-        self::assertArrayHasKey('columnName', $class->fieldMappings['name']);
-
-        self::assertEquals('id', $class->fieldMappings['id']['columnName']);
-        self::assertEquals('name', $class->fieldMappings['name']['columnName']);
+        self::assertEquals('id', $class->fieldMappings['id']->columnName);
+        self::assertEquals('name', $class->fieldMappings['name']->columnName);
 
         self::assertEquals(ClassMetadata::GENERATOR_TYPE_NONE, $class->generatorType);
     }
@@ -533,11 +524,8 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertArrayHasKey('id', $class->fieldMappings);
         self::assertArrayHasKey('value', $class->fieldMappings);
 
-        self::assertArrayHasKey('columnDefinition', $class->fieldMappings['id']);
-        self::assertArrayHasKey('columnDefinition', $class->fieldMappings['value']);
-
-        self::assertEquals('int unsigned not null', strtolower($class->fieldMappings['id']['columnDefinition']));
-        self::assertEquals('varchar(255) not null', strtolower($class->fieldMappings['value']['columnDefinition']));
+        self::assertEquals('int unsigned not null', strtolower($class->fieldMappings['id']->columnDefinition));
+        self::assertEquals('varchar(255) not null', strtolower($class->fieldMappings['value']->columnDefinition));
     }
 
     #[\PHPUnit\Framework\Attributes\Group('DDC-559')]
@@ -713,31 +701,31 @@ abstract class MappingDriverTestCase extends OrmTestCase
         $guestMetadata = $factory->getMetadataFor(DDC964Guest::class);
         $adminMetadata = $factory->getMetadataFor(DDC964Admin::class);
 
-        self::assertTrue($adminMetadata->fieldMappings['id']['id']);
-        self::assertEquals('id', $adminMetadata->fieldMappings['id']['fieldName']);
-        self::assertEquals('user_id', $adminMetadata->fieldMappings['id']['columnName']);
+        self::assertTrue($adminMetadata->fieldMappings['id']->id);
+        self::assertEquals('id', $adminMetadata->fieldMappings['id']->fieldName);
+        self::assertEquals('user_id', $adminMetadata->fieldMappings['id']->columnName);
         self::assertEquals(['user_id' => 'id', 'user_name' => 'name'], $adminMetadata->fieldNames);
         self::assertEquals(['id' => 'user_id', 'name' => 'user_name'], $adminMetadata->columnNames);
-        self::assertEquals(150, $adminMetadata->fieldMappings['id']['length']);
+        self::assertEquals(150, $adminMetadata->fieldMappings['id']->length);
 
-        self::assertEquals('name', $adminMetadata->fieldMappings['name']['fieldName']);
-        self::assertEquals('user_name', $adminMetadata->fieldMappings['name']['columnName']);
-        self::assertEquals(250, $adminMetadata->fieldMappings['name']['length']);
-        self::assertTrue($adminMetadata->fieldMappings['name']['nullable']);
-        self::assertFalse($adminMetadata->fieldMappings['name']['unique']);
+        self::assertEquals('name', $adminMetadata->fieldMappings['name']->fieldName);
+        self::assertEquals('user_name', $adminMetadata->fieldMappings['name']->columnName);
+        self::assertEquals(250, $adminMetadata->fieldMappings['name']->length);
+        self::assertTrue($adminMetadata->fieldMappings['name']->nullable);
+        self::assertFalse($adminMetadata->fieldMappings['name']->unique);
 
-        self::assertTrue($guestMetadata->fieldMappings['id']['id']);
-        self::assertEquals('guest_id', $guestMetadata->fieldMappings['id']['columnName']);
-        self::assertEquals('id', $guestMetadata->fieldMappings['id']['fieldName']);
+        self::assertTrue($guestMetadata->fieldMappings['id']->id);
+        self::assertEquals('guest_id', $guestMetadata->fieldMappings['id']->columnName);
+        self::assertEquals('id', $guestMetadata->fieldMappings['id']->fieldName);
         self::assertEquals(['guest_id' => 'id', 'guest_name' => 'name'], $guestMetadata->fieldNames);
         self::assertEquals(['id' => 'guest_id', 'name' => 'guest_name'], $guestMetadata->columnNames);
-        self::assertEquals(140, $guestMetadata->fieldMappings['id']['length']);
+        self::assertEquals(140, $guestMetadata->fieldMappings['id']->length);
 
-        self::assertEquals('name', $guestMetadata->fieldMappings['name']['fieldName']);
-        self::assertEquals('guest_name', $guestMetadata->fieldMappings['name']['columnName']);
-        self::assertEquals(240, $guestMetadata->fieldMappings['name']['length']);
-        self::assertFalse($guestMetadata->fieldMappings['name']['nullable']);
-        self::assertTrue($guestMetadata->fieldMappings['name']['unique']);
+        self::assertEquals('name', $guestMetadata->fieldMappings['name']->fieldName);
+        self::assertEquals('guest_name', $guestMetadata->fieldMappings['name']->columnName);
+        self::assertEquals(240, $guestMetadata->fieldMappings['name']->length);
+        self::assertFalse($guestMetadata->fieldMappings['name']->nullable);
+        self::assertTrue($guestMetadata->fieldMappings['name']->unique);
     }
 
     #[\PHPUnit\Framework\Attributes\Group('DDC-1955')]
@@ -947,7 +935,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     {
         $metadata = $this->createClassMetadata(ReservedWordInTableColumn::class);
 
-        self::assertSame('count', $metadata->getFieldMapping('count')['columnName']);
+        self::assertSame('count', $metadata->getFieldMapping('count')->columnName);
     }
 
     public function testInsertableColumn(): void
@@ -956,10 +944,8 @@ abstract class MappingDriverTestCase extends OrmTestCase
 
         $mapping = $metadata->getFieldMapping('nonInsertableContent');
 
-        self::assertArrayHasKey('notInsertable', $mapping);
-        self::assertArrayHasKey('generated', $mapping);
-        self::assertSame(ClassMetadata::GENERATED_INSERT, $mapping['generated']);
-        self::assertArrayNotHasKey('notInsertable', $metadata->getFieldMapping('insertableContent'));
+        self::assertSame(ClassMetadata::GENERATED_INSERT, $mapping->generated);
+        self::assertNull($metadata->getFieldMapping('insertableContent')->notInsertable);
     }
 
     public function testUpdatableColumn(): void
@@ -968,10 +954,8 @@ abstract class MappingDriverTestCase extends OrmTestCase
 
         $mapping = $metadata->getFieldMapping('nonUpdatableContent');
 
-        self::assertArrayHasKey('notUpdatable', $mapping);
-        self::assertArrayHasKey('generated', $mapping);
-        self::assertSame(ClassMetadata::GENERATED_ALWAYS, $mapping['generated']);
-        self::assertArrayNotHasKey('notUpdatable', $metadata->getFieldMapping('updatableContent'));
+        self::assertSame(ClassMetadata::GENERATED_ALWAYS, $mapping->generated);
+        self::assertNull($metadata->getFieldMapping('updatableContent')->notUpdatable);
     }
 
     #[RequiresPhp('8.1')]
@@ -979,7 +963,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     {
         $metadata = $this->createClassMetadata(Card::class);
 
-        self::assertEquals(Suit::class, $metadata->fieldMappings['suit']['enumType']);
+        self::assertEquals(Suit::class, $metadata->fieldMappings['suit']->enumType);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -95,9 +95,9 @@ class SchemaToolTest extends OrmTestCase
         $em         = $this->getTestEntityManager();
         $schemaTool = new SchemaTool($em);
 
-        $avatar                                          = $em->getClassMetadata(ForumAvatar::class);
-        $avatar->fieldMappings['id']['columnDefinition'] = $customColumnDef;
-        $user                                            = $em->getClassMetadata(ForumUser::class);
+        $avatar                                        = $em->getClassMetadata(ForumAvatar::class);
+        $avatar->fieldMappings['id']->columnDefinition = $customColumnDef;
+        $user                                          = $em->getClassMetadata(ForumUser::class);
 
         $classes = [$avatar, $user];
 


### PR DESCRIPTION
This makes the array access implementation of FieldMapping useful only to consumers, it is no longer useful internally, and should be deprecated as of Doctrine 3.1.0