### PR TITLE
Throw when loading a proxy without identifiers

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -215,6 +215,9 @@ EOPHP;
             }
 
             $identifier = $classMetadata->getIdentifierValues($proxy);
+            if ($identifier === []) {
+                throw EntityNotFoundException::noIdentifierFound($classMetadata->getName());
+            }
 
             try {
                 $entity = $entityPersister->loadById($identifier, $proxy);
@@ -250,7 +253,11 @@ EOPHP;
     {
         return function (Proxy $proxy, Proxy $original) use ($entityPersister, $classMetadata): void {
             $identifier = $classMetadata->getIdentifierValues($original);
-            $entity     = $entityPersister->loadById($identifier, $original);
+            if ($identifier === []) {
+                throw EntityNotFoundException::noIdentifierFound($classMetadata->getName());
+            }
+
+            $entity = $entityPersister->loadById($identifier, $original);
 
             if ($entity === null) {
                 throw EntityNotFoundException::fromClassNameAndIdentifier(

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -240,6 +240,18 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertSame(1000, $cloned->getSalary(), 'Expect properties on the CompanyEmployee class to be cloned');
         self::assertSame('Bob', $cloned->getName(), 'Expect properties on the CompanyPerson class to be cloned');
     }
+
+    public function testProxyWithoutIdentifierThrowWhenLoaded(): void
+    {
+        $proxy = $this->proxyFactory->getProxy(ECommerceFeature::class, ['id' => 'toBeRemoved']);
+        $id    = new ReflectionProperty(ECommerceFeature::class, 'id');
+        $id->setAccessible(true);
+        $id->setValue($proxy, null);
+
+        $this->expectException(EntityNotFoundException::class);
+
+        $proxy->__load();
+    }
 }
 
 abstract class AbstractClass

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -241,7 +241,7 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertSame('Bob', $cloned->getName(), 'Expect properties on the CompanyPerson class to be cloned');
     }
 
-    public function testProxyWithoutIdentifierThrowWhenLoaded(): void
+    public function testProxyWithoutIdentifierThrowsWhenLoaded(): void
     {
         $proxy = $this->proxyFactory->getProxy(ECommerceFeature::class, ['id' => 'toBeRemoved']);
         $id    = new ReflectionProperty(ECommerceFeature::class, 'id');


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/discussions/50874

Loading a proxy without identifiers currently leads to its hydration using its table’s first row; it is better to throw in that case.
Not sure if it should be done in `EntityPersister:loadById` though :thinking: 