### PR TITLE
Compute entity-level commit order for entity insertions

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3031,7 +3031,6 @@
       <code>setValue</code>
     </PossiblyNullReference>
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$assoc['joinColumns']]]></code>
       <code><![CDATA[$assoc['orphanRemoval']]]></code>
       <code><![CDATA[$assoc['targetToSourceKeyColumns']]]></code>
     </PossiblyUndefinedArrayOffset>

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -74,9 +74,11 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
 
     public function testEagerLoadsAssociation(): void
     {
-        $this->createFixture();
+        $customerId = $this->createFixture();
 
-        $query    = $this->_em->createQuery('select c, m from Doctrine\Tests\Models\ECommerce\ECommerceCustomer c left join c.mentor m order by c.id asc');
+        $query = $this->_em->createQuery('select c, m from Doctrine\Tests\Models\ECommerce\ECommerceCustomer c left join c.mentor m where c.id = :id');
+        $query->setParameter('id', $customerId);
+
         $result   = $query->getResult();
         $customer = $result[0];
         $this->assertLoadingOfAssociation($customer);

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -421,6 +421,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM ecommerce_products_categories');
             $conn->executeStatement('DELETE FROM ecommerce_products_related');
             $conn->executeStatement('DELETE FROM ecommerce_carts');
+            $conn->executeStatement('DELETE FROM ecommerce_customers WHERE mentor_id IS NOT NULL');
             $conn->executeStatement('DELETE FROM ecommerce_customers');
             $conn->executeStatement('DELETE FROM ecommerce_features');
             $conn->executeStatement('DELETE FROM ecommerce_products');


### PR DESCRIPTION
Make the UoW find a commit order for entity insertions not on the class, but at the entity level. This is the third step to break https://github.com/doctrine/orm/pull/10547 into smaller PRs suitable for reviewing. It uses the new topological sort implementation from #10592 and the refactoring from #10651.

#### Current situation

`UnitOfWork::getCommitOrder()` would compute the entity sequence on the class level with the following code:

https://github.com/doctrine/orm/blob/70477d81e96c0044ad6fd8c13c37b2270d082792/lib/Doctrine/ORM/UnitOfWork.php#L1310-L1325

#### Suggested change

* Instead of considering the classes of all entities that need to be inserted, updated or deleted, consider the new (inserted) entities only. We only need to find a sequence in situations where there are foreign key relationships between two _new_ entities.
* In the dependency graph, add edges for all to-one association target entities.
* Make edges "optional" when the association is nullable.

#### Extra bonus

This is what the DALL·E AI thinks it looks like when the `UnitOfWork` is scheduling the sequence of entity insertions.

![DALL·E 2023-05-08 18 32 54](https://user-images.githubusercontent.com/1202333/236879540-40e98ff2-581e-41d0-a09e-aa8c622bbc18.png)
