### PR TITLE
Migrate to DiscriminatorColumnMapping's object API

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -77,7 +77,7 @@ class SimpleObjectHydrator extends AbstractHydrator
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {
             $discrColumn     = $this->class->getDiscriminatorColumn();
-            $discrColumnName = $this->getSQLResultCasing($this->platform, $discrColumn['name']);
+            $discrColumnName = $this->getSQLResultCasing($this->platform, $discrColumn->name);
 
             // Find mapped discriminator column from the result set.
             $metaMappingDiscrColumnName = array_search($discrColumnName, $this->resultSetMapping()->metaMappings, true);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1204,7 +1204,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         $this->columnNames[$mapping->fieldName] = $mapping->columnName;
 
-        if (isset($this->fieldNames[$mapping->columnName]) || ($this->discriminatorColumn && $this->discriminatorColumn['name'] === $mapping->columnName)) {
+        if (isset($this->fieldNames[$mapping->columnName]) || ($this->discriminatorColumn && $this->discriminatorColumn->name === $mapping->columnName)) {
             throw MappingException::duplicateColumnName($this->name, $mapping->columnName);
         }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -24,9 +24,9 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
         $data = parent::prepareInsertData($entity);
 
         // Populate the discriminator column
-        $discColumn                                                          = $this->class->getDiscriminatorColumn();
-        $this->columnTypes[$discColumn['name']]                              = $discColumn['type'];
-        $data[$this->getDiscriminatorColumnTableName()][$discColumn['name']] = $this->class->discriminatorValue;
+        $discColumn                                                        = $this->class->getDiscriminatorColumn();
+        $this->columnTypes[$discColumn->name]                              = $discColumn->type;
+        $data[$this->getDiscriminatorColumnTableName()][$discColumn->name] = $this->class->discriminatorValue;
 
         return $data;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -367,8 +367,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         $columnList       = [];
         $discrColumn      = $this->class->getDiscriminatorColumn();
-        $discrColumnName  = $discrColumn['name'];
-        $discrColumnType  = $discrColumn['type'];
+        $discrColumnName  = $discrColumn->name;
+        $discrColumnType  = $discrColumn->type;
         $baseTableAlias   = $this->getSQLTableAlias($this->class->name);
         $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumnName);
 

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -42,8 +42,8 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
         // Append discriminator column
         $discrColumn     = $this->class->getDiscriminatorColumn();
-        $discrColumnName = $discrColumn['name'];
-        $discrColumnType = $discrColumn['type'];
+        $discrColumnName = $discrColumn->name;
+        $discrColumnType = $discrColumn->type;
 
         $columnList[] = $tableAlias . '.' . $discrColumnName;
 
@@ -146,7 +146,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
             $values[] = $this->conn->quote((string) $discrValues[$subclassName]);
         }
 
-        $discColumnName = $this->class->getDiscriminatorColumn()['name'];
+        $discColumnName = $this->class->getDiscriminatorColumn()->name;
 
         $values     = implode(', ', $values);
         $tableAlias = $this->getSQLTableAlias($this->class->name);

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -399,7 +399,7 @@ class SqlWalker
                 ? $this->getSQLTableAlias($class->getTableName(), $dqlAlias) . '.'
                 : '';
 
-            $sqlParts[] = $sqlTableAlias . $class->getDiscriminatorColumn()['name'] . ' IN (' . implode(', ', $values) . ')';
+            $sqlParts[] = $sqlTableAlias . $class->getDiscriminatorColumn()->name . ' IN (' . implode(', ', $values) . ')';
         }
 
         $sql = implode(' AND ', $sqlParts);
@@ -663,14 +663,14 @@ class SqlWalker
                 $rootClass   = $this->em->getClassMetadata($class->rootEntityName);
                 $tblAlias    = $this->getSQLTableAlias($rootClass->getTableName(), $dqlAlias);
                 $discrColumn = $rootClass->getDiscriminatorColumn();
-                $columnAlias = $this->getSQLColumnAlias($discrColumn['name']);
+                $columnAlias = $this->getSQLColumnAlias($discrColumn->name);
 
-                $sqlSelectExpressions[] = $tblAlias . '.' . $discrColumn['name'] . ' AS ' . $columnAlias;
+                $sqlSelectExpressions[] = $tblAlias . '.' . $discrColumn->name . ' AS ' . $columnAlias;
 
                 $this->rsm->setDiscriminatorColumn($dqlAlias, $columnAlias);
-                $this->rsm->addMetaResult($dqlAlias, $columnAlias, $discrColumn['fieldName'], false, $discrColumn['type']);
-                if (! empty($discrColumn['enumType'])) {
-                    $this->rsm->addEnumResult($columnAlias, $discrColumn['enumType']);
+                $this->rsm->addMetaResult($dqlAlias, $columnAlias, $discrColumn->fieldName, false, $discrColumn->type);
+                if (! empty($discrColumn->enumType)) {
+                    $this->rsm->addEnumResult($columnAlias, $discrColumn->enumType);
                 }
             }
 
@@ -1994,7 +1994,7 @@ class SqlWalker
             $sql .= $this->getSQLTableAlias($discrClass->getTableName(), $dqlAlias) . '.';
         }
 
-        $sql .= $class->getDiscriminatorColumn()['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
+        $sql .= $class->getDiscriminatorColumn()->name . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
         $sql .= $this->getChildDiscriminatorsFromClassMetadata($discrClass, $instanceOfExpr);
 
         return $sql;

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -406,25 +406,22 @@ class SchemaTool
         $discrColumn = $class->discriminatorColumn;
         assert($discrColumn !== null);
 
-        if (
-            ! isset($discrColumn['type']) ||
-            (strtolower($discrColumn['type']) === 'string' && ! isset($discrColumn['length']))
-        ) {
-            $discrColumn['type']   = 'string';
-            $discrColumn['length'] = 255;
+        if (strtolower($discrColumn->type) === 'string' && ! isset($discrColumn->length)) {
+            $discrColumn->type   = 'string';
+            $discrColumn->length = 255;
         }
 
         $options = [
-            'length'    => $discrColumn['length'] ?? null,
+            'length'    => $discrColumn->length ?? null,
             'notnull'   => true,
         ];
 
-        if (isset($discrColumn['columnDefinition'])) {
-            $options['columnDefinition'] = $discrColumn['columnDefinition'];
+        if (isset($discrColumn->columnDefinition)) {
+            $options['columnDefinition'] = $discrColumn->columnDefinition;
         }
 
         $options = $this->gatherColumnOptions($discrColumn) + $options;
-        $table->addColumn($discrColumn['name'], $discrColumn['type'], $options);
+        $table->addColumn($discrColumn->name, $discrColumn->type, $options);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -551,11 +551,8 @@ abstract class MappingDriverTestCase extends OrmTestCase
     {
         $class = $this->createClassMetadata(DDC807Entity::class);
 
-        self::assertArrayHasKey('columnDefinition', $class->discriminatorColumn);
-        self::assertArrayHasKey('name', $class->discriminatorColumn);
-
-        self::assertEquals("ENUM('ONE','TWO')", $class->discriminatorColumn['columnDefinition']);
-        self::assertEquals('dtype', $class->discriminatorColumn['name']);
+        self::assertEquals("ENUM('ONE','TWO')", $class->discriminatorColumn->columnDefinition);
+        self::assertEquals('dtype', $class->discriminatorColumn->name);
     }
 
     #[\PHPUnit\Framework\Attributes\Group('GH10288')]
@@ -563,11 +560,8 @@ abstract class MappingDriverTestCase extends OrmTestCase
     {
         $class = $this->createClassMetadata(GH10288EnumTypePerson::class);
 
-        self::assertArrayHasKey('enumType', $class->discriminatorColumn);
-        self::assertArrayHasKey('name', $class->discriminatorColumn);
-
-        self::assertEquals(GH10288People::class, $class->discriminatorColumn['enumType']);
-        self::assertEquals('discr', $class->discriminatorColumn['name']);
+        self::assertEquals(GH10288People::class, $class->discriminatorColumn->enumType);
+        self::assertEquals('discr', $class->discriminatorColumn->name);
     }
 
     #[\PHPUnit\Framework\Attributes\Group('DDC-889')]
@@ -898,9 +892,9 @@ abstract class MappingDriverTestCase extends OrmTestCase
         }
 
         $class = $this->createClassMetadata(SingleTableEntityNoDiscriminatorColumnMapping::class);
-        self::assertEquals(255, $class->discriminatorColumn['length']);
+        self::assertEquals(255, $class->discriminatorColumn->length);
         $class = $this->createClassMetadata(SingleTableEntityIncompleteDiscriminatorColumnMapping::class);
-        self::assertEquals(255, $class->discriminatorColumn['length']);
+        self::assertEquals(255, $class->discriminatorColumn->length);
     }
 
     #[\PHPUnit\Framework\Attributes\Group('DDC-514')]
@@ -912,9 +906,9 @@ abstract class MappingDriverTestCase extends OrmTestCase
         }
 
         $class = $this->createClassMetadata(SingleTableEntityNoDiscriminatorColumnMapping::class);
-        self::assertEquals('string', $class->discriminatorColumn['type']);
+        self::assertEquals('string', $class->discriminatorColumn->type);
         $class = $this->createClassMetadata(SingleTableEntityIncompleteDiscriminatorColumnMapping::class);
-        self::assertEquals('string', $class->discriminatorColumn['type']);
+        self::assertEquals('string', $class->discriminatorColumn->type);
     }
 
     #[\PHPUnit\Framework\Attributes\Group('DDC-514')]
@@ -926,9 +920,9 @@ abstract class MappingDriverTestCase extends OrmTestCase
         }
 
         $class = $this->createClassMetadata(SingleTableEntityNoDiscriminatorColumnMapping::class);
-        self::assertEquals('dtype', $class->discriminatorColumn['name']);
+        self::assertEquals('dtype', $class->discriminatorColumn->name);
         $class = $this->createClassMetadata(SingleTableEntityIncompleteDiscriminatorColumnMapping::class);
-        self::assertEquals('dtype', $class->discriminatorColumn['name']);
+        self::assertEquals('dtype', $class->discriminatorColumn->name);
     }
 
     public function testReservedWordInTableColumn(): void


### PR DESCRIPTION
Its array access implementation should stay for external consumers, but should be deprecated as of Doctrine 3.1.0