### PR TITLE
docs: recommend safer way to disable logging

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -18,14 +18,20 @@ especially what the strategies presented here provide help with.
 
 .. note::
 
-    Having an SQL logger enabled when processing batches can have a serious impact on performance and resource usage.
-    To avoid that you should remove the corresponding middleware.
-    To remove all middlewares, you can use this line:
+    Having an SQL logger enabled when processing batches can have a
+    serious impact on performance and resource usage.
+    To avoid that, you should use a PSR logger implementation that can be
+    disabled at runtime.
+    For example, with Monolog, you can use ``Logger::pushHandler()``
+    to push a ``NullHandler`` to the logger instance, and then pop it
+    when you need to enable logging again.
+
+    With DBAL 2, you can disable the SQL logger like below:
+
 .. code-block:: php
 
     <?php
-    $em->getConnection()->getConfiguration()->setMiddlewares([]); // DBAL 3
-    $em->getConnection()->getConfiguration()->setSQLLogger(null); // DBAL 2
+    $em->getConnection()->getConfiguration()->setSQLLogger(null);
 
 Bulk Inserts
 ------------

--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -188,6 +188,3 @@ problems using the following approach:
     Iterating results is not possible with queries that
     fetch-join a collection-valued association. The nature of such SQL
     result sets is not suitable for incremental hydration.
-
-
-


### PR DESCRIPTION
Resetting the middlewares on the configuration object will only work if the connection object hasn't been built from that configuration object yet. Instead, people should find the logger bound to the logging middleware and disable it.

Note: I think that with Symfony, another solution might be to have this bundle configuration:

```yaml
dbal:
    regular_connection:
        logging: true
    batch_connection:
        logging: false
```

Let me know what you think.