### PR TITLE
Fix/Self deprecation with getQueryCacheImpl

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -333,7 +333,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getQueryCacheImpl()
     {
-        Deprecation::triggerIfCalledFromOutside(
+        Deprecation::trigger(
             'doctrine/orm',
             'https://github.com/doctrine/orm/pull/9002',
             'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getQueryCache() instead.',

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -333,7 +333,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getQueryCacheImpl()
     {
-        Deprecation::trigger(
+        Deprecation::triggerIfCalledFromOutside(
             'doctrine/orm',
             'https://github.com/doctrine/orm/pull/9002',
             'Method %s() is deprecated and will be removed in Doctrine ORM 3.0. Use getQueryCache() instead.',

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function assert;
 use function get_debug_type;
 use function sprintf;
 
@@ -96,7 +97,13 @@ EOT
 
         $ui->comment('Clearing <info>all</info> Query cache entries');
 
-        $result  = $cache ? $cache->clear() : $cacheDriver->deleteAll();
+        if ($cache) {
+            $result = $cache->clear();
+        } else {
+            assert($cacheDriver !== null);
+            $result = $cacheDriver->deleteAll();
+        }
+
         $message = $result ? 'Successfully deleted cache entries.' : 'No cache entries were deleted.';
 
         if ($input->getOption('flush') === true && ! $cache) {


### PR DESCRIPTION
Hi @greg0ire, I got another "non solvable deprecation" from doctrine.

`getQueryCacheImpl` is used in `QueryCommand::execute`