### PR TITLE
Introduce lock fo ProxyFactory

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -519,7 +519,7 @@ EOPHP;
                 }
                 // no break
             case self::AUTOGENERATE_ALWAYS:
-                $handle = fopen(sys_get_temp_dir() . '/generate_proxy_class.lock', 'w+');
+                $handle = fopen(sys_get_temp_dir() . '/generate_proxy_class.lock', 'wb');
                 if (flock($handle, LOCK_EX)) {
                     $this->generateProxyClass($class, $fileName, $proxyClassName);
                     flock($handle, LOCK_UN);

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -33,6 +33,8 @@ use function dirname;
 use function file_exists;
 use function file_put_contents;
 use function filemtime;
+use function flock;
+use function fopen;
 use function is_bool;
 use function is_dir;
 use function is_int;
@@ -48,9 +50,12 @@ use function strpos;
 use function strrpos;
 use function strtr;
 use function substr;
+use function sys_get_temp_dir;
 use function ucfirst;
 
 use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
+use const LOCK_UN;
 use const PHP_VERSION_ID;
 
 /**
@@ -514,11 +519,12 @@ EOPHP;
                 }
                 // no break
             case self::AUTOGENERATE_ALWAYS:
-                $handle = fopen(sys_get_temp_dir() . '/generate_proxy_class.lock', "w+");
+                $handle = fopen(sys_get_temp_dir() . '/generate_proxy_class.lock', 'w+');
                 if (flock($handle, LOCK_EX)) {
                     $this->generateProxyClass($class, $fileName, $proxyClassName);
                     flock($handle, LOCK_UN);
                 }
+
                 break;
         }
 

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -514,7 +514,11 @@ EOPHP;
                 }
                 // no break
             case self::AUTOGENERATE_ALWAYS:
-                $this->generateProxyClass($class, $fileName, $proxyClassName);
+                $handle = fopen(sys_get_temp_dir() . '/generate_proxy_class.lock', "w+");
+                if (flock($handle, LOCK_EX)) {
+                    $this->generateProxyClass($class, $fileName, $proxyClassName);
+                    flock($handle, LOCK_UN);
+                }
                 break;
         }
 


### PR DESCRIPTION
When there is a concurrent access to ProxyFactory it can lead to fatal error when generated proxy class can't be required.

My test case is Docker with bindfs filesystem and Sveltekit on frontend which does several requests at same time. This results in

```

[2024-01-19T06:12:53.821565+00:00] request.INFO: Matched route "api-sales-channel-channel". {"route":"api-sales-channel-channel","route_parameters":{"_route":"api-sales-channel-channel","_controller":"App\\Controller\\Api\\ApiController::salesChannelAction","salesChannelUrlPath":"test"},"request_uri":"/api/sales-channel/test/?uniqueId=NDORU","method":"GET"} []
[2024-01-19T06:12:53.821567+00:00] request.INFO: Matched route "api-sales-channel-cylinders". {"route":"api-sales-channel-cylinders","route_parameters":{"_route":"api-sales-channel-cylinders","_controller":"App\\Controller\\Api\\ApiController::cylindersAction","salesChannelUrlPath":"test"},"request_uri":"/api/sales-channel/test/cylinders/","method":"GET"} []
[2024-01-19T06:12:53.824909+00:00] security.DEBUG: Checking for authenticator support. {"firewall_name":"api","authenticators":1} []
[2024-01-19T06:12:53.824910+00:00] security.DEBUG: Checking for authenticator support. {"firewall_name":"api","authenticators":1} []
[2024-01-19T06:12:53.825020+00:00] security.DEBUG: Checking support on authenticator. {"firewall_name":"api","authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.825103+00:00] security.DEBUG: Checking support on authenticator. {"firewall_name":"api","authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.827537+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserProviderListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserProviderListener::checkPassport"} []
[2024-01-19T06:12:53.827541+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserProviderListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserProviderListener::checkPassport"} []
[2024-01-19T06:12:53.827674+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserProviderListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserProviderListener::checkPassport"} []
[2024-01-19T06:12:53.827767+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserProviderListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserProviderListener::checkPassport"} []
[2024-01-19T06:12:53.827847+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\CsrfProtectionListener::checkPassport"} []
[2024-01-19T06:12:53.827929+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\CsrfProtectionListener::checkPassport"} []
[2024-01-19T06:12:53.828010+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserCheckerListener::preCheckCredentials". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserCheckerListener::preCheckCredentials"} []
[2024-01-19T06:12:53.828090+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\UserCheckerListener::preCheckCredentials". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserCheckerListener::preCheckCredentials"} []
[2024-01-19T06:12:53.828218+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\CheckCredentialsListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\CheckCredentialsListener::checkPassport"} []
[2024-01-19T06:12:53.828292+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\CheckPassportEvent" to listener "Symfony\Component\Security\Http\EventListener\CheckCredentialsListener::checkPassport". {"event":"Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\CheckCredentialsListener::checkPassport"} []
[2024-01-19T06:12:53.828881+00:00] app.DEBUG: Notified event "security.authentication.success" to listener "Symfony\Component\Security\Http\EventListener\UserCheckerListener::postCheckCredentials". {"event":"security.authentication.success","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserCheckerListener::postCheckCredentials"} []
[2024-01-19T06:12:53.828881+00:00] app.DEBUG: Notified event "security.authentication.success" to listener "Symfony\Component\Security\Http\EventListener\UserCheckerListener::postCheckCredentials". {"event":"security.authentication.success","listener":"Symfony\\Component\\Security\\Http\\EventListener\\UserCheckerListener::postCheckCredentials"} []
[2024-01-19T06:12:53.829000+00:00] security.INFO: Authenticator successful! {"token":{"Symfony\\Component\\Security\\Http\\Authenticator\\Token\\PostAuthenticationToken":"PostAuthenticationToken(user=\"56d1c2b4-7d71-4be0-aed9-157217599b73\", roles=\"ROLE_API\")"},"authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.829088+00:00] security.INFO: Authenticator successful! {"token":{"Symfony\\Component\\Security\\Http\\Authenticator\\Token\\PostAuthenticationToken":"PostAuthenticationToken(user=\"56d1c2b4-7d71-4be0-aed9-157217599b73\", roles=\"ROLE_API\")"},"authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.830330+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\LoginSuccessEvent" to listener "Symfony\Component\Security\Http\EventListener\SessionStrategyListener::onSuccessfulLogin". {"event":"Symfony\\Component\\Security\\Http\\Event\\LoginSuccessEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\SessionStrategyListener::onSuccessfulLogin"} []
[2024-01-19T06:12:53.830504+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\LoginSuccessEvent" to listener "Symfony\Component\Security\Http\EventListener\PasswordMigratingListener::onLoginSuccess". {"event":"Symfony\\Component\\Security\\Http\\Event\\LoginSuccessEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\PasswordMigratingListener::onLoginSuccess"} []
[2024-01-19T06:12:53.830427+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\LoginSuccessEvent" to listener "Symfony\Component\Security\Http\EventListener\SessionStrategyListener::onSuccessfulLogin". {"event":"Symfony\\Component\\Security\\Http\\Event\\LoginSuccessEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\SessionStrategyListener::onSuccessfulLogin"} []
[2024-01-19T06:12:53.830665+00:00] security.DEBUG: Authenticator set no success response: request continues. {"authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.830785+00:00] app.DEBUG: Notified event "Symfony\Component\Security\Http\Event\LoginSuccessEvent" to listener "Symfony\Component\Security\Http\EventListener\PasswordMigratingListener::onLoginSuccess". {"event":"Symfony\\Component\\Security\\Http\\Event\\LoginSuccessEvent","listener":"Symfony\\Component\\Security\\Http\\EventListener\\PasswordMigratingListener::onLoginSuccess"} []
[2024-01-19T06:12:53.831018+00:00] security.DEBUG: Authenticator set no success response: request continues. {"authenticator":"App\\Security\\ApiKeyAuthenticator"} []
[2024-01-19T06:12:53.848146+00:00] doctrine.INFO: Connecting with parameters *
[2024-01-19T06:12:53.848146+00:00] doctrine.INFO: Connecting with parameters *
[2024-01-19T06:12:53.854635+00:00] doctrine.DEBUG: Executing statement: SELECT xy FROM y s0_ WHERE z (parameters: array{"1":"test","2":1}, types: array{"1":2,"2":5}) {"sql":"SELECT xy FROM z s0_ WHERE s0_.url_path = ? AND s0_.active = ?","params":{"1":"test","2":1},"types":{"1":2,"2":5}} []
[2024-01-19T06:12:53.854634+00:00] doctrine.DEBUG: Executing statement: SELECT xy FROM y s0_ WHERE z (parameters: array{"1":"test","2":1}, types: array{"1":2,"2":5}) {"sql":"SELECT xy FROM z s0_ WHERE s0_.url_path = ? AND s0_.active = ?","params":{"1":"test","2":1},"types":{"1":2,"2":5}} []
[2024-01-19T06:12:53.863755+00:00] request.CRITICAL: Uncaught PHP Exception ErrorException: "Warning: require(/var/www/html/backend/var/cache/dev/doctrine/orm/Proxies/__CG__AppEntityMandate.php): Failed to open stream: No such file or directory" at ProxyFactory.php line 526 {"exception":"[object] (ErrorException(code: 0): Warning: require(/var/www/html/backend/var/cache/dev/doctrine/orm/Proxies/__CG__AppEntityMandate.php): Failed to open stream: No such file or directory at /var/www/html/backend/vendor/doctrine/orm/lib/Doctrine/ORM/Proxy/ProxyFactory.php:526)"} []

```
