### PR TITLE
Update ObjectHydrator.php

### DIFF
--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -419,7 +419,7 @@ class ObjectHydrator extends AbstractHydrator
                                         $reflFieldValue->last();
                                     }
 
-                                    $this->identifierMap[$path][$id[$parentAlias]][$id[$dqlAlias]] = $reflFieldValue->key();
+                                    $this->identifierMap[$path][$id[$parentAlias]][$id[$dqlAlias]] = $reflFieldValue->indexOf($element);
                                 }
 
                                 // Update result pointer

--- a/tests/Tests/Models/ComplexeHydration/Item.php
+++ b/tests/Tests/Models/ComplexeHydration/Item.php
@@ -12,18 +12,37 @@ use Doctrine\ORM\Mapping\Table;
 
 #[Table(name: 'item')]
 #[Entity]
+/**
+ * @Entity
+ * @Table(name="item")
+ */
 class Item
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
+    /**
+     * @var int
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
     private int|null $id;
 
     #[ORM\Column(type: 'string', length: 255)]
+    /**
+     * @var string
+     * @Column(length=255)
+     */
     private string|null $libelle;
 
     #[ORM\OneToMany(targetEntity: ItemSerie::class, mappedBy: 'item', cascade: ['persist'], orphanRemoval: true)]
     #[ORM\JoinColumn(name: 'itemSeries', referencedColumnName: 'item_id')]
+    /**
+     * @var Collection<int, CmsComment>
+     * @OneToMany(targetEntity="CmsComment", mappedBy="article")
+     * @JoinColumn(name="itemSeries", referencedColumnName="item_id")
+     */
     private $itemSeries;
 
     public function __construct()

--- a/tests/Tests/Models/ComplexeHydration/Item.php
+++ b/tests/Tests/Models/ComplexeHydration/Item.php
@@ -10,12 +10,12 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: 'item')]
-#[Entity]
 /**
  * @Entity
  * @Table(name="item")
  */
+#[Table(name: 'item')]
+#[Entity]
 class Item
 {
     /**

--- a/tests/Tests/Models/ComplexeHydration/Item.php
+++ b/tests/Tests/Models/ComplexeHydration/Item.php
@@ -18,31 +18,31 @@ use Doctrine\ORM\Mapping\Table;
  */
 class Item
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
     /**
      * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private int|null $id;
 
-    #[ORM\Column(type: 'string', length: 255)]
     /**
      * @var string
      * @Column(length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     private string|null $libelle;
 
-    #[ORM\OneToMany(targetEntity: ItemSerie::class, mappedBy: 'item', cascade: ['persist'], orphanRemoval: true)]
-    #[ORM\JoinColumn(name: 'itemSeries', referencedColumnName: 'item_id')]
     /**
      * @var Collection<int, CmsComment>
      * @OneToMany(targetEntity="CmsComment", mappedBy="article")
      * @JoinColumn(name="itemSeries", referencedColumnName="item_id")
      */
+    #[ORM\OneToMany(targetEntity: ItemSerie::class, mappedBy: 'item', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\JoinColumn(name: 'itemSeries', referencedColumnName: 'item_id')]
     private $itemSeries;
 
     public function __construct()

--- a/tests/Tests/Models/ComplexeHydration/Item.php
+++ b/tests/Tests/Models/ComplexeHydration/Item.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ComplexeHydration;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'item')]
+#[Entity]
+class Item
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private int|null $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string|null $libelle;
+
+    #[ORM\OneToMany(targetEntity: ItemSerie::class, mappedBy: 'item', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\JoinColumn(name: 'itemSeries', referencedColumnName: 'item_id')]
+    private $itemSeries;
+
+    public function __construct()
+    {
+        $this->itemSeries = new ArrayCollection();
+    }
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function getLibelle(): string|null
+    {
+        return $this->libelle;
+    }
+
+    public function setLibelle(string $libelle): self
+    {
+        $this->libelle = $libelle;
+
+        return $this;
+    }
+
+    /** @return Collection<int, ItemSerie> */
+    public function getItemSeries(): Collection
+    {
+        return $this->itemSeries;
+    }
+
+    public function addItemSeries(ItemSerie $itemSeries): self
+    {
+        if (! $this->itemSeries->contains($itemSeries)) {
+            $this->itemSeries[] = $itemSeries;
+            $itemSeries->setItem($this);
+        }
+
+        return $this;
+    }
+
+    public function removeItemSeries(ItemSerie $itemSeries): self
+    {
+        if ($this->itemSeries->removeElement($itemSeries)) {
+            // set the owning side to null (unless already changed)
+            if ($itemSeries->getItem() === $this) {
+                $itemSeries->setItem(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/tests/Tests/Models/ComplexeHydration/ItemSerie.php
+++ b/tests/Tests/Models/ComplexeHydration/ItemSerie.php
@@ -11,12 +11,12 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: 'item_serie')]
-#[Entity]
 /**
  * @Entity
  * @Table(name="item_serie")
  */
+#[Table(name: 'item_serie')]
+#[Entity]
 class ItemSerie
 {
     /**
@@ -44,7 +44,7 @@ class ItemSerie
      * @var string
      * @Column(length=50)
      */
-	#[ORM\Column(type: 'string', length: 50)]
+    #[ORM\Column(type: 'string', length: 50)]
     private string|null $number;
 
     public function getItem(): item|null

--- a/tests/Tests/Models/ComplexeHydration/ItemSerie.php
+++ b/tests/Tests/Models/ComplexeHydration/ItemSerie.php
@@ -13,20 +13,39 @@ use Doctrine\ORM\Mapping\Table;
 
 #[Table(name: 'item_serie')]
 #[Entity]
+/**
+ * @Entity
+ * @Table(name="item_serie")
+ */
 class ItemSerie
 {
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: Item::class, inversedBy: 'itemSeries')]
     #[ORM\JoinColumn(name: 'item_id', referencedColumnName: 'id')]
+    /**
+     * @var int
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
     private Item $item;
 
 
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: Serie::class, inversedBy: 'itemSeries')]
     #[ORM\JoinColumn(name: 'serie_id', referencedColumnName: 'id')]
+    /**
+     * @var serie
+     * @ManyToOne(targetEntity="Serie", inversedBy="itemSeries")
+     * @JoinColumn(name="serie_id", referencedColumnName="id")
+     */
     private Serie $serie;
 
     #[ORM\Column(type: 'string', length: 50)]
+    /**
+     * @var string
+     * @Column(length=50)
+     */
     private string|null $number;
 
     public function getItem(): item|null

--- a/tests/Tests/Models/ComplexeHydration/ItemSerie.php
+++ b/tests/Tests/Models/ComplexeHydration/ItemSerie.php
@@ -19,33 +19,32 @@ use Doctrine\ORM\Mapping\Table;
  */
 class ItemSerie
 {
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: Item::class, inversedBy: 'itemSeries')]
-    #[ORM\JoinColumn(name: 'item_id', referencedColumnName: 'id')]
     /**
      * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Item::class, inversedBy: 'itemSeries')]
+    #[ORM\JoinColumn(name: 'item_id', referencedColumnName: 'id')]
     private Item $item;
 
-
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: Serie::class, inversedBy: 'itemSeries')]
-    #[ORM\JoinColumn(name: 'serie_id', referencedColumnName: 'id')]
     /**
      * @var serie
      * @ManyToOne(targetEntity="Serie", inversedBy="itemSeries")
      * @JoinColumn(name="serie_id", referencedColumnName="id")
      */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Serie::class, inversedBy: 'itemSeries')]
+    #[ORM\JoinColumn(name: 'serie_id', referencedColumnName: 'id')]
     private Serie $serie;
 
-    #[ORM\Column(type: 'string', length: 50)]
     /**
      * @var string
      * @Column(length=50)
      */
+	#[ORM\Column(type: 'string', length: 50)]
     private string|null $number;
 
     public function getItem(): item|null

--- a/tests/Tests/Models/ComplexeHydration/ItemSerie.php
+++ b/tests/Tests/Models/ComplexeHydration/ItemSerie.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ComplexeHydration;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'item_serie')]
+#[Entity]
+class ItemSerie
+{
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Item::class, inversedBy: 'itemSeries')]
+    #[ORM\JoinColumn(name: 'item_id', referencedColumnName: 'id')]
+    private Item $item;
+
+
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Serie::class, inversedBy: 'itemSeries')]
+    #[ORM\JoinColumn(name: 'serie_id', referencedColumnName: 'id')]
+    private Serie $serie;
+
+    #[ORM\Column(type: 'string', length: 50)]
+    private string|null $number;
+
+    public function getItem(): item|null
+    {
+        return $this->item;
+    }
+
+    public function setItem(item|null $item): self
+    {
+        $this->item = $item;
+
+        return $this;
+    }
+
+    public function getSerie(): serie|null
+    {
+        return $this->serie;
+    }
+
+    public function setSerie(serie|null $serie): self
+    {
+        $this->serie = $serie;
+
+        return $this;
+    }
+
+    public function getNumber(): string|null
+    {
+        return $this->number;
+    }
+
+    public function setNumber(string $number): self
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+}

--- a/tests/Tests/Models/ComplexeHydration/Serie.php
+++ b/tests/Tests/Models/ComplexeHydration/Serie.php
@@ -12,20 +12,42 @@ use Doctrine\ORM\Mapping\Table;
 
 #[Table(name: 'serie')]
 #[Entity]
+/**
+ * @Entity
+ * @Table(name="serie")
+ */
 class Serie
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
+    /**
+     * @var int
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
     private int $id;
 
     #[ORM\Column(type: 'string', length: 255)]
+    /**
+     * @var string
+     * @Column(length=255)
+     */
     private string|null $libelle;
 
     #[ORM\OneToMany(mappedBy: 'serie', targetEntity: ItemSerie::class, cascade: ['persist'], orphanRemoval: true)]
+    /**
+     * @var Collection<int, ItemSerie>
+     * @OneToMany(targetEntity="ItemSerie", mappedBy="serie")
+     */
     private $itemSeries;
 
     #[ORM\OneToMany(mappedBy: 'serie', targetEntity: SerieImportator::class, cascade: ['persist'], orphanRemoval: true)]
+    /**
+     * @var Collection<int, SerieImportator>
+     * @OneToMany(targetEntity="SerieImportator", mappedBy="serie")
+     */
     private $serieImportators;
 
     public function __construct()

--- a/tests/Tests/Models/ComplexeHydration/Serie.php
+++ b/tests/Tests/Models/ComplexeHydration/Serie.php
@@ -18,36 +18,36 @@ use Doctrine\ORM\Mapping\Table;
  */
 class Serie
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
     /**
      * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private int $id;
 
-    #[ORM\Column(type: 'string', length: 255)]
     /**
      * @var string
      * @Column(length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     private string|null $libelle;
 
-    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: ItemSerie::class, cascade: ['persist'], orphanRemoval: true)]
     /**
      * @var Collection<int, ItemSerie>
      * @OneToMany(targetEntity="ItemSerie", mappedBy="serie")
      */
+    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: ItemSerie::class, cascade: ['persist'], orphanRemoval: true)]
     private $itemSeries;
 
-    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: SerieImportator::class, cascade: ['persist'], orphanRemoval: true)]
     /**
      * @var Collection<int, SerieImportator>
      * @OneToMany(targetEntity="SerieImportator", mappedBy="serie")
      */
+    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: SerieImportator::class, cascade: ['persist'], orphanRemoval: true)]
     private $serieImportators;
 
     public function __construct()

--- a/tests/Tests/Models/ComplexeHydration/Serie.php
+++ b/tests/Tests/Models/ComplexeHydration/Serie.php
@@ -10,16 +10,15 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: 'serie')]
-#[Entity]
 /**
  * @Entity
  * @Table(name="serie")
  */
+#[Table(name: 'serie')]
+#[Entity]
 class Serie
 {
     /**
-     * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue

--- a/tests/Tests/Models/ComplexeHydration/Serie.php
+++ b/tests/Tests/Models/ComplexeHydration/Serie.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ComplexeHydration;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'serie')]
+#[Entity]
+class Serie
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string|null $libelle;
+
+    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: ItemSerie::class, cascade: ['persist'], orphanRemoval: true)]
+    private $itemSeries;
+
+    #[ORM\OneToMany(mappedBy: 'serie', targetEntity: SerieImportator::class, cascade: ['persist'], orphanRemoval: true)]
+    private $serieImportators;
+
+    public function __construct()
+    {
+        $this->itemSeries       = new ArrayCollection();
+        $this->serieImportators = new ArrayCollection();
+    }
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function getLibelle(): string|null
+    {
+        return $this->libelle;
+    }
+
+    public function setLibelle(string $libelle): self
+    {
+        $this->libelle = $libelle;
+
+        return $this;
+    }
+
+    /** @return Collection<int, ItemSerie> */
+    public function getItemSeries(): Collection
+    {
+        return $this->itemSeries;
+    }
+
+    public function addItemSeries(ItemSerie $itemSeries): self
+    {
+        if (! $this->itemSeries->contains($itemSeries)) {
+            $this->itemSeries[] = $itemSeries;
+            $itemSeries->setSerie($this);
+        }
+
+        return $this;
+    }
+
+    public function removeItemSeries(ItemSerie $itemSeries): self
+    {
+        if ($this->itemSeries->removeElement($itemSeries)) {
+            // set the owning side to null (unless already changed)
+            if ($itemSeries->getSerie() === $this) {
+                $itemSeries->setSerie(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, SerieImportator> */
+    public function getSerieImportators(): Collection
+    {
+        return $this->serieImportators;
+    }
+
+    public function addSerieImportator(SerieImportator $serieImportator): static
+    {
+        if (! $this->serieImportators->contains($serieImportator)) {
+            $this->serieImportators->add($serieImportator);
+            $serieImportator->setSerie($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSerieImportator(SerieImportator $serieImportator): static
+    {
+        if ($this->serieImportators->removeElement($serieImportator)) {
+            // set the owning side to null (unless already changed)
+            if ($serieImportator->getSerie() === $this) {
+                $serieImportator->setSerie(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/tests/Tests/Models/ComplexeHydration/SerieImportator.php
+++ b/tests/Tests/Models/ComplexeHydration/SerieImportator.php
@@ -8,12 +8,12 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: 'serie_importator')]
-#[Entity]
 /**
  * @Entity
  * @Table(name="serie_importator")
  */
+#[Table(name: 'serie_importator')]
+#[Entity]
 class SerieImportator
 {
     /**

--- a/tests/Tests/Models/ComplexeHydration/SerieImportator.php
+++ b/tests/Tests/Models/ComplexeHydration/SerieImportator.php
@@ -10,18 +10,37 @@ use Doctrine\ORM\Mapping\Table;
 
 #[Table(name: 'serie_importator')]
 #[Entity]
+/**
+ * @Entity
+ * @Table(name="serie_importator")
+ */
 class SerieImportator
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    /**
+     * @var int
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
     private int|null $id = null;
 
     #[ORM\ManyToOne(inversedBy: 'serieImportators')]
     #[ORM\JoinColumn(nullable: false)]
+    /**
+     * @var Serie
+     * @ManyToOne(targetEntity="Serie", inversedBy="serieImportators")
+     * @JoinColumn(nullable= false)
+     */
     private Serie|null $serie = null;
 
     #[ORM\Column(type: 'string', length: 255)]
+    /**
+     * @var string
+     * @Column(length=255)
+     */
     private string|null $libelle;
 
     public function getId(): int|null

--- a/tests/Tests/Models/ComplexeHydration/SerieImportator.php
+++ b/tests/Tests/Models/ComplexeHydration/SerieImportator.php
@@ -16,31 +16,31 @@ use Doctrine\ORM\Mapping\Table;
  */
 class SerieImportator
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
     /**
      * @var int
      * @Column(type="integer")
      * @Id
      * @GeneratedValue
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
     private int|null $id = null;
 
-    #[ORM\ManyToOne(inversedBy: 'serieImportators')]
-    #[ORM\JoinColumn(nullable: false)]
     /**
      * @var Serie
      * @ManyToOne(targetEntity="Serie", inversedBy="serieImportators")
      * @JoinColumn(nullable= false)
      */
+    #[ORM\ManyToOne(inversedBy: 'serieImportators')]
+    #[ORM\JoinColumn(nullable: false)]
     private Serie|null $serie = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
     /**
      * @var string
      * @Column(length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     private string|null $libelle;
 
     public function getId(): int|null

--- a/tests/Tests/Models/ComplexeHydration/SerieImportator.php
+++ b/tests/Tests/Models/ComplexeHydration/SerieImportator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ComplexeHydration;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'serie_importator')]
+#[Entity]
+class SerieImportator
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private int|null $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'serieImportators')]
+    #[ORM\JoinColumn(nullable: false)]
+    private Serie|null $serie = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string|null $libelle;
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function getSerie(): Serie|null
+    {
+        return $this->serie;
+    }
+
+    public function setSerie(Serie|null $serie): static
+    {
+        $this->serie = $serie;
+
+        return $this;
+    }
+
+    public function getLibelle(): string|null
+    {
+        return $this->libelle;
+    }
+
+    public function setLibelle(string $libelle): self
+    {
+        $this->libelle = $libelle;
+
+        return $this;
+    }
+}

--- a/tests/Tests/ORM/Hydration/ComplexeObjectHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/ComplexeObjectHydratorTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Hydration;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\Models\ComplexeHydration\Item;
+use Doctrine\Tests\Models\ComplexeHydration\ItemSerie;
+use Doctrine\Tests\Models\ComplexeHydration\Serie;
+use Doctrine\Tests\Models\ComplexeHydration\SerieImportator;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function count;
+use function dirname;
+
+class ComplexeObjectHydratorTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_em         = $this->getEntityManager(null, new AttributeDriver([dirname(__DIR__, 2) . '/Models/ComplexeHydration'], true));
+        $this->_schemaTool = new SchemaTool($this->_em);
+
+        $this->setUpEntitySchema([Serie::class, Item::class, SerieImportator::class, ItemSerie::class]);
+
+        for ($iSerie = 1; $iSerie <= 2; $iSerie++) {
+            $serie = new Serie();
+            $serie->setLibelle('Serie ' . $iSerie);
+            $this->_em->persist($serie);
+
+            $serieImportator = new SerieImportator();
+            $serieImportator->setLibelle('imp ' . $iSerie);
+            $serieImportator->setSerie($serie);
+            $this->_em->persist($serieImportator);
+
+            for ($iItem = 1; $iItem <= 12; $iItem++) {
+                $item = new Item();
+                $item->setLibelle('Item ' . $iSerie . '.' . $iItem);
+
+                $itemSerie = new ItemSerie();
+                $itemSerie->setSerie($serie);
+                $itemSerie->setItem($item);
+                $itemSerie->setNumber('Num ' . $iSerie . '.' . $iItem);
+
+                $this->_em->persist($item);
+                $this->_em->persist($itemSerie);
+            }
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testComplexEntityQueryInObject(): void
+    {
+        $dql  = 'SELECT s0_, i1_, i2_, s4_, s5_, i6_ FROM ' . Serie::class . ' s0_ LEFT JOIN s0_.itemSeries i1_ LEFT JOIN i1_.item i2_ LEFT JOIN s0_.serieImportators s4_ LEFT JOIN s4_.serie s5_ LEFT JOIN s5_.itemSeries i6_';
+        $data = $this->_em->createQuery($dql)->getResult();
+
+        self::assertEquals(2, count($data));
+
+        self::assertEquals('Num 1.1', $data[0]->getItemSeries()->toArray()[0]->getNumber());
+        self::assertEquals('Item 1.1', $data[0]->getItemSeries()->toArray()[0]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.2', $data[0]->getItemSeries()->toArray()[1]->getNumber());
+        self::assertEquals('Item 1.2', $data[0]->getItemSeries()->toArray()[1]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.3', $data[0]->getItemSeries()->toArray()[2]->getNumber());
+        self::assertEquals('Item 1.3', $data[0]->getItemSeries()->toArray()[2]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.4', $data[0]->getItemSeries()->toArray()[3]->getNumber());
+        self::assertEquals('Item 1.4', $data[0]->getItemSeries()->toArray()[3]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.5', $data[0]->getItemSeries()->toArray()[4]->getNumber());
+        self::assertEquals('Item 1.5', $data[0]->getItemSeries()->toArray()[4]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.6', $data[0]->getItemSeries()->toArray()[5]->getNumber());
+        self::assertEquals('Item 1.6', $data[0]->getItemSeries()->toArray()[5]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.7', $data[0]->getItemSeries()->toArray()[6]->getNumber());
+        self::assertEquals('Item 1.7', $data[0]->getItemSeries()->toArray()[6]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.8', $data[0]->getItemSeries()->toArray()[7]->getNumber());
+        self::assertEquals('Item 1.8', $data[0]->getItemSeries()->toArray()[7]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.9', $data[0]->getItemSeries()->toArray()[8]->getNumber());
+        self::assertEquals('Item 1.9', $data[0]->getItemSeries()->toArray()[8]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.10', $data[0]->getItemSeries()->toArray()[9]->getNumber());
+        self::assertEquals('Item 1.10', $data[0]->getItemSeries()->toArray()[9]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.11', $data[0]->getItemSeries()->toArray()[10]->getNumber());
+        self::assertEquals('Item 1.11', $data[0]->getItemSeries()->toArray()[10]->getItem()->getLibelle());
+
+        self::assertEquals('Num 1.12', $data[0]->getItemSeries()->toArray()[11]->getNumber());
+        self::assertEquals('Item 1.12', $data[0]->getItemSeries()->toArray()[11]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.1', $data[1]->getItemSeries()->toArray()[0]->getNumber());
+        self::assertEquals('Item 2.1', $data[1]->getItemSeries()->toArray()[0]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.2', $data[1]->getItemSeries()->toArray()[1]->getNumber());
+        self::assertEquals('Item 2.2', $data[1]->getItemSeries()->toArray()[1]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.3', $data[1]->getItemSeries()->toArray()[2]->getNumber());
+        self::assertEquals('Item 2.3', $data[1]->getItemSeries()->toArray()[2]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.4', $data[1]->getItemSeries()->toArray()[3]->getNumber());
+        self::assertEquals('Item 2.4', $data[1]->getItemSeries()->toArray()[3]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.5', $data[1]->getItemSeries()->toArray()[4]->getNumber());
+        self::assertEquals('Item 2.5', $data[1]->getItemSeries()->toArray()[4]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.6', $data[1]->getItemSeries()->toArray()[5]->getNumber());
+        self::assertEquals('Item 2.6', $data[1]->getItemSeries()->toArray()[5]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.7', $data[1]->getItemSeries()->toArray()[6]->getNumber());
+        self::assertEquals('Item 2.7', $data[1]->getItemSeries()->toArray()[6]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.8', $data[1]->getItemSeries()->toArray()[7]->getNumber());
+        self::assertEquals('Item 2.8', $data[1]->getItemSeries()->toArray()[7]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.9', $data[1]->getItemSeries()->toArray()[8]->getNumber());
+        self::assertEquals('Item 2.9', $data[1]->getItemSeries()->toArray()[8]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.10', $data[1]->getItemSeries()->toArray()[9]->getNumber());
+        self::assertEquals('Item 2.10', $data[1]->getItemSeries()->toArray()[9]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.11', $data[1]->getItemSeries()->toArray()[10]->getNumber());
+        self::assertEquals('Item 2.11', $data[1]->getItemSeries()->toArray()[10]->getItem()->getLibelle());
+
+        self::assertEquals('Num 2.12', $data[1]->getItemSeries()->toArray()[11]->getNumber());
+        self::assertEquals('Item 2.12', $data[1]->getItemSeries()->toArray()[11]->getItem()->getLibelle());
+    }
+
+    public function testComplexEntityQueryInArray(): void
+    {
+        $dql  = 'SELECT s0_, i1_, i2_, s4_, s5_, i6_ FROM ' . Serie::class . ' s0_ LEFT JOIN s0_.itemSeries i1_ LEFT JOIN i1_.item i2_ LEFT JOIN s0_.serieImportators s4_ LEFT JOIN s4_.serie s5_ LEFT JOIN s5_.itemSeries i6_';
+        $data = $this->_em->createQuery($dql)->getResult(AbstractQuery::HYDRATE_ARRAY);
+
+        self::assertEquals(2, count($data));
+
+        self::assertEquals('Num 1.1', $data[0]['itemSeries'][0]['number']);
+        self::assertEquals('Item 1.1', $data[0]['itemSeries'][0]['item']['libelle']);
+
+        self::assertEquals('Num 1.2', $data[0]['itemSeries'][1]['number']);
+        self::assertEquals('Item 1.2', $data[0]['itemSeries'][1]['item']['libelle']);
+
+        self::assertEquals('Num 1.3', $data[0]['itemSeries'][2]['number']);
+        self::assertEquals('Item 1.3', $data[0]['itemSeries'][2]['item']['libelle']);
+
+        self::assertEquals('Num 1.4', $data[0]['itemSeries'][3]['number']);
+        self::assertEquals('Item 1.4', $data[0]['itemSeries'][3]['item']['libelle']);
+
+        self::assertEquals('Num 1.5', $data[0]['itemSeries'][4]['number']);
+        self::assertEquals('Item 1.5', $data[0]['itemSeries'][4]['item']['libelle']);
+
+        self::assertEquals('Num 1.6', $data[0]['itemSeries'][5]['number']);
+        self::assertEquals('Item 1.6', $data[0]['itemSeries'][5]['item']['libelle']);
+
+        self::assertEquals('Num 1.7', $data[0]['itemSeries'][6]['number']);
+        self::assertEquals('Item 1.7', $data[0]['itemSeries'][6]['item']['libelle']);
+
+        self::assertEquals('Num 1.8', $data[0]['itemSeries'][7]['number']);
+        self::assertEquals('Item 1.8', $data[0]['itemSeries'][7]['item']['libelle']);
+
+        self::assertEquals('Num 1.9', $data[0]['itemSeries'][8]['number']);
+        self::assertEquals('Item 1.9', $data[0]['itemSeries'][8]['item']['libelle']);
+
+        self::assertEquals('Num 1.10', $data[0]['itemSeries'][9]['number']);
+        self::assertEquals('Item 1.10', $data[0]['itemSeries'][9]['item']['libelle']);
+
+        self::assertEquals('Num 1.11', $data[0]['itemSeries'][10]['number']);
+        self::assertEquals('Item 1.11', $data[0]['itemSeries'][10]['item']['libelle']);
+
+        self::assertEquals('Num 1.12', $data[0]['itemSeries'][11]['number']);
+        self::assertEquals('Item 1.12', $data[0]['itemSeries'][11]['item']['libelle']);
+
+        self::assertEquals('Num 2.1', $data[1]['itemSeries'][0]['number']);
+        self::assertEquals('Item 2.1', $data[1]['itemSeries'][0]['item']['libelle']);
+
+        self::assertEquals('Num 2.2', $data[1]['itemSeries'][1]['number']);
+        self::assertEquals('Item 2.2', $data[1]['itemSeries'][1]['item']['libelle']);
+
+        self::assertEquals('Num 2.3', $data[1]['itemSeries'][2]['number']);
+        self::assertEquals('Item 2.3', $data[1]['itemSeries'][2]['item']['libelle']);
+
+        self::assertEquals('Num 2.4', $data[1]['itemSeries'][3]['number']);
+        self::assertEquals('Item 2.4', $data[1]['itemSeries'][3]['item']['libelle']);
+
+        self::assertEquals('Num 2.5', $data[1]['itemSeries'][4]['number']);
+        self::assertEquals('Item 2.5', $data[1]['itemSeries'][4]['item']['libelle']);
+
+        self::assertEquals('Num 2.6', $data[1]['itemSeries'][5]['number']);
+        self::assertEquals('Item 2.6', $data[1]['itemSeries'][5]['item']['libelle']);
+
+        self::assertEquals('Num 2.7', $data[1]['itemSeries'][6]['number']);
+        self::assertEquals('Item 2.7', $data[1]['itemSeries'][6]['item']['libelle']);
+
+        self::assertEquals('Num 2.8', $data[1]['itemSeries'][7]['number']);
+        self::assertEquals('Item 2.8', $data[1]['itemSeries'][7]['item']['libelle']);
+
+        self::assertEquals('Num 2.9', $data[1]['itemSeries'][8]['number']);
+        self::assertEquals('Item 2.9', $data[1]['itemSeries'][8]['item']['libelle']);
+
+        self::assertEquals('Num 2.10', $data[1]['itemSeries'][9]['number']);
+        self::assertEquals('Item 2.10', $data[1]['itemSeries'][9]['item']['libelle']);
+
+        self::assertEquals('Num 2.11', $data[1]['itemSeries'][10]['number']);
+        self::assertEquals('Item 2.11', $data[1]['itemSeries'][10]['item']['libelle']);
+
+        self::assertEquals('Num 2.12', $data[1]['itemSeries'][11]['number']);
+        self::assertEquals('Item 2.12', $data[1]['itemSeries'][11]['item']['libelle']);
+    }
+}


### PR DESCRIPTION
correction for bug when multiple calls : 

when I automaticly made a DQL like : 

```
		return $this
			->createQueryBuilder('s0_')

			->leftJoin('s0_.itemSeries','i1_')->addSelect('i1_')
			->leftJoin('i1_.item','i2_')->addSelect('i2_')
			->leftJoin('s0_.serieImportators','s4_')->addSelect('s4_')
			->leftJoin('s4_.serie','s5_')->addSelect('s5_')
			->leftJoin('s5_.itemSeries','i6_')->addSelect('i6_')			
```

ItemSerie Entity : 

```
class ItemSerie
{
	#[ORM\Id]
	#[ORM\ManyToOne( inversedBy: 'itemSeries')]
    #[ORM\JoinColumn(nullable: false)]
    private ?Item $item = null;

	#[ORM\Id]
    #[ORM\ManyToOne( inversedBy: 'itemSeries')]
    #[ORM\JoinColumn(nullable: false)]
    private ?Serie $serie = null;

    #[ORM\Column(type: 'string', length: 50)]
    private $numero;
   ...
}
```

on each series, the last itemSeries has the good number but the item witch is associate is bad, it take the second of list