### PR TITLE
Restore document proxy state to uninitialized on load exception

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -21,6 +21,7 @@ use Doctrine\Persistence\Proxy;
 use ReflectionProperty;
 use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\VarExporter;
+use Throwable;
 
 use function array_flip;
 use function str_replace;
@@ -204,7 +205,17 @@ EOPHP;
 
             $identifier = $classMetadata->getIdentifierValues($proxy);
 
-            if ($entityPersister->loadById($identifier, $proxy) === null) {
+            try {
+                $entity = $entityPersister->loadById($identifier, $proxy);
+            } catch (Throwable $exception) {
+                $proxy->__setInitializer($initializer);
+                $proxy->__setCloner($cloner);
+                $proxy->__setInitialized(false);
+
+                throw $exception;
+            }
+
+            if ($entity === null) {
                 $proxy->__setInitializer($initializer);
                 $proxy->__setCloner($cloner);
                 $proxy->__setInitialized(false);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
I had an issue in mongodb-odm bundle with proxy left in initialized state on load exception and thought if same could be applied in orm bundle. Test shows same issue is here.

#### Related
https://github.com/doctrine/mongodb-odm/pull/2521