### PR TITLE
Fix templated phpdoc return type

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -335,7 +335,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param string|class-string<T> $className
+     * @param string $className
+     * @psalm-param class-string<T> $className
      *
      * @return Mapping\ClassMetadata
      * @psalm-return Mapping\ClassMetadata<T>

--- a/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
@@ -22,7 +22,7 @@ use const PHP_VERSION_ID;
 /** @psalm-type ScalarName = 'array'|'bool'|'float'|'int'|'string' */
 final class DefaultTypedFieldMapper implements TypedFieldMapper
 {
-    /** @var array<class-string|ScalarName, class-string<Type>|string> $typedFieldMappings */
+    /** @var array<class-string|ScalarName, class-string<Type>> $typedFieldMappings */
     private $typedFieldMappings;
 
     private const DEFAULT_TYPED_FIELD_MAPPINGS = [
@@ -36,7 +36,7 @@ final class DefaultTypedFieldMapper implements TypedFieldMapper
         'string' => Types::STRING,
     ];
 
-    /** @param array<class-string|ScalarName, class-string<Type>|string> $typedFieldMappings */
+    /** @param array<class-string|ScalarName, class-string<Type>> $typedFieldMappings */
     public function __construct(array $typedFieldMappings = [])
     {
         $this->typedFieldMappings = array_merge(self::DEFAULT_TYPED_FIELD_MAPPINGS, $typedFieldMappings);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
-			message: "#^Template type T of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getClassMetadata\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/EntityManagerInterface.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\EntityRepository\\:\\:matching\\(\\) should return Doctrine\\\\Common\\\\Collections\\\\AbstractLazyCollection\\<int, T of object\\>&Doctrine\\\\Common\\\\Collections\\\\Selectable\\<int, T of object\\> but returns Doctrine\\\\ORM\\\\LazyCriteriaCollection\\<\\(int\\|string\\), object\\>\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityRepository.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -257,12 +257,6 @@
       <code>transactional</code>
       <code>transactional</code>
     </DeprecatedMethod>
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->wrapped->getClassMetadata($className)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>getClassMetadata</code>
-    </InvalidReturnType>
     <MissingParamType>
       <code>$entity</code>
       <code>$lockMode</code>
@@ -281,7 +275,6 @@
   </file>
   <file src="lib/Doctrine/ORM/EntityManager.php">
     <ArgumentTypeCoercion>
-      <code>$className</code>
       <code>$connection</code>
       <code>$entityName</code>
     </ArgumentTypeCoercion>
@@ -1151,9 +1144,6 @@
     <InvalidReturnType>
       <code><![CDATA[Collection<TKey, T>]]></code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->unwrap()->matching($criteria)]]></code>
-    </LessSpecificReturnStatement>
     <MissingParamType>
       <code>$offset</code>
     </MissingParamType>


### PR DESCRIPTION
When split between `@param` and `@psalm-param`, only the `@psalm-param` is used by psalm/phpstan, ie `class-string<T>` is used instead of (too wide) `class|class-string<T>`.

In the 2nd commit, I fixed all other simillar problems in the whole repo. I used `@.*(string.*\|class-s|class-string.*\|.*string)` regex to find the lines to check/fix.