### PR TITLE
Fix Lexer deprecation

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -582,7 +582,7 @@ class Parser
         assert($this->lexer->lookahead !== null);
 
         return in_array(
-            $this->lexer->lookahead['type'],
+            $this->lexer->lookahead->type,
             [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME],
             true
         );


### PR DESCRIPTION
Hi,

This (very) small PR to fix a lexer deprecation:

> Accessing Doctrine\Common\Lexer\Token properties via ArrayAccess is deprecated, use the value, type or position property instead (Token.php:104 called by Parser.php:585, https://github.com/doctrine/lexer/pull/79, package doctrine/lexer)

I think the fix is okay for 2.15.x branch as it requires doctrine/lexer:^2.