### PR TITLE
Decouple public API from Doctrine\Persistence\Proxy

### DIFF
--- a/docs/en/reference/unitofwork.rst
+++ b/docs/en/reference/unitofwork.rst
@@ -37,8 +37,8 @@ will still end up with the same reference:
     public function testIdentityMapReference(): void
     {
         $objectA = $this->entityManager->getReference('EntityName', 1);
-        // check for proxyinterface
-        $this->assertInstanceOf('Doctrine\Persistence\Proxy', $objectA);
+        // check entity is not initialized
+        $this->assertTrue($this->entityManager->isUninitializedObject($objectA));
 
         $objectB = $this->entityManager->find('EntityName', 1);
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Persistence\Proxy;
 
 use function array_map;
 use function array_shift;
@@ -345,7 +344,7 @@ class DefaultQueryCache implements QueryCache
             $assocIdentifier = $this->uow->getEntityIdentifier($assocValue);
             $entityKey       = new EntityCacheKey($assocMetadata->rootEntityName, $assocIdentifier);
 
-            if (! $assocValue instanceof Proxy && ($key->cacheMode & Cache::MODE_REFRESH) || ! $assocRegion->contains($entityKey)) {
+            if (! $this->uow->isUninitializedObject($assocValue) && ($key->cacheMode & Cache::MODE_REFRESH) || ! $assocRegion->contains($entityKey)) {
                 // Entity put fail
                 if (! $assocPersister->storeEntityCache($assocValue, $entityKey)) {
                     return null;

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -954,6 +954,14 @@ class EntityManager implements EntityManagerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function isUninitializedObject($obj): bool
+    {
+        return $this->unitOfWork->isUninitializedObject($obj);
+    }
+
+    /**
      * Factory method to create EntityManager instances.
      *
      * @deprecated Use {@see DriverManager::getConnection()} to bootstrap the connection and call the constructor.

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Persistence\Proxy;
 
 use function array_fill_keys;
 use function array_keys;
@@ -439,7 +438,7 @@ class ObjectHydrator extends AbstractHydrator
                     // PATH B: Single-valued association
                     $reflFieldValue = $reflField->getValue($parentObject);
 
-                    if (! $reflFieldValue || isset($this->_hints[Query::HINT_REFRESH]) || ($reflFieldValue instanceof Proxy && ! $reflFieldValue->__isInitialized())) {
+                    if (! $reflFieldValue || isset($this->_hints[Query::HINT_REFRESH]) || $this->_uow->isUninitializedObject($reflFieldValue)) {
                         // we only need to take action if this value is null,
                         // we refresh the entity or its an uninitialized proxy.
                         if (isset($nonemptyComponents[$dqlAlias])) {

--- a/lib/Doctrine/ORM/Proxy/InternalProxy.php
+++ b/lib/Doctrine/ORM/Proxy/InternalProxy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Proxy;
+
+use Doctrine\Persistence\Proxy;
+
+/**
+ * @internal
+ *
+ * @template T of object
+ * @template-extends Proxy<T>
+ *
+ * @method void __setInitialized(bool $initialized)
+ */
+interface InternalProxy extends Proxy
+{
+}

--- a/lib/Doctrine/ORM/Proxy/Proxy.php
+++ b/lib/Doctrine/ORM/Proxy/Proxy.php
@@ -10,7 +10,11 @@ use Doctrine\Common\Proxy\Proxy as BaseProxy;
  * Interface for proxy classes.
  *
  * @deprecated 2.14. Use \Doctrine\Persistence\Proxy instead
+ *
+ * @template T of object
+ * @template-extends BaseProxy<T>
+ * @template-extends InternalProxy<T>
  */
-interface Proxy extends BaseProxy
+interface Proxy extends BaseProxy, InternalProxy
 {
 }

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Proxy\Proxy as LegacyProxy;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy;
 use ReflectionProperty;
 use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\VarExporter;
@@ -101,7 +100,7 @@ EOPHP;
         $proxyGenerator = new ProxyGenerator($proxyDir, $proxyNs);
 
         if ($em->getConfiguration()->isLazyGhostObjectEnabled()) {
-            $proxyGenerator->setPlaceholder('baseProxyInterface', Proxy::class);
+            $proxyGenerator->setPlaceholder('baseProxyInterface', InternalProxy::class);
             $proxyGenerator->setPlaceholder('useLazyGhostTrait', Closure::fromCallable([$this, 'generateUseLazyGhostTrait']));
             $proxyGenerator->setPlaceholder('skippedProperties', Closure::fromCallable([$this, 'generateSkippedProperties']));
             $proxyGenerator->setPlaceholder('serializeImpl', Closure::fromCallable([$this, 'generateSerializeImpl']));
@@ -131,7 +130,7 @@ EOPHP;
 
         $initializer = $this->definitions[$className]->initializer;
 
-        $proxy->__construct(static function (Proxy $object) use ($initializer, $proxy): void {
+        $proxy->__construct(static function (InternalProxy $object) use ($initializer, $proxy): void {
             $initializer($object, $proxy);
         });
 
@@ -238,13 +237,13 @@ EOPHP;
     /**
      * Creates a closure capable of initializing a proxy
      *
-     * @return Closure(Proxy, Proxy):void
+     * @return Closure(InternalProxy, InternalProxy):void
      *
      * @throws EntityNotFoundException
      */
     private function createLazyInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister): Closure
     {
-        return function (Proxy $proxy, Proxy $original) use ($entityPersister, $classMetadata): void {
+        return function (InternalProxy $proxy, InternalProxy $original) use ($entityPersister, $classMetadata): void {
             $identifier = $classMetadata->getIdentifierValues($original);
             $entity     = $entityPersister->loadById($identifier, $original);
 

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Persistence\Proxy;
 use ReflectionObject;
 
 use function count;
@@ -87,7 +86,7 @@ class DebugUnitOfWorkListener
                         if ($value === null) {
                             fwrite($fh, " NULL\n");
                         } else {
-                            if ($value instanceof Proxy && ! $value->__isInitialized()) {
+                            if ($uow->isUninitializedObject($value)) {
                                 fwrite($fh, '[PROXY] ');
                             }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -38,12 +38,12 @@ use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\ORM\Persisters\Entity\SingleTablePersister;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\ObjectManagerAware;
 use Doctrine\Persistence\PropertyChangedListener;
-use Doctrine\Persistence\Proxy;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
@@ -581,7 +581,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         // Ignore uninitialized proxy objects
-        if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
+        if ($this->isUninitializedObject($entity)) {
             return;
         }
 
@@ -906,7 +906,7 @@ class UnitOfWork implements PropertyChangedListener
 
             foreach ($entitiesToProcess as $entity) {
                 // Ignore uninitialized proxy objects
-                if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
+                if ($this->isUninitializedObject($entity)) {
                     continue;
                 }
 
@@ -931,7 +931,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function computeAssociationChanges(array $assoc, $value): void
     {
-        if ($value instanceof Proxy && ! $value->__isInitialized()) {
+        if ($this->isUninitializedObject($value)) {
             return;
         }
 
@@ -2172,7 +2172,7 @@ EXCEPTION
         $entity,
         $managedCopy
     ): void {
-        if (! ($class->isVersioned && $this->isLoaded($managedCopy) && $this->isLoaded($entity))) {
+        if (! ($class->isVersioned && ! $this->isUninitializedObject($managedCopy) && ! $this->isUninitializedObject($entity))) {
             return;
         }
 
@@ -2188,16 +2188,6 @@ EXCEPTION
         }
 
         throw OptimisticLockException::lockFailedVersionMismatch($entity, $entityVersion, $managedCopyVersion);
-    }
-
-    /**
-     * Tests if an entity is loaded - must either be a loaded proxy or not a proxy
-     *
-     * @param object $entity
-     */
-    private function isLoaded($entity): bool
-    {
-        return ! ($entity instanceof Proxy) || $entity->__isInitialized();
     }
 
     /**
@@ -2495,7 +2485,7 @@ EXCEPTION
      */
     private function cascadePersist($entity, array &$visited): void
     {
-        if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
+        if ($this->isUninitializedObject($entity)) {
             // nothing to do - proxy is not initialized, therefore we don't do anything with it
             return;
         }
@@ -2569,13 +2559,13 @@ EXCEPTION
             }
         );
 
+        if ($associationMappings) {
+            $this->initializeObject($entity);
+        }
+
         $entitiesToCascade = [];
 
         foreach ($associationMappings as $assoc) {
-            if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
-                $entity->__load();
-            }
-
             $relatedEntities = $class->reflFields[$assoc['fieldName']]->getValue($entity);
 
             switch (true) {
@@ -2631,9 +2621,7 @@ EXCEPTION
                     return;
                 }
 
-                if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
-                    $entity->__load();
-                }
+                $this->initializeObject($entity);
 
                 assert($class->versionField !== null);
                 $entityVersion = $class->reflFields[$class->versionField]->getValue($entity);
@@ -2823,7 +2811,6 @@ EXCEPTION
                 $unmanagedProxy = $hints[Query::HINT_REFRESH_ENTITY];
                 if (
                     $unmanagedProxy !== $entity
-                    && $unmanagedProxy instanceof Proxy
                     && $this->isIdentifierEquals($unmanagedProxy, $entity)
                 ) {
                     // We will hydrate the given un-managed proxy anyway:
@@ -2832,7 +2819,7 @@ EXCEPTION
                 }
             }
 
-            if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
+            if ($this->isUninitializedObject($entity)) {
                 $entity->__setInitialized(true);
             } else {
                 if (
@@ -2978,8 +2965,7 @@ EXCEPTION
                                 $hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER &&
                                 isset($hints[self::HINT_DEFEREAGERLOAD]) &&
                                 ! $targetClass->isIdentifierComposite &&
-                                $newValue instanceof Proxy &&
-                                $newValue->__isInitialized() === false
+                                $this->isUninitializedObject($newValue)
                             ) {
                                 $this->eagerLoadingEntities[$targetClass->rootEntityName][$relatedIdHash] = current($associatedId);
                             }
@@ -3377,7 +3363,7 @@ EXCEPTION
 
         $this->addToIdentityMap($entity);
 
-        if ($entity instanceof NotifyPropertyChanged && ( ! $entity instanceof Proxy || $entity->__isInitialized())) {
+        if ($entity instanceof NotifyPropertyChanged && ! $this->isUninitializedObject($entity)) {
             $entity->addPropertyChangedListener($this);
         }
     }
@@ -3485,7 +3471,7 @@ EXCEPTION
      */
     public function initializeObject($obj)
     {
-        if ($obj instanceof Proxy) {
+        if ($obj instanceof InternalProxy) {
             $obj->__load();
 
             return;
@@ -3494,6 +3480,18 @@ EXCEPTION
         if ($obj instanceof PersistentCollection) {
             $obj->initialize();
         }
+    }
+
+    /**
+     * Tests if a value is an uninitialized entity.
+     *
+     * @param mixed $obj
+     *
+     * @psalm-assert-if-true InternalProxy $obj
+     */
+    public function isUninitializedObject($obj): bool
+    {
+        return $obj instanceof InternalProxy && ! $obj->__isInitialized();
     }
 
     /**
@@ -3646,13 +3644,11 @@ EXCEPTION
      */
     private function mergeEntityStateIntoManagedCopy($entity, $managedCopy): void
     {
-        if (! $this->isLoaded($entity)) {
+        if ($this->isUninitializedObject($entity)) {
             return;
         }
 
-        if (! $this->isLoaded($managedCopy)) {
-            $managedCopy->__load();
-        }
+        $this->initializeObject($managedCopy);
 
         $class = $this->em->getClassMetadata(get_class($entity));
 
@@ -3673,7 +3669,7 @@ EXCEPTION
                     if ($other === null) {
                         $prop->setValue($managedCopy, null);
                     } else {
-                        if ($other instanceof Proxy && ! $other->__isInitialized()) {
+                        if ($this->isUninitializedObject($other)) {
                             // do not merge fields marked lazy that have not been fetched.
                             continue;
                         }

--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -34,10 +34,5 @@ parameters:
             count: 1
             path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
 
-        -
-            message: '/^Call to an undefined method Doctrine\\Persistence\\Proxy::__setInitialized\(\)\.$/'
-            count: 1
-            path: lib/Doctrine/ORM/UnitOfWork.php
-
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1380,11 +1380,6 @@
       <code>$columnList</code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="lib/Doctrine/ORM/Proxy/Proxy.php">
-    <MissingTemplateParam>
-      <code>BaseProxy</code>
-    </MissingTemplateParam>
-  </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
     <ArgumentTypeCoercion>
       <code>$classMetadata</code>
@@ -1392,7 +1387,7 @@
       <code>$classMetadata</code>
     </ArgumentTypeCoercion>
     <DirectConstructorCall>
-      <code><![CDATA[$proxy->__construct(static function (Proxy $object) use ($initializer, $proxy): void {
+      <code><![CDATA[$proxy->__construct(static function (InternalProxy $object) use ($initializer, $proxy): void {
             $initializer($object, $proxy);
         })]]></code>
     </DirectConstructorCall>

--- a/tests/Doctrine/Performance/LazyLoading/ProxyInitializationTimeBench.php
+++ b/tests/Doctrine/Performance/LazyLoading/ProxyInitializationTimeBench.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Performance\LazyLoading;
 
+use Doctrine\ORM\Proxy\InternalProxy as Proxy;
 use Doctrine\Performance\EntityManagerFactory;
 use Doctrine\Performance\Mock\NonProxyLoadingEntityManager;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 use Doctrine\Tests\Models\CMS\CmsUser;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use DateTime;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\IterableTester;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
@@ -300,7 +299,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $mainEvent = $result[0]->getMainEvent();
         // mainEvent should have been loaded because it can't be lazy
         self::assertInstanceOf(CompanyAuction::class, $mainEvent);
-        self::assertNotInstanceOf(Proxy::class, $mainEvent);
+        self::assertFalse($this->isUninitializedObject($mainEvent));
 
         $this->_em->clear();
 
@@ -432,13 +431,13 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $ref = $this->_em->getReference(CompanyPerson::class, $manager->getId());
-        self::assertNotInstanceOf(Proxy::class, $ref, 'Cannot Request a proxy from a class that has subclasses.');
+        self::assertFalse($this->isUninitializedObject($ref), 'Cannot Request a proxy from a class that has subclasses.');
         self::assertInstanceOf(CompanyPerson::class, $ref);
         self::assertInstanceOf(CompanyEmployee::class, $ref, 'Direct fetch of the reference has to load the child class Employee directly.');
         $this->_em->clear();
 
         $ref = $this->_em->getReference(CompanyManager::class, $manager->getId());
-        self::assertInstanceOf(Proxy::class, $ref, 'A proxy can be generated only if no subclasses exists for the requested reference.');
+        self::assertTrue($this->isUninitializedObject($ref), 'A proxy can be generated only if no subclasses exists for the requested reference.');
     }
 
     /** @group DDC-992 */

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -43,7 +43,7 @@ class DefaultValuesTest extends OrmFunctionalTestCase
         $user2  = $this->_em->getReference(get_class($user), $userId);
 
         $this->_em->flush();
-        self::assertFalse($user2->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($user2));
 
         $a          = new DefaultValueAddress();
         $a->country = 'de';
@@ -55,7 +55,7 @@ class DefaultValuesTest extends OrmFunctionalTestCase
         $this->_em->persist($a);
         $this->_em->flush();
 
-        self::assertFalse($user2->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($user2));
         $this->_em->clear();
 
         $a2 = $this->_em->find(get_class($a), $a->id);

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\OptimisticLockException;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
@@ -150,16 +149,13 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $address2 = $this->_em->find(get_class($address), $address->id);
-        self::assertInstanceOf(Proxy::class, $address2->user);
-        self::assertFalse($address2->user->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($address2->user));
         $detachedAddress2 = unserialize(serialize($address2));
-        self::assertInstanceOf(Proxy::class, $detachedAddress2->user);
-        self::assertFalse($detachedAddress2->user->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($detachedAddress2->user));
 
         $managedAddress2 = $this->_em->merge($detachedAddress2);
-        self::assertInstanceOf(Proxy::class, $managedAddress2->user);
         self::assertFalse($managedAddress2->user === $detachedAddress2->user);
-        self::assertFalse($managedAddress2->user->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($managedAddress2->user));
     }
 
     /** @group DDC-822 */

--- a/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\DirectoryTree\Directory;
 use Doctrine\Tests\Models\DirectoryTree\File;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -46,7 +45,7 @@ class MappedSuperclassTest extends OrmFunctionalTestCase
         $cleanFile = $this->_em->find(get_class($file), $file->getId());
 
         self::assertInstanceOf(Directory::class, $cleanFile->getParent());
-        self::assertInstanceOf(Proxy::class, $cleanFile->getParent());
+        self::assertTrue($this->isUninitializedObject($cleanFile->getParent()));
         self::assertEquals($directory->getId(), $cleanFile->getParent()->getId());
         self::assertInstanceOf(Directory::class, $cleanFile->getParent()->getParent());
         self::assertEquals($root->getId(), $cleanFile->getParent()->getParent()->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\DbalExtensions\Connection;
 use Doctrine\Tests\DbalExtensions\QueryLog;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
@@ -48,8 +47,8 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         self::assertSame($managed, $this->_em->merge($detachedUninitialized));
 
-        self::assertFalse($managed->__isInitialized());
-        self::assertFalse($detachedUninitialized->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($managed));
+        self::assertTrue($this->isUninitializedObject($detachedUninitialized));
     }
 
     /**
@@ -71,8 +70,8 @@ class MergeProxiesTest extends OrmFunctionalTestCase
             $this->_em->merge(unserialize(serialize($this->_em->merge($detachedUninitialized))))
         );
 
-        self::assertFalse($managed->__isInitialized());
-        self::assertFalse($detachedUninitialized->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($managed));
+        self::assertTrue($this->isUninitializedObject($detachedUninitialized));
     }
 
     /**
@@ -87,7 +86,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         self::assertSame($managed, $this->_em->merge($managed));
 
-        self::assertFalse($managed->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($managed));
     }
 
     /**
@@ -109,13 +108,12 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         $managed = $this->_em->getReference(DateTimeModel::class, $date->id);
 
-        self::assertInstanceOf(Proxy::class, $managed);
-        self::assertFalse($managed->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($managed));
 
         $date->date = $dateTime = new DateTime();
 
         self::assertSame($managed, $this->_em->merge($date));
-        self::assertTrue($managed->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($managed));
         self::assertSame($dateTime, $managed->date, 'Data was merged into the proxy after initialization');
     }
 
@@ -150,8 +148,8 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         self::assertNotSame($proxy1, $merged2);
         self::assertSame($proxy2, $merged2);
 
-        self::assertFalse($proxy1->__isInitialized());
-        self::assertFalse($proxy2->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($proxy1));
+        self::assertTrue($this->isUninitializedObject($proxy2));
 
         $proxy1->__load();
 
@@ -207,9 +205,8 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         $unManagedProxy = $em1->getReference(DateTimeModel::class, $file1->id);
         $mergedInstance = $em2->merge($unManagedProxy);
 
-        self::assertNotInstanceOf(Proxy::class, $mergedInstance);
-        self::assertNotSame($unManagedProxy, $mergedInstance);
-        self::assertFalse($unManagedProxy->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($mergedInstance));
+        self::assertTrue($this->isUninitializedObject($unManagedProxy));
 
         self::assertCount(
             0,

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -90,12 +89,12 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $features = $product->getFeatures();
 
         self::assertInstanceOf(ECommerceFeature::class, $features[0]);
-        self::assertNotInstanceOf(Proxy::class, $features[0]->getProduct());
+        self::assertFalse($this->isUninitializedObject($features[0]->getProduct()));
         self::assertSame($product, $features[0]->getProduct());
         self::assertEquals('Model writing tutorial', $features[0]->getDescription());
         self::assertInstanceOf(ECommerceFeature::class, $features[1]);
         self::assertSame($product, $features[1]->getProduct());
-        self::assertNotInstanceOf(Proxy::class, $features[1]->getProduct());
+        self::assertFalse($this->isUninitializedObject($features[1]->getProduct()));
         self::assertEquals('Annotations examples', $features[1]->getDescription());
     }
 
@@ -126,11 +125,10 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $features = $query->getResult();
 
         $product = $features[0]->getProduct();
-        self::assertInstanceOf(Proxy::class, $product);
         self::assertInstanceOf(ECommerceProduct::class, $product);
-        self::assertFalse($product->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($product));
         self::assertSame('Doctrine Cookbook', $product->getName());
-        self::assertTrue($product->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($product));
     }
 
     public function testLazyLoadsObjectsOnTheInverseSide2(): void
@@ -141,7 +139,7 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $features = $query->getResult();
 
         $product = $features[0]->getProduct();
-        self::assertNotInstanceOf(Proxy::class, $product);
+        self::assertFalse($this->isUninitializedObject($product));
         self::assertInstanceOf(ECommerceProduct::class, $product);
         self::assertSame('Doctrine Cookbook', $product->getName());
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -100,7 +99,7 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
 
         self::assertNull($customer->getMentor());
         self::assertInstanceOf(ECommerceCart::class, $customer->getCart());
-        self::assertNotInstanceOf(Proxy::class, $customer->getCart());
+        self::assertFalse($this->isUninitializedObject($customer->getCart()));
         self::assertEquals('paypal', $customer->getCart()->getPayment());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
@@ -52,7 +51,7 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
 
         $train = $this->_em->find(get_class($train), $train->id);
-        self::assertNotInstanceOf(Proxy::class, $train->driver);
+        self::assertFalse($this->isUninitializedObject($train->driver));
         self::assertEquals('Benjamin', $train->driver->name);
 
         $this->assertQueryCount(1);
@@ -70,7 +69,6 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
 
         $train = $this->_em->find(get_class($train), $train->id);
-        self::assertNotInstanceOf(Proxy::class, $train->driver);
         self::assertNull($train->driver);
 
         $this->assertQueryCount(1);
@@ -88,9 +86,9 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
 
         $this->getQueryLog()->reset()->enable();
 
-        $driver = $this->_em->find(get_class($owner), $owner->id);
-        self::assertNotInstanceOf(Proxy::class, $owner->train);
-        self::assertNotNull($owner->train);
+        $this->_em->find(get_class($owner), $owner->id);
+        self::assertFalse($this->isUninitializedObject($owner->train));
+        self::assertInstanceOf(Train::class, $owner->train);
 
         $this->assertQueryCount(1);
     }
@@ -109,7 +107,6 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->getQueryLog()->reset()->enable();
 
         $driver = $this->_em->find(get_class($driver), $driver->id);
-        self::assertNotInstanceOf(Proxy::class, $driver->train);
         self::assertNull($driver->train);
 
         $this->assertQueryCount(1);
@@ -126,8 +123,8 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $waggon = $this->_em->find(get_class($waggon), $waggon->id);
-        self::assertNotInstanceOf(Proxy::class, $waggon->train);
-        self::assertNotNull($waggon->train);
+        self::assertFalse($this->isUninitializedObject($waggon->train));
+        self::assertInstanceOf(Train::class, $waggon->train);
     }
 
     /** @group non-cacheable */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -69,7 +68,7 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
         $id = $this->createFixture();
 
         $customer = $this->_em->find(ECommerceCustomer::class, $id);
-        self::assertNotInstanceOf(Proxy::class, $customer->getMentor());
+        self::assertFalse($this->isUninitializedObject($customer->getMentor()));
     }
 
     public function testEagerLoadsAssociation(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -59,7 +59,7 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     {
         // Considering case (a)
         $proxy = $this->_em->getProxyFactory()->getProxy(CmsUser::class, ['id' => 123]);
-        $proxy->__setInitialized(true);
+
         $proxy->id       = null;
         $proxy->username = 'ocra';
         $proxy->name     = 'Marco';
@@ -84,7 +84,7 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
 
         $this->_em->persist($uninitializedProxy);
         $this->_em->flush();
-        self::assertFalse($uninitializedProxy->__isInitialized(), 'Proxy didn\'t get initialized during flush operations');
+        self::assertTrue($this->isUninitializedObject($uninitializedProxy), 'Proxy didn\'t get initialized during flush operations');
         self::assertEquals($userId, $uninitializedProxy->getId());
         $this->_em->remove($uninitializedProxy);
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\UnexpectedResultException;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\IterableTester;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
@@ -624,8 +623,7 @@ class QueryTest extends OrmFunctionalTestCase
         self::assertEquals(1, count($result));
         self::assertInstanceOf(CmsArticle::class, $result[0]);
         self::assertEquals('dr. dolittle', $result[0]->topic);
-        self::assertInstanceOf(Proxy::class, $result[0]->user);
-        self::assertFalse($result[0]->user->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($result[0]->user));
     }
 
     /** @group DDC-952 */
@@ -653,7 +651,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         self::assertCount(10, $articles);
         foreach ($articles as $article) {
-            self::assertNotInstanceOf(Proxy::class, $article);
+            self::assertFalse($this->isUninitializedObject($article));
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Proxy\Proxy as CommonProxy;
 use Doctrine\Common\Util\ClassUtils;
-use Doctrine\Persistence\Proxy;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceShipping;
@@ -120,9 +120,9 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $entity = $this->_em->getReference(ECommerceProduct::class, $id);
         assert($entity instanceof ECommerceProduct);
 
-        self::assertFalse($entity->__isInitialized(), 'Pre-Condition: Object is unitialized proxy.');
+        self::assertTrue($this->isUninitializedObject($entity), 'Pre-Condition: Object is unitialized proxy.');
         $this->_em->getUnitOfWork()->initializeObject($entity);
-        self::assertTrue($entity->__isInitialized(), 'Should be initialized after called UnitOfWork::initializeObject()');
+        self::assertFalse($this->isUninitializedObject($entity), 'Should be initialized after called UnitOfWork::initializeObject()');
     }
 
     /** @group DDC-1163 */
@@ -167,9 +167,9 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $entity = $this->_em->getReference(ECommerceProduct::class, $id);
         assert($entity instanceof ECommerceProduct);
 
-        self::assertFalse($entity->__isInitialized(), 'Pre-Condition: Object is unitialized proxy.');
+        self::assertTrue($this->isUninitializedObject($entity), 'Pre-Condition: Object is unitialized proxy.');
         self::assertEquals($id, $entity->getId());
-        self::assertFalse($entity->__isInitialized(), "Getting the identifier doesn't initialize the proxy.");
+        self::assertTrue($this->isUninitializedObject($entity), "Getting the identifier doesn't initialize the proxy.");
     }
 
     /** @group DDC-1625 */
@@ -180,9 +180,9 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $entity = $this->_em->getReference(CompanyAuction::class, $id);
         assert($entity instanceof CompanyAuction);
 
-        self::assertFalse($entity->__isInitialized(), 'Pre-Condition: Object is unitialized proxy.');
+        self::assertTrue($this->isUninitializedObject($entity), 'Pre-Condition: Object is unitialized proxy.');
         self::assertEquals($id, $entity->getId());
-        self::assertFalse($entity->__isInitialized(), "Getting the identifier doesn't initialize the proxy when extending.");
+        self::assertTrue($this->isUninitializedObject($entity), "Getting the identifier doesn't initialize the proxy when extending.");
     }
 
     public function testDoNotInitializeProxyOnGettingTheIdentifierAndReturnTheRightType(): void
@@ -202,10 +202,10 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $product = $this->_em->getRepository(ECommerceProduct::class)->find($product->getId());
 
         $entity = $product->getShipping();
-        self::assertFalse($entity->__isInitialized(), 'Pre-Condition: Object is unitialized proxy.');
+        self::assertTrue($this->isUninitializedObject($entity), 'Pre-Condition: Object is unitialized proxy.');
         self::assertEquals($id, $entity->getId());
         self::assertSame($id, $entity->getId(), "Check that the id's are the same value, and type.");
-        self::assertFalse($entity->__isInitialized(), "Getting the identifier doesn't initialize the proxy.");
+        self::assertTrue($this->isUninitializedObject($entity), "Getting the identifier doesn't initialize the proxy.");
     }
 
     public function testInitializeProxyOnGettingSomethingOtherThanTheIdentifier(): void
@@ -215,9 +215,9 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $entity = $this->_em->getReference(ECommerceProduct::class, $id);
         assert($entity instanceof ECommerceProduct);
 
-        self::assertFalse($entity->__isInitialized(), 'Pre-Condition: Object is unitialized proxy.');
+        self::assertTrue($this->isUninitializedObject($entity), 'Pre-Condition: Object is unitialized proxy.');
         self::assertEquals('Doctrine Cookbook', $entity->getName());
-        self::assertTrue($entity->__isInitialized(), 'Getting something other than the identifier initializes the proxy.');
+        self::assertFalse($this->isUninitializedObject($entity), 'Getting something other than the identifier initializes the proxy.');
     }
 
     /** @group DDC-1604 */
@@ -229,8 +229,8 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         assert($entity instanceof ECommerceProduct);
         $className = ClassUtils::getClass($entity);
 
-        self::assertInstanceOf(Proxy::class, $entity);
-        self::assertFalse($entity->__isInitialized());
+        self::assertInstanceOf(InternalProxy::class, $entity);
+        self::assertTrue($this->isUninitializedObject($entity));
         self::assertEquals(ECommerceProduct::class, $className);
 
         $restName      = str_replace($this->_em->getConfiguration()->getProxyNamespace(), '', get_class($entity));
@@ -239,6 +239,6 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         self::assertTrue(file_exists($proxyFileName), 'Proxy file name cannot be found generically.');
 
         $entity->__load();
-        self::assertTrue($entity->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($entity));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -10,9 +10,9 @@ use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Cache\QueryCacheKey;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\Cache\Attraction;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\Models\Cache\Country;
@@ -938,7 +938,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state1->getCountry());
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(Proxy::class, $state1->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertEquals($countryName, $state1->getCountry()->getName());
         self::assertEquals($stateId, $state1->getId());
 
@@ -956,7 +956,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state2->getCountry());
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(Proxy::class, $state2->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertEquals($countryName, $state2->getCountry()->getName());
         self::assertEquals($stateId, $state2->getId());
     }
@@ -1030,7 +1030,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(Proxy::class, $state1->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertInstanceOf(City::class, $state1->getCities()->get(0));
         self::assertInstanceOf(State::class, $state1->getCities()->get(0)->getState());
         self::assertSame($state1, $state1->getCities()->get(0)->getState());
@@ -1047,7 +1047,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(Proxy::class, $state2->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertInstanceOf(City::class, $state2->getCities()->get(0));
         self::assertInstanceOf(State::class, $state2->getCities()->get(0)->getState());
         self::assertSame($state2, $state2->getCities()->get(0)->getState());

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Persistence\Proxy;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
 
@@ -197,8 +197,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // load from cache
         $this->getQueryLog()->reset()->enable();
@@ -211,8 +211,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // invalidate cache
         $this->_em->persist(new State('foo', $this->_em->find(Country::class, $this->countries[0]->getId())));
@@ -230,8 +230,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // load from cache
         $this->getQueryLog()->reset()->enable();
@@ -244,7 +244,7 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(Proxy::class, $entities[1]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
+        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\MatchingAssociationFieldRequiresObject;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\Company\CompanyContract;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\Models\Company\CompanyFixContract;
@@ -397,13 +396,14 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
         $this->loadFullFixture();
 
         $ref = $this->_em->getReference(CompanyContract::class, $this->fix->getId());
-        self::assertNotInstanceOf(Proxy::class, $ref, 'Cannot Request a proxy from a class that has subclasses.');
+        self::assertFalse($this->isUninitializedObject($ref), 'Cannot Request a proxy from a class that has subclasses.');
         self::assertInstanceOf(CompanyContract::class, $ref);
         self::assertInstanceOf(CompanyFixContract::class, $ref, 'Direct fetch of the reference has to load the child class Employee directly.');
         $this->_em->clear();
 
         $ref = $this->_em->getReference(CompanyFixContract::class, $this->fix->getId());
-        self::assertInstanceOf(Proxy::class, $ref, 'A proxy can be generated only if no subclasses exists for the requested reference.');
+
+        self::assertTrue($this->isUninitializedObject($ref), 'A proxy can be generated only if no subclasses exists for the requested reference.');
     }
 
     /** @group DDC-952 */
@@ -417,6 +417,6 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
                               ->setParameter(1, $this->fix->getId())
                               ->getSingleResult();
 
-        self::assertNotInstanceOf(Proxy::class, $contract->getSalesPerson());
+        self::assertFalse($this->isUninitializedObject($contract->getSalesPerson()));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinColumns;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function assert;
@@ -92,7 +91,7 @@ class DDC1163Test extends OrmFunctionalTestCase
         assert($specialProduct instanceof DDC1163SpecialProduct);
 
         self::assertInstanceOf(DDC1163SpecialProduct::class, $specialProduct);
-        self::assertInstanceOf(Proxy::class, $specialProduct);
+        self::assertTrue($this->isUninitializedObject($specialProduct));
 
         $specialProduct->setSubclassProperty('foobar');
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -45,7 +45,7 @@ class DDC1193Test extends OrmFunctionalTestCase
         $company = $this->_em->find(get_class($company), $companyId);
 
         self::assertTrue($this->_em->getUnitOfWork()->isInIdentityMap($company), 'Company is in identity map.');
-        self::assertFalse($company->member->__isInitialized(), 'Pre-Condition');
+        self::assertTrue($this->isUninitializedObject($company->member), 'Pre-Condition');
         self::assertTrue($this->_em->getUnitOfWork()->isInIdentityMap($company->member), 'Member is in identity map.');
 
         $this->_em->remove($company);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -38,9 +38,9 @@ class DDC1228Test extends OrmFunctionalTestCase
 
         $user = $this->_em->find(DDC1228User::class, $user->id);
 
-        self::assertFalse($user->getProfile()->__isInitialized(), 'Proxy is not initialized');
+        self::assertTrue($this->isUninitializedObject($user->getProfile()), 'Proxy is not initialized');
         $user->getProfile()->setName('Bar');
-        self::assertTrue($user->getProfile()->__isInitialized(), 'Proxy is not initialized');
+        self::assertFalse($this->isUninitializedObject($user->getProfile()), 'Proxy is not initialized');
 
         self::assertEquals('Bar', $user->getProfile()->getName());
         self::assertEquals(['id' => 1, 'name' => 'Foo'], $this->_em->getUnitOfWork()->getOriginalEntityData($user->getProfile()));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -54,7 +53,7 @@ class DDC1452Test extends OrmFunctionalTestCase
         $results = $this->_em->createQuery($dql)->setMaxResults(1)->getResult();
 
         self::assertSame($results[0], $results[0]->entitiesB[0]->entityAFrom);
-        self::assertNotInstanceOf(Proxy::class, $results[0]->entitiesB[0]->entityATo);
+        self::assertFalse($this->isUninitializedObject($results[0]->entitiesB[0]->entityATo));
         self::assertInstanceOf(Collection::class, $results[0]->entitiesB[0]->entityATo->getEntitiesB());
     }
 
@@ -82,12 +81,12 @@ class DDC1452Test extends OrmFunctionalTestCase
         $data = $this->_em->createQuery($dql)->getResult();
         $this->_em->clear();
 
-        self::assertNotInstanceOf(Proxy::class, $data[0]->user);
+        self::assertFalse($this->isUninitializedObject($data[0]->user));
 
         $dql  = 'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.address a';
         $data = $this->_em->createQuery($dql)->getResult();
 
-        self::assertNotInstanceOf(Proxy::class, $data[0]->address);
+        self::assertFalse($this->isUninitializedObject($data[0]->address));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function count;
@@ -57,9 +56,10 @@ class DDC1690Test extends OrmFunctionalTestCase
         $child  = $this->_em->find(DDC1690Child::class, $childId);
 
         self::assertEquals(1, count($parent->listeners));
-        self::assertInstanceOf(Proxy::class, $child, 'Verifying that $child is a proxy before using proxy API');
         self::assertCount(0, $child->listeners);
-        $child->__load();
+
+        $this->_em->getUnitOfWork()->initializeObject($child);
+
         self::assertCount(1, $child->listeners);
         unset($parent, $child);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Persistence\Proxy;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -37,8 +37,7 @@ class DDC1734Test extends OrmFunctionalTestCase
 
         $proxy = $this->getProxy($group);
 
-        self::assertInstanceOf(Proxy::class, $proxy);
-        self::assertFalse($proxy->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($proxy));
 
         $this->_em->detach($proxy);
         $this->_em->clear();
@@ -67,8 +66,7 @@ class DDC1734Test extends OrmFunctionalTestCase
 
         $proxy = $this->getProxy($group);
 
-        self::assertInstanceOf(Proxy::class, $proxy);
-        self::assertFalse($proxy->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($proxy));
 
         $this->_em->detach($proxy);
         $serializedProxy = serialize($proxy);
@@ -79,7 +77,7 @@ class DDC1734Test extends OrmFunctionalTestCase
     }
 
     /** @param object $object */
-    private function getProxy($object): Proxy
+    private function getProxy($object): InternalProxy
     {
         $metadataFactory = $this->_em->getMetadataFactory();
         $className       = get_class($object);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function assert;
@@ -47,10 +46,8 @@ class DDC2230Test extends OrmFunctionalTestCase
         $mergedUser = $this->_em->merge($user);
 
         $address = $mergedUser->address;
-        assert($address instanceof Proxy);
 
-        self::assertInstanceOf(Proxy::class, $address);
-        self::assertFalse($address->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($address));
     }
 
     public function testNotifyTrackingCalledOnProxyInitialization(): void
@@ -62,12 +59,12 @@ class DDC2230Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $addressProxy = $this->_em->getReference(DDC2230Address::class, $insertedAddress->id);
-        assert($addressProxy instanceof Proxy || $addressProxy instanceof DDC2230Address);
+        assert($addressProxy instanceof DDC2230Address);
 
-        self::assertFalse($addressProxy->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($addressProxy));
         self::assertNull($addressProxy->listener);
 
-        $addressProxy->__load();
+        $this->_em->getUnitOfWork()->initializeObject($addressProxy);
 
         self::assertSame($this->_em->getUnitOfWork(), $addressProxy->listener);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\Table;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectManagerAware;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
@@ -43,12 +42,11 @@ class DDC2231Test extends OrmFunctionalTestCase
 
         $y1ref = $this->_em->getReference(get_class($y1), $y1->id);
 
-        self::assertInstanceOf(Proxy::class, $y1ref);
-        self::assertFalse($y1ref->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($y1ref));
 
         $id = $y1ref->doSomething();
 
-        self::assertTrue($y1ref->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($y1ref));
         self::assertEquals($this->_em, $y1ref->om);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function assert;
@@ -63,16 +62,15 @@ class DDC2306Test extends OrmFunctionalTestCase
         $address = $this->_em->find(DDC2306Address::class, $address->id);
         assert($address instanceof DDC2306Address);
         $user = $address->users->first()->user;
-        assert($user instanceof DDC2306User || $user instanceof Proxy);
 
-        self::assertInstanceOf(Proxy::class, $user);
+        $this->assertTrue($this->isUninitializedObject($user));
         self::assertInstanceOf(DDC2306User::class, $user);
 
         $userId = $user->id;
 
         self::assertNotNull($userId);
 
-        $user->__load();
+        $this->_em->getUnitOfWork()->initializeObject($user);
 
         self::assertEquals(
             $userId,

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
@@ -50,16 +49,14 @@ class DDC237Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $x2 = $this->_em->find(get_class($x), $x->id); // proxy injected for Y
-        self::assertInstanceOf(Proxy::class, $x2->y);
-        self::assertFalse($x2->y->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($x2->y));
 
         // proxy for Y is in identity map
 
         $z2 = $this->_em->createQuery('select z,y from ' . get_class($z) . ' z join z.y y where z.id = ?1')
                 ->setParameter(1, $z->id)
                 ->getSingleResult();
-        self::assertInstanceOf(Proxy::class, $z2->y);
-        self::assertTrue($z2->y->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($z2->y));
         self::assertEquals('Y', $z2->y->data);
         self::assertEquals($y->id, $z2->y->id);
 
@@ -69,7 +66,6 @@ class DDC237Test extends OrmFunctionalTestCase
         self::assertNotSame($x, $x2);
         self::assertNotSame($z, $z2);
         self::assertSame($z2->y, $x2->y);
-        self::assertInstanceOf(Proxy::class, $z2->y);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -61,21 +60,20 @@ class DDC2494Test extends OrmFunctionalTestCase
 
         $this->getQueryLog()->reset()->enable();
 
-        self::assertInstanceOf(Proxy::class, $item->getCurrency());
-        self::assertFalse($item->getCurrency()->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($item->getCurrency()));
 
         self::assertArrayHasKey('convertToPHPValue', DDC2494TinyIntType::$calls);
         self::assertCount(1, DDC2494TinyIntType::$calls['convertToPHPValue']);
 
         self::assertIsInt($item->getCurrency()->getId());
         self::assertCount(1, DDC2494TinyIntType::$calls['convertToPHPValue']);
-        self::assertFalse($item->getCurrency()->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($item->getCurrency()));
 
         $this->assertQueryCount(0);
 
         self::assertIsInt($item->getCurrency()->getTemp());
         self::assertCount(3, DDC2494TinyIntType::$calls['convertToPHPValue']);
-        self::assertTrue($item->getCurrency()->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($item->getCurrency()));
 
         $this->assertQueryCount(1);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\Legacy\LegacyUser;
 use Doctrine\Tests\Models\Legacy\LegacyUserReference;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -36,15 +35,10 @@ class DDC2519Test extends OrmFunctionalTestCase
         self::assertInstanceOf(LegacyUser::class, $result[1]->source());
         self::assertInstanceOf(LegacyUser::class, $result[1]->target());
 
-        self::assertInstanceOf(Proxy::class, $result[0]->source());
-        self::assertInstanceOf(Proxy::class, $result[0]->target());
-        self::assertInstanceOf(Proxy::class, $result[1]->source());
-        self::assertInstanceOf(Proxy::class, $result[1]->target());
-
-        self::assertFalse($result[0]->target()->__isInitialized());
-        self::assertFalse($result[0]->source()->__isInitialized());
-        self::assertFalse($result[1]->target()->__isInitialized());
-        self::assertFalse($result[1]->source()->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($result[0]->target()));
+        self::assertTrue($this->isUninitializedObject($result[0]->source()));
+        self::assertTrue($this->isUninitializedObject($result[1]->target()));
+        self::assertTrue($this->isUninitializedObject($result[1]->source()));
 
         self::assertNotNull($result[0]->source()->getId());
         self::assertNotNull($result[0]->target()->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Query;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /** @group DDC-371 */
@@ -51,7 +50,7 @@ class DDC371Test extends OrmFunctionalTestCase
                 ->getResult();
 
         self::assertCount(1, $children);
-        self::assertNotInstanceOf(Proxy::class, $children[0]->parent);
+        self::assertFalse($this->isUninitializedObject($children[0]->parent));
         self::assertFalse($children[0]->parent->children->isInitialized());
         self::assertEquals(0, $children[0]->parent->children->unwrap()->count());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function get_class;
@@ -52,7 +51,7 @@ class DDC522Test extends OrmFunctionalTestCase
 
         self::assertInstanceOf(DDC522Cart::class, $r[0]);
         self::assertInstanceOf(DDC522Customer::class, $r[0]->customer);
-        self::assertNotInstanceOf(Proxy::class, $r[0]->customer);
+        self::assertFalse($this->isUninitializedObject($r[0]->customer));
         self::assertEquals('name', $r[0]->customer->name);
 
         $fkt         = new DDC522ForeignKeyTest();
@@ -64,8 +63,7 @@ class DDC522Test extends OrmFunctionalTestCase
 
         $fkt2 = $this->_em->find(get_class($fkt), $fkt->id);
         self::assertEquals($fkt->cart->id, $fkt2->cartId);
-        self::assertInstanceOf(Proxy::class, $fkt2->cart);
-        self::assertFalse($fkt2->cart->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($fkt2->cart));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC531Test extends OrmFunctionalTestCase
@@ -46,7 +45,7 @@ class DDC531Test extends OrmFunctionalTestCase
         // parent will already be loaded, cannot be lazy because it has mapped subclasses and we would not
         // know which proxy type to put in.
         self::assertInstanceOf(DDC531Item::class, $item3->parent);
-        self::assertNotInstanceOf(Proxy::class, $item3->parent);
+        self::assertFalse($this->isUninitializedObject($item3->parent));
         $item4 = $this->_em->find(DDC531Item::class, $item1->id); // Load parent item (id 1)
         self::assertNull($item4->parent);
         self::assertNotNull($item4->getChildren());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC633Test extends OrmFunctionalTestCase
@@ -44,7 +43,7 @@ class DDC633Test extends OrmFunctionalTestCase
         $eagerAppointment = $this->_em->find(DDC633Appointment::class, $app->id);
 
         // Eager loading of one to one leads to fetch-join
-        self::assertNotInstanceOf(Proxy::class, $eagerAppointment->patient);
+        self::assertFalse($this->isUninitializedObject($eagerAppointment->patient));
         self::assertTrue($this->_em->contains($eagerAppointment->patient));
     }
 
@@ -70,8 +69,7 @@ class DDC633Test extends OrmFunctionalTestCase
         $appointments = $this->_em->createQuery('SELECT a FROM ' . __NAMESPACE__ . '\DDC633Appointment a')->getResult();
 
         foreach ($appointments as $eagerAppointment) {
-            self::assertInstanceOf(Proxy::class, $eagerAppointment->patient);
-            self::assertTrue($eagerAppointment->patient->__isInitialized(), 'Proxy should already be initialized due to eager loading!');
+            self::assertFalse($this->isUninitializedObject($eagerAppointment->patient), 'Proxy should already be initialized due to eager loading!');
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6460Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6460Test.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC6460Test extends OrmFunctionalTestCase
@@ -61,11 +60,10 @@ class DDC6460Test extends OrmFunctionalTestCase
 
         $secondEntityWithLazyParameter = $this->_em->getRepository(DDC6460ParentEntity::class)->findOneById(1);
 
-        self::assertInstanceOf(Proxy::class, $secondEntityWithLazyParameter->lazyLoaded);
         self::assertInstanceOf(DDC6460Entity::class, $secondEntityWithLazyParameter->lazyLoaded);
-        self::assertFalse($secondEntityWithLazyParameter->lazyLoaded->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($secondEntityWithLazyParameter->lazyLoaded));
         self::assertEquals($secondEntityWithLazyParameter->lazyLoaded->embedded, $entity->embedded);
-        self::assertTrue($secondEntityWithLazyParameter->lazyLoaded->__isInitialized());
+        self::assertFalse($this->isUninitializedObject($secondEntityWithLazyParameter->lazyLoaded));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -46,7 +45,7 @@ class DDC736Test extends OrmFunctionalTestCase
         unset($result[0]);
 
         self::assertInstanceOf(ECommerceCart::class, $cart2);
-        self::assertNotInstanceOf(Proxy::class, $cart2->getCustomer());
+        self::assertFalse($this->isUninitializedObject($cart2->getCustomer()));
         self::assertInstanceOf(ECommerceCustomer::class, $cart2->getCustomer());
         self::assertEquals(['name' => 'roman', 'payment' => 'cash'], $result);
     }
@@ -77,7 +76,7 @@ class DDC736Test extends OrmFunctionalTestCase
 
         $cart2 = $result[0][0];
         assert($cart2 instanceof ECommerceCart);
-        self::assertInstanceOf(Proxy::class, $cart2->getCustomer());
+        self::assertTrue($this->isUninitializedObject($cart2->getCustomer()));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\JoinColumns;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC881Test extends OrmFunctionalTestCase
@@ -90,8 +89,8 @@ class DDC881Test extends OrmFunctionalTestCase
         $calls = $this->_em->createQuery($dql)->getResult();
 
         self::assertCount(2, $calls);
-        self::assertNotInstanceOf(Proxy::class, $calls[0]->getPhoneNumber());
-        self::assertNotInstanceOf(Proxy::class, $calls[1]->getPhoneNumber());
+        self::assertFalse($this->isUninitializedObject($calls[0]->getPhoneNumber()));
+        self::assertFalse($this->isUninitializedObject($calls[1]->getPhoneNumber()));
 
         $dql     = 'SELECT p, c FROM ' . DDC881PhoneNumber::class . ' p JOIN p.calls c';
         $numbers = $this->_em->createQuery($dql)->getResult();

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -967,4 +967,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         $this->dropTableIfExists($tableName);
         $schemaManager->createTable($table);
     }
+
+    /** @param object $entity */
+    final protected function isUninitializedObject($entity): bool
+    {
+        return $this->_em->getUnitOfWork()->isUninitializedObject($entity);
+    }
 }


### PR DESCRIPTION
Related to https://github.com/doctrine/persistence/pull/334
On the path to deprecating `Doctrine\Persistence\Proxy` in the future.

Adding `EntityManager::isUninitializedEntity()` will allow userland to decouple from the `Proxy` interface:

before:
```php
if ($entity instanceof Proxy && !$entity->__isInitialized()) {
    $entity->__load();
}
```

after:
```php
if ($em->isUninitializedEntity($entity)) {
    $em->initializeObject($entity);
}
```
