### PR TITLE
Fix enum change set recomputation on single entity

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1124,6 +1124,20 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($actualData as $propName => $actualValue) {
             $orgValue = $originalData[$propName] ?? null;
 
+            if (isset($class->fieldMappings[$propName]['enumType'])) {
+                if (is_array($orgValue)) {
+                    foreach ($orgValue as $id => $val) {
+                        if ($val instanceof BackedEnum) {
+                            $orgValue[$id] = $val->value;
+                        }
+                    }
+                } else {
+                    if ($orgValue instanceof BackedEnum) {
+                        $orgValue = $orgValue->value;
+                    }
+                }
+            }
+
             if ($orgValue !== $actualValue) {
                 $changeSet[$propName] = [$orgValue, $actualValue];
             }

--- a/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EnumTest.php
@@ -260,6 +260,78 @@ class EnumTest extends OrmFunctionalTestCase
         self::assertEqualsCanonicalizing([Unit::Gram, Unit::Meter], $result[0]->supportedUnits);
     }
 
+    public function testEnumSingleEntityChangeSetsSimpleObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card       = new Card();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->find(Card::class, $card->id);
+
+        $this->_em->getUnitOfWork()->recomputeSingleEntityChangeSet(
+            $this->_em->getClassMetadata(Card::class),
+            $result
+        );
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($result));
+
+        $result->suit = Suit::Hearts;
+
+        $this->_em->getUnitOfWork()->recomputeSingleEntityChangeSet(
+            $this->_em->getClassMetadata(Card::class),
+            $result
+        );
+
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForUpdate($result));
+    }
+
+    public function testEnumSingleEntityChangeSetsObjectHydrator(): void
+    {
+        $this->setUpEntitySchema([Card::class]);
+
+        $card       = new Card();
+        $card->suit = Suit::Clubs;
+
+        $this->_em->persist($card);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->find(Card::class, $card->id);
+
+        $this->_em->getUnitOfWork()->recomputeSingleEntityChangeSet(
+            $this->_em->getClassMetadata(Card::class),
+            $result
+        );
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($result));
+    }
+
+    public function testEnumArraySingleEntityChangeSets(): void
+    {
+        $this->setUpEntitySchema([Scale::class]);
+
+        $scale                 = new Scale();
+        $scale->supportedUnits = [Unit::Gram];
+
+        $this->_em->persist($scale);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $result = $this->_em->find(Scale::class, $scale->id);
+
+        $this->_em->getUnitOfWork()->recomputeSingleEntityChangeSet(
+            $this->_em->getClassMetadata(Scale::class),
+            $result
+        );
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($result));
+    }
+
     public function testEnumChangeSetsSimpleObjectHydrator(): void
     {
         $this->setUpEntitySchema([Card::class]);


### PR DESCRIPTION
The root cause is well explained in #10074 and #10277
These PRs mitigate the issue in `computeChangeSet` method, but in some cases `recomputeSingleEntityChangeSet` might also be called. 
One of the cases where `recomputeSingleEntityChangeSet` might be called are in event listeners when you want to modify some other existing entity. Due to the fact that `originalEntityData` contains enum objects and `ReflectionEnumProperty::getValue()` returns value of enum - comparison of values are always falsy, resulting to update column value even though its exactly the same. In case nothing changed in entity it can even result to additional queries to DB if entity contains enum attribute