### PR TITLE
Remove outdated comment

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -207,13 +207,6 @@ class EntityManager implements EntityManagerInterface
     /**
      * Returns the ORM metadata descriptor for a class.
      *
-     * The class name must be the fully-qualified class name without a leading backslash
-     * (as it is returned by get_class($obj)) or an aliased class name.
-     *
-     * Examples:
-     * MyProject\Domain\User
-     * sales:PriceRequest
-     *
      * Internal note: Performance-sensitive method.
      *
      * {@inheritDoc}


### PR DESCRIPTION
Since support for persistence 2 has been dropped, this method may no longer acces an aliased class name.
Besides, providing an FQCN with a leading backslash should work since removing it is the first thing that happens inside `AbstractClassMetadataFactory::getMetadataFor()`: https://github.com/doctrine/persistence/blob/413eb71a22c31c309b5a1cea9701d723cc0d4ae2/src/Persistence/Mapping/AbstractClassMetadataFactory.php#L164-L177

