### PR TITLE
Let XML driver treat <id> field attributes same as regular <field> tag

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -376,7 +376,7 @@ class XmlDriver extends FileDriver
                 continue;
             }
 
-            $mapping = $this->columnToArray($idElement);
+            $mapping       = $this->columnToArray($idElement);
             $mapping['id'] = true;
 
             $metadata->mapField($mapping);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -376,30 +376,8 @@ class XmlDriver extends FileDriver
                 continue;
             }
 
-            $mapping = [
-                'id' => true,
-                'fieldName' => (string) $idElement['name'],
-            ];
-
-            if (isset($idElement['type'])) {
-                $mapping['type'] = (string) $idElement['type'];
-            }
-
-            if (isset($idElement['length'])) {
-                $mapping['length'] = (int) $idElement['length'];
-            }
-
-            if (isset($idElement['column'])) {
-                $mapping['columnName'] = (string) $idElement['column'];
-            }
-
-            if (isset($idElement['column-definition'])) {
-                $mapping['columnDefinition'] = (string) $idElement['column-definition'];
-            }
-
-            if (isset($idElement->options)) {
-                $mapping['options'] = $this->parseOptions($idElement->options->children());
-            }
+            $mapping = $this->columnToArray($idElement);
+            $mapping['id'] = true;
 
             $metadata->mapField($mapping);
 


### PR DESCRIPTION
According to other drivers, `id` field, should be treated as regular field and marked as an `id`.
In XML driver for id-field, there was code duplication in parsing field attributes. However, it was not updated at all for a while, so regular field growth with new attributes (e.g. `enum-type`) but id-field not.

Similar to other drivers, id-field attributes are parsed by same method in regular-field and enriched by `id` flag.

For example, without that fix, it is impossible to use XML driver and enum field as part of composite primary key.

Let me know if you need more details for that change.