### PR TITLE
Rename AbstractSqlExecutor class to AbstractSQLExecutor

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\AST\DeleteStatement;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\AST\UpdateStatement;
-use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\AbstractSQLExecutor;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query\Parser;
@@ -331,7 +331,7 @@ final class Query extends AbstractQuery
      * @param array<string,mixed> $connectionParams
      */
     private function evictResultSetCache(
-        AbstractSqlExecutor $executor,
+        AbstractSQLExecutor $executor,
         array $sqlParams,
         array $types,
         array $connectionParams

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -13,10 +13,8 @@ use Doctrine\DBAL\Types\Type;
  * Base class for SQL statement executors.
  *
  * @link        http://www.doctrine-project.org
- *
- * @todo Rename: AbstractSQLExecutor
  */
-abstract class AbstractSqlExecutor
+abstract class AbstractSQLExecutor
 {
     /** @var list<string>|string */
     protected $_sqlStatements;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -23,7 +23,7 @@ use function implode;
  *
  * @link        http://www.doctrine-project.org
  */
-class MultiTableDeleteExecutor extends AbstractSqlExecutor
+class MultiTableDeleteExecutor extends AbstractSQLExecutor
 {
     /** @var string */
     private $_createTempTableSql;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -22,7 +22,7 @@ use function implode;
  * Executes the SQL statements for bulk DQL UPDATE statements on classes in
  * Class Table Inheritance (JOINED).
  */
-class MultiTableUpdateExecutor extends AbstractSqlExecutor
+class MultiTableUpdateExecutor extends AbstractSQLExecutor
 {
     /** @var string */
     private $_createTempTableSql;

--- a/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Query\SqlWalker;
  *
  * @link        www.doctrine-project.org
  */
-class SingleSelectExecutor extends AbstractSqlExecutor
+class SingleSelectExecutor extends AbstractSQLExecutor
 {
     public function __construct(SelectStatement $AST, SqlWalker $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Query\SqlWalker;
  *
  * @todo This is exactly the same as SingleSelectExecutor. Unify in SingleStatementExecutor.
  */
-class SingleTableDeleteUpdateExecutor extends AbstractSqlExecutor
+class SingleTableDeleteUpdateExecutor extends AbstractSQLExecutor
 {
     /** @param SqlWalker $sqlWalker */
     public function __construct(AST\Node $AST, $sqlWalker)

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
-use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\AbstractSQLExecutor;
 
 /**
  * Encapsulates the resulting components from a DQL query parsing process that
@@ -17,7 +17,7 @@ class ParserResult
     /**
      * The SQL executor used for executing the SQL.
      *
-     * @var AbstractSqlExecutor
+     * @var AbstractSQLExecutor
      */
     private $_sqlExecutor;
 
@@ -67,7 +67,7 @@ class ParserResult
     /**
      * Sets the SQL executor that should be used for this ParserResult.
      *
-     * @param AbstractSqlExecutor $executor
+     * @param AbstractSQLExecutor $executor
      *
      * @return void
      */
@@ -79,7 +79,7 @@ class ParserResult
     /**
      * Gets the SQL executor used by this ParserResult.
      *
-     * @return AbstractSqlExecutor
+     * @return AbstractSQLExecutor
      */
     public function getSqlExecutor()
     {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -277,7 +277,7 @@ class SqlWalker implements TreeWalker
      *
      * @param AST\DeleteStatement|AST\UpdateStatement|AST\SelectStatement $AST
      *
-     * @return Exec\AbstractSqlExecutor
+     * @return Exec\AbstractSQLExecutor
      *
      * @not-deprecated
      */

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -545,7 +545,7 @@ interface TreeWalker
      *
      * @param AST\DeleteStatement|AST\UpdateStatement|AST\SelectStatement $AST
      *
-     * @return Exec\AbstractSqlExecutor
+     * @return Exec\AbstractSQLExecutor
      */
     public function getExecutor($AST);
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -228,8 +228,8 @@
         <exclude-pattern>lib/Doctrine/ORM/Configuration.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/EntityRepository.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php</exclude-pattern>
-        <exclude-pattern>lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php</exclude-pattern>
-        <exclude-pattern>lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Query/Exec/AbstractSQLExecutor.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Query/Exec/AbstractSQLExecutor.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Query/Printer.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php</exclude-pattern>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -356,9 +356,9 @@ parameters:
 			path: lib/Doctrine/ORM/Query/AST/WhenClause.php
 
 		-
-			message: "#^Property Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSqlExecutor\\:\\:\\$queryCacheProfile \\(Doctrine\\\\DBAL\\\\Cache\\\\QueryCacheProfile\\) does not accept null\\.$#"
+			message: "#^Property Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSQLExecutor\\:\\:\\$queryCacheProfile \\(Doctrine\\\\DBAL\\\\Cache\\\\QueryCacheProfile\\) does not accept null\\.$#"
 			count: 1
-			path: lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+			path: lib/Doctrine/ORM/Query/Exec/AbstractSQLExecutor.php
 
 		-
 			message: "#^PHPDoc type array\\<string\\> of property Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Andx\\:\\:\\$allowedClasses is not covariant with PHPDoc type array\\<int, class\\-string\\> of overridden property Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Base\\:\\:\\$allowedClasses\\.$#"
@@ -441,12 +441,12 @@ parameters:
 			path: lib/Doctrine/ORM/Query/SqlWalker.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\TreeWalkerAdapter\\:\\:getExecutor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSqlExecutor but returns null\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\TreeWalkerAdapter\\:\\:getExecutor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSQLExecutor but returns null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\TreeWalkerChain\\:\\:getExecutor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSqlExecutor but returns null\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\TreeWalkerChain\\:\\:getExecutor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\Exec\\\\AbstractSQLExecutor but returns null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/TreeWalkerChain.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2031,7 +2031,7 @@
       <code>$sqlWalker</code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
+  <file src="lib/Doctrine/ORM/Query/Exec/AbstractSQLExecutor.php">
     <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>

--- a/tests/Doctrine/Tests/Mocks/NullSqlWalker.php
+++ b/tests/Doctrine/Tests/Mocks/NullSqlWalker.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Mocks;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query\AST;
-use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\AbstractSQLExecutor;
 use Doctrine\ORM\Query\SqlWalker;
 
 /**
@@ -29,9 +29,9 @@ class NullSqlWalker extends SqlWalker
         return '';
     }
 
-    public function getExecutor($AST): AbstractSqlExecutor
+    public function getExecutor($AST): AbstractSQLExecutor
     {
-        return new class extends AbstractSqlExecutor {
+        return new class extends AbstractSQLExecutor {
             public function execute(Connection $conn, array $params, array $types): int
             {
                 return 0;

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\AbstractSQLExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Psr\Cache\CacheItemInterface;
@@ -121,7 +121,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $sqlExecMock = $this->getMockBuilder(AbstractSqlExecutor::class)
+        $sqlExecMock = $this->getMockBuilder(AbstractSQLExecutor::class)
                             ->getMockForAbstractClass();
 
         $sqlExecMock->expects(self::once())

--- a/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
-use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\AbstractSQLExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\ResultSetMapping;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +28,7 @@ class ParserResultTest extends TestCase
     {
         self::assertNull($this->parserResult->getSqlExecutor());
 
-        $executor = $this->getMockForAbstractClass(AbstractSqlExecutor::class);
+        $executor = $this->getMockForAbstractClass(AbstractSQLExecutor::class);
         $this->parserResult->setSqlExecutor($executor);
         self::assertSame($executor, $this->parserResult->getSqlExecutor());
     }


### PR DESCRIPTION
Resolve https://github.com/doctrine/orm/issues/10664
This task was in the todo list of the and can be considered as improvement/maintenance PR:
https://github.com/doctrine/orm/blob/f82485e651763fbd1b34879726f4d3b91c358bd9/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php#L17 