### PR TITLE
Fix calls to removed lock methods

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -37,6 +37,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\Exception\InvalidFindByCall;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
+use Doctrine\ORM\Utility\LockSqlHelper;
 use Doctrine\ORM\Utility\PersisterHelper;
 use LengthException;
 
@@ -96,6 +97,8 @@ use function trim;
  */
 class BasicEntityPersister implements EntityPersister
 {
+    use LockSqlHelper;
+
     /** @var array<string,string> */
     private static array $comparisonMap = [
         Comparison::EQ          => '= %s',
@@ -1074,8 +1077,8 @@ class BasicEntityPersister implements EntityPersister
             : $this->getSelectConditionSQL($criteria, $assoc);
 
         $lockSql = match ($lockMode) {
-            LockMode::PESSIMISTIC_READ => ' ' . $this->platform->getReadLockSQL(),
-            LockMode::PESSIMISTIC_WRITE => ' ' . $this->platform->getWriteLockSQL(),
+            LockMode::PESSIMISTIC_READ => ' ' . $this->getReadLockSQL($this->platform),
+            LockMode::PESSIMISTIC_WRITE => ' ' . $this->getWriteLockSQL($this->platform),
             default => '',
         };
 
@@ -1505,8 +1508,8 @@ class BasicEntityPersister implements EntityPersister
         $conditionSql = $this->getSelectConditionSQL($criteria);
 
         $lockSql = match ($lockMode) {
-            LockMode::PESSIMISTIC_READ => $this->platform->getReadLockSQL(),
-            LockMode::PESSIMISTIC_WRITE => $this->platform->getWriteLockSQL(),
+            LockMode::PESSIMISTIC_READ => $this->getReadLockSQL($this->platform),
+            LockMode::PESSIMISTIC_WRITE => $this->getWriteLockSQL($this->platform),
             default => '',
         };
 

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Utility\LockSqlHelper;
 use Doctrine\ORM\Utility\PersisterHelper;
 use LengthException;
 
@@ -27,6 +28,7 @@ use function implode;
  */
 class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 {
+    use LockSqlHelper;
     use SQLResultCasing;
 
     /**
@@ -279,12 +281,12 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         switch ($lockMode) {
             case LockMode::PESSIMISTIC_READ:
-                $lockSql = ' ' . $this->platform->getReadLockSQL();
+                $lockSql = ' ' . $this->getReadLockSQL($this->platform);
 
                 break;
 
             case LockMode::PESSIMISTIC_WRITE:
-                $lockSql = ' ' . $this->platform->getWriteLockSQL();
+                $lockSql = ' ' . $this->getWriteLockSQL($this->platform);
 
                 break;
         }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
+use Doctrine\ORM\Utility\LockSqlHelper;
 use Doctrine\ORM\Utility\PersisterHelper;
 use InvalidArgumentException;
 use LogicException;
@@ -46,6 +47,8 @@ use function trim;
  */
 class SqlWalker
 {
+    use LockSqlHelper;
+
     public const HINT_DISTINCT = 'doctrine.distinct';
 
     private readonly ResultSetMapping $rsm;
@@ -475,11 +478,11 @@ class SqlWalker
         }
 
         if ($lockMode === LockMode::PESSIMISTIC_READ) {
-            return $sql . ' ' . $this->platform->getReadLockSQL();
+            return $sql . ' ' . $this->getReadLockSQL($this->platform);
         }
 
         if ($lockMode === LockMode::PESSIMISTIC_WRITE) {
-            return $sql . ' ' . $this->platform->getWriteLockSQL();
+            return $sql . ' ' . $this->getWriteLockSQL($this->platform);
         }
 
         if ($lockMode !== LockMode::OPTIMISTIC) {

--- a/lib/Doctrine/ORM/Utility/LockSqlHelper.php
+++ b/lib/Doctrine/ORM/Utility/LockSqlHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Utility;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+
+/** @internal */
+trait LockSqlHelper
+{
+    private function getReadLockSQL(AbstractPlatform $platform): string
+    {
+        return match (true) {
+            $platform instanceof AbstractMySQLPlatform => 'LOCK IN SHARE MODE',
+            $platform instanceof PostgreSQLPlatform => 'FOR SHARE',
+            default => $this->getWriteLockSQL($platform),
+        };
+    }
+
+    private function getWriteLockSQL(AbstractPlatform $platform): string
+    {
+        return match (true) {
+            $platform instanceof DB2Platform => 'WITH RR USE AND KEEP UPDATE LOCKS',
+            $platform instanceof SQLitePlatform,
+            $platform instanceof SQLServerPlatform => '',
+            default => 'FOR UPDATE',
+        };
+    }
+}

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -24,6 +24,8 @@ parameters:
             message: '~^Unreachable statement \- code above always terminates\.$~'
             path: lib/Doctrine/ORM/Mapping/AssociationMapping.php
 
+        - '~^Class Doctrine\\DBAL\\Platforms\\SQLitePlatform not found\.$~'
+
         # To be removed in 4.0
         -
             message: '#Negated boolean expression is always false\.#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -193,12 +193,13 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php"/>
                 <!-- DBAL 3 compatibility -->
                 <file name="lib/Doctrine/ORM/UnitOfWork.php"/>
+                <file name="lib/Doctrine/ORM/Utility/LockSqlHelper.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
         <UndefinedClass>
             <errorLevel type="suppress">
-                <!-- Persistence 2 compatibility -->
-                <referencedClass name="Doctrine\Persistence\ObjectManagerAware"/>
+                <!-- Compatibility with DBAL 3 -->
+                <referencedClass name="Doctrine\DBAL\Platforms\SQLitePlatform"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMethod>


### PR DESCRIPTION
`getReadLockSQL()` and `getWriteLockSQL()` have been removed from the DBAL. This PR restores the functionality in order to get the pipeline green again. I'll try to leverage the DBAL query builder instead when I find some time. 😓 