### PR TITLE
added functional test case for issue#10927

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -624,13 +624,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 // Platforms that do not have native IDENTITY support need a sequence to emulate this behaviour.
                 /** @psalm-suppress UndefinedClass, InvalidClass */
-                if (
-                    ! $class->isMappedSuperclass
-                    && ! $platform instanceof MySQLPlatform
-                    && ! $platform instanceof SqlitePlatform
-                    && ! $platform instanceof SQLServerPlatform
-                    && $platform->usesSequenceEmulatedIdentityColumns()
-                ) {
+                if (! $platform instanceof MySQLPlatform && ! $platform instanceof SqlitePlatform && ! $platform instanceof SQLServerPlatform && $platform->usesSequenceEmulatedIdentityColumns()) {
                     Deprecation::trigger(
                         'doctrine/orm',
                         'https://github.com/doctrine/orm/issues/8850',

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -624,7 +624,13 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 // Platforms that do not have native IDENTITY support need a sequence to emulate this behaviour.
                 /** @psalm-suppress UndefinedClass, InvalidClass */
-                if (! $platform instanceof MySQLPlatform && ! $platform instanceof SqlitePlatform && ! $platform instanceof SQLServerPlatform && $platform->usesSequenceEmulatedIdentityColumns()) {
+                if (
+                    ! $class->isMappedSuperclass
+                    && ! $platform instanceof MySQLPlatform
+                    && ! $platform instanceof SqlitePlatform
+                    && ! $platform instanceof SQLServerPlatform
+                    && $platform->usesSequenceEmulatedIdentityColumns()
+                ) {
                     Deprecation::trigger(
                         'doctrine/orm',
                         'https://github.com/doctrine/orm/issues/8850',

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10927Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10927Test.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH10927Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH10927Parent::class,
+            GH10927Child::class,
+        ]);
+    }
+
+    public function testChildEntitySequenceShouldBeCorrect(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->usesSequenceEmulatedIdentityColumns()) {
+            self::markTestSkipped(
+                'This test is special to platforms emulating IDENTITY key generation strategy through sequences.'
+            );
+        }
+        $child = new GH10927Child();
+
+        $this->_em->persist($child);
+        $this->_em->flush();
+        self::assertNotNull($child->getId());
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class GH10927Parent
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\Column(type="integer")
+     *
+     * @var int|null
+     */
+    private $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="gh10927_child")
+ */
+class GH10927Child extends GH10927Parent
+{
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10927Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10927Test.php
@@ -26,6 +26,7 @@ class GH10927Test extends OrmFunctionalTestCase
                 'This test is special to platforms emulating IDENTITY key generation strategy through sequences.'
             );
         }
+
         $child = new GH10927Child();
 
         $this->_em->persist($child);


### PR DESCRIPTION
added test functional test case for issue https://github.com/doctrine/orm/issues/10927
at the moment in version 2.16.0 the test fails with exception
```
PDOException: SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "gh10927parent_id_seq" does not exist
```
but passes on version 2.15.5

test is meant to run against PostgreSQL RDBMS