### PR TITLE
Deprecate annotation classes for named queries

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade to 2.17
 
+## Deprecate annotations classes for named queries
+
+The following classes have been deprecated:
+
+* `Doctrine\ORM\Mapping\NamedNativeQueries`
+* `Doctrine\ORM\Mapping\NamedNativeQuery`
+* `Doctrine\ORM\Mapping\NamedQueries`
+* `Doctrine\ORM\Mapping\NamedQuery`
+
 ## Deprecate `Doctrine\ORM\Query\Exec\AbstractSqlExecutor::_sqlStatements`
 
 Use `Doctrine\ORM\Query\Exec\AbstractSqlExecutor::sqlStatements` instead.

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
@@ -8,6 +8,8 @@ namespace Doctrine\ORM\Mapping;
  * Is used to specify an array of native SQL named queries.
  * The NamedNativeQueries annotation can be applied to an entity or mapped superclass.
  *
+ * @deprecated Named queries won't be supported in ORM 3.
+ *
  * @Annotation
  * @Target("CLASS")
  */

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
@@ -8,6 +8,8 @@ namespace Doctrine\ORM\Mapping;
  * Is used to specify a native SQL named query.
  * The NamedNativeQuery annotation can be applied to an entity or mapped superclass.
  *
+ * @deprecated Named queries won't be supported in ORM 3.
+ *
  * @Annotation
  * @Target("ANNOTATION")
  */

--- a/lib/Doctrine/ORM/Mapping/NamedQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQueries.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 /**
+ * @deprecated Named queries won't be supported in ORM 3.
+ *
  * @Annotation
  * @Target("CLASS")
  */

--- a/lib/Doctrine/ORM/Mapping/NamedQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQuery.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 /**
+ * @deprecated Named queries won't be supported in ORM 3.
+ *
  * @Annotation
  * @Target("ANNOTATION")
  */

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,6 +38,10 @@
                 <referencedClass name="Doctrine\ORM\Exception\UnknownEntityNamespace"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\AnnotationDriver"/>
                 <referencedClass name="Doctrine\ORM\Mapping\Driver\YamlDriver"/>
+                <referencedClass name="Doctrine\ORM\Mapping\NamedNativeQueries"/>
+                <referencedClass name="Doctrine\ORM\Mapping\NamedNativeQuery"/>
+                <referencedClass name="Doctrine\ORM\Mapping\NamedQueries"/>
+                <referencedClass name="Doctrine\ORM\Mapping\NamedQuery"/>
                 <referencedClass name="Doctrine\ORM\Query\AST\InExpression"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand"/>
                 <referencedClass name="Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand"/>


### PR DESCRIPTION
Named queries have been deprecated in #8592. This PR flags the corresponding annotation classes as deprecated to make their usage discoverable for static analysis.