### PR TITLE
Remove lone dash

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -578,8 +578,6 @@ of DQL. It takes 3 parameters: ``$dqlPartName``, ``$dqlPart`` and
    not (no effect on the ``where`` and ``having`` DQL query parts,
    which always override all previously defined items)
 
--
-
 .. code-block:: php
 
     <?php


### PR DESCRIPTION
It renders as an extra bullet point at
https://www.doctrine-project.org/projects/doctrine-orm/en/stable/reference/query-builder.html#low-level-api, and I do not think that was intended.

It causes an issue when trying phpDocumentor/guides , but that's another story.