### PR TITLE
Bug: Enum could not be converted to string

### DIFF
--- a/tests/Doctrine/Tests/Models/Enums/ReferenceToTypedCardEnumId.php
+++ b/tests/Doctrine/Tests/Models/Enums/ReferenceToTypedCardEnumId.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+/** @Entity */
+#[Entity]
+class ReferenceToTypedCardEnumId
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     * @var int
+     */
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="TypedCardEnumId")
+     * @ORM\JoinColumn(name="typed_card_id", referencedColumnName="suit", nullable=false)
+     */
+    #[ManyToOne(targetEntity: TypedCardEnumId::class)]
+    #[JoinColumn(nullable: false)]
+    public TypedCardEnumId $typedCard;
+
+}

--- a/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
@@ -26,7 +26,7 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
         $this->createSchemaForModels(
             TypedCardEnumId::class,
             TypedCardEnumCompositeId::class,
-            ReferenceToTypedCardEnumId::class,
+            ReferenceToTypedCardEnumId::class
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
@@ -60,13 +60,13 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
     public function testEnumReference(): void
     {
         $typedCardEnumIdEntity       = new TypedCardEnumId();
-        $typedCardEnumIdEntity->suit = Suit::Clubs;
+        $typedCardEnumIdEntity->suit = Suit::Diamonds;
 
         $this->_em->persist($typedCardEnumIdEntity);
         $this->_em->flush();
         $this->_em->clear();
 
-        $proxy = $this->_em->getReference(TypedCardEnumId::class, Suit::Clubs);
+        $proxy = $this->_em->getReference(TypedCardEnumId::class, Suit::Diamonds);
 
         $referenceToTypedCardEnumId            = new ReferenceToTypedCardEnumId();
         $referenceToTypedCardEnumId->typedCard = $proxy;

--- a/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Utility;
 
+use Doctrine\Tests\Models\Enums\ReferenceToTypedCardEnumId;
 use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\Enums\TypedCardEnumCompositeId;
 use Doctrine\Tests\Models\Enums\TypedCardEnumId;
@@ -24,7 +25,8 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
 
         $this->createSchemaForModels(
             TypedCardEnumId::class,
-            TypedCardEnumCompositeId::class
+            TypedCardEnumCompositeId::class,
+            ReferenceToTypedCardEnumId::class,
         );
     }
 
@@ -53,6 +55,23 @@ class IdentifierFlattenerEnumIdTest extends OrmFunctionalTestCase
         self::assertCount(1, $id, 'We should have 1 identifier');
 
         self::assertEquals(Suit::Clubs, $findTypedCardEnumIdEntity->suit);
+    }
+
+    public function testEnumReference(): void
+    {
+        $typedCardEnumIdEntity       = new TypedCardEnumId();
+        $typedCardEnumIdEntity->suit = Suit::Clubs;
+
+        $this->_em->persist($typedCardEnumIdEntity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $proxy = $this->_em->getReference(TypedCardEnumId::class, Suit::Clubs);
+
+        $referenceToTypedCardEnumId            = new ReferenceToTypedCardEnumId();
+        $referenceToTypedCardEnumId->typedCard = $proxy;
+        $this->_em->persist($referenceToTypedCardEnumId);
+        $this->_em->flush();
     }
 
     /** @group utilities */


### PR DESCRIPTION
```
Error : Object of class Doctrine\Tests\Models\Enums\Suit could not be converted to string
 /home/olda/www/doctrine-orm/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:43
 /home/olda/www/doctrine-orm/vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:35
 /home/olda/www/doctrine-orm/vendor/doctrine/dbal/src/Logging/Statement.php:84
 /home/olda/www/doctrine-orm/vendor/doctrine/dbal/src/Statement.php:115
 /home/olda/www/doctrine-orm/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:276
 /home/olda/www/doctrine-orm/lib/Doctrine/ORM/UnitOfWork.php:1186
 /home/olda/www/doctrine-orm/lib/Doctrine/ORM/UnitOfWork.php:441
 /home/olda/www/doctrine-orm/lib/Doctrine/ORM/EntityManager.php:403
 /home/olda/www/doctrine-orm/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerEnumIdTest.php:74

```