### PR TITLE
Use required classes for Lifecycle Callback examples

### DIFF
--- a/docs/en/cookbook/validation-of-entities.rst
+++ b/docs/en/cookbook/validation-of-entities.rst
@@ -58,7 +58,10 @@ First Attributes:
 .. code-block:: php
 
     <?php
-    use Doctrine\ORM\Mapping\{Entity, HasLifecycleCallbacks, PrePersist, PreUpdate};
+    use Doctrine\ORM\Mapping\Entity;
+    use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+    use Doctrine\ORM\Mapping\PrePersist;
+    use Doctrine\ORM\Mapping\PreUpdate;
 
     #[Entity]
     #[HasLifecycleCallbacks]

--- a/docs/en/cookbook/validation-of-entities.rst
+++ b/docs/en/cookbook/validation-of-entities.rst
@@ -58,6 +58,7 @@ First Attributes:
 .. code-block:: php
 
     <?php
+    use Doctrine\ORM\Mapping\{Entity, HasLifecycleCallbacks, PrePersist, PreUpdate};
 
     #[Entity]
     #[HasLifecycleCallbacks]

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -215,7 +215,10 @@ specific to a particular entity class's lifecycle.
         <?php
         use Doctrine\DBAL\Types\Types;
         use Doctrine\ORM\Event\PrePersistEventArgs;
-        use Doctrine\ORM\Mapping\{Entity, HasLifecycleCallbacks, PrePersist, PreUpdate};
+        use Doctrine\ORM\Mapping\Entity;
+        use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+        use Doctrine\ORM\Mapping\PrePersist;
+        use Doctrine\ORM\Mapping\PreUpdate;
 
         #[Entity]
         #[HasLifecycleCallbacks]

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -215,6 +215,7 @@ specific to a particular entity class's lifecycle.
         <?php
         use Doctrine\DBAL\Types\Types;
         use Doctrine\ORM\Event\PrePersistEventArgs;
+        use Doctrine\ORM\Mapping\{Entity, HasLifecycleCallbacks, PrePersist, PreUpdate};
 
         #[Entity]
         #[HasLifecycleCallbacks]


### PR DESCRIPTION
Imports `Doctrine\ORM\Mapping\{Entity, HasLifecycleCallbacks, PrePersist, PreUpdate};` in Lifecycle Callback examples