### PR TITLE
Fix missing setFilterSchemaAssetsExpression in phpdoc

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -80,7 +80,7 @@ on a global level:
             $assetName = $assetName->getName();
         }
 
-        return str_starts_with($assetName, 'audit_');
+        return !str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -75,7 +75,13 @@ in Doctrine 2 and can be used as runtime mapping for the ORM.
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setFilterSchemaAssetsExpression($regexp);
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return (bool) preg_match($regexp, $assetName);
+    });
 EOT
              );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -75,12 +75,12 @@ in Doctrine 2 and can be used as runtime mapping for the ORM.
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName): bool {
         if ($assetName instanceof AbstractAsset) {
             $assetName = $assetName->getName();
         }
 
-        return (bool) preg_match($regexp, $assetName);
+        return str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -40,7 +40,7 @@ on a global level:
             $assetName = $assetName->getName();
         }
 
-        return str_starts_with($assetName, 'audit_');
+        return !str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -35,7 +35,13 @@ Processes the schema and either create it directly on EntityManager Storage Conn
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setFilterSchemaAssetsExpression($regexp);
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return (bool) preg_match($regexp, $assetName);
+    });
 EOT
              );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -35,12 +35,12 @@ Processes the schema and either create it directly on EntityManager Storage Conn
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName): bool {
         if ($assetName instanceof AbstractAsset) {
             $assetName = $assetName->getName();
         }
 
-        return (bool) preg_match($regexp, $assetName);
+        return str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -44,7 +44,7 @@ on a global level:
             $assetName = $assetName->getName();
         }
 
-        return str_starts_with($assetName, 'audit_');
+        return !str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -39,12 +39,12 @@ Beware that the complete database is dropped by this command, even tables that a
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName): bool {
         if ($assetName instanceof AbstractAsset) {
             $assetName = $assetName->getName();
         }
 
-        return (bool) preg_match($regexp, $assetName);
+        return str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -39,7 +39,13 @@ Beware that the complete database is dropped by this command, even tables that a
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setFilterSchemaAssetsExpression($regexp);
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return (bool) preg_match($regexp, $assetName);
+    });
 EOT
              );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -63,12 +63,12 @@ described by any metadata.
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName): bool {
         if ($assetName instanceof AbstractAsset) {
             $assetName = $assetName->getName();
         }
 
-        return (bool) preg_match($regexp, $assetName);
+        return str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -68,7 +68,7 @@ on a global level:
             $assetName = $assetName->getName();
         }
 
-        return str_starts_with($assetName, 'audit_');
+        return !str_starts_with($assetName, 'audit_');
     });
 EOT
              );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -63,7 +63,13 @@ described by any metadata.
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    $config->setFilterSchemaAssetsExpression($regexp);
+    $config->setSchemaAssetsFilter(function (string|AbstractAsset $assetName) use ($regexp): bool {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return (bool) preg_match($regexp, $assetName);
+    });
 EOT
              );
     }


### PR DESCRIPTION
Starting from `doctrine/dbal`  `2.9.0` [MR](https://github.com/doctrine/dbal/pull/3316) method `setFilterSchemaAssetsExpression` is deprecated and finally removed in `3.0.0` [MR](https://github.com/doctrine/dbal/pull/3518)

The PR updates docs to the current schema