### PR TITLE
Recommend SEQUENCE until doctrine/dbal 4 is released

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,16 +9,17 @@ It will be a full-fledged class, no longer extending
 
 When the `AUTO` identifier generation strategy was introduced, the best
 strategy at the time was selected for each database platform.
-A lot of time has passed since then, and support for better strategies has been
-added.
+A lot of time has passed since then, and with ORM 3.0.0 and DBAL 4.0.0, support
+for better strategies will be added.
 
 Because of that, it is now deprecated to rely on the historical defaults when
-they differ from what we recommend now.
+they differ from what we will be recommended in the future.
 
 Instead, you should pick a strategy for each database platform you use, and it
 will be used when using `AUTO`. As of now, only PostgreSQL is affected by this.
-It is recommended that PostgreSQL user configure their new applications to use
-`IDENTITY`:
+
+It is recommended that PostgreSQL users configure their existing and new
+applications to use `SEQUENCE` until `doctrine/dbal` 4.0.0 is released:
 
 ```php
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -26,12 +27,12 @@ use Doctrine\ORM\Configuration;
 
 assert($configuration instanceof Configuration);
 $configuration->setIdentityGenerationPreferences([
-    PostgreSQLPlatform::CLASS => ClassMetadata::GENERATOR_TYPE_IDENTITY,
+    PostgreSQLPlatform::CLASS => ClassMetadata::GENERATOR_TYPE_SEQUENCE,
 ]);
 ```
 
-If migrating an existing application is too costly, the deprecation can be
-addressed by configuring `SEQUENCE` as the default strategy.
+When DBAL 4 is released, `AUTO` will result in `IDENTITY`, and the above
+configuration should be removed to migrate to it.
 
 ## Deprecate `EntityManagerInterface::getPartialReference()`
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -427,20 +427,6 @@ defaults to the identifier generation mechanism your current database
 vendor preferred at the time that strategy was introduced:
 ``AUTO_INCREMENT`` with MySQL, sequences with PostgreSQL and Oracle and
 so on.
-We now recommend using ``IDENTITY`` for PostgreSQL, and you can achieve
-that while still using the ``AUTO`` strategy, by configuring what it
-defaults to.
-
-.. code-block:: php
-
-    <?php
-    use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-    use Doctrine\ORM\Configuration;
-
-    $config = new Configuration();
-    $config->setIdentityGenerationPreferences([
-        PostgreSQLPlatform::class => ClassMetadata::GENERATOR_TYPE_IDENTITY,
-    ]);
 
 .. _identifier-generation-strategies:
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -537,6 +537,7 @@
       <code>$class</code>
       <code>$class</code>
       <code>$platformFamily</code>
+      <code><![CDATA['Doctrine\DBAL\Platforms\PostgreSqlPlatform']]></code>
       <code><![CDATA[new $definition['class']()]]></code>
     </ArgumentTypeCoercion>
     <DeprecatedClass>

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -170,7 +170,18 @@ class ClassMetadataFactoryTest extends OrmTestCase
         return $cmf;
     }
 
-    public function testRelyingOnLegacyIdGenerationDefaultsIsDeprecatedIfItResultsInASuboptimalDefault(): void
+    public function testRelyingOnLegacyIdGenerationDefaultsIsOKIfItResultsInTheCurrentlyRecommendedStrategyBeingUsed(): void
+    {
+        $cm = $this->createValidClassMetadata();
+        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+        $cmf = $this->setUpCmfForPlatform(new OraclePlatform());
+        $cmf->setMetadataForClass($cm->name, $cm);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8893');
+        $cmf->getMetadataFor($cm->name);
+    }
+
+    public function testRelyingOnLegacyIdGenerationDefaultsIsDeprecatedIfItResultsInADefaultThatWillChange(): void
     {
         $cm = $this->createValidClassMetadata();
         $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
@@ -188,19 +199,8 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
         $cmf = $this->setUpCmfForPlatform(new PostgreSQLPlatform(), [
-            PostgreSQLPlatform::class => ClassMetadata::GENERATOR_TYPE_IDENTITY,
+            PostgreSQLPlatform::class => ClassMetadata::GENERATOR_TYPE_SEQUENCE,
         ]);
-        $cmf->setMetadataForClass($cm->name, $cm);
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8893');
-        $cmf->getMetadataFor($cm->name);
-    }
-
-    public function testRelyingOnLegacyIdGenerationDefaultsIsOKIfItResultsInTheCurrentlyRecommendedStrategyBeingUsed(): void
-    {
-        $cm = $this->createValidClassMetadata();
-        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
-        $cmf = $this->setUpCmfForPlatform(new OraclePlatform());
         $cmf->setMetadataForClass($cm->name, $cm);
 
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8893');


### PR DESCRIPTION
Using `IDENTITY` with `doctrine/dbal` 3 results in `SERIAL`, which is not recommended.

On 3.0.x, we should make a different recommendation based on the version of `doctrine/dbal`

Companion PR: https://github.com/doctrine/orm/pull/11045