### PR TITLE
Make `PersistentCollection::first()` "extra" lazy

### DIFF
--- a/docs/en/tutorials/extra-lazy-associations.rst
+++ b/docs/en/tutorials/extra-lazy-associations.rst
@@ -17,6 +17,7 @@ can be called without triggering a full load of the collection:
 -  ``Collection#contains($entity)``
 -  ``Collection#containsKey($key)``
 -  ``Collection#count()``
+-  ``Collection#first()``
 -  ``Collection#get($key)``
 -  ``Collection#slice($offset, $length = null)``
 

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -505,6 +505,20 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function first()
+    {
+        if (! $this->initialized && ! $this->isDirty && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
+
+            return array_values($persister->slice($this, 0, 1))[0] ?? false;
+        }
+
+        return parent::first();
+    }
+
+    /**
      * Extracts a slice of $length elements starting at position $offset from the Collection.
      *
      * If $length is null it returns all elements from $offset to the end of the Collection.


### PR DESCRIPTION
I think it's common to _not_ want the entire collection loaded when calling `->first()` on an extra-lazy collection.