### PR TITLE
ProxyFactory: do not generate long file names

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -432,8 +432,8 @@ EOPHP;
     {
         $baseDirectory = $baseDirectory ?: $this->proxyDir;
 
-        return rtrim($baseDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . InternalProxy::MARKER
-            . str_replace('\\', '', $className) . '.php';
+        return rtrim($baseDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . InternalProxy::MARKER . DIRECTORY_SEPARATOR
+            . str_replace('\\', DIRECTORY_SEPARATOR, $className) . '.php';
     }
 
     private function getProxyFactory(string $className): Closure

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -235,7 +235,8 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
 
         $restName      = str_replace($this->_em->getConfiguration()->getProxyNamespace(), '', get_class($entity));
         $restName      = substr(get_class($entity), strlen($this->_em->getConfiguration()->getProxyNamespace()) + 1);
-        $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace('\\', '', $restName) . '.php';
+        $separator     = $this->_em->getConfiguration()->isLazyGhostObjectEnabled() ? DIRECTORY_SEPARATOR : '';
+        $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace('\\', $separator, $restName) . '.php';
         self::assertTrue(file_exists($proxyFileName), 'Proxy file name cannot be found generically.');
 
         $entity->__load();


### PR DESCRIPTION
This is a follow up to https://github.com/doctrine/common/pull/1005, because the logic was moved from doctrine/common to doctrine/orm in 2.17.

---

The maximum file name length when using [eCryptfs](https://www.ecryptfs.org/) is 143 bytes. This causes issues with Doctrine proxies where with current implementation this limit can be exceeded.

This PR changes how proxy file name is generated to avoid hitting this limit.

> eCryptfs can only store filenames of up to 143 characters when filename encryption is enabled. The remaining 112 characters are used for storing metadata such as the encrypted filename prefix, the signature of the filename encryption key, and an identifier for the cipher used, as well as random bytes to make /foo/file and /bar/file encrypt to different ciphertext and padding bytes to achieve proper cipher block size alignment.
> https://bugs.launchpad.net/ecryptfs/+bug/344878