### PR TITLE
Allow creating mocks of the `Query` class

### DIFF
--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -11,8 +11,10 @@ use function ksort;
 
 /**
  * Represents a native SQL query.
+ *
+ * @final
  */
-final class NativeQuery extends AbstractQuery
+class NativeQuery extends AbstractQuery
 {
     /** @var string */
     private $sql;

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -44,8 +44,10 @@ use function stripos;
 
 /**
  * A Query object represents a DQL query.
+ *
+ * @final
  */
-final class Query extends AbstractQuery
+class Query extends AbstractQuery
 {
     /**
      * A query object is in CLEAN state when it has NO unparsed/unprocessed DQL parts.


### PR DESCRIPTION
Replaces #10957.

This change allows mocking the query builder even with the native return types added in 3.0. While we do not recommend or encourage to mock the query builder, I believe we should not actively prevent this kind of test.

This change also allows us to create mocks of the `Query` class and intercept calls to the `Query::execute()` method. The presence of the method shows us that the `Query` is not a pure value object, so intercepting this kind of call might be reasonable to a certain degree.