### PR TITLE
Added doc for the fields parameter of the UniqueConstraint attribute

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1104,7 +1104,8 @@ context.
 Required parameters:
 
 -  **name**: Name of the Index
--  **columns**: Array of columns.
+-  **fields**: Array of fields (the names of the properties, used in the entity class).
+-  **columns**: Array of columns (the names of the columns, used in the schema).
 
 Optional parameters:
 


### PR DESCRIPTION
The description for the *fields* parameter of the `UniqueConstraint` attribute is missing at the moment (see [here](https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/reference/attributes-reference.html#uniqueconstraint)).