### PR TITLE
XmlDriver: remove dead code

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -255,7 +255,6 @@ class XmlDriver extends FileDriver
 
         // The mapping assignment is done in 2 times as a bug might occurs on some php/xml lib versions
         // The internal SimpleXmlIterator get resetted, to this generate a duplicate field exception
-        $mappings = [];
         // Evaluate <field ...> mappings
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $fieldMapping) {
@@ -288,14 +287,6 @@ class XmlDriver extends FileDriver
 
                 $metadata->mapEmbedded($mapping);
             }
-        }
-
-        foreach ($mappings as $mapping) {
-            if (isset($mapping['version'])) {
-                $metadata->setVersionMapping($mapping);
-            }
-
-            $metadata->mapField($mapping);
         }
 
         // Evaluate <id ...> mappings

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,16 +136,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-
-			message: "#^Empty array passed to foreach\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
-
-		-
-			message: "#^Offset 'version' on \\*NEVER\\* in isset\\(\\) always exists and is always null\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ToOneOwningSideMapping\\:\\:fromMappingArray\\(\\) should return static\\(Doctrine\\\\ORM\\\\Mapping\\\\ToOneOwningSideMapping\\) but returns Doctrine\\\\ORM\\\\Mapping\\\\ManyToOneAssociationMapping\\|Doctrine\\\\ORM\\\\Mapping\\\\OneToOneOwningSideMapping\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/ToOneOwningSideMapping.php


### PR DESCRIPTION
the variable `$mappings` is always containing a empty-array and therefore the code in question is dead