### PR TITLE
Emit `postFlush` events as the very last thing in `UoW::flush()`

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -402,9 +402,8 @@ class UnitOfWork implements PropertyChangedListener
                 $this->orphanRemovals)
         ) {
             $this->dispatchOnFlushEvent();
-            $this->dispatchPostFlushEvent();
-
             $this->postCommitCleanup($entity);
+            $this->dispatchPostFlushEvent();
 
             return; // Nothing to do.
         }
@@ -499,9 +498,9 @@ class UnitOfWork implements PropertyChangedListener
             $coll->takeSnapshot();
         }
 
-        $this->dispatchPostFlushEvent();
-
         $this->postCommitCleanup($entity);
+
+        $this->dispatchPostFlushEvent();
     }
 
     /** @param object|object[]|null $entity */


### PR DESCRIPTION
This PR moves the `postFlush` event dispatching _after_ final clean-up steps in `UnitOfWork::commit()`.

The idea is that at this time, `commit()` is "as done as it gets", and it might be possible to call `EntityManager::flush()` again from event listeners – we'd return from that method on the very next line, and everything would be in the same state if users dediced to call `flush()` again themselves.

Obviously, infinite recursion is one thing either the ORM or users would need to think about.

The intent is to make it somehow possible for users to have event listeners that get notified e. g. through `postPersist` to prepare "cascading" changes. These changes could be collected and applied in a `postFlush` listener, which might then call `flush()` again.

This sparked off from #10869, where the reporting user is calling `flush()` even from `postPersist` – a questionable practice, probably never endorsed but it "somehow worked" until 2.16.0.

⚠️ BC Break: If `postFlush` listeners inspect UoW state through methods like `isSchedulesForInsert` or `getEntityChangeSet`, this information will no longer available with this change. → Maybe we need an additional event?