### PR TITLE
Introduce convenience methods to narrow types

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,7 +28,6 @@ parameters:
         -
             message: "#^Access to an undefined property .*Mapping\\:\\:\\$(inversedBy|mappedBy|joinColumns|joinTableColumns|(relation|source|target)To(Target|Source)KeyColumns|joinTable|indexBy)\\.$#"
             paths:
-                - lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
                 - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
                 - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
                 - lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -51,3 +50,7 @@ parameters:
             paths:
                 - lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
                 - lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+
+        -
+            message: '#^.*OneToManyPersister::getMapping\(\) should return.*#'
+            path: lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -725,9 +725,7 @@
       <code><![CDATA[$collection->getOwner()]]></code>
       <code><![CDATA[$collection->getOwner()]]></code>
     </PossiblyNullArgument>
-    <UndefinedPropertyFetch>
-      <code><![CDATA[$mapping->mappedBy]]></code>
-    </UndefinedPropertyFetch>
+    <UndefinedPropertyFetch/>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
     <DocblockTypeContradiction>


### PR DESCRIPTION
These methods assert the type of the mapping provided by the collection according to the name of the class they are in: the one to many persister only ever deals with one to many associations, and the many to many persister only ever deals with many to many associations.