### PR TITLE
Be less restrictive in DiscriminatorColumnMapping phpdoc

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2113,7 +2113,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     length?: int|null,
      *     columnDefinition?: string|null,
      *     enumType?: class-string<BackedEnum>|null,
-     *     options?:array<string, mixed>|null
+     *     options?: array<string, mixed>|null
      * }|null $columnDef
      *
      * @throws MappingException
@@ -2136,8 +2136,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
 
             $columnDef['fieldName'] ??= $columnDef['name'];
-            $columnDef['type'] ??= 'string';
-            $columnDef['options'] ??= [];
+            $columnDef['type']      ??= 'string';
+            $columnDef['options']   ??= [];
 
             if (in_array($columnDef['type'], ['boolean', 'array', 'object', 'datetime', 'time', 'date'], true)) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2113,7 +2113,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     length?: int|null,
      *     columnDefinition?: string|null,
      *     enumType?: class-string<BackedEnum>|null,
-     *     options?:array<string, mixed>
+     *     options?:array<string, mixed>|null
      * }|null $columnDef
      *
      * @throws MappingException
@@ -2145,6 +2145,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
             if (in_array($columnDef['type'], ['boolean', 'array', 'object', 'datetime', 'time', 'date'], true)) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
+            }
+
+            if (! isset($columnDef['options'])) {
+                $columnDef['options'] = [];
             }
 
             $this->discriminatorColumn = DiscriminatorColumnMapping::fromMappingArray($columnDef);

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2135,20 +2135,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 throw MappingException::duplicateColumnName($this->name, $columnDef['name']);
             }
 
-            if (! isset($columnDef['fieldName'])) {
-                $columnDef['fieldName'] = $columnDef['name'];
-            }
-
-            if (! isset($columnDef['type'])) {
-                $columnDef['type'] = 'string';
-            }
+            $columnDef['fieldName'] ??= $columnDef['name'];
+            $columnDef['type'] ??= 'string';
+            $columnDef['options'] ??= [];
 
             if (in_array($columnDef['type'], ['boolean', 'array', 'object', 'datetime', 'time', 'date'], true)) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
-            }
-
-            if (! isset($columnDef['options'])) {
-                $columnDef['options'] = [];
             }
 
             $this->discriminatorColumn = DiscriminatorColumnMapping::fromMappingArray($columnDef);

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2108,13 +2108,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * @param DiscriminatorColumnMapping|mixed[]|null $columnDef
      * @psalm-param DiscriminatorColumnMapping|array{
      *     name: string|null,
-     *     fieldName?: string,
-     *     type?: string,
-     *     length?: int,
+     *     fieldName?: string|null,
+     *     type?: string|null,
+     *     length?: int|null,
      *     columnDefinition?: string|null,
      *     enumType?: class-string<BackedEnum>|null,
-     *     options?:array<string,
-     *     mixed>|null
+     *     options?:array<string, mixed>
      * }|null $columnDef
      *
      * @throws MappingException

--- a/src/Mapping/DiscriminatorColumnMapping.php
+++ b/src/Mapping/DiscriminatorColumnMapping.php
@@ -42,7 +42,7 @@ final class DiscriminatorColumnMapping implements ArrayAccess
      *     length?: int|null,
      *     columnDefinition?: string|null,
      *     enumType?: class-string<BackedEnum>|null,
-     *     options?: array<string, mixed>,
+     *     options?: array<string, mixed>|null,
      * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): self
@@ -58,7 +58,7 @@ final class DiscriminatorColumnMapping implements ArrayAccess
             }
 
             if (property_exists($mapping, $key)) {
-                $mapping->$key = $value;
+                $mapping->$key = $value ?? $mapping->$key;
             } else {
                 throw new Exception('Unknown property ' . $key . ' on class ' . static::class);
             }

--- a/src/Mapping/DiscriminatorColumnMapping.php
+++ b/src/Mapping/DiscriminatorColumnMapping.php
@@ -39,9 +39,9 @@ final class DiscriminatorColumnMapping implements ArrayAccess
      *     type: string,
      *     fieldName: string,
      *     name: string,
-     *     length?: int,
-     *     columnDefinition?: string,
-     *     enumType?: class-string<BackedEnum>,
+     *     length?: int|null,
+     *     columnDefinition?: string|null,
+     *     enumType?: class-string<BackedEnum>|null,
      *     options?: array<string, mixed>,
      * } $mappingArray
      */


### PR DESCRIPTION
Currently static analysis returns error when writing
```
$classMetadata->setDiscriminatorColumn((array) $discriminatorColumnMapping);
```
with errors like the fact that the array need to have keys like `length?: int` but received `length?: int|null`.

But since `DiscriminatorColumnMapping` is using `null` as default value, it should allow both
- A missing key
- A key with null value