### PR TITLE
Make the join table name and join column name mandatory

### DIFF
--- a/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMapping.php
@@ -13,7 +13,6 @@ final class JoinColumnMapping implements ArrayAccess
 {
     use ArrayAccessImplementation;
 
-    public string|null $name             = null;
     public bool|null $unique             = null;
     public bool|null $quoted             = null;
     public string|null $fieldName        = null;
@@ -25,6 +24,7 @@ final class JoinColumnMapping implements ArrayAccess
     public array|null $options = null;
 
     public function __construct(
+        public string $name,
         public string $referencedColumnName,
     ) {
     }
@@ -35,7 +35,7 @@ final class JoinColumnMapping implements ArrayAccess
      */
     public static function fromMappingArray(array $mappingArray): self
     {
-        $mapping = new self($mappingArray['referencedColumnName']);
+        $mapping = new self($mappingArray['name'], $mappingArray['referencedColumnName']);
         foreach ($mappingArray as $key => $value) {
             if (property_exists($mapping, $key) && $value !== null) {
                 $mapping->$key = $value;

--- a/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTableMapping.php
@@ -27,12 +27,14 @@ final class JoinTableMapping implements ArrayAccess
 
     public string|null $schema = null;
 
-    public string|null $name = null;
+    public function __construct(public string $name)
+    {
+    }
 
     /**
      * @param mixed[] $mappingArray
      * @psalm-param array{
-     *    name?: string,
+     *    name: string,
      *    quoted?: bool,
      *    joinColumns?: mixed[],
      *    inverseJoinColumns?: mixed[],
@@ -41,9 +43,9 @@ final class JoinTableMapping implements ArrayAccess
      */
     public static function fromMappingArray(array $mappingArray): self
     {
-        $mapping = new self();
+        $mapping = new self($mappingArray['name']);
 
-        foreach (['name', 'quoted', 'schema', 'options'] as $key) {
+        foreach (['quoted', 'schema', 'options'] as $key) {
             if (isset($mappingArray[$key])) {
                 $mapping[$key] = $mappingArray[$key];
             }

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -47,17 +47,16 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
      */
     public static function fromMappingArrayAndNamingStrategy(array $mappingArray, NamingStrategy $namingStrategy): self
     {
-        $mapping = parent::fromMappingArray($mappingArray);
-
         // owning side MUST have a join table
-        if (! isset($mapping->joinTable->name)) {
-            $mapping->joinTable     ??= new JoinTableMapping();
-            $mapping->joinTable->name = $namingStrategy->joinTableName(
-                $mapping->sourceEntity,
-                $mapping->targetEntity,
-                $mapping->fieldName,
+        if (! isset($mappingArray['joinTable']['name'])) {
+            $mappingArray['joinTable']['name'] = $namingStrategy->joinTableName(
+                $mappingArray['sourceEntity'],
+                $mappingArray['targetEntity'],
+                $mappingArray['fieldName'],
             );
         }
+
+        $mapping = parent::fromMappingArray($mappingArray);
 
         $selfReferencingEntityWithoutJoinColumns = $mapping->sourceEntity === $mapping->targetEntity
             && $mapping->joinTable->joinColumns === []

--- a/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToManyOwningSideMapping.php
@@ -47,8 +47,30 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
      */
     public static function fromMappingArrayAndNamingStrategy(array $mappingArray, NamingStrategy $namingStrategy): self
     {
+        if (isset($mappingArray['joinTable']['joinColumns'])) {
+            foreach ($mappingArray['joinTable']['joinColumns'] as $key => $joinColumn) {
+                if (empty($joinColumn['name'])) {
+                    $mappingArray['joinTable']['joinColumns'][$key]['name'] = $namingStrategy->joinKeyColumnName(
+                        $mappingArray['sourceEntity'],
+                        $joinColumn['referencedColumnName'] ?? null,
+                    );
+                }
+            }
+        }
+
+        if (isset($mappingArray['joinTable']['inverseJoinColumns'])) {
+            foreach ($mappingArray['joinTable']['inverseJoinColumns'] as $key => $joinColumn) {
+                if (empty($joinColumn['name'])) {
+                    $mappingArray['joinTable']['inverseJoinColumns'][$key]['name'] = $namingStrategy->joinKeyColumnName(
+                        $mappingArray['targetEntity'],
+                        $joinColumn['referencedColumnName'] ?? null,
+                    );
+                }
+            }
+        }
+
         // owning side MUST have a join table
-        if (! isset($mappingArray['joinTable']['name'])) {
+        if (! isset($mappingArray['joinTable']) || ! isset($mappingArray['joinTable']['name'])) {
             $mappingArray['joinTable']['name'] = $namingStrategy->joinTableName(
                 $mappingArray['sourceEntity'],
                 $mappingArray['targetEntity'],
@@ -85,10 +107,6 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
         $mapping->joinTableColumns = [];
 
         foreach ($mapping->joinTable->joinColumns as $joinColumn) {
-            if (empty($joinColumn->name)) {
-                $joinColumn->name = $namingStrategy->joinKeyColumnName($mapping->sourceEntity, $joinColumn->referencedColumnName);
-            }
-
             if (empty($joinColumn->referencedColumnName)) {
                 $joinColumn->referencedColumnName = $namingStrategy->referenceColumnName();
             }
@@ -112,10 +130,6 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
         }
 
         foreach ($mapping->joinTable->inverseJoinColumns as $inverseJoinColumn) {
-            if (empty($inverseJoinColumn->name)) {
-                $inverseJoinColumn->name = $namingStrategy->joinKeyColumnName($mapping->targetEntity, $inverseJoinColumn->referencedColumnName);
-            }
-
             if (empty($inverseJoinColumn->referencedColumnName)) {
                 $inverseJoinColumn->referencedColumnName = $namingStrategy->referenceColumnName();
             }

--- a/lib/Doctrine/ORM/Mapping/ToOneOwningSideMapping.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneOwningSideMapping.php
@@ -74,6 +74,14 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
         array|null $table,
         bool $isInheritanceTypeSingleTable,
     ): static {
+        if (isset($mappingArray['joinColumns'])) {
+            foreach ($mappingArray['joinColumns'] as $index => $joinColumn) {
+                if (empty($joinColumn['name'])) {
+                    $mappingArray['joinColumns'][$index]['name'] = $namingStrategy->joinColumnName($mappingArray['fieldName'], $name);
+                }
+            }
+        }
+
         $mapping = static::fromMappingArray($mappingArray);
 
         assert($mapping->isToOneOwningSide());
@@ -98,10 +106,6 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
                 } else {
                     $uniqueConstraintColumns[] = $joinColumn->name;
                 }
-            }
-
-            if (empty($joinColumn->name)) {
-                $joinColumn->name = $namingStrategy->joinColumnName($mapping->fieldName, $name);
             }
 
             if (empty($joinColumn->referencedColumnName)) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -582,12 +582,6 @@
     <PropertyNotSetInConstructor>
       <code>$joinTable</code>
     </PropertyNotSetInConstructor>
-    <RedundantCondition>
-      <code><![CDATA[$mapping->joinTable]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainType>
-      <code>new JoinTableMapping()</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/OneToManyAssociationMapping.php">
     <PropertyNotSetInConstructor>

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinColumnMappingTest.php
@@ -15,9 +15,8 @@ final class JoinColumnMappingTest extends TestCase
 {
     public function testItSurvivesSerialization(): void
     {
-        $mapping = new JoinColumnMapping('id');
+        $mapping = new JoinColumnMapping('foo', 'id');
 
-        $mapping->name                 = 'foo';
         $mapping->unique               = true;
         $mapping->quoted               = true;
         $mapping->fieldName            = 'bar';

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
@@ -16,13 +16,12 @@ final class JoinTableMappingTest extends TestCase
 {
     public function testItSurvivesSerialization(): void
     {
-        $mapping = new JoinTableMapping();
+        $mapping = new JoinTableMapping('bar');
 
         $mapping->quoted             = true;
         $mapping->joinColumns        = [new JoinColumnMapping('id')];
         $mapping->inverseJoinColumns = [new JoinColumnMapping('id')];
         $mapping->schema             = 'foo';
-        $mapping->name               = 'bar';
         $mapping->options            = ['foo' => 'bar'];
 
         $resurrectedMapping = unserialize(serialize($mapping));

--- a/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/JoinTableMappingTest.php
@@ -19,8 +19,8 @@ final class JoinTableMappingTest extends TestCase
         $mapping = new JoinTableMapping('bar');
 
         $mapping->quoted             = true;
-        $mapping->joinColumns        = [new JoinColumnMapping('id')];
-        $mapping->inverseJoinColumns = [new JoinColumnMapping('id')];
+        $mapping->joinColumns        = [new JoinColumnMapping('foo_id', 'id')];
+        $mapping->inverseJoinColumns = [new JoinColumnMapping('bar_id', 'id')];
         $mapping->schema             = 'foo';
         $mapping->options            = ['foo' => 'bar'];
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
@@ -22,8 +22,7 @@ final class ManyToManyOwningSideMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->joinTable                  = new JoinTableMapping();
-        $mapping->joinTable->name            = 'bar';
+        $mapping->joinTable                  = new JoinTableMapping('bar');
         $mapping->joinTableColumns           = ['foo', 'bar'];
         $mapping->relationToSourceKeyColumns = ['foo' => 'bar'];
         $mapping->relationToTargetKeyColumns = ['bar' => 'baz'];

--- a/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
@@ -22,7 +22,7 @@ final class ManyToOneAssociationMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->joinColumns              = [new JoinColumnMapping('id')];
+        $mapping->joinColumns              = [new JoinColumnMapping('foo_id', 'id')];
         $mapping->joinColumnFieldNames     = ['foo' => 'bar'];
         $mapping->sourceToTargetKeyColumns = ['foo' => 'bar'];
         $mapping->targetToSourceKeyColumns = ['bar' => 'foo'];

--- a/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
@@ -22,7 +22,7 @@ final class OneToOneOwningSideMappingTest extends TestCase
             targetEntity: self::class,
         );
 
-        $mapping->joinColumns              = [new JoinColumnMapping('id')];
+        $mapping->joinColumns              = [new JoinColumnMapping('foo_id', 'id')];
         $mapping->joinColumnFieldNames     = ['foo' => 'bar'];
         $mapping->sourceToTargetKeyColumns = ['foo' => 'bar'];
         $mapping->targetToSourceKeyColumns = ['bar' => 'foo'];


### PR DESCRIPTION
Found while working on migrating towards the object API of `Join{Column,Table}Mapping`.