### PR TITLE
PHPStan 1.10.18, Psalm 5.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,14 @@
         "doctrine/annotations": "^1.13 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "phpbench/phpbench": "^0.16.10 || ^1.0",
-        "phpstan/phpstan": "~1.4.10 || 1.10.14",
+        "phpstan/phpstan": "~1.4.10 || 1.10.18",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.2",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "vimeo/psalm": "4.30.0 || 5.11.0"
+        "vimeo/psalm": "4.30.0 || 5.12.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >= 3.0"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
+<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
     <DeprecatedClass>
       <code>IterableResult</code>
@@ -212,6 +212,11 @@
     <MoreSpecificReturnType>
       <code>CacheProvider</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/FileLockRegion.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[sprintf('%s/*.%s', $this->directory, self::LOCK_EXTENSION)]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Cache/RegionsConfiguration.php">
     <RedundantCastGivenDocblockType>
@@ -437,6 +442,9 @@
     <ReferenceReusedFromConfusingScope>
       <code>$baseElement</code>
     </ReferenceReusedFromConfusingScope>
+    <UnsupportedPropertyReferenceUsage>
+      <code><![CDATA[$baseElement =& $this->resultPointers[$parent]]]></code>
+    </UnsupportedPropertyReferenceUsage>
     <UnsupportedReferenceUsage>
       <code><![CDATA[$baseElement =& $this->resultPointers[$parent][key($first)]]]></code>
       <code><![CDATA[$this->resultPointers[$dqlAlias] =& $coll[key($coll)]]]></code>
@@ -2456,6 +2464,9 @@
     </MissingTemplateParam>
   </file>
   <file src="lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$path . '/*.yml']]></code>
+    </ArgumentTypeCoercion>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$column['type']]]></code>
     </PossiblyUndefinedArrayOffset>


### PR DESCRIPTION
Psalm started to report false-positive errors about `glob()` requiring a non-empty string, but I could not manage to get a clean reproducer. Maybe this has been solved already?