### PR TITLE
fix: support array-type arg in QB variadic calls

### DIFF
--- a/src/Query/Expr/Base.php
+++ b/src/Query/Expr/Base.php
@@ -7,10 +7,12 @@ namespace Doctrine\ORM\Query\Expr;
 use InvalidArgumentException;
 use Stringable;
 
+use function array_key_exists;
 use function count;
 use function get_debug_type;
 use function implode;
 use function in_array;
+use function is_array;
 use function is_string;
 use function sprintf;
 
@@ -33,6 +35,10 @@ abstract class Base implements Stringable
 
     public function __construct(mixed $args = [])
     {
+        if (is_array($args) && array_key_exists(0, $args) && is_array($args[0])) {
+            $args = $args[0];
+        }
+
         $this->addMultiple($args);
     }
 

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -80,6 +80,15 @@ class QueryBuilderTest extends OrmTestCase
         $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
+    public function testSimpleSelectArray(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select(['u.id', 'u.username']);
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testSimpleDelete(): void
     {
         $qb = $this->entityManager->createQueryBuilder()


### PR DESCRIPTION
Broke the behaviour in https://github.com/doctrine/orm/pull/8319 (see https://github.com/doctrine/orm/pull/8319#discussion_r1484269817)

Fixes https://github.com/doctrine/orm/issues/11241