### PR TITLE
Fix deprecations from doctrine/lexer

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -582,7 +582,7 @@ class Parser
         assert($this->lexer->lookahead !== null);
 
         return in_array(
-            $this->lexer->lookahead['type'],
+            $this->lexer->lookahead->type,
             [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME],
             true
         );
@@ -978,7 +978,7 @@ class Parser
             $this->match(Lexer::T_IDENTIFIER);
             assert($this->lexer->token !== null);
 
-            return $this->lexer->token['value'];
+            return $this->lexer->token->value;
         }
 
         $this->match(Lexer::T_ALIASED_NAME);
@@ -989,10 +989,10 @@ class Parser
             'doctrine/orm',
             'https://github.com/doctrine/orm/issues/8818',
             'Short namespace aliases such as "%s" are deprecated and will be removed in Doctrine ORM 3.0.',
-            $this->lexer->token['value']
+            $this->lexer->token->value
         );
 
-        [$namespaceAlias, $simpleClassName] = explode(':', $this->lexer->token['value']);
+        [$namespaceAlias, $simpleClassName] = explode(':', $this->lexer->token->value);
 
         return $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
     }


### PR DESCRIPTION
Not triggering self-deprecations is easy when you have the right process.

Since we enabled reporting of Doctrine deprecations on the CI of Symfony, we can tell that the processes here are severely broken, as in: E_TOO_MANY_SELF_DEPRECATIONS.

Here is one of them, the community will send more fixes as we make progress on the topic.

Doctrine v3 is going to be a risky release if the processes are not fixed before.

This feels so Symfony-2.7 :(

Sorry for the bad-mood message but it's not like I didn't extensively explain that this was about to happen when doctrine/deprecations was introduced...

With the right processes, deprecations would have been MUCH cheaper to deal with for everybody: maintainers and users.