### PR TITLE
Introduce method to get to the owning side

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -65,9 +65,7 @@ class DefaultEntityHydrator implements EntityHydrator
 
             if (! isset($assoc['cache'])) {
                 $targetClassMetadata = $this->em->getClassMetadata($assoc['targetEntity']);
-                $owningAssociation   = ! $assoc->isOwningSide()
-                    ? $targetClassMetadata->associationMappings[$assoc['mappedBy']]
-                    : $assoc;
+                $owningAssociation   = $this->em->getMetadataFactory()->getOwningSide($assoc);
                 $associationIds      = $this->identifierFlattener->flattenIdentifier(
                     $targetClassMetadata,
                     $targetClassMetadata->getIdentifierValues($data[$name]),

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -61,6 +61,22 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $this->em = $em;
     }
 
+    final public function getOwningSide(AssociationMapping $maybeOwningSide): OwningSideMapping
+    {
+        if ($maybeOwningSide instanceof OwningSideMapping) {
+            return $maybeOwningSide;
+        }
+
+        assert($maybeOwningSide instanceof InverseSideMapping);
+
+        $owningSide = $this->getMetadataFor($maybeOwningSide->targetEntity)
+            ->associationMappings[$maybeOwningSide->mappedBy];
+
+        assert($owningSide instanceof OwningSideMapping);
+
+        return $owningSide;
+    }
+
     protected function initialize(): void
     {
         $this->driver      = $this->em->getConfiguration()->getMetadataDriverImpl();

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -514,9 +514,10 @@ class BasicEntityPersister implements EntityPersister
 
             if (! $mapping->isOwningSide()) {
                 assert($mapping instanceof InverseSideMapping);
-                $class       = $this->em->getClassMetadata($mapping->targetEntity);
-                $association = $class->associationMappings[$mapping->mappedBy];
+                $class = $this->em->getClassMetadata($mapping->targetEntity);
             }
+
+            $association = $this->em->getMetadataFactory()->getOwningSide($association);
 
             assert($association->isManyToManyOwningSide());
 
@@ -977,9 +978,10 @@ class BasicEntityPersister implements EntityPersister
 
         if (! $assoc->isOwningSide()) {
             assert(isset($assoc->mappedBy));
-            $class       = $this->em->getClassMetadata($assoc->targetEntity);
-            $association = $class->associationMappings[$assoc->mappedBy];
+            $class = $this->em->getClassMetadata($assoc->targetEntity);
         }
+
+        $association = $this->em->getMetadataFactory()->getOwningSide($assoc);
 
         assert($association->isManyToManyOwningSide());
 
@@ -1335,12 +1337,7 @@ class BasicEntityPersister implements EntityPersister
         $association      = $manyToMany;
         $sourceTableAlias = $this->getSQLTableAlias($this->class->name);
 
-        if (! $manyToMany->isOwningSide()) {
-            assert(isset($manyToMany->mappedBy));
-            $targetEntity = $this->em->getClassMetadata($manyToMany->targetEntity);
-            $association  = $targetEntity->associationMappings[$manyToMany->mappedBy];
-        }
-
+        $association = $this->em->getMetadataFactory()->getOwningSide($manyToMany);
         assert($association->isManyToManyOwningSide());
 
         $joinTableName = $this->quoteStrategy->getJoinTableName($association, $this->class, $this->platform);
@@ -1858,16 +1855,8 @@ class BasicEntityPersister implements EntityPersister
                 break;
 
             case isset($class->associationMappings[$field]):
-                $assoc = $class->associationMappings[$field];
+                $assoc = $this->em->getMetadataFactory()->getOwningSide($class->associationMappings[$field]);
                 $class = $this->em->getClassMetadata($assoc->targetEntity);
-
-                if (! $assoc->isOwningSide()) {
-                    assert(isset($assoc->mappedBy));
-                    $assoc = $class->associationMappings[$assoc->mappedBy];
-                    $class = $this->em->getClassMetadata($assoc->targetEntity);
-                }
-
-                assert($assoc->isOwningSide());
 
                 if ($assoc->isManyToManyOwningSide()) {
                     $columns = $assoc->relationToTargetKeyColumns;

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -61,9 +61,7 @@ class SizeFunction extends FunctionNode
                       . $sourceTableAlias . '.' . $quoteStrategy->getColumnName($class->fieldNames[$targetColumn], $class, $platform);
             }
         } else { // many-to-many
-            $targetClass = $entityManager->getClassMetadata($assoc->targetEntity);
-
-            $owningAssoc = $assoc->isOwningSide() ? $assoc : $targetClass->associationMappings[$assoc['mappedBy']];
+            $owningAssoc = $entityManager->getMetadataFactory()->getOwningSide($assoc);
             $joinTable   = $owningAssoc['joinTable'];
 
             // SQL table aliases
@@ -71,7 +69,8 @@ class SizeFunction extends FunctionNode
             $sourceTableAlias = $sqlWalker->getSQLTableAlias($class->getTableName(), $dqlAlias);
 
             // join to target table
-            $sql .= $quoteStrategy->getJoinTableName($owningAssoc, $targetClass, $platform) . ' ' . $joinTableAlias . ' WHERE ';
+            $targetClass = $entityManager->getClassMetadata($assoc->targetEntity);
+            $sql        .= $quoteStrategy->getJoinTableName($owningAssoc, $targetClass, $platform) . ' ' . $joinTableAlias . ' WHERE ';
 
             $joinColumns = $assoc->isOwningSide()
                 ? $joinTable['joinColumns']

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -895,7 +895,7 @@ class SqlWalker
         $sourceTableAlias = $this->getSQLTableAlias($sourceClass->getTableName(), $associationPathExpression->identificationVariable);
 
         // Ensure we got the owning side, since it has all mapping info
-        $assoc = ! $relation['isOwningSide'] ? $targetClass->associationMappings[$relation['mappedBy']] : $relation;
+        $assoc = $this->em->getMetadataFactory()->getOwningSide($relation);
 
         if ($this->query->getHint(Query::HINT_INTERNAL_ITERATION) === true && (! $this->query->getHint(self::HINT_DISTINCT) || isset($this->selectedClasses[$joinedDqlAlias]))) {
             if ($relation->isToMany()) {
@@ -1885,7 +1885,7 @@ class SqlWalker
             assert($assoc->isManyToMany());
             $targetClass = $this->em->getClassMetadata($assoc->targetEntity);
 
-            $owningAssoc = $assoc['isOwningSide'] ? $assoc : $targetClass->associationMappings[$assoc['mappedBy']];
+            $owningAssoc = $this->em->getMetadataFactory()->getOwningSide($assoc);
             $joinTable   = $owningAssoc['joinTable'];
 
             // SQL table aliases


### PR DESCRIPTION
Throughout the codebase, there is this pattern where we ensure we have the owning side of an association.
It involves accessing it from the associationMappings array. In the end, static analysis cannot know that the association is indeed owning. By introducing this convenience method, we make this clear, and also delegate the complexity to the class metadata factory.