### PR TITLE
distinct() updates QueryBuilder state correctly

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -809,7 +809,12 @@ class QueryBuilder
      */
     public function distinct($flag = true)
     {
-        $this->dqlParts['distinct'] = (bool) $flag;
+        $flag = (bool) $flag;
+
+        if ($this->dqlParts['distinct'] !== $flag) {
+            $this->dqlParts['distinct'] = $flag;
+            $this->state                = self::STATE_DIRTY;
+        }
 
         return $this;
     }

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1087,6 +1087,18 @@ class QueryBuilderTest extends OrmTestCase
         self::assertEquals('SELECT DISTINCT u FROM Doctrine\Tests\Models\CMS\CmsUser u', $qb->getDQL());
     }
 
+    public function testDistinctUpdatesState(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u');
+
+        $qb->getDQL();
+        $qb->distinct();
+
+        self::assertEquals('SELECT DISTINCT u FROM Doctrine\Tests\Models\CMS\CmsUser u', $qb->getDQL());
+    }
+
     /** @group DDC-2192 */
     public function testWhereAppend(): void
     {


### PR DESCRIPTION
Previously calling distinct() when the QueryBuilder was in clean state would cause subsequent getDQL() calls to ignore the distinct queryPart

Fixes #10784