### PR TITLE
Change EntityPersister return type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 3.0
 
+## BC BREAK: `Doctrine\ORM\Persister\Entity\EntityPersister::executeInserts()` return type changed to `void`
+
+Implementors should adapt to the new signature, and should call
+`UnitOfWork::assignPostInsertId()` for each entry in the previously returned
+array.
+
 ## BC BREAK: `Doctrine\ORM\Proxy\ProxyFactory` no longer extends abstract factory from `doctrine/common`
 
 It is no longer possible to call methods, constants or properties inherited

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -268,10 +268,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         return $this->persister->getOwningTable($fieldName);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function executeInserts()
+    public function executeInserts(): void
     {
         // The commit order/foreign key relationships may make it necessary that multiple calls to executeInsert()
         // are performed, so collect all the new entities.
@@ -281,7 +278,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             $this->queuedCache['insert'] = array_merge($this->queuedCache['insert'] ?? [], $newInserts);
         }
 
-        return $this->persister->executeInserts();
+        $this->persister->executeInserts();
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -218,10 +218,7 @@ class BasicEntityPersister implements EntityPersister
         return $this->queuedInserts;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function executeInserts()
+    public function executeInserts(): void
     {
         if (! $this->queuedInserts) {
             return;

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -100,14 +100,8 @@ interface EntityPersister
      * Executes all queued entity insertions.
      *
      * If no inserts are queued, invoking this method is a NOOP.
-     *
-     * @psalm-return void|list<array{
-     *                   generatedId: int,
-     *                   entity: object
-     *               }> Returning an array of generated post-insert IDs is deprecated, implementations
-     *                  should call UnitOfWork::assignPostInsertId() and return void.
      */
-    public function executeInserts();
+    public function executeInserts(): void;
 
     /**
      * Updates a managed entity. The entity is updated according to its current changeset

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -94,10 +94,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         return $tableName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function executeInserts()
+    public function executeInserts(): void
     {
         if (! $this->queuedInserts) {
             return;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1042,20 +1042,7 @@ class UnitOfWork implements PropertyChangedListener
 
             unset($this->entityInsertions[$oid]);
 
-            $postInsertIds = $persister->executeInserts();
-
-            if (is_array($postInsertIds)) {
-                Deprecation::trigger(
-                    'doctrine/orm',
-                    'https://github.com/doctrine/orm/pull/10743/',
-                    'Returning post insert IDs from \Doctrine\ORM\Persisters\Entity\EntityPersister::executeInserts() is deprecated and will not be supported in Doctrine ORM 3.0. Make the persister call Doctrine\ORM\UnitOfWork::assignPostInsertId() instead.',
-                );
-
-                // Persister returned post-insert IDs
-                foreach ($postInsertIds as $postInsertId) {
-                    $this->assignPostInsertId($postInsertId['entity'], $postInsertId['generatedId']);
-                }
-            }
+            $persister->executeInserts();
 
             if (! isset($this->entityIdentifiers[$oid])) {
                 //entity was not added to identity map because some identifiers are foreign keys to new entities.

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -38,10 +38,11 @@ class EntityPersisterMock extends BasicEntityPersister
         ];
     }
 
-    /** @psalm-return list<array{generatedId: int, entity: object}> */
-    public function executeInserts(): array
+    public function executeInserts(): void
     {
-        return $this->postInsertIds;
+        foreach ($this->postInsertIds as $item) {
+            $this->em->getUnitOfWork()->assignPostInsertId($item['entity'], $item['generatedId']);
+        }
     }
 
     public function setMockIdGeneratorType(int $genType): void

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
@@ -173,10 +173,9 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $persister = $this->createPersisterDefault();
 
         $this->entityPersister->expects(self::once())
-            ->method('executeInserts')
-            ->willReturn(['id' => 1]);
+            ->method('executeInserts');
 
-        self::assertSame(['id' => 1], $persister->executeInserts());
+        $persister->executeInserts();
     }
 
     public function testInvokeUpdate(): void


### PR DESCRIPTION
Calling `UnitOfWork::assignPostInsertId()` is now the way to go.