### PR TITLE
[RFC] - Add support for tracking what throwable closed the entity manager

### DIFF
--- a/lib/Doctrine/ORM/Exception/EntityManagerClosed.php
+++ b/lib/Doctrine/ORM/Exception/EntityManagerClosed.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Exception;
 
+use Throwable;
+
 final class EntityManagerClosed extends ORMException implements ManagerException
 {
+    const EXCEPTION_CLOSED = 'The EntityManager is closed.';
+
     public static function create(): self
     {
-        return new self('The EntityManager is closed.');
+        return new self(self::EXCEPTION_CLOSED);
+    }
+
+    public static function createWithClosingThrowable(Throwable $previousThrowable): self
+    {
+        return (new self(self::EXCEPTION_CLOSED, 0, $previousThrowable));
     }
 }

--- a/lib/Doctrine/ORM/Exception/EntityManagerClosed.php
+++ b/lib/Doctrine/ORM/Exception/EntityManagerClosed.php
@@ -8,7 +8,7 @@ use Throwable;
 
 final class EntityManagerClosed extends ORMException implements ManagerException
 {
-    const EXCEPTION_CLOSED = 'The EntityManager is closed.';
+    private const EXCEPTION_CLOSED = 'The EntityManager is closed.';
 
     public static function create(): self
     {
@@ -17,6 +17,6 @@ final class EntityManagerClosed extends ORMException implements ManagerException
 
     public static function createWithClosingThrowable(Throwable $previousThrowable): self
     {
-        return (new self(self::EXCEPTION_CLOSED, 0, $previousThrowable));
+        return new self(self::EXCEPTION_CLOSED, 0, $previousThrowable);
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -480,6 +480,10 @@ class UnitOfWork implements PropertyChangedListener
         } catch (Throwable $e) {
             $this->em->close();
 
+            if ($this->em instanceof EntityManager) {
+                $this->em->setClosingThrowable($e);
+            }
+
             if ($conn->isTransactionActive()) {
                 $conn->rollBack();
             }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -44,8 +44,8 @@ use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
-
 use Throwable;
+
 use function assert;
 use function count;
 use function gc_collect_cycles;

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -14,6 +14,7 @@ use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Exception\EntityIdentityCollisionException;
+use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -44,6 +45,7 @@ use Doctrine\Tests\PHPUnitCompatibility\MockBuilderCompatibilityTools;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
+use Throwable;
 use function assert;
 use function count;
 use function gc_collect_cycles;
@@ -869,6 +871,61 @@ class UnitOfWorkTest extends OrmTestCase
     {
         $this->expectException(EntityNotFoundException::class);
         $this->_unitOfWork->getEntityIdentifier(new stdClass());
+    }
+
+    public function testWeKeepTrackOfExceptionThatClosedManager(): void
+    {
+        $driver = $this->createMock(Driver::class);
+        $driver->method('connect')
+            ->willReturn($this->createMock(Driver\Connection::class));
+
+        // Set another connection mock that fail on commit
+        $this->_connectionMock = $this->getMockBuilderWithOnlyMethods(ConnectionMock::class, ['commit'])
+            ->setConstructorArgs([[], $driver])
+            ->getMock();
+        $this->_emMock         = new EntityManagerMock($this->_connectionMock);
+        $this->_unitOfWork     = new UnitOfWorkMock($this->_emMock);
+        $this->_emMock->setUnitOfWork($this->_unitOfWork);
+
+        $this->_connectionMock->method('commit')->willReturn(false);
+
+        // Create a test user
+        $user           = new ForumUser();
+        $user->username = 'Ifigenia';
+        $this->_unitOfWork->persist($user);
+
+        try {
+            $this->_unitOfWork->commit();
+        } catch (Throwable $exception) {
+            // We get an optimistic lock exception and internally the entity manager closes.
+            $this->assertInstanceOf(OptimisticLockException::class, $exception);
+
+            // We should have no previous exception here.
+            $this->assertNull($exception->getPrevious());
+
+            // Let's assume we do nothing here with this exception, and we try to do more operations
+            // on the database.
+        }
+
+        // Turn the mock commit to normal.
+        $this->_connectionMock->method('commit')->willReturn(true);
+
+        // Try to persist the user again.
+        $user->username = 'Petros';
+        $this->_unitOfWork->persist($user);
+
+        try {
+            $this->_emMock->flush();
+        } catch (Throwable $exception) {
+            $this->assertInstanceOf(EntityManagerClosed::class, $exception);
+
+            // We should also have a previous exception.
+            $this->assertInstanceOf(OptimisticLockException::class, $exception->getPrevious());
+
+            return;
+        }
+
+        self::fail('We should have thrown an before this point');
     }
 
     public function testRemovedEntityIsRemovedFromManyToManyCollection(): void


### PR DESCRIPTION
#SymfonyHackDay

I would like some feedback on this before I go on and also try to write some tests.

**Problem I am trying to solve:**
When we run long process, usually in workers consuming a queue of tasks, we might get an exception. That exception is not thrown immediately but it is added in a result object. This object will then be persisted in Mysql in a task_note table.

Interesting to mention that we use multiple database servers so a process might access 3 database servers during the same execution.

When the exception is not closing the entity manager, everything is ok. 

When the entity manager is closed, the insert to task_note fails. Other inserts/updates before that, using the other entity managers, work fine.

So when this happens, our mysql task_note doesn't have the error. We then have to go to new relic. What we see there is only "Entity Manager closed" and the stacktrace points to the save($taskNote) which is basically not the place where the error occurred.

Then it is very time consuming to travel up the whole process until you find a mysql operation that might have failed. There is no trace of it.

It's important to note here that just throwing the exception and killing everything is not a good choice for us because we want the worker to keep working if the exception is not DB related.

in order to mitigate this we have to do this:

```
 try {
            $this->setNewRelicCustomParameter("Task", $task->getId());

            // do the job

            $daemonActivity->setResultFromDaemonActivityResultEnum($daemonActivityResult);
            $this->getDaemonActivityRepository()->save($daemonActivity);
            $this->outputMessage("Finished executing");
        } catch (DBALException $databaseException) {
            // we throw the exception here so at least new relic can catch it with correct stacktrace before we hit an
            // entity manager closed error. Unfortunately, some times the error here is again "entity manager closed" because 
            // of a nested try / catch
            throw $databaseException;
        } catch (Exception $exception) {
            // this will mark the task as failed, store the exception as a note it in the db and continue running
            $this->reactToExceptionWhileExecuting($task, $exception);
        }

```

**Solution I am proposing**
- store the exception that caused the entity manager to close
- once we throw the "Entity manager closed" exception, also attach the previous throwable

**Examples**
- how we deal with a non DB exception in the task

<img width="1090" alt="1-caught-exception" src="https://github.com/doctrine/orm/assets/454539/05e4c70f-19a1-45aa-a1da-cc9d180b1216">

2. an "Entity manager closed" exception before my change

<img width="1250" alt="2-before" src="https://github.com/doctrine/orm/assets/454539/4bd8653c-aa52-4b27-afea-67afcedbc963">

3. after this change

<img width="1152" alt="3-after" src="https://github.com/doctrine/orm/assets/454539/757b9c47-3d9e-47e5-9e71-2678207cdf69">
