### PR TITLE
Create `ReflectionReadonlyProperty` from their declaring class so their value can be set

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3862,7 +3862,14 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $reflectionProperty = $reflService->getAccessibleProperty($class, $field);
         if ($reflectionProperty !== null && PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
-            $reflectionProperty = new ReflectionReadonlyProperty($reflectionProperty);
+            $declaringClass = $reflectionProperty->getDeclaringClass()->name;
+            if ($declaringClass !== $class) {
+                $reflectionProperty = $reflService->getAccessibleProperty($declaringClass, $field);
+            }
+
+            if ($reflectionProperty !== null) {
+                $reflectionProperty = new ReflectionReadonlyProperty($reflectionProperty);
+            }
         }
 
         return $reflectionProperty;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/GH10049Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/GH10049Test.php
@@ -9,7 +9,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 /**
  * @requires PHP 8.1
  */
-class SetInheritedReadOnlyPropertyValueTest extends OrmFunctionalTestCase
+class GH10049Test extends OrmFunctionalTestCase
 {
     public function setUp(): void
     {
@@ -24,7 +24,7 @@ class SetInheritedReadOnlyPropertyValueTest extends OrmFunctionalTestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function test(): void
+    public function testInheritedReadOnlyPropertyValueCanBeSet(): void
     {
         $child = new ReadOnlyPropertyInheritor(10049);
         $this->_em->persist($child);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/ReadOnlyPropertyInheritor.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/ReadOnlyPropertyInheritor.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10049;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class ReadOnlyPropertyInheritor extends ReadOnlyPropertyOwner
+{
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/ReadOnlyPropertyOwner.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/ReadOnlyPropertyOwner.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10049;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+abstract class ReadOnlyPropertyOwner
+{
+    public function __construct(
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         */
+        public readonly int $id
+    ) {
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/SetInheritedReadOnlyPropertyValueTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/SetInheritedReadOnlyPropertyValueTest.php
@@ -21,6 +21,9 @@ class SetInheritedReadOnlyPropertyValueTest extends OrmFunctionalTestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function test(): void
     {
         $child = new ReadOnlyPropertyInheritor(10049);
@@ -28,9 +31,6 @@ class SetInheritedReadOnlyPropertyValueTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $entity = $this->_em->find(ReadOnlyPropertyInheritor::class, 10049);
-
-        self::assertInstanceOf(ReadOnlyPropertyInheritor::class, $entity);
-        self::assertSame(10049, $entity->id);
+        $this->_em->find(ReadOnlyPropertyInheritor::class, 10049);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/SetInheritedReadOnlyPropertyValueTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10049/SetInheritedReadOnlyPropertyValueTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10049;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @requires PHP 8.1
+ */
+class SetInheritedReadOnlyPropertyValueTest extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            ReadOnlyPropertyOwner::class,
+            ReadOnlyPropertyInheritor::class
+        );
+    }
+
+    public function test(): void
+    {
+        $child = new ReadOnlyPropertyInheritor(10049);
+        $this->_em->persist($child);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(ReadOnlyPropertyInheritor::class, 10049);
+
+        self::assertInstanceOf(ReadOnlyPropertyInheritor::class, $entity);
+        self::assertSame(10049, $entity->id);
+    }
+}


### PR DESCRIPTION
Fixes #10049 and supersedes #10059.

I must have missed an RFC because from https://wiki.php.net/rfc/readonly_properties_v2#reflection

> `ReflectionProperty::setValue()` can bypass the requirement that initialization occurs from the scope where the property has been declared.

[But that does not seem to be the case](https://3v4l.org/iDlpi). This makes `ReflectionReadonlyProperty::setValue()` crash when hydrating an inherited readonly property.

This PR makes `ClassMetadataInfo` build `ReflectionReadonlyProperty` with a property whose class is its declaring one to avoid this issue.