### PR TITLE
Allow to skip property type validation

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -31,6 +31,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
              ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('skip-mapping', null, InputOption::VALUE_NONE, 'Skip the mapping validation check')
              ->addOption('skip-sync', null, InputOption::VALUE_NONE, 'Skip checking if the mapping is in sync with the database')
+             ->addOption('skip-property-types', null, InputOption::VALUE_NONE, 'Skip checking if property types match the Doctrine types')
              ->setHelp('Validate that the mapping files are correct and in sync with the database.');
     }
 
@@ -39,7 +40,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
         $em        = $this->getEntityManager($input);
-        $validator = new SchemaValidator($em);
+        $validator = new SchemaValidator($em, ! $input->getOption('skip-property-types'));
         $exit      = 0;
 
         $ui->section('Mapping');

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -56,6 +56,9 @@ class SchemaValidator
     /** @var EntityManagerInterface */
     private $em;
 
+    /** @var bool */
+    private $validatePropertyTypes;
+
     /**
      * It maps built-in Doctrine types to PHP types
      */
@@ -74,9 +77,10 @@ class SchemaValidator
         TextType::class => 'string',
     ];
 
-    public function __construct(EntityManagerInterface $em)
+    public function __construct(EntityManagerInterface $em, bool $validatePropertyTypes = true)
     {
-        $this->em = $em;
+        $this->em                    = $em;
+        $this->validatePropertyTypes = $validatePropertyTypes;
     }
 
     /**
@@ -136,7 +140,7 @@ class SchemaValidator
         }
 
         // PHP 7.4 introduces the ability to type properties, so we can't validate them in previous versions
-        if (PHP_VERSION_ID >= 70400) {
+        if (PHP_VERSION_ID >= 70400 && $this->validatePropertyTypes) {
             array_push($ce, ...$this->validatePropertiesTypes($class));
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10661/GH10661Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH10661/GH10661Test.php
@@ -16,32 +16,36 @@ final class GH10661Test extends OrmTestCase
     /** @var EntityManagerInterface */
     private $em;
 
-    /** @var SchemaValidator */
-    private $validator;
-
     protected function setUp(): void
     {
-        $this->em        = $this->getTestEntityManager();
-        $this->validator = new SchemaValidator($this->em);
+        $this->em = $this->getTestEntityManager();
     }
 
     public function testMetadataFieldTypeNotCoherentWithEntityPropertyType(): void
     {
         $class = $this->em->getClassMetadata(InvalidEntity::class);
-        $ce    = $this->validator->validateClass($class);
+        $ce    = $this->bootstrapValidator()->validateClass($class);
 
-        self::assertEquals(
+        self::assertSame(
             ["The field 'Doctrine\Tests\ORM\Functional\Ticket\GH10661\InvalidEntity#property1' has the property type 'float' that differs from the metadata field type 'string' returned by the 'decimal' DBAL type."],
             $ce
         );
     }
 
+    public function testPropertyTypeErrorsCanBeSilenced(): void
+    {
+        $class = $this->em->getClassMetadata(InvalidEntity::class);
+        $ce    = $this->bootstrapValidator(false)->validateClass($class);
+
+        self::assertSame([], $ce);
+    }
+
     public function testMetadataFieldTypeNotCoherentWithEntityPropertyTypeWithInheritance(): void
     {
         $class = $this->em->getClassMetadata(InvalidChildEntity::class);
-        $ce    = $this->validator->validateClass($class);
+        $ce    = $this->bootstrapValidator()->validateClass($class);
 
-        self::assertEquals(
+        self::assertSame(
             [
                 "The field 'Doctrine\Tests\ORM\Functional\Ticket\GH10661\InvalidChildEntity#property1' has the property type 'float' that differs from the metadata field type 'string' returned by the 'decimal' DBAL type.",
                 "The field 'Doctrine\Tests\ORM\Functional\Ticket\GH10661\InvalidChildEntity#property2' has the property type 'int' that differs from the metadata field type 'string' returned by the 'string' DBAL type.",
@@ -49,5 +53,10 @@ final class GH10661Test extends OrmTestCase
             ],
             $ce
         );
+    }
+
+    private function bootstrapValidator(bool $validatePropertyTypes = true): SchemaValidator
+    {
+        return new SchemaValidator($this->em, $validatePropertyTypes);
     }
 }


### PR DESCRIPTION
See https://github.com/doctrine/orm/issues/11073#issuecomment-1822705925 for context.

#10946 introduced validation of property types for the `ValidateSchemaCommand`. For existing projects, this new feature might uncover quite a few valid problems, that need a little time to fix. This is problematic because if schema validation is run in CI, a project basically can't upgrade until all of the newly discovered errors have been fixed. This leaves two options:

* Disable schema validation completely and upgrade to 2.17.
* Stay on 2.16 until all error have been resolved.

Both strategies are not desirable which is why I propose to add a flag to the command that allows us to opt out of the validation of property types. This allows this kind of projects to upgrade to 2.17 and fix the type mismatches iteratively.