### PR TITLE
Remove redundant tags

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -148,7 +148,6 @@
         <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="entity-result" type="orm:entity-result"/>
             <xs:element name="column-result" type="orm:column-result"/>
-            <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
         </xs:choice>
         <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
@@ -226,22 +225,13 @@
 
   <xs:complexType name="mapped-superclass" >
     <xs:complexContent>
-      <xs:extension base="orm:entity">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
-        </xs:choice>
-        <xs:anyAttribute namespace="##other"/>
-      </xs:extension>
+      <xs:extension base="orm:entity"/>
     </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="embeddable">
     <xs:complexContent>
-      <xs:extension base="orm:entity">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
-        </xs:choice>
-      </xs:extension>
+      <xs:extension base="orm:entity"/>
     </xs:complexContent>
   </xs:complexType>
 
@@ -565,7 +555,6 @@
       <xs:choice minOccurs="0" maxOccurs="1">
         <xs:element name="join-column" type="orm:join-column"/>
         <xs:element name="join-columns" type="orm:join-columns"/>
-        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:choice>
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
@@ -583,7 +572,6 @@
       <xs:choice minOccurs="0" maxOccurs="1">
         <xs:element name="join-column" type="orm:join-column"/>
         <xs:element name="join-columns" type="orm:join-columns"/>
-        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:choice>
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>


### PR DESCRIPTION
The `any` tags inside the definition for mapped superclasses and embeddables duplicate what is already done for entities.

The other removed "any" tags are also redundant, as they duplicate what's already done inside the grandparent "choice" tag.

Starting with version libxml 2.12, such redundant tags cause errors about the content model not being "determinist".

Fixes #11117