### PR TITLE
Bug fix for cascade persist of entity with inheritance

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1023,6 +1023,11 @@ class UnitOfWork implements PropertyChangedListener
     private function persistNew(ClassMetadata $class, $entity): void
     {
         $oid    = spl_object_id($entity);
+
+        if (! $class->isInheritanceTypeNone()) {
+            $class = $this->em->getClassMetadata(get_class($entity));
+        }
+
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::prePersist);
 
         if ($invoke !== ListenersInvoker::INVOKE_NONE) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1022,7 +1022,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function persistNew(ClassMetadata $class, $entity): void
     {
-        $oid    = spl_object_id($entity);
+        $oid = spl_object_id($entity);
 
         if (! $class->isInheritanceTypeNone()) {
             $class = $this->em->getClassMetadata(get_class($entity));

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -935,7 +935,7 @@ class UnitOfWorkTest extends OrmTestCase
          *    and only that call commit
          */
 
-        $childWithLifecycleCallback = new EntityInheritedChildWithLifecycleCallback();
+        $childWithLifecycleCallback       = new EntityInheritedChildWithLifecycleCallback();
         $childWithParentLifecycleCallback = new EntityInheritedChildWithParentLifecycleCallback();
 
         self::assertFalse($childWithLifecycleCallback->wasPrepersitCall);
@@ -945,7 +945,7 @@ class UnitOfWorkTest extends OrmTestCase
 
         $this->_unitOfWork->persist($mainEntity);
 
-        $mainEntity->entityWithChildLifecycleEvent = $childWithLifecycleCallback;
+        $mainEntity->entityWithChildLifecycleEvent  = $childWithLifecycleCallback;
         $mainEntity->entityWithParentLifecycleEvent = $childWithParentLifecycleCallback;
 
         $this->_unitOfWork->commit();
@@ -1220,12 +1220,13 @@ class EntityWithNonCascadingAssociation
 }
 
 /**
- * @Entity
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", length="5")
  * @ORM\DiscriminatorMap({
  *     "child" = EntityInheritedChildWithLifecycleCallback::class,
  * })
+ *
+ * @Entity
  */
 abstract class EntityParentWithInheritance
 {
@@ -1244,13 +1245,14 @@ abstract class EntityParentWithInheritance
 }
 
 /**
- * @Entity
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", length="5")
  * @ORM\DiscriminatorMap({
  *     "child" = EntityInheritedChildWithParentLifecycleCallback::class,
  * })
  * @ORM\HasLifecycleCallbacks()
+ *
+ * @Entity
  */
 abstract class EntityParentWithInheritanceWithLifecycleCallback
 {
@@ -1278,8 +1280,9 @@ abstract class EntityParentWithInheritanceWithLifecycleCallback
 }
 
 /**
- * @Entity
  * @ORM\HasLifecycleCallbacks()
+ *
+ * @Entity
  */
 class EntityInheritedChildWithLifecycleCallback extends EntityParentWithInheritance
 {


### PR DESCRIPTION
1. We have entity with inheritance
2. We have lifecycle callback on child entity, not on parent
3. We have main entity with association to entity with inheritance with cascade persist
4. We call persist on main entity, when association value is null, than we set association value and only that call commit

Current behavior - lifecycle callback on child entity was not called.
Expected behavior - lifecycle callback on child entity was called