### PR TITLE
Fixes #10713 - Duplicate entries in CommitOrderCalculator output

### DIFF
--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -143,9 +143,11 @@ class CommitOrderCalculator
                             }
                         }
 
-                        $adjacentVertex->state = VertexState::VISITED;
+                        if ($adjacentVertex->state !== VertexState::VISITED) {
+                            $adjacentVertex->state = VertexState::VISITED;
 
-                        $this->sortedNodeList[] = $adjacentVertex->value;
+                            $this->sortedNodeList[] = $adjacentVertex->value;
+                        }
                     }
 
                     break;

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -143,11 +143,7 @@ class CommitOrderCalculator
                             }
                         }
 
-                        if ($adjacentVertex->state !== VertexState::VISITED) {
-                            $adjacentVertex->state = VertexState::VISITED;
-
-                            $this->sortedNodeList[] = $adjacentVertex->value;
-                        }
+                        $this->addVertexToSortedList($adjacentVertex);
                     }
 
                     break;
@@ -157,6 +153,11 @@ class CommitOrderCalculator
             }
         }
 
+        $this->addVertexToSortedList($vertex);
+    }
+
+    private function addVertexToSortedList(Vertex $vertex): void
+    {
         if ($vertex->state !== VertexState::VISITED) {
             $vertex->state = VertexState::VISITED;
 

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -112,14 +112,12 @@ class CommitOrderCalculatorTest extends OrmTestCase
         $class3 = new ClassMetadata(NodeClass3::class);
         $class4 = new ClassMetadata(NodeClass4::class);
         $class5 = new ClassMetadata(NodeClass5::class);
-        $class6 = new ClassMetadata(NodeClass6::class);
 
         $this->_calc->addNode($class1->name, $class1);
         $this->_calc->addNode($class2->name, $class2);
         $this->_calc->addNode($class3->name, $class3);
         $this->_calc->addNode($class4->name, $class4);
         $this->_calc->addNode($class5->name, $class5);
-        $this->_calc->addNode($class6->name, $class6);
 
         $this->_calc->addDependency($class1->name, $class5->name, 1);
         $this->_calc->addDependency($class1->name, $class4->name, 1);
@@ -129,24 +127,22 @@ class CommitOrderCalculatorTest extends OrmTestCase
         $this->_calc->addDependency($class3->name, $class5->name, 0);
         $this->_calc->addDependency($class3->name, $class4->name, 0);
         $this->_calc->addDependency($class3->name, $class3->name, 1);
-        $this->_calc->addDependency($class3->name, $class6->name, 1);
         $this->_calc->addDependency($class3->name, $class2->name, 0);
         $this->_calc->addDependency($class4->name, $class3->name, 1);
         $this->_calc->addDependency($class4->name, $class1->name, 0);
         $this->_calc->addDependency($class5->name, $class3->name, 1);
         $this->_calc->addDependency($class5->name, $class1->name, 0);
-        $this->_calc->addDependency($class6->name, $class3->name, 0);
 
         $sorted = $this->_calc->sort();
 
         // There are multiple valid orderings for this constellation
         $correctOrders = [
-            [$class1, $class2, $class4, $class5, $class3, $class6],
-            [$class1, $class2, $class5, $class4, $class3, $class6],
-            [$class1, $class4, $class2, $class5, $class3, $class6],
-            [$class1, $class4, $class5, $class2, $class3, $class6],
-            [$class1, $class5, $class2, $class4, $class3, $class6],
-            [$class1, $class5, $class4, $class2, $class3, $class6],
+            [$class1, $class2, $class4, $class5, $class3],
+            [$class1, $class2, $class5, $class4, $class3],
+            [$class1, $class4, $class2, $class5, $class3],
+            [$class1, $class4, $class5, $class2, $class3],
+            [$class1, $class5, $class2, $class4, $class3],
+            [$class1, $class5, $class4, $class2, $class3],
         ];
 
         // We want to perform a strict comparison of the array
@@ -167,8 +163,5 @@ class NodeClass4
 {
 }
 class NodeClass5
-{
-}
-class NodeClass6
 {
 }

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -91,13 +91,62 @@ class CommitOrderCalculatorTest extends OrmTestCase
 
         $sorted = $this->_calc->sort();
 
-        // There is only multiple valid ordering for this constellation, but
+        // There are multiple valid orderings for this constellation, but
         // the class4, class1, class2 ordering is important to break the cycle
         // on the nullable link.
         $correctOrders = [
             [$class4, $class1, $class2, $class3],
             [$class4, $class1, $class3, $class2],
             [$class4, $class3, $class1, $class2],
+        ];
+
+        // We want to perform a strict comparison of the array
+        self::assertContains($sorted, $correctOrders, '', false, true);
+    }
+
+    public function testCommitOrdering4(): void
+    {
+        // this test corresponds to the GH7259Test::testPersistFileBeforeVersion functional test
+        $class1 = new ClassMetadata(NodeClass1::class);
+        $class2 = new ClassMetadata(NodeClass2::class);
+        $class3 = new ClassMetadata(NodeClass3::class);
+        $class4 = new ClassMetadata(NodeClass4::class);
+        $class5 = new ClassMetadata(NodeClass5::class);
+        $class6 = new ClassMetadata(NodeClass6::class);
+
+        $this->_calc->addNode($class1->name, $class1);
+        $this->_calc->addNode($class2->name, $class2);
+        $this->_calc->addNode($class3->name, $class3);
+        $this->_calc->addNode($class4->name, $class4);
+        $this->_calc->addNode($class5->name, $class5);
+        $this->_calc->addNode($class6->name, $class6);
+
+        $this->_calc->addDependency($class1->name, $class5->name, 1);
+        $this->_calc->addDependency($class1->name, $class4->name, 1);
+        $this->_calc->addDependency($class1->name, $class2->name, 1);
+        $this->_calc->addDependency($class2->name, $class3->name, 1);
+        $this->_calc->addDependency($class2->name, $class1->name, 0);
+        $this->_calc->addDependency($class3->name, $class5->name, 0);
+        $this->_calc->addDependency($class3->name, $class4->name, 0);
+        $this->_calc->addDependency($class3->name, $class3->name, 1);
+        $this->_calc->addDependency($class3->name, $class6->name, 1);
+        $this->_calc->addDependency($class3->name, $class2->name, 0);
+        $this->_calc->addDependency($class4->name, $class3->name, 1);
+        $this->_calc->addDependency($class4->name, $class1->name, 0);
+        $this->_calc->addDependency($class5->name, $class3->name, 1);
+        $this->_calc->addDependency($class5->name, $class1->name, 0);
+        $this->_calc->addDependency($class6->name, $class3->name, 0);
+
+        $sorted = $this->_calc->sort();
+
+        // There are multiple valid orderings for this constellation
+        $correctOrders = [
+            [$class1, $class2, $class4, $class5, $class3, $class6],
+            [$class1, $class2, $class5, $class4, $class3, $class6],
+            [$class1, $class4, $class2, $class5, $class3, $class6],
+            [$class1, $class4, $class5, $class2, $class3, $class6],
+            [$class1, $class5, $class2, $class4, $class3, $class6],
+            [$class1, $class5, $class4, $class2, $class3, $class6],
         ];
 
         // We want to perform a strict comparison of the array
@@ -118,5 +167,8 @@ class NodeClass4
 {
 }
 class NodeClass5
+{
+}
+class NodeClass6
 {
 }


### PR DESCRIPTION
`CommitOrderCalculator` may return duplicate entries when visiting complex trees as dependencies nodes can be visited and added to the sorted list while visiting other nodes as reported by https://github.com/doctrine/orm/issues/10713 (this PR solves it)

The issue comes from line 142 where adjacent dependencies are visited: a given `$adjacentVertex` state can change to `VISITED` and this is not checked before adding it to the sorted node list.