### PR TITLE
Fix attach entity listener when reset class metadata factory

### DIFF
--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -56,7 +56,5 @@ class AttachEntityListenersListener
                 $metadata->addEntityListener($listener['event'], $listener['class'], $listener['method']);
             }
         }
-
-        unset($this->entityListeners[$metadata->name]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -56,6 +56,17 @@ class AttachEntityListenersListenerTest extends OrmTestCase
         self::assertCount(1, $metadata->entityListeners['postLoad']);
         self::assertEquals('postLoadHandler', $metadata->entityListeners['postLoad'][0]['method']);
         self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postLoad'][0]['class']);
+
+        // Can reattach entity listeners even class metadata factory recreated.
+        $factory2 = new ClassMetadataFactory();
+        $factory2->setEntityManager($this->em);
+
+        $metadata2 = $factory2->getMetadataFor(AttachEntityListenersListenerTestFooEntity::class);
+
+        self::assertArrayHasKey('postLoad', $metadata2->entityListeners);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata2->entityListeners['postLoad'][0]['class']);
+        self::assertCount(1, $metadata2->entityListeners['postLoad']);
+        self::assertEquals('postLoadHandler', $metadata2->entityListeners['postLoad'][0]['method']);
     }
 
     public function testAttachToExistingEntityListeners(): void

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -64,9 +64,9 @@ class AttachEntityListenersListenerTest extends OrmTestCase
         $metadata2 = $factory2->getMetadataFor(AttachEntityListenersListenerTestFooEntity::class);
 
         self::assertArrayHasKey('postLoad', $metadata2->entityListeners);
-        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata2->entityListeners['postLoad'][0]['class']);
         self::assertCount(1, $metadata2->entityListeners['postLoad']);
         self::assertEquals('postLoadHandler', $metadata2->entityListeners['postLoad'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata2->entityListeners['postLoad'][0]['class']);
     }
 
     public function testAttachToExistingEntityListeners(): void


### PR DESCRIPTION
When resetting entity manager via registry, if we use `Doctrine\ORM\Tools\AttachEntityListenersListener` to add entity event listeners, it can not be reattached because it delete listener after add on the first time then we will lose all entity listeners after reset entity manager.

Symfony entity listener example:

```php
<?php

declare(strict_types=1);

namespace App\EntityEventListener;


use App\Entity\Company;
use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;


#[AsEntityListener(event: 'prePersist', entity: Company::class)]
class CompanyListener
{
    public function prePersist() : void
    {
        echo 'It work!';
    }
}
```

and console command execution:

```php
    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $manager = $this->registry->getManager();
        $company = new Company();
        $company->setText('1');
        $manager->persist($company);
        $manager->flush();

        $this->registry->resetManager(); /// there's the problem

        $company = new Company();
        $company->setText('2');
        $manager->persist($company);
        $manager->flush();


        return 0;
    }
```

Expect `It work!` should be printed twice but only once.
