### PR TITLE
Don't call deprecated getSQLResultCasing and usesSequenceEmulatedIdentityColumns when we know the platform

### DIFF
--- a/lib/Doctrine/ORM/Internal/SQLResultCasing.php
+++ b/lib/Doctrine/ORM/Internal/SQLResultCasing.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
+use function get_class;
 use function method_exists;
+use function strpos;
 use function strtolower;
 use function strtoupper;
 
@@ -26,7 +28,7 @@ trait SQLResultCasing
             return strtolower($column);
         }
 
-        if (method_exists(AbstractPlatform::class, 'getSQLResultCasing')) {
+        if (strpos(get_class($platform), 'Doctrine\\DBAL\\Platforms\\') !== 0 && method_exists(AbstractPlatform::class, 'getSQLResultCasing')) {
             return $platform->getSQLResultCasing($column);
         }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -7,6 +7,9 @@ namespace Doctrine\ORM\Mapping;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
@@ -621,9 +624,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             case ClassMetadata::GENERATOR_TYPE_IDENTITY:
                 $sequenceName = null;
                 $fieldName    = $class->identifier ? $class->getSingleIdentifierFieldName() : null;
+                $platform     = $this->getTargetPlatform();
 
                 // Platforms that do not have native IDENTITY support need a sequence to emulate this behaviour.
-                if ($this->getTargetPlatform()->usesSequenceEmulatedIdentityColumns()) {
+                /** @psalm-suppress UndefinedClass, InvalidClass */
+                if (! $platform instanceof MySQLPlatform && ! $platform instanceof SqlitePlatform && ! $platform instanceof SQLServerPlatform && $platform->usesSequenceEmulatedIdentityColumns()) {
                     Deprecation::trigger(
                         'doctrine/orm',
                         'https://github.com/doctrine/orm/issues/8850',

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -10,6 +10,9 @@ parameters:
         - '/Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\./'
         # Class name will change in DBAL 3.
         - '/^Class Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform not found\.$/'
+        -
+            message: '/Doctrine\\DBAL\\Platforms\\MyS(ql|QL)Platform/'
+            path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
         # Forward compatibility for DBAL 3.5
         - '/^Call to an undefined method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getAlterSchemaSQL\(\).$/'


### PR DESCRIPTION
Saves triggering the deprecation on PHP 7 where only DBAL v2 can be used:

> "AbstractPlatform::getSQLResultCasing is deprecated without replacement and removed in DBAL 3.Use Portability\\Connection with PORTABILITY_FIX_CASE to get portable result cases. (AbstractPlatform.php:3515 called by SQLResultCasing.php:30, https://github.com/doctrine/dbal/pull/4229, package doctrine/dbal)": 246,
    