### PR TITLE
Deprecate EntityManager*::getPartialReference()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.17
 
+## Deprecate `EntityManagerInterface::getPartialReference()`
+
+This method does not have a replacement and will be removed in 3.0.
+
 ## Deprecate not-enabling lazy-ghosts
 
 Not enabling lazy ghost objects is deprecated. In ORM 3.0, they will be always enabled.

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Decorator;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -170,6 +171,13 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
      */
     public function getPartialReference($entityName, $identifier)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10987',
+            'Method %s is deprecated and will be removed in 3.0.',
+            __METHOD__
+        );
+
         return $this->wrapped->getPartialReference($entityName, $identifier);
     }
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -571,6 +571,12 @@ class EntityManager implements EntityManagerInterface
      */
     public function getPartialReference($entityName, $identifier)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/10987',
+            'Method %s is deprecated and will be removed in 3.0.',
+            __METHOD__
+        );
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
         $entity = $this->unitOfWork->tryGetById($identifier, $class->rootEntityName);

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -200,6 +200,8 @@ interface EntityManagerInterface extends ObjectManager
      * never be visible to the application (especially not event listeners) as it will
      * never be loaded in the first place.
      *
+     * @deprecated 2.7 This method is being removed from the ORM and won't have any replacement
+     *
      * @param string $entityName The name of the entity type.
      * @param mixed  $identifier The entity identifier.
      * @psalm-param class-string<T> $entityName

--- a/psalm.xml
+++ b/psalm.xml
@@ -90,6 +90,7 @@
                 <referencedMethod name="Doctrine\ORM\Configuration::ensureProductionSettings"/>
                 <referencedMethod name="Doctrine\ORM\Configuration::newDefaultAnnotationDriver"/>
                 <referencedMethod name="Doctrine\ORM\EntityManager::createConnection"/>
+                <referencedMethod name="Doctrine\ORM\EntityManagerInterface::getPartialReference"/>
                 <referencedMethod name="Doctrine\ORM\Id\AbstractIdGenerator::generate"/>
                 <referencedMethod name="Doctrine\ORM\ORMInvalidArgumentException::invalidEntityName"/>
                 <referencedMethod name="Doctrine\ORM\ORMSetup::createDefaultAnnotationDriver"/>

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Decorator;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -22,6 +23,8 @@ use function sprintf;
 
 class EntityManagerDecoratorTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public const VOID_METHODS = [
         'persist',
         'remove',
@@ -121,5 +124,13 @@ class EntityManagerDecoratorTest extends TestCase
         };
 
         self::assertSame($return, $decorator->$method(...$parameters));
+    }
+
+    public function testGetPartialReferenceIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10987');
+        $decorator = new class ($this->wrapped) extends EntityManagerDecorator {
+        };
+        $decorator->getPartialReference(stdClass::class, 1);
     }
 }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -131,6 +131,7 @@ class EntityManagerTest extends OrmTestCase
 
     public function testGetPartialReference(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10987');
         $user = $this->entityManager->getPartialReference(CmsUser::class, 42);
         self::assertTrue($this->entityManager->contains($user));
         self::assertEquals(42, $user->id);


### PR DESCRIPTION
Partial objects have been deprecated, so it makes no sense to still have this way of getting some.