### PR TITLE
Fix unserialize() errors when running tests on PHP 8.3

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -13,6 +13,7 @@ use Generator;
 use ReflectionMethod;
 
 use function file_get_contents;
+use function rtrim;
 use function serialize;
 use function unserialize;
 
@@ -56,8 +57,8 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
     /** @return Generator<string, array{string}> */
     public static function provideSerializedSingleSelectResults(): Generator
     {
-        yield '2.14.3' => [file_get_contents(__DIR__ . '/ParserResults/single_select_2_14_3.txt')];
-        yield '2.15.0' => [file_get_contents(__DIR__ . '/ParserResults/single_select_2_15_0.txt')];
+        yield '2.14.3' => [rtrim(file_get_contents(__DIR__ . '/ParserResults/single_select_2_14_3.txt'), "\n")];
+        yield '2.15.0' => [rtrim(file_get_contents(__DIR__ . '/ParserResults/single_select_2_15_0.txt'), "\n")];
     }
 
     private static function parseQuery(Query $query): ParserResult


### PR DESCRIPTION
Without this patch:

There were 2 errors:

1) Doctrine\Tests\ORM\Functional\ParserResultSerializationTest::testUnserializeSingleSelectResult with data set "2.14.3" (Binary String: 0x4f3a33313a224...d7d7d0a)
unserialize(): Extra data starting at offset 2372 of 2373 bytes

tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php:48

2) Doctrine\Tests\ORM\Functional\ParserResultSerializationTest::testUnserializeSingleSelectResult with data set "2.15.0" (Binary String: 0x4f3a33313a224...d7d7d0a)
unserialize(): Extra data starting at offset 2369 of 2370 bytes

tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php:48
