### PR TITLE
Use --fail-on-log instead of arcane bash tricks

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,4 +44,4 @@ jobs:
           dependency-versions: "highest"
 
       - name: "Run guides-cli"
-        run: "vendor/bin/guides -vvv --no-progress docs/en /tmp/test 2>&1 | ( ! grep WARNING )"
+        run: "vendor/bin/guides -vvv --no-progress docs/en /tmp/test --fail-on-log"


### PR DESCRIPTION
`--fail-on-log` is a brand new option. As its name indicates, it will fail not just on warnings, and that should be fine.