### PR TITLE
Factor out finding discriminator values for a class

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2199,6 +2199,35 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         $this->addSubClass($className);
     }
 
+    /**
+     * @internal
+     *
+     * @return list<int|string>
+     *
+     * @psalm-internal Doctrine\ORM
+     */
+    public function getDiscriminatorValuesForClassAndSubclasses(): array
+    {
+        $values       = [];
+        $valueByClass = array_flip($this->discriminatorMap);
+
+        // Even if this class is part of an inheritance hierarchy, the discriminator
+        // value may be null in case the class is abstract.
+        if ($this->discriminatorValue !== null) {
+            $values[] = $this->discriminatorValue;
+        }
+
+        foreach ($this->subClasses as $subClass) {
+            // Abstract entity classes show up in the list of subClasses,
+            // but may be omitted from the discriminator map.
+            if (isset($valueByClass[$subClass])) {
+                $values[] = $valueByClass[$subClass];
+            }
+        }
+
+        return $values;
+    }
+
     /** @param array<class-string> $classes */
     public function addSubClasses(array $classes): void
     {


### PR DESCRIPTION
While reviewing #11200, I noticed that almost the same bug that was fixed in the `SqlWalker` had been fixed in #10643 for the `SingleTablePersister`.

The underlying question is what the possible discriminator column values may be for a given class.

This PR is a refactoring that moves this logic to an internal method in `ClassMetadata`, and uses it from both other places.

(This is a draft for the time being. Waiting for #11200 to be merged and merged up, then this PR will keep only the actual refactoring for 3.1.x.)