### PR TITLE
Bump dependencies in the "getting started" docs page

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -82,9 +82,9 @@ that directory with the following contents:
 
     {
         "require": {
-            "doctrine/orm": "^2.11.0",
-            "doctrine/dbal": "^3.2",
-            "symfony/cache": "^5.4"
+            "doctrine/orm": "^3",
+            "doctrine/dbal": "^4",
+            "symfony/cache": "^7"
         },
         "autoload": {
             "psr-0": {"": "src/"}


### PR DESCRIPTION
The "getting started" section of the documentation of ORM 3 recommends installing ORM 2. 🙃 

I've bumped all libraries that are mentioned there to their latest major. This means that the tutorial requires PHP 8.2 at least, but if someone started out a new project, they likely won't do that on PHP 8.1. We could however recommend Symfony Cache 6.4 instead if we think that this is an issue.