### PR TITLE
Forbid null as query parameter value

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -44,6 +44,8 @@ use function sha1;
  * Base contract for ORM queries. Base class for Query and NativeQuery.
  *
  * @link    www.doctrine-project.org
+ *
+ * @psalm-import-type ParameterValue from Parameter
  */
 abstract class AbstractQuery
 {
@@ -296,7 +298,7 @@ abstract class AbstractQuery
      * Sets a collection of query parameters.
      *
      * @param ArrayCollection|mixed[] $parameters
-     * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
+     * @psalm-param ArrayCollection<int, Parameter>|array<ParameterValue> $parameters
      *
      * @return $this
      */
@@ -327,6 +329,7 @@ abstract class AbstractQuery
      *                                                                will be run through the type conversion of this
      *                                                                type. This is usually not needed for strings and
      *                                                                numeric types.
+     * @psalm-param ParameterValue $value
      *
      * @return $this
      */

--- a/src/Query/Parameter.php
+++ b/src/Query/Parameter.php
@@ -10,6 +10,8 @@ use function trim;
  * Defines a Query Parameter.
  *
  * @link    www.doctrine-project.org
+ *
+ * @psalm-type ParameterValue = bool|int|float|string|array<mixed>|object
  */
 class Parameter
 {
@@ -28,6 +30,8 @@ class Parameter
 
     /**
      * The parameter value.
+     *
+     * @psalm-var ParameterValue $value
      */
     private mixed $value;
 
@@ -41,6 +45,7 @@ class Parameter
      */
     private readonly bool $typeSpecified;
 
+    /** @psalm-param ParameterValue $value */
     public function __construct(int|string $name, mixed $value, mixed $type = null)
     {
         $this->name          = self::normalizeName($name);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -35,6 +35,8 @@ use function substr;
 /**
  * This class is responsible for building DQL query strings via an object oriented
  * PHP interface.
+ *
+ * @psalm-import-type ParameterValue from Parameter
  */
 class QueryBuilder implements Stringable
 {
@@ -430,6 +432,7 @@ class QueryBuilder implements Stringable
      *
      * @param string|int      $key  The parameter position or name.
      * @param string|int|null $type ParameterType::* or \Doctrine\DBAL\Types\Type::* constant
+     * @psalm-param ParameterValue $value
      *
      * @return $this
      */


### PR DESCRIPTION
I'm not sure about this one, I was driven by:
- https://github.com/phpstan/phpstan-doctrine/issues/414
- https://github.com/doctrine/orm/issues/7289

```
$qb
  ->andWhere('entity.id != :value')
  ->setParameter('value', null);
```
produce invalid/unexpected results and the right way is something like
```
if(is_null($value)){
    $qb->andWhere('entity.id IS NULL');
} else { 
    $qb->andWhere('entity.id != :value')->setParameter('value', $value);
}
```

By updating the PHPDoc, doctrine prevent developers (with static analysis) to pass null.

I'm not sure:
- if this PR is correct
- which branch should be target (it could be helpful for developer to "fix" the phpdoc on 2.x)
- if I should add a deprecation for null values (and in doctrine ORM 4 the signature could be changed)