### PR TITLE
Ignore deprecations handled in next major

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -88,6 +88,8 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsForeignKeyConstraints"/>
                 <!-- Remove on 3.0.x -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getEventManager"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getReadLockSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getWriteLockSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Schema::visit"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\SchemaDiff::toSaveSql"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\SchemaDiff::toSql"/>


### PR DESCRIPTION
These deprecations have been handled on 4.0.x in
https://github.com/doctrine/orm/pull/11061, it is safe to ignore them.