### PR TITLE
More valid docs

### DIFF
--- a/docs/en/cookbook/implementing-arrayaccess-for-domain-objects.rst
+++ b/docs/en/cookbook/implementing-arrayaccess-for-domain-objects.rst
@@ -1,7 +1,7 @@
 Implementing ArrayAccess for Domain Objects
 ===========================================
 
-.. sectionauthor:: Roman Borschel (roman@code-factory.org)
+.. sectionauthor:: Roman Borschel <roman@code-factory.org>
 
 This recipe will show you how to implement ArrayAccess for your
 domain objects in order to allow more uniform access, for example

--- a/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
+++ b/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
@@ -1,7 +1,7 @@
 Implementing the Notify ChangeTracking Policy
 =============================================
 
-.. sectionauthor:: Roman Borschel (roman@code-factory.org)
+.. sectionauthor:: Roman Borschel <roman@code-factory.org>
 
 The NOTIFY change-tracking policy is the most effective
 change-tracking policy provided by Doctrine but it requires some

--- a/docs/en/reference/installation.rst
+++ b/docs/en/reference/installation.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Installation
 ============
 

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -33,6 +33,7 @@
       reference/inheritance-mapping
       reference/working-with-objects
       reference/working-with-associations
+      reference/typedfieldmapper
       reference/events
       reference/unitofwork
       reference/unitofwork-associations


### PR DESCRIPTION
`phpdocumentor/guides` v0.3.4 was published. It helps spot more issues in our documentation.

The remaining issues are reduced to this list:

```
[2024-02-17T14:13:22.125246+00:00] app.WARNING: No template found for rendering directive "toc". Expected template "body/directive/toc.html.twig" [] []
[2024-02-17T14:13:22.126710+00:00] app.WARNING: No template found for rendering directive "tocheader". Expected template "body/directive/tocheader.html.twig" [] []
[2024-02-17T14:13:22.130911+00:00] app.WARNING: No template found for rendering directive "toc". Expected template "body/directive/toc.html.twig" [] []
[2024-02-17T14:13:22.130978+00:00] app.WARNING: No template found for rendering directive "tocheader". Expected template "body/directive/tocheader.html.twig" [] []
[2024-02-17T14:13:22.153960+00:00] app.WARNING: No template found for rendering directive "toc". Expected template "body/directive/toc.html.twig" [] []
[2024-02-17T14:13:22.154028+00:00] app.WARNING: No template found for rendering directive "tocheader". Expected template "body/directive/tocheader.html.twig" [] []
```