### PR TITLE
Resort on Query::HINT_FORCE_PARTIAL_LOAD less

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -109,8 +109,7 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
     /** @psalm-return list<ECommerceProduct> */
     protected function findProducts(): array
     {
-        $query = $this->_em->createQuery('SELECT p, c FROM Doctrine\Tests\Models\ECommerce\ECommerceProduct p LEFT JOIN p.categories c ORDER BY p.id, c.id');
-        //$query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
+        $query  = $this->_em->createQuery('SELECT p, c FROM Doctrine\Tests\Models\ECommerce\ECommerceProduct p LEFT JOIN p.categories c ORDER BY p.id, c.id');
         $result = $query->getResult();
         self::assertCount(2, $result);
         $cats1 = $result[0]->getCategories();
@@ -126,8 +125,7 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
     /** @psalm-return list<ECommerceCategory> */
     protected function findCategories(): array
     {
-        $query = $this->_em->createQuery('SELECT c, p FROM Doctrine\Tests\Models\ECommerce\ECommerceCategory c LEFT JOIN c.products p ORDER BY c.id, p.id');
-        //$query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
+        $query  = $this->_em->createQuery('SELECT c, p FROM Doctrine\Tests\Models\ECommerce\ECommerceCategory c LEFT JOIN c.products p ORDER BY c.id, p.id');
         $result = $query->getResult();
         self::assertCount(2, $result);
         self::assertInstanceOf(ECommerceCategory::class, $result[0]);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6362Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6362Test.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Mocks\ArrayResultFactory;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -79,7 +78,7 @@ final class GH6362Test extends OrmFunctionalTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertInstanceOf(GH6362Start::class, $result[0]['base']);
         self::assertInstanceOf(GH6362Child::class, $result[1][0]);

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Mocks\ArrayResultFactory;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -65,7 +64,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id,name}
+     * SELECT u
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      */
     public function testSimpleEntityQuery(): void
@@ -89,7 +88,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -104,7 +103,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id,name} AS user
+     * SELECT u AS user
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      */
     public function testSimpleEntityQueryWithAliasedUserEntity(): void
@@ -128,7 +127,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -146,7 +145,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name}, PARTIAL a.{id, topic}
+     * SELECT u, a
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u, Doctrine\Tests\Models\CMS\CmsArticle a
      */
     public function testSimpleMultipleRootEntityQuery(): void
@@ -177,7 +176,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(4, count($result));
 
@@ -200,7 +199,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name} AS user, PARTIAL a.{id, topic}
+     * SELECT u AS user, a
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u, Doctrine\Tests\Models\CMS\CmsArticle a
      */
     public function testSimpleMultipleRootEntityQueryWithAliasedUserEntity(): void
@@ -231,7 +230,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(4, count($result));
 
@@ -261,7 +260,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name}, PARTIAL a.{id, topic} AS article
+     * SELECT u, a AS article
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u, Doctrine\Tests\Models\CMS\CmsArticle a
      */
     public function testSimpleMultipleRootEntityQueryWithAliasedArticleEntity(): void
@@ -292,7 +291,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(4, count($result));
 
@@ -322,7 +321,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name} AS user, PARTIAL a.{id, topic} AS article
+     * SELECT u AS user, a AS article
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u, Doctrine\Tests\Models\CMS\CmsArticle a
      */
     public function testSimpleMultipleRootEntityQueryWithAliasedEntities(): void
@@ -353,7 +352,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(4, count($result));
 
@@ -383,7 +382,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, COUNT(p.phonenumber) numPhones
+     * SELECT u, COUNT(p.phonenumber) numPhones
      *   FROM User u
      *   JOIN u.phonenumbers p
      *  GROUP BY u.id
@@ -415,7 +414,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -433,7 +432,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, PARTIAL p.{phonenumber}, UPPER(u.name) nameUpper
+     * SELECT u, p, UPPER(u.name) nameUpper
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *   JOIN u.phonenumbers p
      *
@@ -479,7 +478,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -559,7 +558,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -673,7 +672,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -803,7 +802,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -916,7 +915,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -936,7 +935,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id,name}
+     * SELECT u
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *
      * @group DDC-644
@@ -959,7 +958,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(1, count($result));
         self::assertInstanceOf(CmsUser::class, $result[0]);
@@ -992,7 +991,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1104,7 +1103,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, PARTIAL a.{id, topic}, PARTIAL c.{id, topic}
+     * SELECT u, a, c
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *   LEFT JOIN u.articles a
      *   LEFT JOIN a.comments c
@@ -1155,7 +1154,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1167,7 +1166,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status} AS user, PARTIAL a.{id, topic}, PARTIAL c.{id, topic}
+     * SELECT u AS user, a, c
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *   LEFT JOIN u.articles a
      *   LEFT JOIN a.comments c
@@ -1218,7 +1217,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1233,7 +1232,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name}
+     * SELECT u
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      */
     public function testResultIteration(): void
@@ -1259,8 +1258,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $iterableResult = $hydrator->iterate(
             ArrayResultFactory::createFromArray($resultSet),
-            $rsm,
-            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+            $rsm
         );
         $rowNum         = 0;
 
@@ -1283,8 +1281,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $iterableResult = $hydrator->toIterable(
             ArrayResultFactory::createFromArray($resultSet),
-            $rsm,
-            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+            $rsm
         );
         $rowNum         = 0;
 
@@ -1308,7 +1305,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, name}
+     * SELECT u
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      */
     public function testResultIterationWithAliasedUserEntity(): void
@@ -1334,8 +1331,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $rowNum         = 0;
         $iterableResult = $hydrator->iterate(
             ArrayResultFactory::createFromArray($resultSet),
-            $rsm,
-            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+            $rsm
         );
 
         while (($row = $iterableResult->next()) !== false) {
@@ -1360,8 +1356,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $rowNum         = 0;
         $iterableResult = $hydrator->toIterable(
             ArrayResultFactory::createFromArray($resultSet),
-            $rsm,
-            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+            $rsm
         );
 
         foreach ($iterableResult as $row) {
@@ -1388,7 +1383,7 @@ class ObjectHydratorTest extends HydrationTestCase
     /**
      * Checks if multiple joined multiple-valued collections is hydrated correctly.
      *
-     * SELECT PARTIAL u.{id, status}, PARTIAL g.{id, name}, PARTIAL p.{phonenumber}
+     * SELECT u, g, p
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *
      * @group DDC-809
@@ -1495,7 +1490,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1511,7 +1506,7 @@ class ObjectHydratorTest extends HydrationTestCase
     /**
      * Checks if multiple joined multiple-valued collections is hydrated correctly.
      *
-     * SELECT PARTIAL u.{id, status} As user, PARTIAL g.{id, name}, PARTIAL p.{phonenumber}
+     * SELECT u As user, g, p
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *
      * @group DDC-809
@@ -1618,7 +1613,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1635,7 +1630,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, UPPER(u.name) as nameUpper
+     * SELECT u, UPPER(u.name) as nameUpper
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *
      * @group DDC-1358
@@ -1676,7 +1671,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(4, count($result), 'Should hydrate four results.');
 
@@ -1693,7 +1688,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, PARTIAL p.{phonenumber}, UPPER(u.name) AS nameUpper
+     * SELECT u, p, UPPER(u.name) AS nameUpper
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *   LEFT JOIN u.phonenumbers u
      *
@@ -1746,7 +1741,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1755,7 +1750,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, PARTIAL a.{id, city}, UPPER(u.name) AS nameUpper
+     * SELECT u, a, UPPER(u.name) AS nameUpper
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *   JOIN u.address a
      *
@@ -1800,7 +1795,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1809,7 +1804,7 @@ class ObjectHydratorTest extends HydrationTestCase
     }
 
     /**
-     * SELECT PARTIAL u.{id, status}, UPPER(u.name) AS nameUpper
+     * SELECT u, UPPER(u.name) AS nameUpper
      *   FROM Doctrine\Tests\Models\CMS\CmsUser u
      *        INDEX BY u.id
      *
@@ -1842,7 +1837,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(2, count($result));
 
@@ -1876,7 +1871,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $stmt     = ArrayResultFactory::createFromArray($resultSet);
         $hydrator = new ObjectHydrator($this->entityManager);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         self::assertEquals(
             [

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -42,7 +42,6 @@ class LanguageRecognitionTest extends OrmTestCase
     public function parseDql(string $dql, array $hints = []): ParserResult
     {
         $query = $this->entityManager->createQuery($dql);
-        $query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
         $query->setDQL($dql);
 
         foreach ($hints as $key => $value) {


### PR DESCRIPTION
A lot of our tests mention it, but I do not think it is important to the test. Maybe it was a way to have more efficient tests? Most times, removing the hint does not affect the test outcome.