### PR TITLE
Add failing test for #3752 (fka DDC-2988)

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\JoinColumns;
+use Doctrine\ORM\Mapping\JoinTable;
+
+/**
+ * @group DDC-2988
+ */
+class DDC2988Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected $groups;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setup()
+    {
+        parent::setup();
+
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2988User'),
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2988Group'),
+            ));
+        } catch (\Exception $e) {
+            return;
+        }
+
+        $group    = new DDC2988Group();
+        $this->_em->persist($group);
+
+        $user           = new DDC2988User();
+        $user->groups[] = $group;
+        $this->_em->persist($user);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+
+    public function testManyToManyFindBy()
+    {
+        $userRepository  = $this->_em->getRepository(__NAMESPACE__ . '\DDC2988User');
+        $groupRepository = $this->_em->getRepository(__NAMESPACE__ . '\DDC2988Group');
+        $groups          = $groupRepository->findAll();
+        $result          = $userRepository->findBy(array('groups' => $groups));
+    }
+}
+
+/** @Entity  @Table(name="ddc_2988_user") */
+class DDC2988User
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @ManyToMany(targetEntity="DDC2988Group")
+     * @JoinTable(name="users_to_groups",
+     *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id")}
+     * )
+     */
+    public $groups;
+
+    public function __contruct()
+    {
+        $this->groups = new ArrayCollection();
+    }
+}
+
+/** @Entity  @Table(name="ddc_2988_group") */
+class DDC2988Group
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
@@ -3,8 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Mapping\JoinColumns;
-use Doctrine\ORM\Mapping\JoinTable;
 
 /**
  * @group DDC-2988
@@ -13,18 +11,14 @@ class DDC2988Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected $groups;
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function setup()
+    protected function setUp()
     {
-        parent::setup();
-
+        parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
-                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2988User'),
-                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2988Group'),
-            ));
+            $this->_schemaTool->createSchema([
+                $this->_em->getClassMetadata(DDC2988User::class),
+                $this->_em->getClassMetadata(DDC2988Group::class),
+            ]);
         } catch (\Exception $e) {
             return;
         }
@@ -43,14 +37,14 @@ class DDC2988Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testManyToManyFindBy()
     {
-        $userRepository  = $this->_em->getRepository(__NAMESPACE__ . '\DDC2988User');
-        $groupRepository = $this->_em->getRepository(__NAMESPACE__ . '\DDC2988Group');
+        $userRepository  = $this->_em->getRepository(DDC2988User::class);
+        $groupRepository = $this->_em->getRepository(DDC2988Group::class);
         $groups          = $groupRepository->findAll();
         $result          = $userRepository->findBy(array('groups' => $groups));
     }
 }
 
-/** @Entity  @Table(name="ddc_2988_user") */
+/** @Entity */
 class DDC2988User
 {
     /** @Id @Column(type="integer") @GeneratedValue */
@@ -70,7 +64,7 @@ class DDC2988User
     }
 }
 
-/** @Entity  @Table(name="ddc_2988_group") */
+/** @Entity */
 class DDC2988Group
 {
     /** @Id @Column(type="integer") @GeneratedValue */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
@@ -1,29 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
  * @group DDC-2988
  */
-class DDC2988Test extends \Doctrine\Tests\OrmFunctionalTestCase
+class DDC2988Test extends OrmFunctionalTestCase
 {
-    protected $groups;
-
-    protected function setUp()
+    public function testManyToManyFindBy(): void
     {
-        parent::setUp();
-        try {
-            $this->_schemaTool->createSchema([
-                $this->_em->getClassMetadata(DDC2988User::class),
-                $this->_em->getClassMetadata(DDC2988Group::class),
-            ]);
-        } catch (\Exception $e) {
-            return;
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC2988User::class),
+            $this->_em->getClassMetadata(DDC2988Group::class),
+        ]);
 
-        $group    = new DDC2988Group();
+        $group = new DDC2988Group();
         $this->_em->persist($group);
 
         $user           = new DDC2988User();
@@ -32,41 +29,55 @@ class DDC2988Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->flush();
         $this->_em->clear();
-    }
 
-
-    public function testManyToManyFindBy()
-    {
         $userRepository  = $this->_em->getRepository(DDC2988User::class);
         $groupRepository = $this->_em->getRepository(DDC2988Group::class);
         $groups          = $groupRepository->findAll();
-        $result          = $userRepository->findBy(array('groups' => $groups));
+
+        $userRepository->findBy(['groups' => $groups]);
     }
 }
 
-/** @Entity */
+/**
+ * @ORM\Entity
+ */
 class DDC2988User
 {
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
     public $id;
 
-    /** @ManyToMany(targetEntity="DDC2988Group")
-     * @JoinTable(name="users_to_groups",
-     *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id")}
+    /**
+     * @ORM\ManyToMany(targetEntity="DDC2988Group")
+     * @ORM\JoinTable(name="users_to_groups",
+     *      joinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="group_id", referencedColumnName="id")}
      * )
      */
     public $groups;
 
-    public function __contruct()
+    public function __construct()
     {
         $this->groups = new ArrayCollection();
     }
 }
 
-/** @Entity */
+/**
+ * @ORM\Entity
+ */
 class DDC2988Group
 {
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2988Test.php
@@ -20,21 +20,30 @@ class DDC2988Test extends OrmFunctionalTestCase
             $this->_em->getClassMetadata(DDC2988Group::class),
         ]);
 
-        $group = new DDC2988Group();
-        $this->_em->persist($group);
+        $group1 = new DDC2988Group();
+        $this->_em->persist($group1);
 
-        $user           = new DDC2988User();
-        $user->groups[] = $group;
-        $this->_em->persist($user);
+        $group2 = new DDC2988Group();
+        $this->_em->persist($group2);
+
+        $user1           = new DDC2988User();
+        $user1->groups[] = $group1;
+        $this->_em->persist($user1);
+
+        $user2           = new DDC2988User();
+        $user2->groups[] = $group1;
+        $this->_em->persist($user2);
 
         $this->_em->flush();
         $this->_em->clear();
 
-        $userRepository  = $this->_em->getRepository(DDC2988User::class);
         $groupRepository = $this->_em->getRepository(DDC2988Group::class);
         $groups          = $groupRepository->findAll();
 
-        $userRepository->findBy(['groups' => $groups]);
+        $userRepository  = $this->_em->getRepository(DDC2988User::class);
+        $result = $userRepository->findBy(['groups' => $groups]);
+
+        self::assertCount(2, $result);
     }
 }
 


### PR DESCRIPTION
Should it be possible to use `\Doctrine\ORM\EntityRepository::findBy()` and pass a criteria like `['groups' => [$group1, $group2]]` to filter on many-to-many associations?

Not sure this is even doable, see #3752.

Closes #1307, closes #4398.