### PR TITLE
Remove schema visitors

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -33,13 +32,11 @@ use function array_filter;
 use function array_flip;
 use function array_intersect_key;
 use function assert;
-use function class_exists;
 use function count;
 use function current;
 use function implode;
 use function in_array;
 use function is_numeric;
-use function method_exists;
 use function strtolower;
 
 /**
@@ -379,14 +376,6 @@ class SchemaTool
                     new GenerateSchemaTableEventArgs($class, $schema, $table),
                 );
             }
-        }
-
-        if (
-            ! $this->platform->supportsSchemas()
-            && class_exists(RemoveNamespacedAssets::class)
-            && method_exists($schema, 'visit')
-        ) {
-            $schema->visit(new RemoveNamespacedAssets());
         }
 
         if ($eventManager->hasListeners(ToolEvents::postGenerateSchema)) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,7 +27,6 @@
                 <!-- We wire the command as long as DBAL ships it -->
                 <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand" />
                 <!-- Remove on 3.0.x -->
-                <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
                 <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs"/>
                 <referencedClass name="Doctrine\ORM\Exception\UnknownEntityNamespace"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\AnnotationDriver"/>
@@ -47,7 +46,6 @@
                 <!-- Remove on 3.0.x -->
                 <!-- Compatibility with DBAL 3 -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getEventManager"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Schema::visit"/>
                 <file name="lib/Doctrine/ORM/Query/TreeWalkerChain.php"/>
             </errorLevel>
         </DeprecatedMethod>
@@ -196,9 +194,6 @@
             <errorLevel type="suppress">
                 <!-- Persistence 2 compatibility -->
                 <referencedClass name="Doctrine\Persistence\ObjectManagerAware"/>
-
-                <!-- See https://github.com/doctrine/dbal/pull/5432 -->
-                <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMethod>


### PR DESCRIPTION
Schema visitors are a deprecated DBAL feature. Instead of conditionally using it, I think we'd better not use that functionality at all on the 3.0 branch in order to provide a seamless experience when switching from DBAL 3 and 4.