### PR TITLE
Use a dedicated exception for the check added in #10785

### DIFF
--- a/lib/Doctrine/ORM/Exception/EntityIdentityCollisionException.php
+++ b/lib/Doctrine/ORM/Exception/EntityIdentityCollisionException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use function get_class;
+use function sprintf;
+
+final class EntityIdentityCollisionException extends ORMException
+{
+    /**
+     * @param object $existingEntity
+     * @param object $newEntity
+     */
+    public static function create($existingEntity, $newEntity, string $idHash): self
+    {
+        return new self(
+            sprintf(
+                <<<'EXCEPTION'
+While adding an entity of class %s with an ID hash of "%s" to the identity map,
+another object of class %s was already present for the same ID. This exception
+is a safeguard against an internal inconsistency - IDs should uniquely map to
+entity object instances. This problem may occur if:
+
+- you use application-provided IDs and reuse ID values;
+- database-provided IDs are reassigned after truncating the database without
+clearing the EntityManager;
+- you might have been using EntityManager#getReference() to create a reference
+for a nonexistent ID that was subsequently (by the RDBMS) assigned to another
+entity.
+
+Otherwise, it might be an ORM-internal inconsistency, please report it.
+EXCEPTION
+                ,
+                get_class($newEntity),
+                $idHash,
+                get_class($existingEntity)
+            )
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\PersistentCollection;
@@ -20,7 +21,6 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
-use RuntimeException;
 
 use function get_class;
 
@@ -1347,7 +1347,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
         // Now the database will assign an ID to the $user2 entity, but that place
         // in the identity map is already taken by user error.
-        $this->expectException(RuntimeException::class);
+        $this->expectException(EntityIdentityCollisionException::class);
         $this->expectExceptionMessageMatches('/another object .* was already present for the same ID/');
 
         // depending on ID generation strategy, the ID may be asssigned already here

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -41,7 +42,6 @@ use Doctrine\Tests\Models\GeoNames\Country;
 use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\MockObject\MockObject;
-use RuntimeException;
 use stdClass;
 
 use function assert;
@@ -960,7 +960,7 @@ class UnitOfWorkTest extends OrmTestCase
         $phone2              = new CmsPhonenumber();
         $phone2->phonenumber = '1234';
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(EntityIdentityCollisionException::class);
         $this->expectExceptionMessageMatches('/another object .* was already present for the same ID/');
 
         $this->_unitOfWork->persist($phone2);


### PR DESCRIPTION
This adds a dedicated exception for the case that objects with colliding identities are to be put into the identity map.

Implements #10872.
