### PR TITLE
Remove wrong assertion

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -137,7 +137,6 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function hydrateAdd(mixed $element): void
     {
-        assert($this->association !== null);
         $this->unwrap()->add($element);
 
         // If _backRefFieldName is set and its a one-to-many association,


### PR DESCRIPTION
It is useless in that particular method, and wrong.
It was added in #10613 in several methods, and I think I went overboard.