### PR TITLE
docs[query-builder]: fix rendering of `Doctrine\DBAL\ParameterType::*`

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -253,7 +253,7 @@ Calling ``setParameter()`` automatically infers which type you are setting as
 value. This works for integers, arrays of strings/integers, DateTime instances
 and for managed entities. If you want to set a type explicitly you can call
 the third argument to ``setParameter()`` explicitly. It accepts either a DBAL
-Doctrine\DBAL\ParameterType::* or a DBAL Type name for conversion.
+``Doctrine\DBAL\ParameterType::*`` or a DBAL Type name for conversion.
 
 .. note::
 


### PR DESCRIPTION
this change fixes the rendering of `Doctrine\DBAL\ParameterType::*` in the [Binding parameters to your query](https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/query-builder.html#binding-parameters-to-your-query) section of The QueryBuilder documentation