### PR TITLE
Remove inheritance

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11072/GH11072EntityAdvanced.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11072/GH11072EntityAdvanced.php
@@ -6,12 +6,22 @@ namespace Doctrine\Tests\ORM\Functional\Ticket\GH11072;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
 
 /**
  * @Entity
  */
-class GH11072EntityAdvanced extends GH11072EntityBasic
+class GH11072EntityAdvanced
 {
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     * @var int
+     */
+    public $id;
+
     /** @Column(type="json") */
     public mixed $anything;
 


### PR DESCRIPTION
Spotted while trying to merge https://github.com/doctrine/orm/pull/11076 (among other things) up into 3.0.x. On that branch, it is no longer possible for an entity to extend another entity without specifying an inheritance mapping type.

I think the goal of that inheritance was just to reuse the identifier anyway, so let's just duplicate the identifier declaration instead.