### PR TITLE
fix: use platform options instead of deprecated custom options

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -821,8 +821,8 @@ class SchemaTool
             return [];
         }
 
-        $options                        = array_intersect_key($mappingOptions, array_flip(self::KNOWN_COLUMN_OPTIONS));
-        $options['customSchemaOptions'] = array_diff_key($mappingOptions, $options);
+        $options                    = array_intersect_key($mappingOptions, array_flip(self::KNOWN_COLUMN_OPTIONS));
+        $options['platformOptions'] = array_diff_key($mappingOptions, $options);
 
         return $options;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -77,7 +77,7 @@ class SchemaToolTest extends OrmTestCase
         );
         $table  = $schema->getTable('TestEntityWithAnnotationOptionsAttribute');
 
-        foreach ([$table->getOptions(), $table->getColumn('test')->getCustomSchemaOptions()] as $options) {
+        foreach ([$table->getOptions(), $table->getColumn('test')->getPlatformOptions()] as $options) {
             self::assertArrayHasKey('foo', $options);
             self::assertSame('bar', $options['foo']);
             self::assertArrayHasKey('baz', $options);
@@ -139,7 +139,7 @@ class SchemaToolTest extends OrmTestCase
 
         self::assertEquals(
             ['collation' => 'latin1_bin', 'foo' => 'bar'],
-            $tableBoard->getColumn('category_id')->getCustomSchemaOptions()
+            $tableBoard->getColumn('category_id')->getPlatformOptions()
         );
     }
 
@@ -192,13 +192,13 @@ class SchemaToolTest extends OrmTestCase
         $em         = $this->getTestEntityManager();
         $schemaTool = new SchemaTool($em);
 
-        $customSchemaOptions = $schemaTool->getSchemaFromMetadata([$em->getClassMetadata(Card::class)])
+        $platformOptions = $schemaTool->getSchemaFromMetadata([$em->getClassMetadata(Card::class)])
             ->getTable('Card')
             ->getColumn('suit')
-            ->getCustomSchemaOptions();
+            ->getPlatformOptions();
 
-        self::assertArrayHasKey('enumType', $customSchemaOptions);
-        self::assertSame(Suit::class, $customSchemaOptions['enumType']);
+        self::assertArrayHasKey('enumType', $platformOptions);
+        self::assertSame(Suit::class, $platformOptions['enumType']);
     }
 
     /** @group DDC-3671 */


### PR DESCRIPTION
DBAL's custom schema options have been deprecated in favor of platform options.

This patch uses the recommended method to prevent deprecations.

Closes #10854.