### PR TITLE
`Selectable` should compare field values, not call getters for initialized collections

### DIFF
--- a/tests/Tests/ORM/Functional/Ticket/GH3591Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH3591Test.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
+
+class GH3591Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH3591Entity::class,
+            GH3591CollectionEntry::class,
+        ]);
+    }
+
+    /**
+     * @dataProvider provideFieldNamesAndInitializationState
+     */
+    public function testMatchingApiOnUninitializedCollection(string $fieldName): void
+    {
+        $criteria = $this->createComparisonCriteria($fieldName, 'test value');
+        $entity   = $this->createAndLoadEntityWithCollectionEntry('test value');
+
+        $matches = $entity->entries->matching($criteria);
+
+        self::assertCount(1, $matches);
+    }
+
+    /**
+     * @dataProvider provideFieldNamesAndInitializationState
+     */
+    public function testMatchingApiOnInitializedCollection(string $fieldName): void
+    {
+        $criteria = $this->createComparisonCriteria($fieldName, 'test value');
+        $entity   = $this->createAndLoadEntityWithCollectionEntry('test value');
+        $entity->entries->initialize();
+
+        $matches = $entity->entries->matching($criteria);
+
+        self::assertCount(1, $matches);
+    }
+
+    /**
+     * @dataProvider provideFieldNamesAndInitializationState
+     */
+    public function testMatchingApiOnUnpersistedCollection(string $fieldName): void
+    {
+        $criteria = $this->createComparisonCriteria($fieldName, 'test value');
+        $entity = new GH3591Entity();
+        $entry  = new GH3591CollectionEntry('test value');
+        $entity->addEntry($entry);
+
+        $matches = $entity->entries->matching($criteria);
+
+        self::assertCount(1, $matches);
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    public function provideFieldNamesAndInitializationState(): Generator
+    {
+        yield ['privateField'];
+        yield ['protectedField'];
+        yield ['publicField'];
+        yield ['fieldWithAwkwardGetter'];
+        yield ['duplicatePrivateField'];
+    }
+
+    private function createAndLoadEntityWithCollectionEntry(string $entryFieldValue): GH3591Entity
+    {
+        $entity = new GH3591Entity();
+        $entry  = new GH3591CollectionEntry($entryFieldValue);
+
+        $entity->addEntry($entry);
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return $this->_em->find(GH3591Entity::class, $entity->id);
+    }
+
+    private function createComparisonCriteria(string $fieldName, string $expectedValue): Criteria
+    {
+        $expr     = new Comparison($fieldName, '=', $expectedValue);
+        $criteria = new Criteria();
+        $criteria->where($expr);
+
+        return $criteria;
+    }
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH3591Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH3591CollectionEntry", mappedBy="entity", cascade={"persist"})
+     *
+     * @var Collection<int, GH3591CollectionEntry>
+     */
+    public $entries;
+
+    public function __construct()
+    {
+        $this->entries = new ArrayCollection();
+    }
+
+    public function addEntry(GH3591CollectionEntry $child): void
+    {
+        if (! $this->entries->contains($child)) {
+            $this->entries->add($child);
+            $child->setEntity($this);
+        }
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class GH3591CollectionEntrySuperclass
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $duplicatePrivateField;
+
+    public function __construct(string $duplicatePrivateField)
+    {
+        $this->duplicatePrivateField = $duplicatePrivateField;
+    }
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH3591CollectionEntry extends GH3591CollectionEntrySuperclass
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH3591Entity", inversedBy="entries")
+     *
+     * @var GH3591Entity
+     */
+    private $entity;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $privateField;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    protected $protectedField;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $publicField;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $fieldWithAwkwardGetter;
+
+    private $duplicatePrivateField;
+
+    public function __construct($value)
+    {
+        $this->privateField           = $value;
+        $this->protectedField         = $value;
+        $this->publicField            = $value;
+        $this->fieldWithAwkwardGetter = $value;
+
+        parent::__construct($value);
+        $this->duplicatePrivateField = 'this is a transient field';
+    }
+
+    public function setEntity(GH3591Entity $entity): void
+    {
+        $this->entity = $entity;
+        $entity->addEntry($this);
+    }
+
+    public function fieldWithAwkwardGetter(): string
+    {
+        return 'not what you expect' . $this->fieldWithAwkwardGetter;
+    }
+}


### PR DESCRIPTION
This revisits #3591 which I think is not fixed correctly.

When using the [`Selectable` API](https://www.doctrine-project.org/projects/doctrine-collections/en/stable/index.html#selectable-methods) to filter elements from a collection, the result depends on the initialization state of the collection.

When the collection is uninitialized, the filtering happens in the database at the SQL level. The given field name is translated to a database column name and a database column-based lookup (`WHERE`) is performed.

When the collection is initialized, we go through hoops to derive potential getter/isser names and/or access `$object->$field` as a last resort, but completely fail on private properties without getter method access.

To the user, it should not make a difference whether a collection is initialized. We should use plain, direct field access (through reflection?) since that is what most closely resembles the database-based lookup. I think this is what Marco refers to in https://github.com/doctrine/collections/pull/149#issuecomment-475982285 as "rely only on state for lookups". 

I am not aware of any other places where the ORM would be concerned with deriving accessor names, which makes this an additional inconsistency.

Obviously, preferring code (getter based) access is not an option for uninitialized collections.

Note that even for plain "state" lookups, there is a remaining chance for issues when DBAL types come into play that do database-to-PHP value conversion. A SQL level column-value comparison might not come to the same result as a PHP-level comparison for certain DBAL type implementations. Anyways.

#### Suggestions needed

* How can we fix this, given that most of the `Selectable` API lives in doctrine/collections and uses static method calls? Is this an ORM issue or a collections issue?
* Are we risking BC breaks, so this fix needs to come as an opt-in switch with a deprecation?
* If so, is it too late in 2.x now?

Related:
* https://github.com/doctrine/collections/issues/170

