### PR TITLE
Revert "Allow symfony/console 7 (#10724)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/lexer": "^2",
         "doctrine/persistence": "^2.4 || ^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/console": "^4.2 || ^5.0 || ^6.0",
         "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.16"
     },


### PR DESCRIPTION
Follows #10724.

I'm adding this PR to the 2.17.0 milestone so we won't forget to revert Symfony 7 support before the final release.