### PR TITLE
fix: ordering of the edges regardless when the parent node is persisted

### DIFF
--- a/lib/Doctrine/ORM/Internal/TopologicalSort.php
+++ b/lib/Doctrine/ORM/Internal/TopologicalSort.php
@@ -129,7 +129,7 @@ final class TopologicalSort
         $this->states[$oid] = self::IN_PROGRESS;
 
         // Continue the DFS downwards the edge list
-        foreach ($this->edges[$oid] as $adjacentId => $optional) {
+        foreach (array_reverse($this->edges[$oid], true) as $adjacentId => $optional) {
             try {
                 $this->visit($adjacentId);
             } catch (CycleDetectedException $exception) {

--- a/tests/Doctrine/Tests/ORM/Internal/TopologicalSortTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/TopologicalSortTest.php
@@ -153,6 +153,28 @@ class TopologicalSortTest extends OrmTestCase
         self::assertSame(['A', 'B', 'C'], $this->computeResult());
     }
 
+    public function testNodesMaintainOrderWhenEdgesPermit(): void
+    {
+        $this->addNodes( 'A', 'B', 'C');
+        $this->addEdge('A', 'B');
+        $this->addEdge('A', 'C');
+
+        // Nodes shall maintain the order in which they were added
+        // when permitted by edges/constraints
+        self::assertSame(['A', 'B', 'C'], $this->computeResult());
+    }
+
+    public function testNodesMaintainOrderWhenEdgesPermitAndMainNodePersistedLast(): void
+    {
+        $this->addNodes( 'B', 'C', 'A');
+        $this->addEdge('A', 'B');
+        $this->addEdge('A', 'C');
+
+        // Nodes shall maintain the order in which they were added
+        // when permitted by edges/constraints
+        self::assertSame(['A', 'B', 'C'], $this->computeResult());
+    }
+
     public function testDetectSmallCycle(): void
     {
         $this->addNodes('A', 'B');

--- a/tests/Doctrine/Tests/ORM/Internal/TopologicalSortTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/TopologicalSortTest.php
@@ -155,7 +155,7 @@ class TopologicalSortTest extends OrmTestCase
 
     public function testNodesMaintainOrderWhenEdgesPermit(): void
     {
-        $this->addNodes( 'A', 'B', 'C');
+        $this->addNodes('A', 'B', 'C');
         $this->addEdge('A', 'B');
         $this->addEdge('A', 'C');
 
@@ -166,7 +166,7 @@ class TopologicalSortTest extends OrmTestCase
 
     public function testNodesMaintainOrderWhenEdgesPermitAndMainNodePersistedLast(): void
     {
-        $this->addNodes( 'B', 'C', 'A');
+        $this->addNodes('B', 'C', 'A');
         $this->addEdge('A', 'B');
         $this->addEdge('A', 'C');
 


### PR DESCRIPTION
In correlation of #11057