### PR TITLE
Trigger deprecation in AnnotationDriver only if PHP >= 8.0

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -28,6 +28,8 @@ use function get_class;
 use function is_array;
 use function is_numeric;
 
+use const PHP_VERSION_ID;
+
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
  */
@@ -62,11 +64,14 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
      */
     public function __construct($reader, $paths = null)
     {
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/orm/issues/10098',
-            'The annotation mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to the attribute or XML driver.'
-        );
+        if (PHP_VERSION_ID >= 80000) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/10098',
+                'The annotation mapping driver is deprecated and will be removed in Doctrine ORM 3.0, please migrate to the attribute or XML driver.'
+            );
+        }
+
         $this->reader = $reader;
 
         $this->addPaths((array) $paths);


### PR DESCRIPTION
Hello, I think it would make sense to not trigger this deprecation when it's impossible to migrate to the new AttributeDriver because of the PHP version. The deprecation is not actionable: I don't really consider switching to the XML driver a viable migration.
People running PHP < 8.0 won't be able to use Doctrine 3.0 anyway since it requires PHP 8.1.