### PR TITLE
Temporarily allow `symfony/console` 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/lexer": "^2",
         "doctrine/persistence": "^2.4 || ^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^4.2 || ^5.0 || ^6.0",
+        "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.16"
     },


### PR DESCRIPTION
This change helps Symfony to test Symfony 7 against the ORM. We will likely release ORM 2.16 before Symfony 7, which is why we will need to revert this change before releasing 2.16.0. I'll prepare a PR to do that once this one is merged.

cc @nicolas-grekas 