### PR TITLE
Deprecate WITH in joined associations

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1748,14 +1748,6 @@ class Parser
 
         // Check for ad-hoc Join conditions
         if ($adhocConditions) {
-            if ($joinDeclaration instanceof AST\JoinAssociationDeclaration) {
-                Deprecation::trigger(
-                    'doctrine/orm',
-                    'https://github.com/doctrine/orm/issues/10978',
-                    'WITH join conditions are deprecated for joins on associations. Use either a sub-select with another occurance of this table or use Collection::matching(Criteria) in follow-up code.'
-                );
-            }
-
             $this->match(Lexer::T_WITH);
 
             $join->conditionalExpression = $this->ConditionalExpression();

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1752,7 +1752,7 @@ class Parser
                 Deprecation::trigger(
                     'doctrine/orm',
                     'https://github.com/doctrine/orm/issues/10978',
-                    'WITH join conditions are deprecated for joins on associations. Use either a sub-select with another occurance of this table or use Collection::matching(Criteria) in follow-up code.',
+                    'WITH join conditions are deprecated for joins on associations. Use either a sub-select with another occurance of this table or use Collection::matching(Criteria) in follow-up code.'
                 );
             }
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1748,6 +1748,14 @@ class Parser
 
         // Check for ad-hoc Join conditions
         if ($adhocConditions) {
+            if ($joinDeclaration instanceof AST\JoinAssociationDeclaration) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/10978',
+                    'WITH join conditions are deprecated for joins on associations. Use either a sub-select with another occurance of this table or use Collection::matching(Criteria) in follow-up code.',
+                );
+            }
+
             $this->match(Lexer::T_WITH);
 
             $join->conditionalExpression = $this->ConditionalExpression();

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1164,6 +1164,14 @@ class SqlWalker implements TreeWalker
         }
 
         if ($withCondition) {
+            if (isset($this->selectedClasses[$joinedDqlAlias])) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/10978',
+                    'WITH join conditions are deprecated for joins on associations. Use either a sub-select with another occurance of this table or use Collection::matching(Criteria) in follow-up code.'
+                );
+            }
+
             $sql .= ' AND ' . $withCondition;
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -19,8 +18,6 @@ use Doctrine\Tests\OrmTestCase;
 
 class LanguageRecognitionTest extends OrmTestCase
 {
-    use VerifyDeprecations;
-
     /** @var EntityManagerInterface */
     private $entityManager;
 
@@ -268,8 +265,6 @@ class LanguageRecognitionTest extends OrmTestCase
 
     public function testJoinClassPathUsingWITH(): void
     {
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
-
         $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a WITH a.user = u.id');
     }
 
@@ -473,13 +468,6 @@ class LanguageRecognitionTest extends OrmTestCase
     public function testAllExpressionWithCorrelatedSubquery(): void
     {
         $this->assertValidDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id > ALL (SELECT u2.id FROM Doctrine\Tests\Models\CMS\CmsUser u2 WHERE u2.name = u.name)');
-    }
-
-    public function testCustomJoinsAndWithKeywordSupported(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
-
-        $this->assertValidDQL('SELECT u, p FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.phonenumbers p WITH p.phonenumber = 123 WHERE u.id = 1');
     }
 
     public function testAnyExpressionWithCorrelatedSubquery(): void

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -18,6 +19,8 @@ use Doctrine\Tests\OrmTestCase;
 
 class LanguageRecognitionTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     /** @var EntityManagerInterface */
     private $entityManager;
 
@@ -265,6 +268,8 @@ class LanguageRecognitionTest extends OrmTestCase
 
     public function testJoinClassPathUsingWITH(): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
+
         $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a WITH a.user = u.id');
     }
 
@@ -472,6 +477,8 @@ class LanguageRecognitionTest extends OrmTestCase
 
     public function testCustomJoinsAndWithKeywordSupported(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
+
         $this->assertValidDQL('SELECT u, p FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.phonenumbers p WITH p.phonenumber = 123 WHERE u.id = 1');
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -602,4 +602,18 @@ class QueryTest extends OrmTestCase
 
         self::assertSame($cache, CacheAdapter::wrap($query->getQueryCacheDriver()));
     }
+
+    public function testCustomJoinsAndWithKeywordDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
+
+        $this->entityManager->createQuery('SELECT u, p FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.phonenumbers p WITH p.phonenumber = 123 WHERE u.id = 1')->getResult();
+    }
+
+    public function testNoFetchJoinsAndWithKeywordSupported(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/10978');
+
+        $this->entityManager->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.phonenumbers p WITH p.phonenumber = 123 WHERE u.id = 1')->getResult();
+    }
 }


### PR DESCRIPTION
Deprecates `JOIN path.association WITH` type of expressions as they create persistent collections with a subset of related entities and look like they are fully loaded, causing all kinds of trouble.

A user could potentially work around this and move the condition to the `WHERE` clause. I checked the code and its not really possible in this case to detect it without adding tons of more code. So the WITH deprecation is what we can do about this. 

Fixes #10978 