### PR TITLE
tests[ORMSetupTest]: testCacheNamespaceShouldBeGeneratedForApcu requires enabled apc

### DIFF
--- a/tests/Doctrine/Tests/ORM/ORMSetupTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMSetupTest.php
@@ -95,6 +95,8 @@ class ORMSetupTest extends TestCase
 
     /**
      * @requires extension apcu
+     * @requires setting apc.enable_cli 1
+     * @requires setting apc.enabled 1
      */
     public function testCacheNamespaceShouldBeGeneratedForApcu(): void
     {


### PR DESCRIPTION
fix test flakiness

the `apcu` extension is required but if not enabled (e.g. `apc.enable_cli` default is `0` https://www.php.net/manual/en/apcu.configuration.php) the `ORMSetup` utility will choose other Cache adapters (see https://github.com/doctrine/orm/blob/9f555ea8fb4f7ae9a362285dc71e85776a1c5cc3/lib/Doctrine/ORM/ORMSetup.php#L180-L218)