### PR TITLE
Do not defer eager collection loading when in iteration context

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3104,9 +3104,10 @@ EXCEPTION
                     $reflField->setValue($entity, $pColl);
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
-                        if ($assoc['type'] === ClassMetadata::ONE_TO_MANY) {
+                        $isIteration = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];
+                        if (! $isIteration && $assoc['type'] === ClassMetadata::ONE_TO_MANY) {
                             $this->scheduleCollectionForBatchLoading($pColl, $class);
-                        } elseif ($assoc['type'] === ClassMetadata::MANY_TO_MANY) {
+                        } elseif (($isIteration && $assoc['type'] === ClassMetadata::ONE_TO_MANY) || $assoc['type'] === ClassMetadata::MANY_TO_MANY) {
                             $this->loadCollection($pColl);
                             $pColl->takeSnapshot();
                         }

--- a/tests/Doctrine/Tests/ORM/Functional/EagerFetchCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EagerFetchCollectionTest.php
@@ -84,6 +84,18 @@ class EagerFetchCollectionTest extends OrmFunctionalTestCase
         $query->getResult();
     }
 
+    public function testEagerFetchWithIterable(): void
+    {
+        $this->createOwnerWithChildren(2);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $iterable = $this->_em->getRepository(EagerFetchOwner::class)->createQueryBuilder('o')->getQuery()->toIterable();
+        $owner    = $iterable->current();
+
+        $this->assertCount(2, $owner->children);
+    }
+
     protected function createOwnerWithChildren(int $children): EagerFetchOwner
     {
         $owner = new EagerFetchOwner();


### PR DESCRIPTION
The test shows that eager collection loading is broken when used in conjunction with iterating over a query result. I also added a proposed fix to not defer eager collection loading when the iteration hint has been set.

Fixes #11081