### PR TITLE
Use properties instead of getters to read property/class names via reflection

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1176,7 +1176,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->namespace = $reflService->getClassNamespace($this->name);
 
         if ($this->reflClass) {
-            $this->name = $this->rootEntityName = $this->reflClass->getName();
+            $this->name = $this->rootEntityName = $this->reflClass->name;
         }
 
         $this->table['name'] = $this->namingStrategy->classToTableName($this->name);
@@ -3866,7 +3866,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $reflectionProperty = $reflService->getAccessibleProperty($class, $field);
         if ($reflectionProperty !== null && PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
-            $declaringClass = $reflectionProperty->getDeclaringClass()->name;
+            $declaringClass = $reflectionProperty->class;
             if ($declaringClass !== $class) {
                 $reflectionProperty = $reflService->getAccessibleProperty($declaringClass, $field);
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -365,7 +365,7 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
             }
 
             $mapping              = [];
-            $mapping['fieldName'] = $property->getName();
+            $mapping['fieldName'] = $property->name;
 
             // Evaluate @Cache annotation
             $cacheAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Cache::class);
@@ -398,7 +398,7 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
             // @Column, @OneToOne, @OneToMany, @ManyToOne, @ManyToMany
             $columnAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Column::class);
             if ($columnAnnot) {
-                $mapping = $this->columnToArray($property->getName(), $columnAnnot);
+                $mapping = $this->columnToArray($property->name, $columnAnnot);
 
                 $idAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Id::class);
                 if ($idAnnot) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -315,7 +315,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
             }
 
             $mapping              = [];
-            $mapping['fieldName'] = $property->getName();
+            $mapping['fieldName'] = $property->name;
 
             // Evaluate #[Cache] attribute
             $cacheAttribute = $this->reader->getPropertyAttribute($property, Mapping\Cache::class);
@@ -350,7 +350,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
             $embeddedAttribute   = $this->reader->getPropertyAttribute($property, Mapping\Embedded::class);
 
             if ($columnAttribute !== null) {
-                $mapping = $this->columnToArray($property->getName(), $columnAttribute);
+                $mapping = $this->columnToArray($property->name, $columnAttribute);
 
                 if ($this->reader->getPropertyAttribute($property, Mapping\Id::class)) {
                     $mapping['id'] = true;

--- a/lib/Doctrine/ORM/Mapping/Driver/ReflectionBasedDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/ReflectionBasedDriver.php
@@ -32,7 +32,7 @@ trait ReflectionBasedDriver
                 || $metadata->isInheritedEmbeddedClass($property->name);
         }
 
-        $declaringClass = $property->getDeclaringClass()->getName();
+        $declaringClass = $property->class;
 
         if (
             isset($metadata->fieldMappings[$property->name]['declared'])

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -73,7 +73,7 @@ final class ReflectionPropertiesGetter
 
             $parentClass = $currentClass->getParentClass();
             if ($parentClass) {
-                $parentClassName = $parentClass->getName();
+                $parentClassName = $parentClass->name;
             }
         }
 
@@ -111,14 +111,14 @@ final class ReflectionPropertiesGetter
     private function getAccessibleProperty(ReflectionProperty $property): ?ReflectionProperty
     {
         return $this->reflectionService->getAccessibleProperty(
-            $property->getDeclaringClass()->getName(),
-            $property->getName()
+            $property->class,
+            $property->name
         );
     }
 
     private function getLogicalName(ReflectionProperty $property): string
     {
-        $propertyName = $property->getName();
+        $propertyName = $property->name;
 
         if ($property->isPublic()) {
             return $propertyName;
@@ -128,6 +128,6 @@ final class ReflectionPropertiesGetter
             return "\0*\0" . $propertyName;
         }
 
-        return "\0" . $property->getDeclaringClass()->getName() . "\0" . $propertyName;
+        return "\0" . $property->class . "\0" . $propertyName;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -38,7 +38,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
         $this->childProperty  = $childProperty;
         $this->embeddedClass  = (string) $embeddedClass;
 
-        parent::__construct($childProperty->getDeclaringClass()->getName(), $childProperty->getName());
+        parent::__construct($childProperty->class, $childProperty->name);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEnumProperty.php
@@ -28,8 +28,8 @@ class ReflectionEnumProperty extends ReflectionProperty
         $this->enumType                   = $enumType;
 
         parent::__construct(
-            $originalReflectionProperty->getDeclaringClass()->getName(),
-            $originalReflectionProperty->getName()
+            $originalReflectionProperty->class,
+            $originalReflectionProperty->name
         );
     }
 
@@ -98,7 +98,7 @@ class ReflectionEnumProperty extends ReflectionProperty
         } catch (ValueError $e) {
             throw MappingException::invalidEnumValue(
                 get_class($object),
-                $this->originalReflectionProperty->getName(),
+                $this->originalReflectionProperty->name,
                 (string) $value,
                 $enumType,
                 $e

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -335,13 +335,13 @@ EOPHP;
 
         while ($reflector) {
             foreach ($reflector->getProperties($filter) as $property) {
-                $name = $property->getName();
+                $name = $property->name;
 
                 if ($property->isStatic() || (($class->hasField($name) || $class->hasAssociation($name)) && ! isset($identifiers[$name]))) {
                     continue;
                 }
 
-                $prefix = $property->isPrivate() ? "\0" . $property->getDeclaringClass()->getName() . "\0" : ($property->isProtected() ? "\0*\0" : '');
+                $prefix = $property->isPrivate() ? "\0" . $property->class . "\0" : ($property->isProtected() ? "\0*\0" : '');
 
                 $skippedProperties[$prefix . $name] = true;
             }
@@ -376,7 +376,7 @@ EOPHP;
         return $code . '$data = [];
 
         foreach (parent::__sleep() as $name) {
-            $value = $properties[$k = $name] ?? $properties[$k = "\0*\0$name"] ?? $properties[$k = "\0' . $reflector->getName() . '\0$name"] ?? $k = null;
+            $value = $properties[$k = $name] ?? $properties[$k = "\0*\0$name"] ?? $properties[$k = "\0' . $reflector->name . '\0$name"] ?? $k = null;
 
             if (null === $k) {
                 trigger_error(sprintf(\'serialize(): "%s" returned as member variable from __sleep() but does not exist\', $name), \E_USER_NOTICE);

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -969,7 +969,7 @@ public function __construct(<params>)
     {
         $refl = new ReflectionClass($this->getClassToExtend());
 
-        return '\\' . $refl->getName();
+        return '\\' . $refl->name;
     }
 
     /** @return string */


### PR DESCRIPTION
Saves a few methods calls + object instantiations for `getDeclaringClass()`