### PR TITLE
Fixed xsd schema for support FQCN type

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -302,7 +302,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
+    <xs:attribute name="type" type="orm:type" default="string" />
     <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />
@@ -414,7 +414,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="type" type="xs:NMTOKEN" />
+    <xs:attribute name="type" type="orm:type" />
     <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="association-key" type="xs:boolean" default="false" />
@@ -442,6 +442,13 @@
   <xs:simpleType name="fqcn" id="fqcn">
     <xs:restriction base="xs:token">
       <xs:pattern value="[a-zA-Z_u01-uff][a-zA-Z0-9_u01-uff]+" id="fqcn.pattern">
+      </xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="type" id="type">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="([a-zA-Z_u01-uff][a-zA-Z0-9_u01-uff]+)|(\c+)" id="type.class.pattern">
       </xs:pattern>
     </xs:restriction>
   </xs:simpleType>
@@ -630,7 +637,7 @@
       <xs:element name="options" type="orm:options" minOccurs="0" />
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
-    <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
+    <xs:attribute name="type" type="orm:type" default="string" />
     <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />

--- a/tests/Doctrine/Tests/Models/Project/Project.php
+++ b/tests/Doctrine/Tests/Models/Project/Project.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Project;
+
+class Project
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Project/ProjectId.php
+++ b/tests/Doctrine/Tests/Models/Project/ProjectId.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Project;
+
+class ProjectId
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Project/ProjectInvalidMapping.php
+++ b/tests/Doctrine/Tests/Models/Project/ProjectInvalidMapping.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Project;
+
+class ProjectInvalidMapping
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Project/ProjectName.php
+++ b/tests/Doctrine/Tests/Models/Project/ProjectName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Project;
+
+final class ProjectName
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -22,6 +22,10 @@ use Doctrine\Tests\Models\DDC889\DDC889SuperClass;
 use Doctrine\Tests\Models\Generic\BooleanModel;
 use Doctrine\Tests\Models\GH7141\GH7141Article;
 use Doctrine\Tests\Models\GH7316\GH7316Article;
+use Doctrine\Tests\Models\Project\Project;
+use Doctrine\Tests\Models\Project\ProjectId;
+use Doctrine\Tests\Models\Project\ProjectInvalidMapping;
+use Doctrine\Tests\Models\Project\ProjectName;
 use Doctrine\Tests\Models\ValueObjects\Name;
 use Doctrine\Tests\Models\ValueObjects\Person;
 
@@ -239,6 +243,10 @@ class XmlMappingDriverTest extends MappingDriverTestCase
                 UserMissingAttributes::class,
                 ['The attribute \'name\' is required but missing' => 1],
             ],
+            [
+                ProjectInvalidMapping::class,
+                ['attribute \'type\': [facet \'pattern\'] The value' => 2],
+            ],
         ];
     }
 
@@ -278,6 +286,23 @@ class XmlMappingDriverTest extends MappingDriverTestCase
         $this->expectExceptionMessage('libxml error: Element \'{http://doctrine-project.org/schemas/orm/doctrine-mapping}class\': This element is not expected.');
 
         $this->createClassMetadata(DDC889Class::class);
+    }
+
+    public function testClassNameInFieldOrId(): void
+    {
+        $class = new ClassMetadata(Project::class);
+        $class->initializeReflection(new RuntimeReflectionService());
+
+        $driver = $this->loadDriver();
+        $driver->loadMetadataForClass(Project::class, $class);
+
+        /** @var array{type: string} $id */
+        $id = $class->getFieldMapping('id');
+        /** @var array{type: string} $name */
+        $name = $class->getFieldMapping('name');
+
+        self::assertEquals(ProjectId::class, $id['type']);
+        self::assertEquals(ProjectName::class, $name['type']);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Project.Project.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Project.Project.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Project\Project" table="project">
+        <id name="id" type="Doctrine\Tests\Models\Project\ProjectId" column="id">
+            <generator strategy="NONE"/>
+        </id>
+        <field name="name" type="Doctrine\Tests\Models\Project\ProjectName" column="name"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Project.ProjectInvalidMapping.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Project.ProjectInvalidMapping.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Project\ProjectInvalidMapping" table="project">
+        <id name="id" type="Doctrine/Tests/Models/Project/Project/ProjectId" column="id">
+            <generator strategy="NONE"/>
+        </id>
+        <field name="name" type="Doctrine/Tests/Models/Project/Project/ProjectName" column="name"/>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
After update to orm 2.14.2 invalid xsd schema error is occured, when in field,id or attribute-override have type is FQCN

Fix for issue:
#10627 