### PR TITLE
Take `ReflectionType::allowsNull` into account

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -175,8 +175,9 @@ Optional parameters:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column.
-    If not specified, default value is ``false``.
+-  **nullable**: Determines if NULL values allowed for this column.  If not
+   specified, default value is ``false``.  When using typed properties on entity
+   class defaults to true when property is nullable.
 
 -  **insertable**: Boolean value to determine if the column should be
    included when inserting a new row into the underlying entities table.

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1111,7 +1111,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @param  array{fieldName: string, type?: string} $mapping The field mapping to validate & complete.
      *
-     * @return array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
+     * @return array{fieldName: string, nullable?: bool, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
      */
     private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {

--- a/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultTypedFieldMapper.php
@@ -62,6 +62,10 @@ final class DefaultTypedFieldMapper implements TypedFieldMapper
                 assert($type instanceof ReflectionNamedType);
             }
 
+            if (! isset($mapping['nullable'])) {
+                $mapping['nullable'] = $type->allowsNull();
+            }
+
             if (isset($this->typedFieldMappings[$type->getName()])) {
                 $mapping['type'] = $this->typedFieldMappings[$type->getName()];
             }

--- a/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
@@ -12,9 +12,9 @@ interface TypedFieldMapper
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} $mapping The field mapping to validate & complete.
+     * @param array{fieldName: string, nullable: ?bool, enumType?: class-string<BackedEnum>, type?: string} $mapping The field mapping to validate & complete.
      *
-     * @return array{fieldName: string, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
+     * @return array{fieldName: string, nullable: ?bool, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
      */
     public function validateAndComplete(array $mapping, ReflectionProperty $field): array;
 }

--- a/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
+++ b/lib/Doctrine/ORM/Mapping/TypedFieldMapper.php
@@ -12,9 +12,9 @@ interface TypedFieldMapper
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param array{fieldName: string, nullable: ?bool, enumType?: class-string<BackedEnum>, type?: string} $mapping The field mapping to validate & complete.
+     * @param array{fieldName: string, nullable?: bool, enumType?: class-string<BackedEnum>, type?: string} $mapping The field mapping to validate & complete.
      *
-     * @return array{fieldName: string, nullable: ?bool, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
+     * @return array{fieldName: string, nullable?: bool, enumType?: class-string<BackedEnum>, type?: string} The updated mapping.
      */
     public function validateAndComplete(array $mapping, ReflectionProperty $field): array;
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;

--- a/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\Tests\OrmTestCase;
+
+class DefaultTypedFieldMapperTest extends OrmTestCase
+{
+    public function testItTakesAllowsNullIntoAccount(): void
+    {
+        $mapper = new DefaultTypedFieldMapper();
+        $reflectionClass = new \ReflectionClass(DefaultTypedFieldExample::class);
+
+        $mapping = $mapper->validateAndComplete(['fieldName' => 'name'], $reflectionClass->getProperty('name'));
+        $mapping2 = $mapper->validateAndComplete(['fieldName' => 'surname'], $reflectionClass->getProperty('surname'));
+
+        $this->assertEquals(['fieldName' => 'name', 'nullable' => true, 'type' => 'string'], $mapping);
+        $this->assertEquals(['fieldName' => 'surname', 'nullable' => false, 'type' => 'string'], $mapping2);
+    }
+}
+
+class DefaultTypedFieldExample
+{
+    public ?string $name;
+    public string $surname;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/DefaultTypedFieldMapperTest.php
@@ -1,18 +1,20 @@
 <?php
+declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Doctrine\Tests\OrmTestCase;
+use ReflectionClass;
 
 class DefaultTypedFieldMapperTest extends OrmTestCase
 {
     public function testItTakesAllowsNullIntoAccount(): void
     {
-        $mapper = new DefaultTypedFieldMapper();
-        $reflectionClass = new \ReflectionClass(DefaultTypedFieldExample::class);
+        $mapper          = new DefaultTypedFieldMapper();
+        $reflectionClass = new ReflectionClass(DefaultTypedFieldExample::class);
 
-        $mapping = $mapper->validateAndComplete(['fieldName' => 'name'], $reflectionClass->getProperty('name'));
+        $mapping  = $mapper->validateAndComplete(['fieldName' => 'name'], $reflectionClass->getProperty('name'));
         $mapping2 = $mapper->validateAndComplete(['fieldName' => 'surname'], $reflectionClass->getProperty('surname'));
 
         $this->assertEquals(['fieldName' => 'name', 'nullable' => true, 'type' => 'string'], $mapping);
@@ -22,6 +24,6 @@ class DefaultTypedFieldMapperTest extends OrmTestCase
 
 class DefaultTypedFieldExample
 {
-    public ?string $name;
+    public string|null $name;
     public string $surname;
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapperTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/TypedFieldMapperTest.php
@@ -50,21 +50,21 @@ class TypedFieldMapperTest extends OrmTestCase
 
         return [
             // DefaultTypedFieldMapper
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::INTEGER]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateInterval'], ['fieldName' => 'dateInterval', 'type' => Types::DATEINTERVAL]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTime'], ['fieldName' => 'dateTime', 'type' => Types::DATETIME_MUTABLE]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTimeImmutable'], ['fieldName' => 'dateTimeImmutable', 'type' => Types::DATETIME_IMMUTABLE]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'array'], ['fieldName' => 'array', 'type' => Types::JSON]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'boolean'], ['fieldName' => 'boolean', 'type' => Types::BOOLEAN]],
-            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'float'], ['fieldName' => 'float', 'type' => Types::FLOAT]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::INTEGER, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateInterval'], ['fieldName' => 'dateInterval', 'type' => Types::DATEINTERVAL, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTime'], ['fieldName' => 'dateTime', 'type' => Types::DATETIME_MUTABLE, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'dateTimeImmutable'], ['fieldName' => 'dateTimeImmutable', 'type' => Types::DATETIME_IMMUTABLE, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'array'], ['fieldName' => 'array', 'type' => Types::JSON, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'boolean'], ['fieldName' => 'boolean', 'type' => Types::BOOLEAN, 'nullable' => false]],
+            [self::defaultTypedFieldMapper(), $reflectionClass, ['fieldName' => 'float'], ['fieldName' => 'float', 'type' => Types::FLOAT, 'nullable' => false]],
 
             // CustomIntAsStringTypedFieldMapper
             [self::customTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::STRING]],
 
             // ChainTypedFieldMapper
             [self::chainTypedFieldMapper(), $reflectionClass, ['fieldName' => 'id'], ['fieldName' => 'id', 'type' => Types::STRING]],
-            [self::chainTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING]],
+            [self::chainTypedFieldMapper(), $reflectionClass, ['fieldName' => 'username'], ['fieldName' => 'username', 'type' => Types::STRING, 'nullable' => false]],
         ];
     }
 
@@ -79,6 +79,6 @@ class TypedFieldMapperTest extends OrmTestCase
         array $mapping,
         array $finalMapping,
     ): void {
-        self::assertSame($finalMapping, $typedFieldMapper->validateAndComplete($mapping, $reflectionClass->getProperty($mapping['fieldName'])));
+        self::assertEquals($finalMapping, $typedFieldMapper->validateAndComplete($mapping, $reflectionClass->getProperty($mapping['fieldName'])));
     }
 }


### PR DESCRIPTION
This reintroduces the behavior removed in #8732 due to #8723 for 3.0

When you have a column with a typed property, then the null status of the property determines if the column's `nullable` mapping.

This is only done for fields and not for associations, because often association join columns need to be nullable to be updated later after the insert due to extra update and ordering reasons.

For 2.x, we will make this an opt-in behavior in the `DefaultTypedFieldMapper` and emit a deprecation if user is not opted-in.

Follow Up: 
* This allows clean up nullable check in `computeInsertExecutionOrder` and other places mentioned there in a comment.