### PR TITLE
Fix and improve functional test cases expecting `NonUniqueResultException` from `AbstractQuery::getSingleScalarResult()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -486,13 +486,35 @@ class QueryTest extends OrmFunctionalTestCase
     public function testGetSingleScalarResultThrowsExceptionOnNoResult(): void
     {
         $this->expectException('Doctrine\ORM\NoResultException');
-        $this->_em->createQuery('select a from Doctrine\Tests\Models\CMS\CmsArticle a')
+        $this->_em->createQuery('select a.id from Doctrine\Tests\Models\CMS\CmsArticle a')
              ->getSingleScalarResult();
+    }
+
+    public function testGetSingleScalarResultThrowsExceptionOnSingleRowWithMultipleColumns(): void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Javier';
+        $user->username = 'phansys';
+        $user->status   = 'developer';
+
+        $this->_em->persist($user);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->expectException(NonUniqueResultException::class);
+        $this->expectExceptionMessage(
+            'The query returned a row containing multiple columns. Change the query or use a different result function'
+            . ' like getScalarResult().'
+        );
+
+        $this->_em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u')
+            ->setMaxResults(1)
+            ->getSingleScalarResult();
     }
 
     public function testGetSingleScalarResultThrowsExceptionOnNonUniqueResult(): void
     {
-        $this->expectException('Doctrine\ORM\NonUniqueResultException');
         $user           = new CmsUser();
         $user->name     = 'Guilherme';
         $user->username = 'gblanco';
@@ -515,7 +537,12 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->_em->createQuery('select a from Doctrine\Tests\Models\CMS\CmsArticle a')
+        $this->expectException(NonUniqueResultException::class);
+        $this->expectExceptionMessage(
+            'The query returned multiple rows. Change the query or use a different result function like getScalarResult().'
+        );
+
+        $this->_em->createQuery('select a.id from Doctrine\Tests\Models\CMS\CmsArticle a')
              ->getSingleScalarResult();
     }
 


### PR DESCRIPTION
* `QueryTest::testGetSingleScalarResultThrowsExceptionOnNonUniqueResult()` was updated to ensure  `NonUniqueResultException` is thrown only on results with multiple rows;
* `QueryTest::testGetSingleScalarResultThrowsExceptionOnSingleRowWithMultipleColumns()` was added to ensure `NonUniqueResultException` is thrown only on results with multiple columns;