### PR TITLE
Undeprecate flushing and clearing a single entity

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,7 +36,7 @@ and will be an error in 3.0.
 
 ## Deprecated undeclared entity inheritance
 
-As soon as an entity class inherits from another entity class, inheritance has to 
+As soon as an entity class inherits from another entity class, inheritance has to
 be declared by adding the appropriate configuration for the root entity.
 
 ## Deprecated stubs for "concrete table inheritance"
@@ -419,11 +419,6 @@ are not in use anymore and will be removed.
 
 This class won't have a replacement.
 
-## Deprecate `OnClearEventArgs::getEntityClass()` and `OnClearEventArgs::clearsAllEntities()`
-
-These methods will be removed in 3.0 along with the ability to partially clear
-the entity manager.
-
 ## Deprecate `Doctrine\ORM\Configuration::newDefaultAnnotationDriver`
 
 This functionality has been moved to the new `ORMSetup` class. Call
@@ -701,40 +696,6 @@ restful operations, you should look at alternatives such as [JMSSerializer](http
 
 Final keyword will be added to the `EntityManager::class` in Doctrine ORM 3.0 in order to ensure that EntityManager
  is not used as valid extension point. Valid extension point should be EntityManagerInterface.
-
-## Deprecated `EntityManager#clear($entityName)`
-
-If your code relies on clearing a single entity type via `EntityManager#clear($entityName)`,
-the signature has been changed to `EntityManager#clear()`.
-
-The main reason is that partial clears caused multiple issues with data integrity
-in the managed entity graph, which was constantly spawning more edge-case bugs/scenarios.
-
-## Deprecated `EntityManager#flush($entity)` and `EntityManager#flush($entities)`
-
-If your code relies on single entity flushing optimisations via
-`EntityManager#flush($entity)`, the signature has been changed to
-`EntityManager#flush()`.
-
-Said API was affected by multiple data integrity bugs due to the fact
-that change tracking was being restricted upon a subset of the managed
-entities. The ORM cannot support committing subsets of the managed
-entities while also guaranteeing data integrity, therefore this
-utility was removed.
-
-The `flush()` semantics will remain the same, but the change tracking will be performed
-on all entities managed by the unit of work, and not just on the provided
-`$entity` or `$entities`, as the parameter is now completely ignored.
-
-The same applies to `UnitOfWork#commit($entity)`, which will simply be
-`UnitOfWork#commit()`.
-
-If you would still like to perform batching operations over small `UnitOfWork`
-instances, it is suggested to follow these paths instead:
-
- * eagerly use `EntityManager#clear()` in conjunction with a specific second level
-   cache configuration (see http://docs.doctrine-project.org/projects/doctrine-orm/en/stable/reference/second-level-cache.html)
- * use an explicit change tracking policy (see http://docs.doctrine-project.org/projects/doctrine-orm/en/stable/reference/change-tracking-policies.html)
 
 ## Deprecated `YAML` mapping drivers.
 

--- a/docs/en/reference/unitofwork.rst
+++ b/docs/en/reference/unitofwork.rst
@@ -134,11 +134,6 @@ optimize the performance of the Flush Operation:
   explicit strategies of notifying the UnitOfWork what objects/properties
   changed.
 
-.. note::
-
-    Flush only a single entity with ``$entityManager->flush($entity)`` is deprecated and will be removed in ORM 3.0.
-    (`Details <https://github.com/doctrine/orm/issues/8459>`_)
-
 Query Internals
 ---------------
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -389,15 +389,6 @@ class EntityManager implements EntityManagerInterface
      */
     public function flush($entity = null)
     {
-        if ($entity !== null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8459',
-                'Calling %s() with any arguments to flush specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
-                __METHOD__
-            );
-        }
-
         $this->errorIfClosed();
 
         $this->unitOfWork->commit($entity);
@@ -610,15 +601,6 @@ class EntityManager implements EntityManagerInterface
     {
         if ($entityName !== null && ! is_string($entityName)) {
             throw ORMInvalidArgumentException::invalidEntityName($entityName);
-        }
-
-        if ($entityName !== null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8460',
-                'Calling %s() with any arguments to clear specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
-                __METHOD__
-            );
         }
 
         $this->unitOfWork->clear(

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -162,13 +162,6 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function clear()
     {
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/orm/issues/8460',
-            'Calling %s() is deprecated and will not be supported in Doctrine ORM 3.0.',
-            __METHOD__
-        );
-
         if (! class_exists(PersistentObject::class)) {
             throw NotSupported::createForPersistence3(sprintf(
                 'Partial clearing of entities for class %s',

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -362,15 +362,6 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function commit($entity = null)
     {
-        if ($entity !== null) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8459',
-                'Calling %s() with any arguments to commit specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
-                __METHOD__
-            );
-        }
-
         $connection = $this->em->getConnection();
 
         if ($connection instanceof PrimaryReadReplicaConnection) {
@@ -2706,13 +2697,6 @@ EXCEPTION
             $this->eagerLoadingEntities             =
             $this->orphanRemovals                   = [];
         } else {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8460',
-                'Calling %s() with any arguments to clear specific entities is deprecated and will not be supported in Doctrine ORM 3.0.',
-                __METHOD__
-            );
-
             $this->clearIdentityMapForEntityName($entityName);
             $this->clearEntityInsertionsForEntityName($entityName);
         }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -361,24 +361,4 @@ class EntityManagerTest extends OrmTestCase
 
         self::assertFalse($this->entityManager->contains($entity));
     }
-
-    public function testDeprecatedClearWithArguments(): void
-    {
-        $entity = new Country(456, 'United Kingdom');
-        $this->entityManager->persist($entity);
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8460');
-
-        $this->entityManager->clear(Country::class);
-    }
-
-    public function testDeprecatedFlushWithArguments(): void
-    {
-        $entity = new Country(456, 'United Kingdom');
-        $this->entityManager->persist($entity);
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
-
-        $this->entityManager->flush($entity);
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -1093,13 +1093,11 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         }
     }
 
-    public function testDeprecatedClear(): void
+    public function testItThrowsWhenUsingClearAndPersistence3(): void
     {
         $repository = $this->_em->getRepository(CmsAddress::class);
 
-        if (class_exists(PersistentObject::class)) {
-            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8460');
-        } else {
+        if (! class_exists(PersistentObject::class)) {
             $this->expectException(NotSupported::class);
             $this->expectExceptionMessage(CmsAddress::class);
         }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -268,8 +268,6 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity);
         $this->_unitOfWork->persist($entity2);
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
-
         $this->_unitOfWork->commit($entity);
         $this->_unitOfWork->commit();
 
@@ -437,8 +435,6 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity2);
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity2));
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8460');
-
         $this->_unitOfWork->clear(Country::class);
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity1));
         self::assertFalse($this->_unitOfWork->isInIdentityMap($entity2));
@@ -457,8 +453,6 @@ class UnitOfWorkTest extends OrmTestCase
 
         $this->_unitOfWork->persist($entity1);
         $this->_unitOfWork->persist($entity2);
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
 
         $this->_unitOfWork->commit($entity1);
         self::assertEmpty($this->_unitOfWork->getEntityChangeSet($entity1));
@@ -479,8 +473,6 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity1);
         $this->_unitOfWork->persist($entity2);
         $this->_unitOfWork->persist($entity3);
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8459');
 
         $this->_unitOfWork->commit([$entity1, $entity3]);
 


### PR DESCRIPTION
Both features have been deprecated without a replacement, making it hard for people to upgrade to ORM 3.0. Let us undeprecate them.