### PR TITLE
Narrow return types for `AbstractQuery::getSingleScalarResult()`

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1010,7 +1010,7 @@ abstract class AbstractQuery
      *
      * Alias for getSingleResult(HYDRATE_SINGLE_SCALAR).
      *
-     * @return mixed The scalar result.
+     * @return bool|float|int|string The scalar result.
      *
      * @throws NoResultException        If the query returned no result.
      * @throws NonUniqueResultException If the query result is not unique.


### PR DESCRIPTION
~~Tests were also improved:~~
* ~~`QueryTest::testGetSingleScalarResultThrowsExceptionOnNonUniqueResult()` was updated to ensure  `NonUniqueResultException` is thrown only on results with multiple rows;~~
* ~~`QueryTest::testGetSingleScalarResultThrowsExceptionOnSingleRowWithMultipleColumns()` was added to ensure `NonUniqueResultException` is thrown only on results with multiple columns;~~ <- These changes were moved to #10722 (see https://github.com/doctrine/orm/pull/10721#pullrequestreview-1438679926).

Closes #10695