### PR TITLE
Add dummy title to the sidebar before checking docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,5 +43,9 @@ jobs:
         with:
           dependency-versions: "highest"
 
+      - name: "Add dummy title to the sidebar"
+        run: |
+          printf '%s\n%s\n\n%s\n' "Dummy title" "===========" "$(cat docs/en/sidebar.rst)" > docs/en/sidebar.rst
+
       - name: "Run guides-cli"
         run: "vendor/bin/guides -vvv --no-progress docs/en /tmp/test 2>&1 | ( ! grep WARNING )"

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,3 +1,6 @@
+Dummy title
+===========
+
 .. toc::
 
    .. tocheader:: Tutorials


### PR DESCRIPTION
The way we have our docs, the sidebar is a separate document and as such, needs a title. Let us prepend a dummy title until the guides-cli provides a way to ignore that particular error.