### PR TITLE
Add compatibility with the Symfony 4.4 VarExporter

### DIFF
--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -141,7 +141,9 @@ class ParserResult
     {
         foreach (self::LEGACY_PROPERTY_MAPPING as $property => $legacyProperty) {
             $this->$property = $data[sprintf("\0%s\0%s", self::class, $legacyProperty)]
+                ?? $data[self::class][$legacyProperty]
                 ?? $data[sprintf("\0%s\0%s", self::class, $property)]
+                ?? $data[self::class][$property]
                 ?? $this->$property
                 ?? null;
         }

--- a/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -116,6 +116,25 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         yield '2.17.0' => [rtrim(file_get_contents(__DIR__ . '/ParserResults/single_select_2_17_0.txt'), "\n")];
     }
 
+    public function testSymfony44ProvidedData(): void
+    {
+        $sqlExecutor      = $this->createMock(SingleSelectExecutor::class);
+        $resultSetMapping = $this->createMock(ResultSetMapping::class);
+
+        $parserResult = new ParserResult();
+        $parserResult->setSqlExecutor($sqlExecutor);
+        $parserResult->setResultSetMapping($resultSetMapping);
+        $parserResult->addParameterMapping('name', 0);
+
+        $exported     = VarExporter::export($parserResult);
+        $unserialized = eval('return ' . $exported . ';');
+
+        $this->assertInstanceOf(ParserResult::class, $unserialized);
+        $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
+        $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
+        $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
+    }
+
     private static function parseQuery(Query $query): ParserResult
     {
         $r = new ReflectionMethod($query, 'parse');


### PR DESCRIPTION
This issue tries to solve the weird Symfony `__unserialize` data Symfony `4.4` is giving to the method. This seems to be a bug that Symfony solved in `5.4` in https://github.com/symfony/symfony/commit/6ccb85e185bb1774778f687f866d80ab0db96e76. Original report / investigation https://github.com/doctrine/orm/issues/10943.