### PR TITLE
docs: use modern named arguments syntax

### DIFF
--- a/docs/en/cookbook/aggregate-fields.rst
+++ b/docs/en/cookbook/aggregate-fields.rst
@@ -211,7 +211,7 @@ Now look at the following test-code for our entities:
     {
         public function testAddEntry()
         {
-            $account = new Account("123456", $maxCredit = 200);
+            $account = new Account("123456", maxCredit: 200);
             $this->assertEquals(0, $account->getBalance());
     
             $account->addEntry(500);
@@ -223,7 +223,7 @@ Now look at the following test-code for our entities:
     
         public function testExceedMaxLimit()
         {
-            $account = new Account("123456", $maxCredit = 200);
+            $account = new Account("123456", maxCredit: 200);
     
             $this->expectException(Exception::class);
             $account->addEntry(-1000);

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1381,7 +1381,7 @@ Result Cache API:
     $query->setResultCacheDriver(new ApcCache());
 
     $query->useResultCache(true)
-          ->setResultCacheLifeTime($seconds = 3600);
+          ->setResultCacheLifeTime(3600);
 
     $result = $query->getResult(); // cache miss
 
@@ -1392,7 +1392,7 @@ Result Cache API:
     $result = $query->getResult(); // saved in given result cache id.
 
     // or call useResultCache() with all parameters:
-    $query->useResultCache(true, $seconds = 3600, 'my_query_result');
+    $query->useResultCache(true, 3600, 'my_query_result');
     $result = $query->getResult(); // cache hit!
 
     // Introspection
@@ -1457,7 +1457,7 @@ several methods to interact with it:
 
 -  ``Query::setQueryCacheDriver($driver)`` - Allows to set a Cache
    instance
--  ``Query::setQueryCacheLifeTime($seconds = 3600)`` - Set lifetime
+-  ``Query::setQueryCacheLifeTime($seconds)`` - Set lifetime
    of the query caching.
 -  ``Query::expireQueryCache($bool)`` - Enforce the expiring of the
    query cache if set to true.

--- a/docs/en/tutorials/pagination.rst
+++ b/docs/en/tutorials/pagination.rst
@@ -15,7 +15,7 @@ has a very simple API and implements the SPL interfaces ``Countable`` and
                            ->setFirstResult(0)
                            ->setMaxResults(100);
 
-    $paginator = new Paginator($query, $fetchJoinCollection = true);
+    $paginator = new Paginator($query, fetchJoinCollection: true);
 
     $c = count($paginator);
     foreach ($paginator as $post) {
@@ -36,10 +36,10 @@ correct result:
 
 This behavior is only necessary if you actually fetch join a to-many
 collection. You can disable this behavior by setting the
-``$fetchJoinCollection`` flag to ``false``; in that case only 2 instead of the 3 queries
+``fetchJoinCollection`` argument to ``false``; in that case only 2 instead of the 3 queries
 described are executed. We hope to automate the detection for this in
 the future.
 
 .. note::
 
-    ``$fetchJoinCollection`` flag set to ``true`` might affect results if you use aggregations in your query.
+    ``fetchJoinCollection`` argument set to ``true`` might affect results if you use aggregations in your query.


### PR DESCRIPTION
use official named arguments syntax in example instead of pre php 8 codestyle for 'named' arguments