### PR TITLE
Work around slevomat/coding-standard issues

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -208,9 +208,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
-     * @deprecated No replacement planned.
-     *
      * Adds a namespace under a certain alias.
+     *
+     * @deprecated No replacement planned.
      *
      * @param string $alias
      * @param string $namespace

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -313,7 +313,6 @@ class ObjectHydrator extends AbstractHydrator
      * that belongs to a particular component/class. Afterwards, all these chunks
      * are processed, one after the other. For each chunk of class data only one of the
      * following code paths is executed:
-     *
      * Path A: The data chunk belongs to a joined/associated object and the association
      *         is collection-valued.
      * Path B: The data chunk belongs to a joined/associated object and the association

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -53,10 +53,9 @@ abstract class AbstractSqlExecutor
     /**
      * Executes all sql statements.
      *
-     * @param Connection $conn The database connection that is used to execute the queries.
-     * @psalm-param list<mixed>|array<string, mixed> $params The parameters.
-     * @psalm-param array<int, int|string|Type|null>|
-     *              array<string, int|string|Type|null> $types The parameter types.
+     * @param Connection                                                           $conn   The database connection that is used to execute the queries.
+     * @param list<mixed>|array<string, mixed>                                     $params The parameters.
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  The parameter types.
      *
      * @return Result|int
      */

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2566,7 +2566,8 @@ class Parser
      *      EmptyCollectionComparisonExpression | CollectionMemberExpression |
      *      InstanceOfExpression
      *
-     * @return AST\BetweenExpression|
+     * @return AST\Node
+     * @psalm-return AST\BetweenExpression|
      *         AST\CollectionMemberExpression|
      *         AST\ComparisonExpression|
      *         AST\EmptyCollectionComparisonExpression|

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -396,21 +396,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message: """
-				#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
-				        AST\\\\CollectionMemberExpression\\|
-				        AST\\\\ComparisonExpression\\|
-				        AST\\\\EmptyCollectionComparisonExpression\\|
-				        AST\\\\ExistsExpression\\|
-				        AST\\\\InExpression\\|
-				        AST\\\\InstanceOfExpression\\|
-				        AST\\\\LikeExpression\\|
-				        AST\\\\NullComparisonExpression\\)\\: Unexpected token "\\\\n     \\* ", expected type at offset 344$#
-			"""
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
 			message: "#^Parameter \\#2 \\$stringPattern of class Doctrine\\\\ORM\\\\Query\\\\AST\\\\LikeExpression constructor expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\Functions\\\\FunctionNode\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\InputParameter\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\Literal\\|Doctrine\\\\ORM\\\\Query\\\\AST\\\\PathExpression, Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/Parser.php

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -103,7 +103,7 @@ class GH5804Article
      * @Id
      * @Column(type="GH5804Type", length=255)
      * @GeneratedValue(strategy="CUSTOM")
-     * @CustomIdGenerator(class=\Doctrine\Tests\ORM\Functional\Ticket\GH5804Generator::class)
+     * @CustomIdGenerator(class=GH5804Generator::class)
      */
     public $id;
 

--- a/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/ClassMetadataExporterTestCase.php
@@ -15,6 +15,8 @@ use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\ORM\Mapping\PostPersist;
+use Doctrine\ORM\Mapping\PrePersist;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
@@ -399,26 +401,26 @@ class Group
 }
 class UserListener
 {
-    /** @\Doctrine\ORM\Mapping\PrePersist */
+    /** @PrePersist */
     public function customPrePersist(): void
     {
     }
 
-    /** @\Doctrine\ORM\Mapping\PostPersist */
+    /** @PostPersist */
     public function customPostPersist(): void
     {
     }
 }
 class GroupListener
 {
-    /** @\Doctrine\ORM\Mapping\PrePersist */
+    /** @PrePersist */
     public function prePersist(): void
     {
     }
 }
 class AddressListener
 {
-    /** @\Doctrine\ORM\Mapping\PostPersist */
+    /** @PostPersist */
     public function customPostPersist(): void
     {
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -384,7 +384,8 @@ class DDC1649Two
 {
     /**
      * @var DDC1649One
-     * @Id @ManyToOne(targetEntity="DDC1649One")
+     * @Id
+     * @ManyToOne(targetEntity="DDC1649One")
      */
     public $one;
 }


### PR DESCRIPTION
I tweaked the code so that it would not fall victim to
slevomat/coding-standard#1585 or
slevomat/coding-standard#1586, thus fixing the
phpcs job without losing information or breaking other jobs.