### PR TITLE
Narrow integer to param class constants

### DIFF
--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Exec;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 
@@ -15,6 +17,8 @@ use Doctrine\DBAL\Types\Type;
  * @link        http://www.doctrine-project.org
  *
  * @todo Rename: AbstractSQLExecutor
+ * @psalm-type WrapperParameterType = string|Type|ParameterType::*|ArrayParameterType::*
+ * @psalm-type WrapperParameterTypeArray = array<int<0, max>, WrapperParameterType>|array<string, WrapperParameterType>
  */
 abstract class AbstractSqlExecutor
 {
@@ -53,9 +57,9 @@ abstract class AbstractSqlExecutor
     /**
      * Executes all sql statements.
      *
-     * @param Connection                                                           $conn   The database connection that is used to execute the queries.
-     * @param list<mixed>|array<string, mixed>                                     $params The parameters.
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  The parameter types.
+     * @param Connection                       $conn   The database connection that is used to execute the queries.
+     * @param list<mixed>|array<string, mixed> $params The parameters.
+     * @psalm-param WrapperParameterTypeArray  $types  The parameter types.
      *
      * @return Result|int
      */


### PR DESCRIPTION
You cannot just pass any integer as a type, it has to map to something meaningful.

The psalm types introduced here are copied from `doctrine/dbal` 4, with a small difference: since we are not dealing with actual enums yet, but with class constants, we add `::*`, which is compatible with both cases (class or enum).