### PR TITLE
Restore backward compatibility with previous format

### DIFF
--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -89,6 +89,10 @@ abstract class AbstractSqlExecutor
 
     public function __wakeup(): void
     {
+        if ($this->_sqlStatements !== null && $this->sqlStatements === null) {
+            $this->sqlStatements = $this->_sqlStatements;
+        }
+
         $this->_sqlStatements = &$this->sqlStatements;
     }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1844,6 +1844,14 @@
     </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
+    <DeprecatedProperty>
+      <code><![CDATA[$this->_sqlStatements]]></code>
+      <code><![CDATA[$this->_sqlStatements]]></code>
+    </DeprecatedProperty>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$this->_sqlStatements !== null && $this->sqlStatements === null]]></code>
+      <code><![CDATA[$this->sqlStatements === null]]></code>
+    </DocblockTypeContradiction>
     <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -1852,6 +1860,9 @@
       <code>$queryCacheProfile</code>
       <code>$sqlStatements</code>
     </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->_sqlStatements !== null]]></code>
+    </RedundantConditionGivenDocblockType>
     <UninitializedProperty>
       <code><![CDATA[$this->sqlStatements]]></code>
     </UninitializedProperty>

--- a/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -77,6 +77,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
         $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
         $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
+        $this->assertIsString($unserialized->getSqlExecutor()->getSqlStatements());
     }
 
     /** @return Generator<string, array{string}> */


### PR DESCRIPTION
Follow-up to https://github.com/doctrine/orm/pull/11027#issuecomment-1793871887

When unserializing from a cache entry in the previous format, the sqlStatements need to be copied from the legacy property to the new property before the reference is created.