### PR TITLE
Prepare entity-level commit order computation in the `UnitOfWork`

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -707,8 +707,8 @@ not directly mapped by Doctrine.
    ``UPDATE`` statement.
 -  The ``postPersist`` event occurs for an entity after
    the entity has been made persistent. It will be invoked after the
-   database insert operations. Generated primary key values are
-   available in the postPersist event.
+   database insert operation for that entity. A generated primary key value for
+   the entity will be available in the postPersist event.
 -  The ``postRemove`` event occurs for an entity after the
    entity has been deleted. It will be invoked after the database
    delete operations. It is not called for a DQL ``DELETE`` statement.

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\UnitOfWork;
 
+use function array_merge;
 use function assert;
 use function serialize;
 use function sha1;
@@ -314,7 +315,13 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     public function executeInserts()
     {
-        $this->queuedCache['insert'] = $this->persister->getInserts();
+        // The commit order/foreign key relationships may make it necessary that multiple calls to executeInsert()
+        // are performed, so collect all the new entities.
+        $newInserts = $this->persister->getInserts();
+
+        if ($newInserts) {
+            $this->queuedCache['insert'] = array_merge($this->queuedCache['insert'] ?? [], $newInserts);
+        }
 
         return $this->persister->executeInserts();
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3043,10 +3043,6 @@
     <PropertyTypeCoercion>
       <code><![CDATA[$this->nonCascadedNewDetectedEntities]]></code>
     </PropertyTypeCoercion>
-    <RedundantCondition>
-      <code><![CDATA[$i >= 0 && $this->entityDeletions]]></code>
-      <code><![CDATA[$this->entityDeletions]]></code>
-    </RedundantCondition>
     <RedundantConditionGivenDocblockType>
       <code>is_array($entity)</code>
     </RedundantConditionGivenDocblockType>


### PR DESCRIPTION
This is the second chunk to break #10547 into smaller PRs suitable for reviewing. It prepares the `UnitOfWork` to work with a commit order computed on the entity level, as opposed to a class-based ordering as before.

#### Background

#10531 and #10532 show that it is not always possible to run `UnitOfWork::commit()` with a commit order given in terms of  entity _classes_. Instead it is necessary to process entities in an order computed on the _object_ level. That may include

* a particular order for multiple entities of the _same_ class
* a particular order for entities of _different_ classes, possibly even going back and forth (entity `$a1` of class `A`, then `$b` of class `B`, then `$a2` of class `A` – revisiting that class).

This PR is about preparing the `UnitOfWork` so that its methods will be able to perform inserts and deletions on that level of granularity. Subsequent PRs will deal with implementing that particular order computation.

#### Suggested change

Change the private `executeInserts` and `executeDeletions` methods so that they do not take a `ClassMetadata` identifying the class of entities that shall be processed, but pass them the list of entities directly.

The lists of entities are built in two dedicated methods. That happens basically as previously, by iterating over `$this->entityInsertions` or `$this->entityDeletions` and filtering those by class.

#### Potential (BC breaking?) changes that need review scrutiny

* `\Doctrine\ORM\Persisters\Entity\EntityPersister::addInsert()` was previously called multiple times, before the insert would be performed by a call to `\Doctrine\ORM\Persisters\Entity\EntityPersister::executeInserts()`. With the changes here, this batching effectively no longer takes place. `executeInserts()` will always see one entity/insert only, and there may be multiple `executeInserts()` calls during a single `UoW::commit()` phase.
* The caching in `\Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister` previously would cache entities from the last executed insert batch only. Now it will collect entities across multiple batches. I don't know if that poses a problem.
* Overhead in `\Doctrine\ORM\Persisters\Entity\BasicEntityPersister::executeInserts` is incurred multiple times; that may, however, only be about SQL statement preparation and might be salvageable.
* The `postPersist` event previously was not dispatched before _all_ instances of a particular entity class had been written to the database. Now, it will be dispatched immediately after every single entity that has been inserted.

#### `postPersist` event changes – meaningful?

Documentation on the `postPersist` event is here: https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/reference/events.html#postupdate-postremove-postpersist

> The postPersist event occurs for an entity after the entity has been made persistent. It will be invoked after the database insert operations. Generated primary key values are available in the postPersist event.

"It will be invoked after the database insert operations" is a bit imprecise. It previously was "after the database insert operations for that entity class, but before operations for other classes". With this PR, it would be "after the database insert operations for this entity instance".

"Generated primary key values are available in the postPersist event" should better be written as "a generated primary key value for the entity is available in the postPersist event".

Alternatively, we could defer `postPersist` events until _all_ new entities have been inserted. Either way, it's a slight change from the previous implementation where the event would run after all entities of a particular class had been processed.

#### Extra bonus

This is what the DALL·E AI thinks it looks like when an entity persister will have to process entities one-by-one and is no longer able to batch the inserts.

![DALL·E 2023-04-24 14 07 14](https://user-images.githubusercontent.com/1202333/233991642-4564ccc7-c859-411e-a1de-1e051999e653.png)
