### PR TITLE
Limit Count in Entity persister

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1150,9 +1150,15 @@ class BasicEntityPersister implements EntityPersister
                 : $filterSql;
         }
 
-        return 'SELECT COUNT(*) '
-            . 'FROM ' . $tableName . ' ' . $tableAlias
-            . (empty($conditionSql) ? '' : ' WHERE ' . $conditionSql);
+        $sql =  'SELECT COUNT(*) '
+        . 'FROM ' . $tableName . ' ' . $tableAlias
+        . (empty($conditionSql) ? '' : ' WHERE ' . $conditionSql);
+
+        if ($criteria instanceof Criteria && $criteria->getMaxResults() !== null) {
+            $sql .= ' LIMIT ' . $criteria->getMaxResults();
+        }
+
+        return $sql;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -149,6 +149,11 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
         $criteria  = new Criteria(Criteria::expr()->eq('value', 'bar'));
         $statement = $persister->getCountSQL($criteria);
         self::assertEquals('SELECT COUNT(*) FROM "not-a-simple-entity" t0 WHERE t0."simple-entity-value" = ?', $statement);
+
+        // Using a criteria object w/ Limit
+        $criteria  = new Criteria(Criteria::expr()->eq('value', 'bar'), null, null, 5000);
+        $statement = $persister->getCountSQL($criteria);
+        self::assertEquals('SELECT COUNT(*) FROM "not-a-simple-entity" t0 WHERE t0."simple-entity-value" = ? LIMIT 5000', $statement);
     }
 
     public function testCountEntities(): void


### PR DESCRIPTION
Closes #10766

I wasn't sure how to test it beyond following what was already in there, so if more rigorous testing is desired please suggest what you'd like to see. That said, I think it's pretty straightforward. If the maintainers would prefer, I can put the added code in a helper method (`getCriteriaLimit`) to make it less ugly.