### PR TITLE
Hydrate AbstractSqlExecutor::sqlStatements

### DIFF
--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 
+use function sprintf;
+
 /**
  * Base class for SQL statement executors.
  *
@@ -58,4 +60,16 @@ abstract class AbstractSqlExecutor
      * @psalm-param WrapperParameterTypeArray  $types  The parameter types.
      */
     abstract public function execute(Connection $conn, array $params, array $types): Result|int;
+
+    public function __wakeup(): void
+    {
+        $this->__unserialize((array) $this);
+    }
+
+    /** @param array<string, mixed> $data */
+    public function __unserialize(array $data): void
+    {
+        $this->sqlStatements = $data[sprintf("\0*\0%s", '_sqlStatements')]
+            ?? $data[sprintf("\0*\0%s", 'sqlStatements')];
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -40,6 +40,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
         $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
         $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
+        $this->assertIsString($unserialized->getSqlExecutor()->getSqlStatements());
     }
 
     #[DataProvider('provideSerializedSingleSelectResults')]
@@ -51,6 +52,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
         $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
         $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
+        $this->assertIsString($unserialized->getSqlExecutor()->getSqlStatements());
     }
 
     /** @return Generator<string, array{string}> */


### PR DESCRIPTION
This test caused deprecations because
`AbstractSqlExecutor::_sqlStatements`, a property that no longer exists since it was renamed was hydrated instead.