### PR TITLE
Fix array parameters with DBAL 4

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
@@ -320,15 +321,16 @@ abstract class AbstractQuery
     /**
      * Sets a query parameter.
      *
-     * @param string|int                    $key   The parameter position or name.
-     * @param mixed                         $value The parameter value.
-     * @param ParameterType|string|int|null $type  The parameter type. If specified, the given value will be run through
-     *                                             the type conversion of this type. This is usually not needed for
-     *                                             strings and numeric types.
+     * @param string|int                                       $key   The parameter position or name.
+     * @param mixed                                            $value The parameter value.
+     * @param ParameterType|ArrayParameterType|string|int|null $type  The parameter type. If specified, the given value
+     *                                                                will be run through the type conversion of this
+     *                                                                type. This is usually not needed for strings and
+     *                                                                numeric types.
      *
      * @return $this
      */
-    public function setParameter(string|int $key, mixed $value, ParameterType|string|int|null $type = null): static
+    public function setParameter(string|int $key, mixed $value, ParameterType|ArrayParameterType|string|int|null $type = null): static
     {
         $existingParameter = $this->getParameter($key);
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Query;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\ArrayResult;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
@@ -186,6 +187,26 @@ class QueryTest extends OrmTestCase
         $query = $this->entityManager
                 ->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.city IN (:cities)')
                 ->setParameter('cities', $cities);
+
+        $parameters = $query->getParameters();
+        $parameter  = $parameters->first();
+
+        self::assertEquals('cities', $parameter->getName());
+        self::assertEquals($cities, $parameter->getValue());
+    }
+
+    #[Group('DDC-1697')]
+    public function testExplicitCollectionParameters(): void
+    {
+        $cities = [
+            0 => 'Paris',
+            3 => 'Cannes',
+            9 => 'St Julien',
+        ];
+
+        $query = $this->entityManager
+                ->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.city IN (:cities)')
+                ->setParameter('cities', $cities, ArrayParameterType::STRING);
 
         $parameters = $query->getParameters();
         $parameter  = $parameters->first();


### PR DESCRIPTION
Calling `AbstractQuery::setParameter()` with an array parameter on DBAL 4 currently results in a `TypeError`. This PR fixes that. I'm going to backport the new tests to the 2.16.x branch.