### PR TITLE
Add space before backquote

### DIFF
--- a/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
+++ b/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
@@ -13,7 +13,7 @@ for all our domain objects.
 .. note::
 
     The notify change tracking policy is deprecated and will be removed in ORM 3.0.
-    (`Details <https://github.com/doctrine/orm/issues/8383>`_)
+    (\ `Details <https://github.com/doctrine/orm/issues/8383>`_)
 
 Implementing NotifyPropertyChanged
 ----------------------------------

--- a/docs/en/reference/change-tracking-policies.rst
+++ b/docs/en/reference/change-tracking-policies.rst
@@ -63,7 +63,7 @@ Notify
 .. note::
 
     The notify change tracking policy is deprecated and will be removed in ORM 3.0.
-    (`Details <https://github.com/doctrine/orm/issues/8383>`_)
+    (\ `Details <https://github.com/doctrine/orm/issues/8383>`_)
 
 This policy is based on the assumption that the entities notify
 interested listeners of changes to their properties. For that

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1425,7 +1425,7 @@ userland:
    reloading this data. Partially loaded objects have to be passed to
    ``EntityManager::refresh()`` if they are to be reloaded fully from
    the database. This query hint is deprecated and will be removed
-   in the future (`Details <https://github.com/doctrine/orm/issues/8471>`_)
+   in the future (\ `Details <https://github.com/doctrine/orm/issues/8471>`_)
 -  ``Query::HINT_REFRESH`` - This query is used internally by
    ``EntityManager::refresh()`` and can be used in userland as well.
    If you specify this hint and a query returns the data for an entity

--- a/docs/en/reference/partial-objects.rst
+++ b/docs/en/reference/partial-objects.rst
@@ -6,7 +6,7 @@ Partial Objects
 
     Creating Partial Objects through DQL is deprecated and
     will be removed in the future, use data transfer object
-    support in DQL instead. (`Details
+    support in DQL instead. (\ `Details
     <https://github.com/doctrine/orm/issues/8471>`_)
 
 A partial object is an object whose state is not fully initialized

--- a/docs/en/reference/unitofwork.rst
+++ b/docs/en/reference/unitofwork.rst
@@ -137,7 +137,7 @@ optimize the performance of the Flush Operation:
 .. note::
 
     Flush only a single entity with ``$entityManager->flush($entity)`` is deprecated and will be removed in ORM 3.0.
-    (`Details <https://github.com/doctrine/orm/issues/8459>`_)
+    (\ `Details <https://github.com/doctrine/orm/issues/8459>`_)
 
 Query Internals
 ---------------

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -18,7 +18,7 @@ before. There are some prerequisites for the tutorial that have to be
 installed:
 
 - PHP (latest stable version)
-- Composer Package Manager (`Install Composer
+- Composer Package Manager (\ `Install Composer
   <https://getcomposer.org/doc/00-intro.md>`_)
 
 The code of this tutorial is `available on Github <https://github.com/doctrine/doctrine2-orm-tutorial>`_.
@@ -321,7 +321,7 @@ data in your storage, and later in your application when the data is loaded agai
 .. note::
 
     This method, although very common, is inappropriate for Domain Driven
-    Design (`DDD <https://en.wikipedia.org/wiki/Domain-driven_design>`_)
+    Design (\ `DDD <https://en.wikipedia.org/wiki/Domain-driven_design>`_)
     where methods should represent real business operations and not simple
     property change, And business invariants should be maintained both in the
     application state (entities in this case) and in the database, with no


### PR DESCRIPTION
According to the RST docs,

> [inline markup] it must be separated from surrounding text by non-word
> characters. Use a backslash escaped space to work around that: thisis\ *one*\ word.

Because we were missing a space before backquotes here, the links were not rendered. Escaping the space allow not to actually produce a space in the output.

See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup