### PR TITLE
Changing return type of `getSingleScalarResult()` to `array|bool|float|int|string|null`

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1010,7 +1010,7 @@ abstract class AbstractQuery
      *
      * Alias for getSingleResult(HYDRATE_SINGLE_SCALAR).
      *
-     * @return mixed The scalar result.
+     * @return array|bool|float|int|string|null The scalar result.
      *
      * @throws NoResultException        If the query returned no result.
      * @throws NonUniqueResultException If the query result is not unique.


### PR DESCRIPTION
Reason: I'm using `intval()` to sanitize the result of `getSingleScalarResult()`. But now, PHPStan 1.10.15 complains that `intval()` only accepts `bool|float|int|resource|string|null` as input: https://github.com/phpstan/phpstan/issues/9295
So I threw all of these (except `resource`) in here :-)
I didn't doublecheck anything - waiting for some feedback first.