### PR TITLE
Ignore subclasses without discriminatorValue when generating discriminator column condition SQL

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -491,7 +491,7 @@ class SqlWalker implements TreeWalker
                 $values[] = $conn->quote($subclassMetadata->discriminatorValue);
             }
 
-            if ($values) {
+            if ($values !== []) {
                 $sqlParts[] = $sqlTableAlias . $class->getDiscriminatorColumn()['name'] . ' IN (' . implode(', ', $values) . ')';
             } else {
                 $sqlParts[] = '1=0'; // impossible condition

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -482,7 +482,7 @@ class SqlWalker implements TreeWalker
             foreach ($class->subClasses as $subclassName) {
                 $subclassMetadata = $this->em->getClassMetadata($subclassName);
 
-                if ($subclassMetadata->reflClass->isAbstract()) {
+                if ($subclassMetadata->reflClass && $subclassMetadata->reflClass->isAbstract()) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -476,7 +476,11 @@ class SqlWalker implements TreeWalker
             }
 
             foreach ($class->subClasses as $subclassName) {
-                $values[] = $conn->quote($this->em->getClassMetadata($subclassName)->discriminatorValue);
+                $discriminatorValue = $this->em->getClassMetadata($subclassName)->discriminatorValue;
+                if ($discriminatorValue === null) {
+                    continue;
+                }
+                $values[] = $conn->quote($discriminatorValue);
             }
 
             $sqlTableAlias = $this->useSqlTableAliases

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -480,6 +480,7 @@ class SqlWalker implements TreeWalker
                 if ($discriminatorValue === null) {
                     continue;
                 }
+
                 $values[] = $conn->quote($discriminatorValue);
             }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -482,7 +482,9 @@ class SqlWalker implements TreeWalker
             foreach ($class->subClasses as $subclassName) {
                 $subclassMetadata = $this->em->getClassMetadata($subclassName);
 
-                if ($subclassMetadata->reflClass && $subclassMetadata->reflClass->isAbstract()) {
+                // Abstract entity classes show up in the list of subClasses, but may be omitted
+                // from the discriminator map. In that case, they have a null discriminator value.
+                if ($subclassMetadata->discriminatorValue === null) {
                     continue;
                 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11199Test.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function substr;
+use function strpos;
+use function trim;
+use function explode;
+use function array_map;
+
+class GH11199Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH11199Root::class,
+            GH11199Parent::class,
+            GH11199Foo::class,
+            GH11199Bar::class,
+            GH11199Baz::class,
+        ]);
+    }
+
+    /**
+     * @throws ORMException
+     */
+    public function testGH11199(): void
+    {
+        $em             = $this->getEntityManager();
+        $sql            = $em->createQueryBuilder()->select('e')->from(GH11199Root::class, 'e')->getQuery()->getSQL();
+        $condition      = substr($sql, strpos($sql, '('));
+        $condition      = trim($condition, '()');
+        $conditionParts = explode(',', $condition);
+        $conditionParts = array_map('trim', $conditionParts);
+        self::assertNotContains("''", $conditionParts, 'Discriminator column condition values contain empty string');
+    }
+}
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="gh11199")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="asset_type", type="string")
+ * @ORM\DiscriminatorMap({
+ *     "foo" = "\Doctrine\Tests\ORM\Functional\Ticket\GH11199Foo",
+ *     "bar" = "\Doctrine\Tests\ORM\Functional\Ticket\GH11199Bar",
+ *     "baz" = "\Doctrine\Tests\ORM\Functional\Ticket\GH11199Baz",
+ * })
+ */
+class GH11199Root
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\Column(type="integer")
+     *
+     * @var int|null
+     */
+    private $id = null;
+}
+
+/**
+ * @ORM\Entity()
+ */
+abstract class GH11199Parent extends GH11199Root
+{
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH11199Foo extends GH11199Parent
+{
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH11199Bar extends GH11199Parent
+{
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH11199Baz extends GH11199Root
+{
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH11199Test.php
@@ -8,11 +8,11 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-use function substr;
-use function strpos;
-use function trim;
-use function explode;
 use function array_map;
+use function explode;
+use function strpos;
+use function substr;
+use function trim;
 
 class GH11199Test extends OrmFunctionalTestCase
 {


### PR DESCRIPTION
After commit https://github.com/doctrine/orm/commit/4e8e3ef30b3d214640883aec5a17896afc006116 when `\Doctrine\ORM\Query\SqlWalker` generates dicsriminator column condition SQL (method `\Doctrine\ORM\Query\SqlWalker::generateDiscriminatorColumnConditionSQL`) it adds an empty string to the list of possible values if the inheritance hierarchy contains a non-root abstract class. 

When the discriminator column is implemented with a custom type in PostgreSQL (equivalent of Enum) the query fails because the type cannot have a value of an empty string. It boils down to the fact that `\Doctrine\ORM\Mapping\ClassMetadataInfo::$subClasses` contains an abstract class and in its Metadata the value of `\Doctrine\ORM\Mapping\ClassMetadataInfo::$discriminatorValue` is `null`.

#### Previous behavior

In version 2.14.1 `\Doctrine\ORM\Mapping\ClassMetadataInfo::$subClasses` does not contain an abstract class.

Fixes #11199, fixes #11177, fixes #10846.