### PR TITLE
Deprecate classes related to old commit order computation

### DIFF
--- a/lib/Doctrine/ORM/Internal/CommitOrder/Edge.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrder/Edge.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\CommitOrder;
 
+use Doctrine\Deprecations\Deprecation;
+
 /** @internal */
 final class Edge
 {
@@ -27,6 +29,13 @@ final class Edge
 
     public function __construct(string $from, string $to, int $weight)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10547',
+            'The %s class is deprecated and will be removed in ORM 3.0',
+            self::class
+        );
+
         $this->from   = $from;
         $this->to     = $to;
         $this->weight = $weight;

--- a/lib/Doctrine/ORM/Internal/CommitOrder/Vertex.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrder/Vertex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\CommitOrder;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 /** @internal */
@@ -32,6 +33,13 @@ final class Vertex
 
     public function __construct(string $hash, ClassMetadata $value)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10547',
+            'The %s class is deprecated and will be removed in ORM 3.0',
+            self::class
+        );
+
         $this->hash  = $hash;
         $this->value = $value;
     }

--- a/lib/Doctrine/ORM/Internal/CommitOrder/VertexState.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrder/VertexState.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\CommitOrder;
 
+use Doctrine\Deprecations\Deprecation;
+
 /** @internal */
 final class VertexState
 {
@@ -13,5 +15,11 @@ final class VertexState
 
     private function __construct()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10547',
+            'The %s class is deprecated and will be removed in ORM 3.0',
+            self::class
+        );
     }
 }

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Internal\CommitOrder\Edge;
 use Doctrine\ORM\Internal\CommitOrder\Vertex;
 use Doctrine\ORM\Internal\CommitOrder\VertexState;
@@ -44,6 +45,16 @@ class CommitOrderCalculator
      * @psalm-var list<ClassMetadata>
      */
     private $sortedNodeList = [];
+
+    public function __construct()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10547',
+            'The %s class is deprecated and will be removed in ORM 3.0',
+            self::class
+        );
+    }
 
     /**
      * Checks for node (vertex) existence in graph.


### PR DESCRIPTION
Here is a last addition for #10547: With the new `TopologicalSort` implementation, we do no longer need the old `CommitOrderCalculator` and related classes.