### PR TITLE
AbstractSqlExecutor::__sleep should return property names

### DIFF
--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -11,7 +11,9 @@ use Doctrine\DBAL\Types\Type;
 
 use function array_diff;
 use function array_keys;
+use function array_map;
 use function array_values;
+use function str_replace;
 
 /**
  * Base class for SQL statement executors.
@@ -84,7 +86,9 @@ abstract class AbstractSqlExecutor
              serialized representation becomes compatible with 3.0.x, meaning
              there will not be a deprecation warning about a missing property
              when unserializing data */
-        return array_values(array_diff(array_keys((array) $this), ["\0*\0_sqlStatements"]));
+        return array_values(array_diff(array_map(static function (string $prop): string {
+            return str_replace("\0*\0", '', $prop);
+        }, array_keys((array) $this)), ['_sqlStatements']));
     }
 
     public function __wakeup(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Closure;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\SingleSelectExecutor;
 use Doctrine\ORM\Query\ParserResult;
@@ -12,6 +13,8 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use Generator;
 use ReflectionMethod;
 use ReflectionProperty;
+use Symfony\Component\VarExporter\Instantiator;
+use Symfony\Component\VarExporter\VarExporter;
 
 use function file_get_contents;
 use function rtrim;
@@ -27,19 +30,44 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         parent::setUp();
     }
 
-    public function testSerializeParserResult(): void
+    /**
+     * @param Closure(ParserResult): ParserResult $toSerializedAndBack
+     *
+     * @dataProvider provideToSerializedAndBack
+     */
+    public function testSerializeParserResult(Closure $toSerializedAndBack): void
     {
         $query = $this->_em
             ->createQuery('SELECT u FROM Doctrine\Tests\Models\Company\CompanyEmployee u WHERE u.name = :name');
 
         $parserResult = self::parseQuery($query);
-        $serialized   = serialize($parserResult);
-        $unserialized = unserialize($serialized);
+        $unserialized = $toSerializedAndBack($parserResult);
 
         $this->assertInstanceOf(ParserResult::class, $unserialized);
         $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
         $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
         $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
+    }
+
+    /** @return Generator<string, array{Closure(ParserResult): ParserResult}> */
+    public function provideToSerializedAndBack(): Generator
+    {
+        yield 'native serialization function' => [
+            static function (ParserResult $parserResult): ParserResult {
+                return unserialize(serialize($parserResult));
+            },
+        ];
+
+        $instantiatorMethod = new ReflectionMethod(Instantiator::class, 'instantiate');
+        if ($instantiatorMethod->getReturnType() === null) {
+            $this->markTestSkipped('symfony/var-exporter 5.4+ is required.');
+        }
+
+        yield 'symfony/var-exporter' => [
+            static function (ParserResult $parserResult): ParserResult {
+                return eval('return ' . VarExporter::export($parserResult) . ';');
+            },
+        ];
     }
 
     public function testItSerializesParserResultWithAForwardCompatibleFormat(): void


### PR DESCRIPTION
From php.net:

> If an object is converted to an array, the result is an array whose elements are the object's properties. The keys are the member variable names, with a few notable exceptions: integer properties are unaccessible; private variables have the class name prepended to the variable name; protected variables have a '*' prepended to the variable name. These prepended values have NUL bytes on either side. Uninitialized [typed properties](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.typed-properties) are silently discarded.

`serialize` supports the prepended property names, but this is undocumented. `VarExporter` does not support prepended property names. The `PhpFilesAdapter` uses `VarExporter` to create a php cache file. To prevent issues, we need to return the property names without the prefixes added by php when casting an object to an array.

Fixes #11063