### PR TITLE
Skip joined entity creation for empty relation (#10889)

### DIFF
--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -367,11 +367,15 @@ class ObjectHydrator extends AbstractHydrator
                     $parentObject = $this->resultPointers[$parentAlias];
                 } else {
                     // Parent object of relation not found, mark as not-fetched again
-                    $element = $this->getEntity($data, $dqlAlias);
+                    if (isset($nonemptyComponents[$dqlAlias])) {
+                        $element = $this->getEntity($data, $dqlAlias);
 
-                    // Update result pointer and provide initial fetch data for parent
-                    $this->resultPointers[$dqlAlias]               = $element;
-                    $rowData['data'][$parentAlias][$relationField] = $element;
+                        // Update result pointer and provide initial fetch data for parent
+                        $this->resultPointers[$dqlAlias]               = $element;
+                        $rowData['data'][$parentAlias][$relationField] = $element;
+                    } else {
+                        $element = null;
+                    }
 
                     // Mark as not-fetched again
                     unset($this->_hints['fetched'][$parentAlias][$relationField]);

--- a/tests/Tests/ORM/Functional/Ticket/GH10889Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10889Test.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @see   https://github.com/doctrine/orm/issues/10889
+ *
+ * @group GH10889
+ */
+class GH10889Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH10889Person::class,
+            GH10889Company::class,
+            GH10889Resume::class
+        );
+    }
+
+    public function testIssue(): void
+    {
+        $person = new GH10889Person();
+        $resume = new GH10889Resume($person, null);
+
+        $this->_em->persist($person);
+        $this->_em->persist($resume);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var list<GH10889Resume> $resumes */
+        $resumes = $this->_em
+            ->getRepository(GH10889Resume::class)
+            ->createQueryBuilder('resume')
+            ->leftJoin('resume.currentCompany', 'company')->addSelect('company')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertArrayHasKey(0, $resumes);
+        $this->assertEquals(1, $resumes[0]->person->id);
+        $this->assertNull($resumes[0]->currentCompany);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10889Person
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10889Company
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10889Resume
+{
+    /**
+     * @ORM\Id
+     * @ORM\OneToOne(targetEntity="GH10889Person")
+     *
+     * @var GH10889Person
+     */
+    public $person;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH10889Company")
+     *
+     * @var GH10889Company|null
+     */
+    public $currentCompany;
+
+    public function __construct(GH10889Person $person, ?GH10889Company $currentCompany)
+    {
+        $this->person         = $person;
+        $this->currentCompany = $currentCompany;
+    }
+}


### PR DESCRIPTION
(The following is translated from french with Google Translate, I'm sorry :/ )

In case the root entity has its primary key as a relationship and the joined entity has a simple primary key, the RSM orders the ID of the joined entity before having the ID which defined the root entity.

The ObjectHydrator therefore first tries to hydrate the joined entity. We then fall into a special case where the parent (the root entity) has not yet been created and the hydrator tries to start by creating the child, except that in our case, the child is supposed to be null.

I therefore added the `isset($nonemptyComponents[$dqlAlias])` check which we find further in the code and which is made to skip the creation of the joined entity when the parent is already hydrated. I think it makes sense to do the same check in the case where the hydrator starts with the joined entity.