### PR TITLE
Remove JoinColumn from inverse side

### DIFF
--- a/tests/Doctrine/Tests/Models/Quote/User.php
+++ b/tests/Doctrine/Tests/Models/Quote/User.php
@@ -45,7 +45,6 @@ class User
 
     /**
      * @var Address
-     * @JoinColumn(name="`address-id`", referencedColumnName="`address-id`")
      * @OneToOne(targetEntity="Address", mappedBy="user", cascade={"persist"}, fetch="EAGER")
      */
     public $address;

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -385,11 +385,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertEquals('user-id', $userMetadata->fieldMappings['id']['columnName']);
         self::assertEquals('user-name', $userMetadata->fieldMappings['name']['columnName']);
 
-        $address = $userMetadata->associationMappings['address'];
-        self::assertTrue($address['joinColumns'][0]['quoted']);
-        self::assertEquals('address-id', $address['joinColumns'][0]['name']);
-        self::assertEquals('address-id', $address['joinColumns'][0]['referencedColumnName']);
-
         $groups = $userMetadata->associationMappings['groups'];
         self::assertTrue($groups['joinTable']['quoted']);
         self::assertTrue($groups['joinTable']['joinColumns'][0]['quoted']);

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1929,7 +1929,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     {
         $this->assertSqlGeneration(
             'SELECT u, a FROM Doctrine\Tests\Models\Quote\User u JOIN u.address a',
-            'SELECT q0_."user-id" AS userid_0, q0_."user-name" AS username_1, q1_."address-id" AS addressid_2, q1_."address-zip" AS addresszip_3, q1_.type AS type_4 FROM "quote-user" q0_ INNER JOIN "quote-address" q1_ ON q0_."address-id" = q1_."address-id" AND q1_.type IN (\'simple\', \'full\')'
+            'SELECT q0_."user-id" AS userid_0, q0_."user-name" AS username_1, q1_."address-id" AS addressid_2, q1_."address-zip" AS addresszip_3, q1_.type AS type_4 FROM "quote-user" q0_ INNER JOIN "quote-address" q1_ ON q0_."user-id" = q1_."user-id" AND q1_.type IN (\'simple\', \'full\')'
         );
 
         $this->assertSqlGeneration(

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -331,7 +331,6 @@ class DDC1587ValidEntity1
     /**
      * @var Identifier
      * @OneToOne(targetEntity="DDC1587ValidEntity2", cascade={"all"}, mappedBy="agent")
-     * @JoinColumn(name="pk", referencedColumnName="pk_agent")
      */
     private $identifier;
 }


### PR DESCRIPTION
This makes no sense because it describes a one-to-one where each table references the other one. I do not think this is deliberately supported, and it probably will not be supported at all in 3.0.