### PR TITLE
Restore job with --prefer-lowest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,8 @@ jobs:
           - "pdo_sqlite"
         proxy:
           - "common"
+        deps:
+          - "highest"
         include:
           - php-version: "8.2"
             dbal-version: "3@dev"
@@ -54,6 +56,10 @@ jobs:
           - php-version: "8.1"
             dbal-version: "default"
             proxy: "lazy-ghost"
+            extension: "pdo_sqlite"
+          - php-version: "8.1"
+            dbal-version: "default"
+            deps: "lowest"
             extension: "pdo_sqlite"
 
     steps:
@@ -78,6 +84,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: "--ignore-platform-req=php+"
+          dependency-versions: "${{ matrix.deps }}"
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage-no-cache.xml"
@@ -313,7 +320,6 @@ jobs:
         with:
           name: "${{ github.job }}-${{ matrix.mysql-version }}-${{ matrix.extension }}-${{ matrix.php-version }}-${{ matrix.dbal-version }}-coverage"
           path: "coverage*.xml"
-
 
   upload_coverage:
     name: "Upload coverage to Codecov"

--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,11 @@
         "doctrine/coding-standard": "^12.0",
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "1.10.35",
-        "phpunit/phpunit": "^10.0.14",
+        "phpunit/phpunit": "^10.4.0",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.2",
         "symfony/cache": "^5.4 || ^6.2",
-        "symfony/var-exporter": "^5.4 || ^6.2",
+        "symfony/var-exporter": "^6.2.13",
         "vimeo/psalm": "5.15.0"
     },
     "suggest": {

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -514,11 +514,14 @@ class QueryTest extends OrmTestCase
 
     public function testGetQueryCacheDriverWithDefaults(): void
     {
-        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache         = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock->method('set')->willReturnSelf();
+        $cacheItemMock->method('expiresAfter')->willReturnSelf();
         $cache
             ->expects(self::atLeastOnce())
             ->method('getItem')
-            ->willReturn($this->createMock(CacheItemInterface::class));
+            ->willReturn($cacheItemMock);
 
         $this->entityManager->getConfiguration()->setQueryCache($cache);
         $this->entityManager
@@ -528,11 +531,14 @@ class QueryTest extends OrmTestCase
 
     public function testGetQueryCacheDriverWithCacheExplicitlySet(): void
     {
-        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache         = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock->method('set')->willReturnSelf();
+        $cacheItemMock->method('expiresAfter')->willReturnSelf();
         $cache
             ->expects(self::atLeastOnce())
             ->method('getItem')
-            ->willReturn($this->createMock(CacheItemInterface::class));
+            ->willReturn($cacheItemMock);
 
         $this->entityManager
             ->createQuery('select u from ' . CmsUser::class . ' u')


### PR DESCRIPTION
It is useful to catch misconfigured dependency constraints. It was removed in #9069.