### PR TITLE
Validate phpunit.xml against PHPUnit 10 schema

### DIFF
--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -27,11 +27,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -27,11 +27,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -24,11 +24,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -22,11 +22,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -24,11 +24,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -22,11 +22,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">../../../lib/Doctrine</directory>
         </include>
-    </coverage>
+    </source>
 
     <groups>
         <exclude>


### PR DESCRIPTION
The previous syntax was a PHPUnit 9 syntax.