### PR TITLE
Add a test for sqlite schema tool

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/SqliteSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/SqliteSchemaToolTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\SchemaTool;
+
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\Models\NonPublicSchemaJoins\User;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class SqliteSchemaToolTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
+            self::markTestSkipped('The ' . self::class . ' requires the use of sqlite.');
+        }
+    }
+
+    public function testGetCreateSchemaSql(): void
+    {
+        $classes = [
+            $this->_em->getClassMetadata(User::class),
+        ];
+
+        $tool = new SchemaTool($this->_em);
+        $sql  = $tool->getCreateSchemaSql($classes);
+
+        self::assertEquals('CREATE TABLE readers__user (id INTEGER NOT NULL, PRIMARY KEY(id))', $sql[0]);
+        self::assertEquals('CREATE TABLE readers__author_reader (author_id INTEGER NOT NULL, reader_id INTEGER NOT NULL, PRIMARY KEY(author_id, reader_id), CONSTRAINT FK_83C36113F675F31B FOREIGN KEY (author_id) REFERENCES readers__user (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_83C361131717D737 FOREIGN KEY (reader_id) REFERENCES readers__user (id) NOT DEFERRABLE INITIALLY IMMEDIATE)', $sql[1]);
+        self::assertEquals('CREATE INDEX IDX_83C36113F675F31B ON readers__author_reader (author_id)', $sql[2]);
+        self::assertEquals('CREATE INDEX IDX_83C361131717D737 ON readers__author_reader (reader_id)', $sql[3]);
+
+        self::assertCount(4, $sql);
+    }
+}


### PR DESCRIPTION
I was trying to reproduce the bug found in https://github.com/doctrine/data-fixtures/pull/452, so in `3.x` should fail.

In 3.0.x this is the output:
```sql
CREATE TABLE readers.user (id INTEGER NOT NULL, PRIMARY KEY(id))
CREATE TABLE readers.author_reader (author_id INTEGER NOT NULL, reader_id INTEGER NOT NULL, PRIMARY KEY(author_id, reader_id), CONSTRAINT FK_3155D2E5F675F31B FOREIGN KEY (author_id) REFERENCES readers.user (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_3155D2E51717D737 FOREIGN KEY (reader_id) REFERENCES readers.user (id) NOT DEFERRABLE INITIALLY IMMEDIATE)
CREATE INDEX IDX_3155D2E5F675F31B ON readers.author_reader (author_id)
CREATE INDEX IDX_3155D2E51717D737 ON readers.author_reader (reader_id)
```

**Update**: Related to https://github.com/doctrine/orm/pull/9259 so I guess this can be closed