### PR TITLE
Treat '0' as a legitimate trim char

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1543,15 +1543,6 @@
     </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="src/Query/AST/Functions/DateAddFunction.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-    </ArgumentTypeCoercion>
     <PossiblyInvalidPropertyAssignmentValue>
       <code><![CDATA[$parser->ArithmeticPrimary()]]></code>
       <code><![CDATA[$parser->ArithmeticPrimary()]]></code>
@@ -1572,15 +1563,6 @@
     </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="src/Query/AST/Functions/DateSubFunction.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-      <code><![CDATA[$this->intervalExpression->dispatch($sqlWalker)]]></code>
-    </ArgumentTypeCoercion>
     <UndefinedPropertyFetch>
       <code><![CDATA[$this->unit->value]]></code>
     </UndefinedPropertyFetch>

--- a/src/Query/AST/Functions/TrimFunction.php
+++ b/src/Query/AST/Functions/TrimFunction.php
@@ -74,7 +74,7 @@ class TrimFunction extends FunctionNode
             $this->trimChar = $lexer->token->value;
         }
 
-        if ($this->leading || $this->trailing || $this->both || $this->trimChar) {
+        if ($this->leading || $this->trailing || $this->both || ($this->trimChar !== false)) {
             $parser->match(Lexer::T_FROM);
         }
 

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -172,6 +172,11 @@ class LanguageRecognitionTest extends OrmTestCase
         $this->assertValidDQL("SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE TRIM(u.name) = 'someone'");
     }
 
+    public function testTrimFalsyString(): void
+    {
+        $this->assertValidDQL("SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE TRIM('0' FROM u.name) = 'someone'");
+    }
+
     public function testArithmeticExpressionsSupportedInWherePart(): void
     {
         $this->assertValidDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE ((u.id + 5000) * u.id + 3) < 10000000');


### PR DESCRIPTION
Because of a loose comparison, it was not.

Found while working on recent Psalm compatibility.