### PR TITLE
Add null to AbstractQuery::getSingleScalarResult()'s return type

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1010,7 +1010,7 @@ abstract class AbstractQuery
      *
      * Alias for getSingleResult(HYDRATE_SINGLE_SCALAR).
      *
-     * @return bool|float|int|string The scalar result.
+     * @return bool|float|int|string|null The scalar result.
      *
      * @throws NoResultException        If the query returned no result.
      * @throws NonUniqueResultException If the query result is not unique.


### PR DESCRIPTION
Single scalar results can very well also be the NULL value.