### PR TITLE
Follow recommendation about multiline type

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2566,8 +2566,7 @@ class Parser
      *      EmptyCollectionComparisonExpression | CollectionMemberExpression |
      *      InstanceOfExpression
      *
-     * @return AST\Node
-     * @psalm-return AST\BetweenExpression|
+     * @return (AST\BetweenExpression|
      *         AST\CollectionMemberExpression|
      *         AST\ComparisonExpression|
      *         AST\EmptyCollectionComparisonExpression|
@@ -2575,7 +2574,7 @@ class Parser
      *         AST\InExpression|
      *         AST\InstanceOfExpression|
      *         AST\LikeExpression|
-     *         AST\NullComparisonExpression
+     *         AST\NullComparisonExpression)
      */
     public function SimpleConditionalExpression()
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2008,19 +2008,10 @@
       <code>$factors[0]</code>
       <code>$primary</code>
       <code>$terms[0]</code>
-      <code><![CDATA[$this->CollectionMemberExpression()]]></code>
-      <code><![CDATA[$this->ComparisonExpression()]]></code>
-      <code><![CDATA[$this->EmptyCollectionComparisonExpression()]]></code>
-      <code><![CDATA[$this->ExistsExpression()]]></code>
-      <code><![CDATA[$this->InExpression()]]></code>
-      <code><![CDATA[$this->InstanceOfExpression()]]></code>
-      <code><![CDATA[$this->LikeExpression()]]></code>
-      <code><![CDATA[$this->NullComparisonExpression()]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>AST\ArithmeticFactor</code>
       <code>AST\ArithmeticTerm</code>
-      <code>AST\BetweenExpression|</code>
       <code>AST\SimpleArithmeticExpression|AST\ArithmeticTerm</code>
     </InvalidReturnType>
     <InvalidStringClass>


### PR DESCRIPTION
Apparently, there is consensus about multiline types between:

- PHPStan
- Psalm
- Slevomat Coding Standard

See https://github.com/slevomat/coding-standard/issues/1586#issuecomment-1610195706

Using parenthesis is supposed to be less ambiguous, although I cannot explain how it is ambiguous before… maybe if we had the pipes at the beginning of lines instead of the end it would be ambiguous because you could not clearly tell if the return is multiline or not?

Anyway, the change has a positive impact on the Psalm baseline, showing that psalm-return annotation was not really understood previously. Thanks @ondrejmirtes for the heads up!