### PR TITLE
Defer removing removed entities from to-many collections until after transaction commit

### DIFF
--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -881,6 +881,15 @@ Generated MySQL Schema:
     replaced by one-to-many/many-to-one associations between the 3
     participating classes.
 
+.. note::
+
+    For many-to-many associations, the ORM takes care of managing rows
+    in the join table connecting both sides. Due to the way it deals
+    with entity removals, database-level constraints may not work the
+    way one might intuitively assume. Thus, be sure not to miss the section
+    on :ref:`join table management <remove_object_many_to_many_join_tables>`.
+
+
 Many-To-Many, Bidirectional
 ---------------------------
 
@@ -1018,6 +1027,15 @@ one is bidirectional.
 
 The MySQL schema is exactly the same as for the Many-To-Many
 uni-directional case above.
+
+.. note::
+
+    For many-to-many associations, the ORM takes care of managing rows
+    in the join table connecting both sides. Due to the way it deals
+    with entity removals, database-level constraints may not work the
+    way one might intuitively assume. Thus, be sure not to miss the section
+    on :ref:`join table management <remove_object_many_to_many_join_tables>`.
+
 
 Owning and Inverse Side on a ManyToMany Association
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -538,7 +538,7 @@ class BasicEntityPersister implements EntityPersister
     protected function deleteJoinTableRecords(array $identifier, array $types): void
     {
         foreach ($this->class->associationMappings as $mapping) {
-            if ($mapping['type'] !== ClassMetadata::MANY_TO_MANY) {
+            if ($mapping['type'] !== ClassMetadata::MANY_TO_MANY || isset($mapping['isOnDeleteCascade'])) {
                 continue;
             }
 
@@ -572,10 +572,6 @@ class BasicEntityPersister implements EntityPersister
 
             foreach ($otherColumns as $joinColumn) {
                 $otherKeys[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
-            }
-
-            if (isset($mapping['isOnDeleteCascade'])) {
-                continue;
             }
 
             $joinTableName = $this->quoteStrategy->getJoinTableName($association, $this->class, $this->platform);

--- a/tests/Doctrine/Tests/ORM/Functional/GH10752Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH10752Test.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @Group GH10752
+ */
+class GH10752Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH10752Order::class,
+            GH10752Promotion::class,
+        ]);
+    }
+
+    public function testThrowExceptionWhenRemovingPromotionThatIsInUse(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $order     = $this->createOrder();
+        $promotion = $this->createPromotion();
+
+        $order->addPromotion($promotion);
+
+        $this->_em->persist($order);
+        $this->_em->persist($promotion);
+        $this->_em->flush();
+
+        $this->_em->remove($promotion);
+
+        $this->expectException(ForeignKeyConstraintViolationException::class);
+        $this->_em->flush();
+    }
+
+    public function testThrowExceptionWhenRemovingPromotionThatIsInUseAndOrderIsNotInMemory(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $order     = $this->createOrder();
+        $promotion = $this->createPromotion();
+
+        $order->addPromotion($promotion);
+
+        $this->_em->persist($order);
+        $this->_em->persist($promotion);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $promotion = $this->_em->find(GH10752Promotion::class, $promotion->getId());
+        $this->_em->remove($promotion);
+
+        $this->expectException(ForeignKeyConstraintViolationException::class);
+        $this->_em->flush();
+    }
+
+    private function createOrder(): GH10752Order
+    {
+        return new GH10752Order();
+    }
+
+    private function createPromotion(): GH10752Promotion
+    {
+        return new GH10752Promotion();
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10752Order
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id = null;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="GH10752Promotion", cascade={"persist"})
+     * @ORM\JoinTable(name="order_promotion",
+     *      joinColumns={@ORM\JoinColumn(name="order_id", referencedColumnName="id", onDelete="CASCADE")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="promotion_id", referencedColumnName="id")}
+     * )
+     *
+     * @var Collection
+     */
+    private $promotions;
+
+    public function __construct()
+    {
+        $this->promotions = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPromotions(): Collection
+    {
+        return $this->promotions;
+    }
+
+    public function addPromotion(GH10752Promotion $promotion): void
+    {
+        if (! $this->promotions->contains($promotion)) {
+            $this->promotions->add($promotion);
+        }
+    }
+
+    public function removePromotion(GH10752Promotion $promotion): void
+    {
+        if ($this->promotions->contains($promotion)) {
+            $this->promotions->removeElement($promotion);
+        }
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10752Promotion
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/GH10752Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH10752Test.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
- * @Group GH10752
+ * @group GH10752
  */
 class GH10752Test extends OrmFunctionalTestCase
 {
@@ -31,8 +31,8 @@ class GH10752Test extends OrmFunctionalTestCase
             self::markTestSkipped('Platform does not support foreign keys.');
         }
 
-        $order     = $this->createOrder();
-        $promotion = $this->createPromotion();
+        $order     = new GH10752Order();
+        $promotion = new GH10752Promotion();
 
         $order->addPromotion($promotion);
 
@@ -52,8 +52,8 @@ class GH10752Test extends OrmFunctionalTestCase
             self::markTestSkipped('Platform does not support foreign keys.');
         }
 
-        $order     = $this->createOrder();
-        $promotion = $this->createPromotion();
+        $order     = new GH10752Order();
+        $promotion = new GH10752Promotion();
 
         $order->addPromotion($promotion);
 
@@ -63,21 +63,11 @@ class GH10752Test extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $promotion = $this->_em->find(GH10752Promotion::class, $promotion->getId());
+        $promotion = $this->_em->find(GH10752Promotion::class, $promotion->id);
         $this->_em->remove($promotion);
 
         $this->expectException(ForeignKeyConstraintViolationException::class);
         $this->_em->flush();
-    }
-
-    private function createOrder(): GH10752Order
-    {
-        return new GH10752Order();
-    }
-
-    private function createPromotion(): GH10752Promotion
-    {
-        return new GH10752Promotion();
     }
 }
 
@@ -111,27 +101,10 @@ class GH10752Order
         $this->promotions = new ArrayCollection();
     }
 
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
-
-    public function getPromotions(): Collection
-    {
-        return $this->promotions;
-    }
-
     public function addPromotion(GH10752Promotion $promotion): void
     {
         if (! $this->promotions->contains($promotion)) {
             $this->promotions->add($promotion);
-        }
-    }
-
-    public function removePromotion(GH10752Promotion $promotion): void
-    {
-        if ($this->promotions->contains($promotion)) {
-            $this->promotions->removeElement($promotion);
         }
     }
 }
@@ -148,10 +121,5 @@ class GH10752Promotion
      *
      * @var int
      */
-    private $id = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
+    public $id = null;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -101,6 +101,9 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         //$user->getGroups()->remove(0);
 
         $this->_em->flush();
+
+        self::assertFalse($user->getGroups()->isDirty());
+
         $this->_em->clear();
 
         // Reload same user
@@ -232,8 +235,14 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         }
 
         $this->_em->flush();
+
+        // Changes to in-memory collection have been made and flushed
+        self::assertCount(0, $user->getGroups());
+        self::assertFalse($user->getGroups()->isDirty());
+
         $this->_em->clear();
 
+        // Changes have been made to the database
         $newUser = $this->_em->find(get_class($user), $user->getId());
         self::assertCount(0, $newUser->getGroups());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -144,7 +144,12 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
 
         $user->groups->clear();
 
+        $this->getQueryLog()->reset()->enable();
         $this->_em->flush();
+
+        // Deletions of entire collections happen in a single query
+        $this->removeTransactionCommandsFromQueryLog();
+        self::assertQueryCount(1);
 
         // Check that the links in the association table have been deleted
         $this->assertGblancoGroupCountIs(0);
@@ -215,11 +220,19 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
     /** @group DDC-130 */
     public function testRemoveUserWithManyGroups(): void
     {
-        $user   = $this->addCmsUserGblancoWithGroups(2);
+        $user   = $this->addCmsUserGblancoWithGroups(10);
         $userId = $user->getId();
 
         $this->_em->remove($user);
+
+        $this->getQueryLog()->reset()->enable();
+
         $this->_em->flush();
+
+        // This takes three queries: One to delete all user -> group join table rows for the user,
+        // one to delete all user -> tags join table rows for the user, and a final one to delete the user itself.
+        $this->removeTransactionCommandsFromQueryLog();
+        self::assertQueryCount(3);
 
         $newUser = $this->_em->find(get_class($user), $userId);
         self::assertNull($newUser);
@@ -228,13 +241,32 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
     /** @group DDC-130 */
     public function testRemoveGroupWithUser(): void
     {
-        $user = $this->addCmsUserGblancoWithGroups(2);
+        $user = $this->addCmsUserGblancoWithGroups(5);
+
+        $anotherUser = new CmsUser();
+        $anotherUser->username = 'joe_doe';
+        $anotherUser->name = 'Joe Doe';
+        $anotherUser->status = 'QA Engineer';
+
+        foreach ($user->getGroups() as $group) {
+            $anotherUser->addGroup($group);
+        }
+
+        $this->_em->persist($anotherUser);
+        $this->_em->flush();
 
         foreach ($user->getGroups() as $group) {
             $this->_em->remove($group);
         }
 
+        $this->getQueryLog()->reset()->enable();
         $this->_em->flush();
+
+        // This takes 5 * 2 queries – for each group to be removed, one to remove all join table rows
+        // for the CmsGroup -> CmsUser inverse side association (for both users at once),
+        // and one for the group itself.
+        $this->removeTransactionCommandsFromQueryLog();
+        self::assertQueryCount(10);
 
         // Changes to in-memory collection have been made and flushed
         self::assertCount(0, $user->getGroups());
@@ -252,7 +284,13 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $user         = $this->addCmsUserGblancoWithGroups(2);
         $user->groups = null;
 
+        $this->getQueryLog()->reset()->enable();
         $this->_em->flush();
+
+        // It takes one query to remove all join table rows for the user at once
+        $this->removeTransactionCommandsFromQueryLog();
+        self::assertQueryCount(1);
+
         $this->_em->clear();
 
         $newUser = $this->_em->find(get_class($user), $user->getId());
@@ -536,5 +574,16 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         self::assertEquals('Developers_0', $firstGroup->name);
 
         self::assertFalse($user->groups->isInitialized(), 'Post-condition: matching does not initialize collection');
+    }
+
+    private function removeTransactionCommandsFromQueryLog(): void
+    {
+        $log = $this->getQueryLog();
+
+        foreach ($log->queries as $key => $entry) {
+            if ($entry['sql'] === '"START TRANSACTION"' || $entry['sql'] === '"COMMIT"') {
+                unset($log->queries[$key]);
+            }
+        }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -243,10 +243,10 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
     {
         $user = $this->addCmsUserGblancoWithGroups(5);
 
-        $anotherUser = new CmsUser();
+        $anotherUser           = new CmsUser();
         $anotherUser->username = 'joe_doe';
-        $anotherUser->name = 'Joe Doe';
-        $anotherUser->status = 'QA Engineer';
+        $anotherUser->name     = 'Joe Doe';
+        $anotherUser->status   = 'QA Engineer';
 
         foreach ($user->getGroups() as $group) {
             $anotherUser->addGroup($group);

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
@@ -30,21 +30,22 @@ class ManyToManyEventTest extends OrmFunctionalTestCase
 
     public function testListenerShouldBeNotifiedWhenNewCollectionEntryAdded(): void
     {
-        $user = $this->createNewValidUser();
+        $user        = $this->createNewValidUser();
+        $group       = new CmsGroup();
+        $group->name = 'admins';
+
         $this->_em->persist($user);
+        $this->_em->persist($group);
         $this->_em->flush();
         self::assertFalse($this->listener->wasNotified);
 
-        $group       = new CmsGroup();
-        $group->name = 'admins';
         $user->addGroup($group);
-        $this->_em->persist($user);
         $this->_em->flush();
 
         self::assertTrue($this->listener->wasNotified);
     }
 
-    public function testListenerShouldBeNotifiedWhenNewCollectionEntryRemoved(): void
+    public function testListenerShouldBeNotifiedWhenCollectionEntryRemoved(): void
     {
         $user        = $this->createNewValidUser();
         $group       = new CmsGroup();
@@ -52,10 +53,11 @@ class ManyToManyEventTest extends OrmFunctionalTestCase
         $user->addGroup($group);
 
         $this->_em->persist($user);
+        $this->_em->persist($group);
         $this->_em->flush();
         self::assertFalse($this->listener->wasNotified);
 
-        $this->_em->remove($group);
+        $user->getGroups()->removeElement($group);
         $this->_em->flush();
 
         self::assertTrue($this->listener->wasNotified);


### PR DESCRIPTION
This PR fixes regressions introduced in 2.15.1 related to how the `UnitOfWork` and `EntityPersister`s implement removal of entities that are part of many-to-many collections.

#### Background

To better understand the problem and regressions caused, we need to take a look at how the ORM deals with many-to-many associations when an entity shall be removed that is part of such an association.

`BasicEntityPersister::deleteJoinTableRecords()` is the method responsible for efficient removal of join-table rows in the database when a single entity is removed. It will `DELETE` all join-table rows referring to the entity in question before the entity is removed itself. This only works when the many-to-many association is declared on the entity's side (ie. its a bi-directional many-to-many association, or the entity is the owning side). Otherwise, since the ORM cannot detect associations that are declared in other classes only, join tables are left alone and database-level constraints apply.

`BasicEntityPersister::deleteJoinTableRecords()` implements a rather efficient join-table row removal, since a single `DELETE` query per removed entity and association can be used to possibly delete multiple rows (for associations with different other entities).

Besides deleting join-table rows in the database, we also want to update collections to no longer contain the removed entity. Removing the entity from these collections is the in-memory equivalent to removing the join table rows in the database.

Early during the commit phase, the `UnitOfWork::computeAssociationChanges()` method is responsible for looking at all associations in all in-memory entities. Among a few other tasks, it will identify all "dirty" collections – those that have been changed and need to be flushed to the database. This method will also check all collections for entities pending removal, and it will remove (unset) these entities from the collections.

#### Current situation

#10485 complained that the `computeAssociationChanges` would first take note of the "dirty" collections and then unset entities pending removal. The consequences of this were that 
* in collections that were already dirty (changed) _before_ `flush()` was called, the join-table row would be removed with a dedicated `DELETE` statement, while bringing the collection and database in sync
* more importantly, previously clean collections would be dirty after `flush()` returns (the opposite of what `flush()` is supposed to achieve), and subsequent `flush()` operations would fail since a `DELETE` statement would be issued for an entity that was no longer in the identity map.

The fix in #10486 (contained in 2.15.1) tried to address this by _first_ unsetting the to-be-removed entities _before_ taking note of (then) dirty collections. This caused unintended behavior changes that were not spotted by tests:
* Since collection updates are done first, we now use single `DELETE` statements for every join-table row deletion. `BasicEntityPersister::deleteJoinTableRecords()` was effectively bypassed for those collections that were loaded into memory at that time. More queries are used than necessary.
* #10752 reports a use case where the to-be-removed entity _does not_ declare the many-to-many association. Pre #10486, this would always mean database-level constraints apply, since the ORM does not touch join-table rows in that case. But with the #10486 changes _and_ given a collection containing the to-be-removed entity is in memory, we ended up doing join-table row removals first – circumventing database-level constraints.

#### Suggested fix

* Improve `ManyToManyBasicAssociationTest` to make sure collections are clean after `flush()` returns, and include assertions regarding the expected query count. This would have spotted per-row `DELETE`s instead of using the optimized persister method
* Do not modify collections during `computeAssociationChanges`, but instead track which entity needs to be removed from which collection in a dedicated array
* This way, join-tables will be dealt with by the `deleteJoinTableRecords` method only
* After all changes have been flushed successfully, in the finishing phase of the UoW commit, go back to the list of tracked entity removals. Remove the entities from the respective collections immediately before taking new snapshots (= defining the new "clean" state). This makes sure we only do in-memory cleanups and cause no additional database operations due to removals.
* Improve documentation to raise awareness of how this proess works

Fixes #10752, closes #10753.

