### PR TITLE
Use foreach on iterable to prevent table locks during tests

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/EagerFetchCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EagerFetchCollectionTest.php
@@ -18,6 +18,10 @@ class EagerFetchCollectionTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->createSchemaForModels(EagerFetchOwner::class, EagerFetchChild::class);
+
+        // Ensure tables are empty
+        $this->_em->getRepository(EagerFetchChild::class)->createQueryBuilder('o')->delete()->getQuery()->execute();
+        $this->_em->getRepository(EagerFetchOwner::class)->createQueryBuilder('o')->delete()->getQuery()->execute();
     }
 
     public function testEagerFetchMode(): void
@@ -91,9 +95,11 @@ class EagerFetchCollectionTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $iterable = $this->_em->getRepository(EagerFetchOwner::class)->createQueryBuilder('o')->getQuery()->toIterable();
-        $owner    = $iterable->current();
 
-        $this->assertCount(2, $owner->children);
+        // There is only a single record, but use a foreach to ensure the iterator is marked as finished and the table lock is released
+        foreach ($iterable as $owner) {
+            $this->assertCount(2, $owner->children);
+        }
     }
 
     protected function createOwnerWithChildren(int $children): EagerFetchOwner


### PR DESCRIPTION
Should fix table lock issues when merging into 3.x (see #11166). The iterator was not marked as finished, as this particular test case does not clear it records between the test, which meant that the test I added actually has 5 owners in the iterator.

By cleaning on setup and using a foreach which will yield only a single record, the iterator is closed and the table lock is released.

I am open for improvements to ensure the table contents is cleared between runs, but for now this works.