### PR TITLE
Undeprecate autoloader class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 2.17
 
+## Undeprecate `Doctrine\ORM\Proxy\Autoloader`
+
+It will be a full-fledged class, no longer extending
+`Doctrine\Common\Proxy\Autoloader` in 3.0.x.
+
 ## Deprecated: reliance on the non-optimal defaults that come with the `AUTO` identifier generation strategy
 
 When the `AUTO` identifier generation strategy was introduced, the best

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -408,7 +408,7 @@ means that you have to register a special autoloader for these classes:
 .. code-block:: php
 
     <?php
-    use Doctrine\Common\Proxy\Autoloader;
+    use Doctrine\ORM\Proxy\Autoloader;
 
     $proxyDir = "/path/to/proxies";
     $proxyNamespace = "MyProxies";

--- a/lib/Doctrine/ORM/Proxy/Autoloader.php
+++ b/lib/Doctrine/ORM/Proxy/Autoloader.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Proxy;
 
 use Doctrine\Common\Proxy\Autoloader as BaseAutoloader;
 
-/** @deprecated use \Doctrine\Common\Proxy\Autoloader instead */
 class Autoloader extends BaseAutoloader
 {
 }


### PR DESCRIPTION
We plan to sunset doctrine/common, and should move the `Autoloader` class
to `doctrine/orm`

Companion PR: https://github.com/doctrine/orm/pull/10998