### PR TITLE
Add error handling when misuse of find() with array values

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1781,6 +1781,10 @@ EXCEPTION
      */
     final public static function getIdHashByIdentifier(array $identifier): string
     {
+        if (array_filter($identifier, 'is_array')) {
+            throw new UnexpectedValueException('Unexpected identifier value: Expecting scalar, got array.');
+        }
+
         return implode(
             ' ',
             array_map(

--- a/tests/Tests/ORM/Functional/IdentifierFunctionalTest.php
+++ b/tests/Tests/ORM/Functional/IdentifierFunctionalTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use UnexpectedValueException;
+
+class IdentifierFunctionalTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+    }
+
+    public function testIdentifierArrayValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Unexpected identifier value: Expecting scalar, got array.');
+        $this->_em->find(CmsUser::class, ['id' => ['array']]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.18.x
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #11236


### Issue
When we *(inexpertly)* use `$em->find(...)` with array values in identifer, it returns a PHP warning..
See all details and how to reproduce it in the issue : https://github.com/doctrine/orm/issues/11236.

### Solution
In this PR
 - Add some DX with an exception explaining the problem, to avoid PHP warning
 - Add tests