### PR TITLE
Make indexBy/orderBy easier to understand for SA

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -92,7 +92,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
         $targetHydrator = $targetPersister->getEntityHydrator();
 
         // Only preserve ordering if association configured it
-        if (! (isset($associationMapping['indexBy']) && $associationMapping['indexBy'])) {
+        if (! $associationMapping->isIndexed()) {
             // Elements may be an array or a Collection
             $elements = array_values($elements instanceof Collection ? $elements->getValues() : $elements);
         }

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -56,7 +56,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
         $key     = new CollectionCacheKey($this->sourceEntity->rootEntityName, $this->association['fieldName'], $ownerId);
 
        // Invalidate non initialized collections OR ordered collection
-        if ($isDirty && ! $isInitialized || isset($this->association['orderBy'])) {
+        if ($isDirty && ! $isInitialized || $this->association->isOrdered()) {
             $this->persister->update($collection);
 
             $this->queuedCache['delete'][spl_object_id($collection)] = $key;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -14,6 +14,7 @@ use Doctrine\Persistence\Proxy;
 
 use function array_fill_keys;
 use function array_keys;
+use function assert;
 use function count;
 use function is_array;
 use function key;
@@ -177,6 +178,7 @@ class ObjectHydrator extends AbstractHydrator
         }
 
         if (! $value instanceof PersistentCollection) {
+            assert($relation->isToMany());
             $value = new PersistentCollection(
                 $this->em,
                 $this->metadataCache[$relation['targetEntity']],

--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -205,6 +205,18 @@ abstract class AssociationMapping implements ArrayAccess
         return $this instanceof ManyToManyAssociationMapping;
     }
 
+    /** @psalm-assert-if-true ToManyAssociationMapping $this */
+    final public function isOrdered(): bool
+    {
+        return $this->isToMany() && $this->orderBy() !== [];
+    }
+
+    /** @psalm-assert-if-true ToManyAssociationMapping $this */
+    public function isIndexed(): bool
+    {
+        return false;
+    }
+
     final public function type(): int
     {
         return match (true) {

--- a/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToManyAssociationMapping.php
@@ -6,4 +6,11 @@ namespace Doctrine\ORM\Mapping;
 
 interface ToManyAssociationMapping
 {
+    /** @psalm-assert-if-true string $this->indexBy() */
+    public function isIndexed(): bool;
+
+    public function indexBy(): string;
+
+    /** @return array<string, 'asc'|'desc'> */
+    public function orderBy(): array;
 }

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Selectable;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use RuntimeException;
 use UnexpectedValueException;
 
@@ -56,6 +57,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * The association mapping the collection belongs to.
      * This is currently either a OneToManyMapping or a ManyToManyMapping.
+     *
+     * @var (AssociationMapping&ToManyAssociationMapping)|null
      */
     private AssociationMapping|null $association = null;
 
@@ -98,7 +101,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * Sets the collection's owning entity together with the AssociationMapping that
      * describes the association between the owner and the elements of the collection.
      */
-    public function setOwner(object $entity, AssociationMapping $assoc): void
+    public function setOwner(object $entity, AssociationMapping&ToManyAssociationMapping $assoc): void
     {
         $this->owner            = $entity;
         $this->association      = $assoc;
@@ -245,7 +248,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     }
 
     /** INTERNAL: Gets the association mapping of the collection. */
-    public function getMapping(): AssociationMapping
+    public function getMapping(): AssociationMapping&ToManyAssociationMapping
     {
         if ($this->association === null) {
             throw new UnexpectedValueException('The underlying association mapping is null although it should not be');
@@ -600,7 +603,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         $criteria = clone $criteria;
         $criteria->where($expression);
-        $criteria->orderBy($criteria->getOrderings() ?: $association['orderBy'] ?? []);
+        $criteria->orderBy($criteria->getOrderings() ?: $association->orderBy());
 
         $persister = $this->getUnitOfWork()->getEntityPersister($association['targetEntity']);
 

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -83,7 +83,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
     {
         $mapping = $collection->getMapping();
 
-        if (! isset($mapping->indexBy)) {
+        if (! $mapping->isIndexed()) {
             throw new BadMethodCallException('Selecting a collection by index is only supported on indexed collections.');
         }
 
@@ -95,7 +95,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         assert($mappedKey !== null);
 
         return $persister->load(
-            [$mappedKey => $collection->getOwner(), $mapping->indexBy => $index],
+            [$mappedKey => $collection->getOwner(), $mapping->indexBy() => $index],
             null,
             $mapping,
             [],
@@ -177,7 +177,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
     {
         $mapping = $collection->getMapping();
 
-        if (! isset($mapping->indexBy)) {
+        if (! $mapping->isIndexed()) {
             throw new BadMethodCallException('Selecting a collection by index is only supported on indexed collections.');
         }
 
@@ -574,11 +574,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
     ): array {
         $filterMapping = $collection->getMapping();
         $mapping       = $filterMapping;
-        assert(isset($mapping->indexBy));
-        $indexBy     = $mapping->indexBy;
-        $id          = $this->uow->getEntityIdentifier($collection->getOwner());
-        $sourceClass = $this->em->getClassMetadata($mapping->sourceEntity);
-        $targetClass = $this->em->getClassMetadata($mapping->targetEntity);
+        $indexBy       = $mapping->indexBy();
+        $id            = $this->uow->getEntityIdentifier($collection->getOwner());
+        $sourceClass   = $this->em->getClassMetadata($mapping->sourceEntity);
+        $targetClass   = $this->em->getClassMetadata($mapping->targetEntity);
 
         if (! $mapping->isOwningSide()) {
             assert($mapping instanceof InverseSideMapping);

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -54,8 +54,9 @@ class OneToManyPersister extends AbstractCollectionPersister
     public function get(PersistentCollection $collection, mixed $index): object|null
     {
         $mapping = $collection->getMapping();
+        assert($mapping->isOneToMany());
 
-        if (! isset($mapping['indexBy'])) {
+        if (! $mapping->isIndexed()) {
             throw new BadMethodCallException('Selecting a collection by index is only supported on indexed collections.');
         }
 
@@ -63,8 +64,8 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         return $persister->load(
             [
-                $mapping['mappedBy'] => $collection->getOwner(),
-                $mapping['indexBy']  => $index,
+                $mapping->mappedBy  => $collection->getOwner(),
+                $mapping->indexBy() => $index,
             ],
             null,
             $mapping,
@@ -102,7 +103,7 @@ class OneToManyPersister extends AbstractCollectionPersister
     {
         $mapping = $collection->getMapping();
 
-        if (! isset($mapping['indexBy'])) {
+        if (! $mapping->isIndexed()) {
             throw new BadMethodCallException('Selecting a collection by index is only supported on indexed collections.');
         }
 
@@ -113,8 +114,8 @@ class OneToManyPersister extends AbstractCollectionPersister
         // 'mappedBy' field.
         $criteria = new Criteria();
 
-        $criteria->andWhere(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
-        $criteria->andWhere(Criteria::expr()->eq($mapping['indexBy'], $key));
+        $criteria->andWhere(Criteria::expr()->eq($mapping->mappedBy, $collection->getOwner()));
+        $criteria->andWhere(Criteria::expr()->eq($mapping->indexBy(), $key));
 
         return (bool) $persister->count($criteria);
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -918,9 +918,9 @@ class BasicEntityPersister implements EntityPersister
         $rsm   = $this->currentPersisterContext->rsm;
         $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
 
-        if (isset($assoc->indexBy)) {
+        if ($assoc->isIndexed()) {
             $rsm = clone $this->currentPersisterContext->rsm; // this is necessary because the "default rsm" should be changed.
-            $rsm->addIndexBy('r', $assoc->indexBy);
+            $rsm->addIndexBy('r', $assoc->indexBy());
         }
 
         return $this->em->newHydrator(Query::HYDRATE_OBJECT)->hydrateAll($stmt, $rsm, $hints);
@@ -942,9 +942,9 @@ class BasicEntityPersister implements EntityPersister
             'collection' => $coll,
         ];
 
-        if (isset($assoc->indexBy)) {
+        if ($assoc->isIndexed()) {
             $rsm = clone $this->currentPersisterContext->rsm; // this is necessary because the "default rsm" should be changed.
-            $rsm->addIndexBy('r', $assoc->indexBy);
+            $rsm->addIndexBy('r', $assoc->indexBy());
         }
 
         return $this->em->newHydrator(Query::HYDRATE_OBJECT)->hydrateAll($stmt, $rsm, $hints);
@@ -1049,8 +1049,8 @@ class BasicEntityPersister implements EntityPersister
             $joinSql = $this->getSelectManyToManyJoinSQL($assoc);
         }
 
-        if ($assoc !== null && isset($assoc->orderBy)) {
-            $orderBy = $assoc->orderBy;
+        if ($assoc !== null && $assoc->isOrdered()) {
+            $orderBy = $assoc->orderBy();
         }
 
         if ($orderBy) {
@@ -1244,8 +1244,8 @@ class BasicEntityPersister implements EntityPersister
             $association   = $assoc;
             $joinCondition = [];
 
-            if (isset($assoc->indexBy)) {
-                $this->currentPersisterContext->rsm->addIndexBy($assocAlias, $assoc->indexBy);
+            if ($assoc->isIndexed()) {
+                $this->currentPersisterContext->rsm->addIndexBy($assocAlias, $assoc->indexBy());
             }
 
             if (! $assoc->isOwningSide()) {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -271,8 +271,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         $orderBySql = '';
 
-        if ($assoc !== null && isset($assoc['orderBy'])) {
-            $orderBy = $assoc['orderBy'];
+        if ($assoc !== null && $assoc->isOrdered()) {
+            $orderBy = $assoc->orderBy();
         }
 
         if ($orderBy) {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1027,8 +1027,8 @@ class SqlWalker
         if ($indexBy) {
             // For Many-To-One or One-To-One associations this obviously makes no sense, but is ignored silently.
             $this->walkIndexBy($indexBy);
-        } elseif (isset($relation['indexBy'])) {
-            $this->rsm->addIndexBy($joinedDqlAlias, $relation['indexBy']);
+        } elseif ($relation->isIndexed()) {
+            $this->rsm->addIndexBy($joinedDqlAlias, $relation->indexBy());
         }
 
         return $sql;

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -214,8 +214,8 @@ class SchemaValidator
                 }
             }
 
-            if (isset($assoc['orderBy']) && $assoc['orderBy'] !== null) {
-                foreach ($assoc['orderBy'] as $orderField => $orientation) {
+            if ($assoc->isOrdered()) {
+                foreach ($assoc->orderBy() as $orderField => $orientation) {
                     if (! $targetMetadata->hasField($orderField) && ! $targetMetadata->hasAssociation($orderField)) {
                         $ce[] = 'The association ' . $class->name . '#' . $fieldName . ' is ordered by a foreign field ' .
                                 $orderField . ' that is not a field on the target entity ' . $targetMetadata->name . '.';

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -575,6 +575,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 $assoc = $class->associationMappings[$name];
+                assert($assoc->isToMany());
 
                 // Inject PersistentCollection
                 $value = new PersistentCollection(
@@ -671,6 +672,7 @@ class UnitOfWork implements PropertyChangedListener
                 // created one. This can only mean it was cloned and replaced
                 // on another entity.
                 if ($actualValue instanceof PersistentCollection) {
+                    assert($assoc->isToMany());
                     $owner = $actualValue->getOwner();
                     if ($owner === null) { // cloned
                         $actualValue->setOwner($entity, $assoc);
@@ -2433,6 +2435,7 @@ class UnitOfWork implements PropertyChangedListener
                     break;
 
                 default:
+                    assert($assoc->isToMany());
                     // Ignore if its a cached collection
                     if (isset($hints[Query::HINT_CACHE_ENABLED]) && $class->getFieldValue($entity, $field) instanceof PersistentCollection) {
                         break;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,6 +126,11 @@ parameters:
 			path: lib/Doctrine/ORM/EntityRepository.php
 
 		-
+			message: "#^Parameter \\#2 \\$assoc of method Doctrine\\\\ORM\\\\PersistentCollection\\<\\(int\\|string\\),mixed\\>\\:\\:setOwner\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping&Doctrine\\\\ORM\\\\Mapping\\\\ToManyAssociationMapping, Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping given\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+
+		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\:\\:fullyQualifiedClassName\\(\\) should return class\\-string\\|null but returns string\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -299,6 +304,16 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/SchemaTool.php
+
+		-
+			message: "#^Parameter \\#2 \\$assoc of method Doctrine\\\\ORM\\\\PersistentCollection\\<\\(int\\|string\\),mixed\\>\\:\\:setOwner\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping&Doctrine\\\\ORM\\\\Mapping\\\\ToManyAssociationMapping, Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping given\\.$#"
+			count: 4
+			path: lib/Doctrine/ORM/UnitOfWork.php
+
+		-
+			message: "#^Parameter \\#2 \\$assoc of method Doctrine\\\\ORM\\\\PersistentCollection\\<\\*NEVER\\*,\\*NEVER\\*\\>\\:\\:setOwner\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping&Doctrine\\\\ORM\\\\Mapping\\\\ToManyAssociationMapping, Doctrine\\\\ORM\\\\Mapping\\\\AssociationMapping given\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/UnitOfWork.php
 
 		-
 			message: "#^Parameter \\#3 \\$changeSet of class Doctrine\\\\ORM\\\\Event\\\\PreUpdateEventArgs constructor is passed by reference, so it expects variables only$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,6 +28,7 @@ parameters:
         -
             message: "#^Access to an undefined property .*Mapping\\:\\:\\$(inversedBy|mappedBy|joinColumns|joinTableColumns|(relation|source|target)To(Target|Source)KeyColumns|joinTable|indexBy)\\.$#"
             paths:
+                - lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
                 - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
                 - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
                 - lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -36,3 +37,11 @@ parameters:
                 - lib/Doctrine/ORM/Query/SqlWalker.php
                 - lib/Doctrine/ORM/Tools/SchemaValidator.php
                 - lib/Doctrine/ORM/UnitOfWork.php
+        -
+            message: "#^Call to an undefined method .*Mapping\\:\\:(order|index)By\\(\\)\\.#"
+            paths:
+                - lib/Doctrine/ORM/Mapping/AssociationMapping.php
+                - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+                - lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+                - lib/Doctrine/ORM/Query/SqlWalker.php
+                - lib/Doctrine/ORM/Tools/SchemaValidator.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -720,6 +720,9 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
     </PossiblyNullArgument>
+    <UndefinedPropertyFetch>
+      <code><![CDATA[$mapping->mappedBy]]></code>
+    </UndefinedPropertyFetch>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
     <DocblockTypeContradiction>

--- a/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -396,7 +396,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertTrue($class->associationMappings['groups']['isCascadeDetach']);
         self::assertTrue($class->associationMappings['groups']['isCascadeMerge']);
 
-        self::assertFalse(isset($class->associationMappings['groups']['orderBy']));
+        self::assertFalse($class->associationMappings['groups']->isOrdered());
 
         return $class;
     }
@@ -1128,7 +1128,7 @@ class User
                         ],
                     ],
                 ],
-                'orderBy' => null,
+                'orderBy' => [],
             ],
         );
         $metadata->table['uniqueConstraints'] = [


### PR DESCRIPTION
Interfaces cannot have properties, and we do not have a concept of sealed classes available to us without installing third party packages. Interfaces can have methods however, which allows us to simplify calling code.
I've been avoiding introducing getters for mapping properties because I do not know what the performance implications are, but here, I think it is sensible to make an exception, given the benefits.