### PR TITLE
Remove useless check

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
@@ -69,8 +69,7 @@ final class AttributeReader
             ));
         }
 
-        return $this->getPropertyAttributes($property)[$attributeName]
-            ?? ($this->isRepeatable($attributeName) ? new RepeatableAttributeCollection() : null);
+        return $this->getPropertyAttributes($property)[$attributeName] ?? null;
     }
 
     /**


### PR DESCRIPTION
i was trying to understand the AttributeReader and stumbled over this bit.

intellij complains that we are not supposed to ever return RepeatableAttributeCollection according to the PHPDoc. reading the code, i think the additional isRepeatable check makes no sense, as we already checked above and errored if the property is repeatable.

this code is also in the 2.x branches, not sure which branch would be the right place to fix it.