### PR TITLE
Implement proxy name resolver

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -10,7 +10,6 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Result;
 use Doctrine\Deprecations\Deprecation;
@@ -33,6 +32,7 @@ use function array_shift;
 use function assert;
 use function count;
 use function func_num_args;
+use function get_class;
 use function in_array;
 use function is_array;
 use function is_numeric;
@@ -430,7 +430,7 @@ abstract class AbstractQuery
         }
 
         try {
-            $class = ClassUtils::getClass($value);
+            $class = $this->_em->getConfiguration()->getProxyClassNameResolver()->resolveClassName(get_class($value));
             $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
 
             if ($value === null) {

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
@@ -13,6 +12,7 @@ use Doctrine\ORM\Utility\IdentifierFlattener;
 
 use function array_merge;
 use function assert;
+use function get_class;
 use function is_array;
 use function is_object;
 use function reset;
@@ -112,7 +112,7 @@ class DefaultEntityHydrator implements EntityHydrator
             }
 
             if (! isset($assoc['id'])) {
-                $targetClass = ClassUtils::getClass($data[$name]);
+                $targetClass = $this->em->getConfiguration()->getProxyClassNameResolver()->resolveClassName(get_class($data[$name]));
                 $targetId    = $this->uow->getEntityIdentifier($data[$name]);
                 $data[$name] = new AssociationCacheEntry($targetClass, $targetId);
 

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Cache\Exception\CannotUpdateReadOnlyCollection;
 use Doctrine\ORM\PersistentCollection;
+
+use function get_class;
 
 class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollectionPersister
 {
@@ -17,7 +18,7 @@ class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollecti
     {
         if ($collection->isDirty() && $collection->getSnapshot()) {
             throw CannotUpdateReadOnlyCollection::fromEntityAndField(
-                ClassUtils::getClass($collection->getOwner()),
+                $this->proxyClassNameResolver->resolveClassName(get_class($collection->getOwner())),
                 $this->association['fieldName']
             );
         }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Cache\Exception\CannotUpdateReadOnlyEntity;
+
+use function get_class;
 
 /**
  * Specific read-only region entity persister
@@ -17,6 +18,6 @@ class ReadOnlyCachedEntityPersister extends NonStrictReadWriteCachedEntityPersis
      */
     public function update($entity)
     {
-        throw CannotUpdateReadOnlyEntity::fromEntity(ClassUtils::getClass($entity));
+        throw CannotUpdateReadOnlyEntity::fromEntity($this->proxyClassNameResolver->resolveClassName(get_class($entity)));
     }
 }

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -38,6 +38,7 @@ use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Mapping\TypedFieldMapper;
+use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Filter\SQLFilter;
@@ -45,6 +46,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
 use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use LogicException;
@@ -149,6 +151,20 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setProxyNamespace($ns)
     {
         $this->_attributes['proxyNamespace'] = $ns;
+    }
+
+    /**
+     * Gets the proxy class name resolver.
+     *
+     * @internal
+     */
+    public function getProxyClassNameResolver(): ProxyClassNameResolver
+    {
+        if (! isset($this->_attributes['proxyClassNameResolver'])) {
+            $this->_attributes['proxyClassNameResolver'] = new DefaultProxyClassNameResolver();
+        }
+
+        return $this->_attributes['proxyClassNameResolver'];
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -9,7 +9,6 @@ use BadMethodCallException;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\PersistentObject;
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\LockMode;
@@ -36,6 +35,7 @@ use Throwable;
 
 use function array_keys;
 use function class_exists;
+use function get_class;
 use function get_debug_type;
 use function gettype;
 use function is_array;
@@ -444,7 +444,7 @@ class EntityManager implements EntityManagerInterface
 
         foreach ($id as $i => $value) {
             if (is_object($value)) {
-                $className = ClassUtils::getClass($value);
+                $className = $this->getConfiguration()->getProxyClassNameResolver()->resolveClassName(get_class($value));
                 if ($this->metadataFactory->hasMetadataFor($className)) {
                     $id[$i] = $this->unitOfWork->getSingleIdentifierValue($value);
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -98,6 +98,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /** @return void */
     public function setEntityManager(EntityManagerInterface $em)
     {
+        parent::setProxyClassNameResolver($em->getConfiguration()->getProxyClassNameResolver());
+
         $this->em = $em;
     }
 

--- a/lib/Doctrine/ORM/Proxy/DefaultProxyClassNameResolver.php
+++ b/lib/Doctrine/ORM/Proxy/DefaultProxyClassNameResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Proxy;
+
+use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
+use Doctrine\Persistence\Proxy;
+
+use function strrpos;
+use function substr;
+
+/**
+ * Class-related functionality for objects that might or not be proxy objects
+ * at the moment.
+ *
+ * @internal
+ */
+class DefaultProxyClassNameResolver implements ProxyClassNameResolver
+{
+    public function resolveClassName(string $className): string
+    {
+        $pos = strrpos($className, '\\' . Proxy::MARKER . '\\');
+
+        if ($pos === false) {
+            return $className;
+        }
+
+        return substr($className, $pos + Proxy::MARKER_LENGTH + 2);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -195,6 +195,11 @@
         <exclude-pattern>tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php</exclude-pattern>
     </rule>
 
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <!-- we need to test what happens with an stdClass proxy -->
+        <exclude-pattern>tests/Doctrine/Tests/Proxy/DefaultProxyClassNameResolverTest.php</exclude-pattern>
+    </rule>
+
     <rule ref="Squiz.Commenting.FunctionComment.WrongStyle">
         <!-- https://github.com/squizlabs/PHP_CodeSniffer/issues/1961 -->
         <exclude-pattern>tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php</exclude-pattern>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1366,6 +1366,15 @@
       <code>$columnList</code>
     </PossiblyUndefinedVariable>
   </file>
+  <file src="lib/Doctrine/ORM/Proxy/DefaultProxyClassNameResolver.php">
+    <LessSpecificReturnStatement>
+      <code>$className</code>
+      <code>substr($className, $pos + Proxy::MARKER_LENGTH + 2)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>string</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
     <ArgumentTypeCoercion>
       <code>$classMetadata</code>

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostLoadEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -13,6 +13,9 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use RuntimeException;
+
+use function assert;
+use function get_class;
 
 class PostLoadEventTest extends OrmFunctionalTestCase
 {
@@ -302,7 +305,9 @@ class PostLoadListenerLoadEntityInEventHandler
     public function postLoad(PostLoadEventArgs $event): void
     {
         $object = $event->getObject();
-        $class  = ClassUtils::getClass($object);
+        $om     = $event->getObjectManager();
+        assert($om instanceof EntityManagerInterface);
+        $class = $om->getConfiguration()->getProxyClassNameResolver()->resolveClassName(get_class($object));
         if (! isset($this->firedByClasses[$class])) {
             $this->firedByClasses[$class] = 1;
         } else {

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Proxy\Proxy as CommonProxy;
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
@@ -227,7 +226,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
 
         $entity = $this->_em->getReference(ECommerceProduct::class, $id);
         assert($entity instanceof ECommerceProduct);
-        $className = ClassUtils::getClass($entity);
+        $className = $this->_em->getConfiguration()->getProxyClassNameResolver()->resolveClassName(get_class($entity));
 
         self::assertInstanceOf(InternalProxy::class, $entity);
         self::assertTrue($this->isUninitializedObject($entity));

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -499,7 +499,10 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $classMetadataFactory = new ClassMetadataFactory();
 
+        $configuration = new Configuration();
+
         $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
         $classMetadataFactory->setEntityManager($entityManager);
 
         // not really the cleanest way to check it, but we won't add a getter to the CMF just for the sake of testing.


### PR DESCRIPTION
It is important to have the same implementation as used in `doctrine/persistence` without relying on copy/paste.
Besides, this decouples the ORM from `doctrine/common` a bit more.