### PR TITLE
Correct docs link

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -35,7 +35,7 @@ have to be used.
     superclass, since they require the "many" side to hold the foreign
     key.
 
-    It is, however, possible to use the :doc:```ResolveTargetEntityListener`` <cookbook/resolve-target-entity-listener>`
+    It is, however, possible to use the :doc:`ResolveTargetEntityListener <cookbook/resolve-target-entity-listener>`
     to replace references to a mapped superclass with an entity class at runtime.
     As long as there is only one entity subclass inheriting from the mapped
     superclass and all references to the mapped superclass are resolved to that


### PR DESCRIPTION
https://www.doctrine-project.org/projects/doctrine-orm/en/2.15/reference/inheritance-mapping.html has a broken link, this should fix it (it looks like the intent is to have `ResolveTargetEntityListener` shown as a code element but the parser might not be working?).