### PR TITLE
Dynamically resolve AUTO to SEQUENCE or IDENTITY

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,12 +9,12 @@ Make sure to use the former when writing a type declaration or an `instanceof` c
 To keep PHP mapping attributes consistent, order of arguments passed to above attributes has been changed
 so `$targetEntity` is a first argument now. This change affects only non-named arguments usage.
 
-## BC BREAK: AUTO keyword for identity generation defaults to IDENTITY for PostgreSQL now
+## BC BREAK: AUTO keyword for identity generation defaults to IDENTITY for PostgreSQL when using `doctrine/dbal` 4
 
-When using the AUTO strategy to let Doctrine determine the identity generation mecehanism for
-an entity, PostgreSQL now uses IDENTITY instead of SEQUENCE. When upgrading from ORM 2.x
-and preference is on keeping the SEQUENCE based identity generation, then configure the ORM
-this way:
+When using the `AUTO` strategy to let Doctrine determine the identity generation mechanism for
+an entity, and when using `doctrine/dbal` 4, PostgreSQL now uses `IDENTITY`
+instead of `SEQUENCE`. When upgrading from ORM 2.x and preference is on keeping
+the `SEQUENCE` based identity generation, then configure the ORM this way:
 
 ```php
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -329,9 +329,9 @@ defaults to the identifier generation mechanism your current database
 vendor preferred at the time that strategy was introduced:
 ``AUTO_INCREMENT`` with MySQL, sequences with PostgreSQL and Oracle and
 so on.
-We now recommend using ``IDENTITY`` for PostgreSQL, and you can achieve
-that while still using the ``AUTO`` strategy, by configuring what it
-defaults to.
+If you are using `doctrine/dbal` 4, we now recommend using ``IDENTITY``
+for PostgreSQL, and you can achieve that while still using the ``AUTO``
+strategy, by configuring what it defaults to.
 
 .. code-block:: php
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -34,6 +34,7 @@ use function explode;
 use function in_array;
 use function is_a;
 use function is_subclass_of;
+use function method_exists;
 use function str_contains;
 use function strlen;
 use function strtolower;
@@ -616,7 +617,14 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             }
         }
 
-        foreach (self::NON_IDENTITY_DEFAULT_STRATEGY as $platformFamily => $strategy) {
+        $nonIdentityDefaultStrategy = self::NON_IDENTITY_DEFAULT_STRATEGY;
+
+        // DBAL 3
+        if (method_exists($platform, 'getIdentitySequenceName')) {
+            $nonIdentityDefaultStrategy[Platforms\PostgreSQLPlatform::class] = ClassMetadata::GENERATOR_TYPE_SEQUENCE;
+        }
+
+        foreach ($nonIdentityDefaultStrategy as $platformFamily => $strategy) {
             if (is_a($platform, $platformFamily)) {
                 return $strategy;
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -42,6 +43,11 @@ class DDC832Test extends OrmFunctionalTestCase
         $sm->dropTable($platform->quoteIdentifier('TREE_INDEX'));
         $sm->dropTable($platform->quoteIdentifier('INDEX'));
         $sm->dropTable($platform->quoteIdentifier('LIKE'));
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            $sm->dropSequence($platform->quoteIdentifier('INDEX_id_seq'));
+            $sm->dropSequence($platform->quoteIdentifier('LIKE_id_seq'));
+        }
     }
 
     #[Group('DDC-832')]

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -18,6 +18,8 @@ use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\Group;
 
+use function method_exists;
+
 class DDC832Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
@@ -44,7 +46,8 @@ class DDC832Test extends OrmFunctionalTestCase
         $sm->dropTable($platform->quoteIdentifier('INDEX'));
         $sm->dropTable($platform->quoteIdentifier('LIKE'));
 
-        if ($platform instanceof PostgreSQLPlatform) {
+        // DBAL 3
+        if ($platform instanceof PostgreSQLPlatform && method_exists($platform, 'getIdentitySequenceName')) {
             $sm->dropSequence($platform->quoteIdentifier('INDEX_id_seq'));
             $sm->dropSequence($platform->quoteIdentifier('LIKE_id_seq'));
         }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Configuration;
@@ -127,17 +126,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $entityManager->getConfiguration()->setIdentityGenerationPreferences($preferences);
 
         return $cmf;
-    }
-
-    public function testRelyingOnLegacyIdGenerationDefaultsIsOKIfItResultsInTheCurrentlyRecommendedStrategyBeingUsed(): void
-    {
-        $cm = $this->createValidClassMetadata();
-        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
-        $cmf = $this->setUpCmfForPlatform(new OraclePlatform());
-        $cmf->setMetadataForClass($cm->name, $cm);
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8893');
-        $cmf->getMetadataFor($cm->name);
     }
 
     public function testPostgresSticksWithSequencesWhenDbal3IsUsed(): void


### PR DESCRIPTION
With DBAL 3.x, `IDENTITY` results in `SERIAL`.
With DBAL 4.x, it results in the standard `GENERATED BY DEFAULT AS IDENTITY`.