### PR TITLE
Support Symfony 7 by adding return types conditionally

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,8 @@ use function sprintf;
  */
 class CollectionRegionCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -58,12 +61,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,8 @@ use function sprintf;
  */
 class EntityRegionCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -57,12 +60,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,6 +19,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class MetadataCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -31,12 +34,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Cache\ClearableCache;
 use Doctrine\Common\Cache\FlushableCache;
 use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -28,6 +29,8 @@ use function sprintf;
  */
 class QueryCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -55,12 +58,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,8 @@ use function sprintf;
  */
 class QueryRegionCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -56,12 +59,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Cache\FlushableCache;
 use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -29,6 +30,8 @@ use function sprintf;
  */
 class ResultCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -56,12 +59,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\ConvertDoctrine1Schema;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
@@ -34,6 +35,8 @@ use const PHP_EOL;
  */
 class ConvertDoctrine1SchemaCommand extends Command
 {
+    use CommandCompatibility;
+
     /** @var EntityGenerator|null */
     private $entityGenerator = null;
 
@@ -87,12 +90,7 @@ class ConvertDoctrine1SchemaCommand extends Command
              ->setHelp('Converts Doctrine 1.x schema into a Doctrine 2.x schema.');
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
         $ui->getErrorStyle()->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
@@ -37,6 +38,8 @@ use function strtolower;
  */
 class ConvertMappingCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -84,12 +87,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
         $ui->getErrorStyle()->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,6 +20,8 @@ use Throwable;
  */
 class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -29,12 +32,7 @@ class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
              ->setHelp('Verify that Doctrine is properly configured for a production environment.');
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('This console command has been deprecated and will be removed in a future version of Doctrine ORM.');

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
@@ -28,6 +29,8 @@ use function sprintf;
  */
 class GenerateEntitiesCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -67,12 +70,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -26,6 +27,8 @@ use function sprintf;
  */
 class GenerateProxiesCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -38,12 +41,7 @@ class GenerateProxiesCommand extends AbstractEntityManagerCommand
              ->setHelp('Generates proxy classes for entity classes.');
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\EntityRepositoryGenerator;
 use InvalidArgumentException;
@@ -27,6 +28,8 @@ use function sprintf;
  */
 class GenerateRepositoriesCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -39,12 +42,7 @@ class GenerateRepositoriesCommand extends AbstractEntityManagerCommand
              ->setHelp('Generate repository classes from your mapping information.');
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
         $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine ORM 3.0.');

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,6 +21,8 @@ use function sprintf;
  */
 class InfoCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -34,12 +37,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\Common\Util\Debug;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use LogicException;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -27,6 +28,8 @@ use function strtoupper;
  */
 class RunDqlCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -58,12 +61,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,6 +18,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 abstract class AbstractCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /**
      * @param mixed[] $metadatas
      *
@@ -24,12 +27,7 @@ abstract class AbstractCommand extends AbstractEntityManagerCommand
      */
     abstract protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas, SymfonyStyle $ui);
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,6 +21,8 @@ use function sprintf;
  */
 class ValidateSchemaCommand extends AbstractEntityManagerCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -31,12 +34,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
              ->setHelp('Validate that the mapping files are correct and in sync with the database.');
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 

--- a/lib/Doctrine/ORM/Tools/Console/CommandCompatibility.php
+++ b/lib/Doctrine/ORM/Tools/Console/CommandCompatibility.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console;
+
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+} else {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        /**
+         * {@inheritDoc}
+         *
+         * @return int
+         */
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -6,7 +6,34 @@ namespace Doctrine\ORM\Tools\Console\Helper;
 
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
+use ReflectionMethod;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Helper\HelperInterface;
+
+if ((new ReflectionMethod(HelperInterface::class, 'getName'))->hasReturnType()) {
+    /** @internal */
+    trait EntityManagerHelperCompatibility
+    {
+        public function getName(): string
+        {
+            return 'entityManager';
+        }
+    }
+} else {
+    /** @internal */
+    trait EntityManagerHelperCompatibility
+    {
+        /**
+         * {@inheritDoc}
+         *
+         * @return string
+         */
+        public function getName()
+        {
+            return 'entityManager';
+        }
+    }
+}
 
 /**
  * Doctrine CLI Connection Helper.
@@ -15,6 +42,8 @@ use Symfony\Component\Console\Helper\Helper;
  */
 class EntityManagerHelper extends Helper
 {
+    use EntityManagerHelperCompatibility;
+
     /**
      * Doctrine ORM EntityManagerInterface.
      *
@@ -42,15 +71,5 @@ class EntityManagerHelper extends Helper
     public function getEntityManager()
     {
         return $this->_em;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'entityManager';
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -49,11 +49,14 @@
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>lib/Doctrine/ORM/Mapping/Driver/CompatibilityAnnotationDriver.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Tools/Console/CommandCompatibility.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php</exclude-pattern>
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
-        <exclude-pattern>*/tests/*</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php</exclude-pattern>
+        <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
     <rule ref="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase">

--- a/psalm.xml
+++ b/psalm.xml
@@ -121,6 +121,12 @@
                 <file name="lib/Doctrine/ORM/PersistentCollection.php"/>
             </errorLevel>
         </DocblockTypeContradiction>
+        <DuplicateClass>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/ORM/Tools/Console/CommandCompatibility.php"/>
+                <file name="lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php"/>
+            </errorLevel>
+        </DuplicateClass>
         <InvalidArgument>
             <errorLevel type="suppress">
                 <!-- Argument type changes in DBAL 3.2 -->


### PR DESCRIPTION
Symfony 7 will add more return types to the console component. This PR uses conditional traits to add the necessary return types if they're present upstream. This way, we won't break downstream projects that override our commands unless those projects upgrade to Symfony 7 themselves.