### PR TITLE
Original entity data resolves inverse 1-1 joins

### DIFF
--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -832,17 +832,42 @@ class BasicEntityPersister implements EntityPersister
 
         $computedIdentifier = [];
 
+        /** @var array<string,mixed>|null $sourceEntityData */
+        $sourceEntityData = null;
+
         // TRICKY: since the association is specular source and target are flipped
         foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
             if (! isset($sourceClass->fieldNames[$sourceKeyColumn])) {
-                throw MappingException::joinColumnMustPointToMappedField(
-                    $sourceClass->name,
-                    $sourceKeyColumn
-                );
-            }
+                // The likely case here is that the column is a join column
+                // in an association mapping. However, there is no guarantee
+                // at this point that a corresponding (generally identifying)
+                // association has been mapped in the source entity. To handle
+                // this case we directly reference the column-keyed data used
+                // to initialize the source entity before throwing an exception.
+                $resolvedSourceData = false;
+                if (! isset($sourceEntityData)) {
+                    $sourceEntityData = $this->em->getUnitOfWork()->getOriginalEntityData($sourceEntity);
+                }
 
-            $computedIdentifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
-                $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
+                if (isset($sourceEntityData[$sourceKeyColumn])) {
+                    $dataValue = $sourceEntityData[$sourceKeyColumn];
+                    if ($dataValue !== null) {
+                        $resolvedSourceData                                                    = true;
+                        $computedIdentifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
+                            $dataValue;
+                    }
+                }
+
+                if (! $resolvedSourceData) {
+                    throw MappingException::joinColumnMustPointToMappedField(
+                        $sourceClass->name,
+                        $sourceKeyColumn
+                    );
+                }
+            } else {
+                $computedIdentifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
+                    $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
+            }
         }
 
         $targetEntity = $this->load($computedIdentifier, null, $assoc);

--- a/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/InverseSide.php
+++ b/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/InverseSide.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity()
+ * @Table(name="one_to_one_inverse_side_assoc_id_load_inverse")
+ */
+class InverseSide
+{
+    /**
+     * Associative id (owning identifier)
+     *
+     * @var InverseSideIdTarget
+     * @Id()
+     * @OneToOne(targetEntity=InverseSideIdTarget::class, inversedBy="inverseSide")
+     * @JoinColumn(nullable=false, name="associativeId")
+     */
+    public $associativeId;
+
+    /**
+     * @var OwningSide
+     * @OneToOne(targetEntity=OwningSide::class, mappedBy="inverse")
+     */
+    public $owning;
+}

--- a/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/InverseSideIdTarget.php
+++ b/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/InverseSideIdTarget.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity()
+ * @Table(name="one_to_one_inverse_side_assoc_id_load_inverse_id_target")
+ */
+class InverseSideIdTarget
+{
+    /**
+     * @var string
+     * @Id()
+     * @Column(type="string", length=255)
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    /**
+     * @var InverseSide
+     * @OneToOne(targetEntity=InverseSide::class, mappedBy="associativeId")
+     */
+    public $inverseSide;
+}

--- a/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/OwningSide.php
+++ b/tests/Tests/Models/OneToOneInverseSideWithAssociativeIdLoad/OwningSide.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity()
+ * @Table(name="one_to_one_inverse_side_assoc_id_load_owning")
+ */
+class OwningSide
+{
+    /**
+     * @var string
+     * @Id()
+     * @Column(type="string", length=255)
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    /**
+     * Owning side
+     *
+     * @var InverseSide
+     * @OneToOne(targetEntity=InverseSide::class, inversedBy="owning")
+     * @JoinColumn(name="inverse", referencedColumnName="associativeId")
+     */
+    public $inverse;
+}

--- a/tests/Tests/ORM/Functional/OneToOneInverseSideWithAssociativeIdLoadAfterDqlQueryTest.php
+++ b/tests/Tests/ORM/Functional/OneToOneInverseSideWithAssociativeIdLoadAfterDqlQueryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad\InverseSide;
+use Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad\InverseSideIdTarget;
+use Doctrine\Tests\Models\OneToOneInverseSideWithAssociativeIdLoad\OwningSide;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function assert;
+
+class OneToOneInverseSideWithAssociativeIdLoadAfterDqlQueryTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(OwningSide::class, InverseSideIdTarget::class, InverseSide::class);
+    }
+
+    /** @group GH-11108 */
+    public function testInverseSideWithAssociativeIdOneToOneLoadedAfterDqlQuery(): void
+    {
+        $owner     = new OwningSide();
+        $inverseId = new InverseSideIdTarget();
+        $inverse   = new InverseSide();
+
+        $owner->id              = 'owner';
+        $inverseId->id          = 'inverseId';
+        $inverseId->inverseSide = $inverse;
+        $inverse->associativeId = $inverseId;
+        $owner->inverse         = $inverse;
+        $inverse->owning        = $owner;
+
+        $this->_em->persist($owner);
+        $this->_em->persist($inverseId);
+        $this->_em->persist($inverse);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $fetchedInverse = $this
+            ->_em
+            ->createQueryBuilder()
+            ->select('inverse')
+            ->from(InverseSide::class, 'inverse')
+            ->andWhere('inverse.associativeId = :associativeId')
+            ->setParameter('associativeId', 'inverseId')
+            ->getQuery()
+            ->getSingleResult();
+        assert($fetchedInverse instanceof InverseSide);
+
+        self::assertInstanceOf(InverseSide::class, $fetchedInverse);
+        self::assertInstanceOf(InverseSideIdTarget::class, $fetchedInverse->associativeId);
+        self::assertInstanceOf(OwningSide::class, $fetchedInverse->owning);
+
+        $this->assertSQLEquals(
+            'select o0_.associativeid as associativeid_0 from one_to_one_inverse_side_assoc_id_load_inverse o0_ where o0_.associativeid = ?',
+            $this->getLastLoggedQuery(1)['sql']
+        );
+
+        $this->assertSQLEquals(
+            'select t0.id as id_1, t0.inverse as inverse_2 from one_to_one_inverse_side_assoc_id_load_owning t0 where t0.inverse = ?',
+            $this->getLastLoggedQuery()['sql']
+        );
+    }
+}


### PR DESCRIPTION
If the source entity for an inverse (non-owning) 1-1 relationship is identified by an association then the identifying association may not be set when an inverse one-to-one association is resolved. This means that no data is available in the entity to resolve the needed column value for the join query.

Provide the original entity data for the source entity as a fallback to resolve the query conditions.

The new test will fail if the fix is removed (comment out lines 840-847 in BasicEntityPersister.php).

Fixes #11108