### PR TITLE
Throw on invalid one to one

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1373,15 +1373,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         switch ($mapping['type']) {
             case self::ONE_TO_ONE:
                 if (isset($mapping['joinColumns']) && $mapping['joinColumns'] && ! $mapping['isOwningSide']) {
-                    Deprecation::trigger(
-                        'doctrine/orm',
-                        'https://github.com/doctrine/orm/pull/10654',
-                        'JoinColumn configuration is not allowed on the inverse side of one-to-one associations, and will throw a MappingException in Doctrine ORM 3.0',
+                    throw MappingException::joinColumnNotAllowedOnOneToOneInverseSide(
+                        $this->name,
+                        $mapping['fieldName'],
                     );
-                }
-
-                if (isset($mapping['joinColumns']) && $mapping['joinColumns']) {
-                    $mapping['isOwningSide'] = true;
                 }
 
                 return $mapping['isOwningSide'] ?

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -230,6 +230,15 @@ class MappingException extends PersistenceMappingException implements ORMExcepti
         ));
     }
 
+    public static function joinColumnNotAllowedOnOneToOneInverseSide(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            '%s#%s is a OneToOne inverse side, which does not allow join columns.',
+            $className,
+            $fieldName,
+        ));
+    }
+
     /** @param class-string $className */
     public static function classIsNotAValidEntityOrMappedSuperClass(string $className): self
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -349,6 +349,7 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$mapping['isOwningSide']]]></code>
       <code><![CDATA[$mapping['isOwningSide']]]></code>
+      <code><![CDATA[$mapping['isOwningSide']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$table['name']]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -359,7 +360,6 @@
     <RedundantCondition>
       <code>$mapping !== false</code>
       <code>$mapping !== false</code>
-      <code><![CDATA[$mapping['isOwningSide']]]></code>
     </RedundantCondition>
     <RedundantFunctionCall>
       <code>array_values</code>
@@ -368,15 +368,6 @@
       <code><![CDATA[$this->table]]></code>
       <code>null</code>
     </RedundantPropertyInitializationCheck>
-    <TypeDoesNotContainType>
-      <code><![CDATA[OneToOneAssociationMapping::fromMappingArrayAndName(
-                        $mapping,
-                        $this->namingStrategy,
-                        $this->name,
-                        $this->table,
-                        $this->isInheritanceTypeSingleTable(),
-                    )]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
     <ArgumentTypeCoercion>
@@ -730,7 +721,6 @@
       <code>array</code>
       <code><![CDATA[list<mixed>]]></code>
     </MoreSpecificReturnType>
-    <PossiblyNullArgument/>
     <PossiblyNullReference>
       <code>getValue</code>
       <code>getValue</code>

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -331,6 +331,23 @@ class ClassMetadataTest extends OrmTestCase
         $cm->setVersionMapping($field);
     }
 
+    public function testItThrowsOnJoinColumnForInverseOneToOne(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'Doctrine\Tests\Models\CMS\CmsUser#address is a OneToOne inverse side, which does not allow join columns.',
+        );
+        $cm->mapOneToOne([
+            'fieldName' => 'address',
+            'targetEntity' => CmsAddress::class,
+            'mappedBy' => 'user',
+            'joinColumns' => ['non', 'empty', 'list'],
+        ]);
+    }
+
     public function testGetSingleIdentifierFieldNameMultipleIdentifierEntityThrowsException(): void
     {
         $cm = new ClassMetadata(CmsUser::class);


### PR DESCRIPTION
One to one relationships are not allowed to define a join column. That should be done on the owning side of the relationship.