### PR TITLE
Fix return type of `getSingleScalarResult`

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1010,9 +1010,8 @@ abstract class AbstractQuery
      *
      * Alias for getSingleResult(HYDRATE_SINGLE_SCALAR).
      *
-     * @return bool|float|int|string The scalar result.
+     * @return bool|float|int|string|null The scalar result.
      *
-     * @throws NoResultException        If the query returned no result.
      * @throws NonUniqueResultException If the query result is not unique.
      */
     public function getSingleScalarResult()


### PR DESCRIPTION
`Doctrine\ORM\AbstractQuery::getSingleScalarResult()` does not have `null` as a possible type of returned data while `NoResultException` is listed as one of the possible exceptions thrown.

However `NoResultException` is thrown only when hydration mode is not `HYDRATE_SINGLE_SCALAR`. 

```php
    public function getSingleResult($hydrationMode = null)
    {
        $result = $this->execute(null, $hydrationMode);

        if ($this->_hydrationMode !== self::HYDRATE_SINGLE_SCALAR && ! $result) {
            throw new NoResultException();
        }

```

In `getSingleScalarResult` hydration mode was set to `HYDRATE_SINGLE_SCALAR` via `Doctrine\ORM\AbstractQuery::execute()` which makes it impossible to throw that particular type of exception.