### PR TITLE
Implement named arguments for NEW DTO syntax

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -562,6 +562,16 @@ And then use the ``NEW`` DQL keyword :
 
 Note that you can only pass scalar expressions to the constructor.
 
+The ``NEW`` operator also supports named arguments:
+
+.. code-block:: php
+
+    <?php
+    $query = $em->createQuery('SELECT NEW CustomerDTO(email: e.email, name: c.name, address: a.city) FROM Customer c JOIN c.email e JOIN c.address a');
+    $users = $query->getResult(); // array of CustomerDTO
+
+Note that you must not pass ordered arguments after named ones.
+
 Using INDEX BY
 ~~~~~~~~~~~~~~
 
@@ -1650,7 +1660,7 @@ Select Expressions
     SelectExpression        ::= (IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | "(" Subselect ")" | CaseExpression | NewObjectExpression) [["AS"] ["HIDDEN"] AliasResultVariable]
     SimpleSelectExpression  ::= (StateFieldPathExpression | IdentificationVariable | FunctionDeclaration | AggregateExpression | "(" Subselect ")" | ScalarExpression) [["AS"] AliasResultVariable]
     NewObjectExpression     ::= "NEW" AbstractSchemaName "(" NewObjectArg {"," NewObjectArg}* ")"
-    NewObjectArg            ::= ScalarExpression | "(" Subselect ")"
+    NewObjectArg            ::= ScalarExpression | NamedScalarExpression | "(" Subselect ")"
 
 Conditional Expressions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -554,7 +554,8 @@ class ObjectHydrator extends AbstractHydrator
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class = $newObject['class'];
                 $args  = $newObject['args'];
-                $obj   = $class->newInstanceArgs($args);
+
+                $obj = $class->newInstanceArgs($args);
 
                 if ($scalarCount === 0 && count($rowData['newObjects']) === 1) {
                     $result[$resultKey] = $obj;

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -554,8 +554,7 @@ class ObjectHydrator extends AbstractHydrator
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class = $newObject['class'];
                 $args  = $newObject['args'];
-
-                $obj = $class->newInstanceArgs($args);
+                $obj   = $class->newInstanceArgs($args);
 
                 if ($scalarCount === 0 && count($rowData['newObjects']) === 1) {
                     $result[$resultKey] = $obj;

--- a/src/Query/AST/NamedScalarExpression.php
+++ b/src/Query/AST/NamedScalarExpression.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+class NamedScalarExpression extends Node
+{
+    public function __construct(
+        public readonly Node $innerExpression,
+        public readonly string|null $name = null,
+    ) {
+    }
+
+    public function dispatch(SqlWalker $walker): string
+    {
+        return $this->innerExpression->dispatch($walker);
+    }
+}

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1503,7 +1503,7 @@ class SqlWalker
             $this->rsm->newObjectMappings[$columnAlias] = [
                 'className' => $newObjectExpression->className,
                 'objIndex'  => $objIndex,
-                'argIndex'  => $argIndex,
+                'argIndex'  => $e instanceof AST\NamedScalarExpression ? $e->name : $argIndex,
             ];
         }
 


### PR DESCRIPTION
I love using DTOs but it can get pretty annoying to understand what's going on when using a ton of arguments, having to keep track of what is what, in what order, etc... Using named arguments should really help a lot with that I think :+1:  
Small note but I also made it that trailing commas don't crash the lexer which is a nice qol feature to have imo. I can remove it / move it to another PR if needed 👌

Now the following DQL works as expected
```sql
SELECT NEW CustomerDTO(
  email: e.email,
  name: u.name,
  city: a.address,
) FROM ...
```

Closes #9182