### PR TITLE
fix: DBAL deprecation when default is set

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -821,8 +821,10 @@ class SchemaTool
             return [];
         }
 
-        $options                        = array_intersect_key($mappingOptions, array_flip(self::KNOWN_COLUMN_OPTIONS));
-        $options['customSchemaOptions'] = array_diff_key($mappingOptions, $options);
+        $options = array_intersect_key($mappingOptions, array_flip(self::KNOWN_COLUMN_OPTIONS));
+        if ($customSchemaOptions = array_diff_key($mappingOptions, $options)) {
+            $options['customSchemaOptions'] = $customSchemaOptions;
+        }
 
         return $options;
     }


### PR DESCRIPTION
Prevents creating an empty array that triggers a DBAL deprecation when not necessary.