### PR TITLE
Allow VarExporter 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/persistence": "^3.1.1",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/var-exporter": "~6.2.13 || ^6.3.2"
+        "symfony/var-exporter": "~6.2.13 || ^6.3.2 || ^7.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",


### PR DESCRIPTION
We need this to test Symfony 7 with ORM 3.