### PR TITLE
Deprecate `Join::ON` ?

### DIFF
--- a/src/Query/Expr/Join.php
+++ b/src/Query/Expr/Join.php
@@ -16,6 +16,7 @@ class Join
     public const INNER_JOIN = 'INNER';
     public const LEFT_JOIN  = 'LEFT';
 
+    /** @deprecated This constant is deprecated and will be removed in Doctrine ORM 3.0. */
     public const ON   = 'ON';
     public const WITH = 'WITH';
 


### PR DESCRIPTION
I've been wondering about this for years, what is the purpose of the `Join::ON` constant? This constant seems completely useless, as the DQL parser doesn't even support the `ON` keyword in a join:

```php
$fooRepository->createQueryBuilder('f')
    ->innerJoin('f.bar', 'b', Join::ON, 'b.condition = 1')
    ->getQuery()
    ->execute()
;
```
```
[Syntax Error] line 0, col 51: Error: Expected end of string, got 'ON'
```

I haven't found any issues related to this, nor any explanations regarding the original idea behind this constant.

Also, if it's decided to deprecate and remove this constant, the `$conditionType` parameters of the `QueryBuilder::*Join()` methods and `Expr\Join` class will become redundant since currently, the only two options are `WITH` and `ON`. Therefore, it might be a good idea to consider deprecating them as well.

https://github.com/doctrine/orm/blob/23d36c0d5293ac796f35850b4f082aef60c6fc52/lib/Doctrine/ORM/QueryBuilder.php#L1028-L1052