### PR TITLE
Move joinColumnFieldNames down the class hierarchy

### DIFF
--- a/lib/Doctrine/ORM/Mapping/AssociationMapping.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMapping.php
@@ -62,9 +62,6 @@ abstract class AssociationMapping implements ArrayAccess
 
     public bool|null $isOnDeleteCascade = null;
 
-    /** @var array<string, string>|null */
-    public array|null $joinColumnFieldNames = null;
-
     /** @var class-string|null */
     public string|null $originalClass = null;
 
@@ -335,7 +332,6 @@ abstract class AssociationMapping implements ArrayAccess
                 'inherited',
                 'declared',
                 'cache',
-                'joinColumnFieldNames',
                 'originalClass',
                 'originalField',
             ] as $stringOrArrayProperty

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1727,11 +1727,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             $mapping['fetch'] = $overrideMapping['fetch'];
         }
 
-        $mapping['joinColumnFieldNames'] = null;
-
         switch ($mapping['type']) {
             case self::ONE_TO_ONE:
             case self::MANY_TO_ONE:
+                $mapping['joinColumnFieldNames']     = [];
                 $mapping['sourceToTargetKeyColumns'] = [];
                 break;
             case self::MANY_TO_MANY:

--- a/lib/Doctrine/ORM/Mapping/ToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneOwningSideMapping.php
@@ -22,6 +22,9 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
     /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
 
+    /** @var array<string, string> */
+    public array $joinColumnFieldNames = [];
+
     /**
      * @param array<string, mixed> $mappingArray
      * @psalm-param array{
@@ -169,6 +172,7 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
         return [
             ...parent::__sleep(),
             'joinColumns',
+            'joinColumnFieldNames',
             'sourceToTargetKeyColumns',
             'targetToSourceKeyColumns',
         ];

--- a/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AssociationMappingTest.php
@@ -23,18 +23,17 @@ final class AssociationMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->cascade              = ['persist'];
-        $mapping->fetch                = ClassMetadata::FETCH_EAGER;
-        $mapping->inherited            = self::class;
-        $mapping->declared             = self::class;
-        $mapping->cache                = ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY];
-        $mapping->id                   = true;
-        $mapping->isOnDeleteCascade    = true;
-        $mapping->joinColumnFieldNames = ['foo' => 'bar'];
-        $mapping->originalClass        = self::class;
-        $mapping->originalField        = 'foo';
-        $mapping->orphanRemoval        = true;
-        $mapping->unique               = true;
+        $mapping->cascade           = ['persist'];
+        $mapping->fetch             = ClassMetadata::FETCH_EAGER;
+        $mapping->inherited         = self::class;
+        $mapping->declared          = self::class;
+        $mapping->cache             = ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY];
+        $mapping->id                = true;
+        $mapping->isOnDeleteCascade = true;
+        $mapping->originalClass     = self::class;
+        $mapping->originalField     = 'foo';
+        $mapping->orphanRemoval     = true;
+        $mapping->unique            = true;
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof AssociationMapping);
@@ -46,7 +45,6 @@ final class AssociationMappingTest extends TestCase
         self::assertSame(['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY], $resurrectedMapping->cache);
         self::assertTrue($resurrectedMapping->id);
         self::assertTrue($resurrectedMapping->isOnDeleteCascade);
-        self::assertSame(['foo' => 'bar'], $resurrectedMapping->joinColumnFieldNames);
         self::assertSame(self::class, $resurrectedMapping->originalClass);
         self::assertSame('foo', $resurrectedMapping->originalField);
         self::assertTrue($resurrectedMapping->orphanRemoval);

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
@@ -23,6 +23,7 @@ final class ManyToOneAssociationMappingTest extends TestCase
         );
 
         $mapping->joinColumns              = [new JoinColumnMapping('id')];
+        $mapping->joinColumnFieldNames     = ['foo' => 'bar'];
         $mapping->sourceToTargetKeyColumns = ['foo' => 'bar'];
         $mapping->targetToSourceKeyColumns = ['bar' => 'foo'];
 
@@ -30,6 +31,7 @@ final class ManyToOneAssociationMappingTest extends TestCase
         assert($resurrectedMapping instanceof ManyToOneAssociationMapping);
 
         self::assertCount(1, $resurrectedMapping->joinColumns);
+        self::assertSame(['foo' => 'bar'], $resurrectedMapping->joinColumnFieldNames);
         self::assertSame(['foo' => 'bar'], $resurrectedMapping->sourceToTargetKeyColumns);
         self::assertSame(['bar' => 'foo'], $resurrectedMapping->targetToSourceKeyColumns);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
@@ -23,6 +23,7 @@ final class OneToOneOwningSideMappingTest extends TestCase
         );
 
         $mapping->joinColumns              = [new JoinColumnMapping('id')];
+        $mapping->joinColumnFieldNames     = ['foo' => 'bar'];
         $mapping->sourceToTargetKeyColumns = ['foo' => 'bar'];
         $mapping->targetToSourceKeyColumns = ['bar' => 'foo'];
 
@@ -30,6 +31,7 @@ final class OneToOneOwningSideMappingTest extends TestCase
         assert($resurrectedMapping instanceof OneToOneOwningSideMapping);
 
         self::assertCount(1, $resurrectedMapping->joinColumns);
+        self::assertSame(['foo' => 'bar'], $resurrectedMapping->joinColumnFieldNames);
         self::assertSame(['foo' => 'bar'], $resurrectedMapping->sourceToTargetKeyColumns);
         self::assertSame(['bar' => 'foo'], $resurrectedMapping->targetToSourceKeyColumns);
     }


### PR DESCRIPTION
It has only meaning for `ToOneOwningSideMapping`