### PR TITLE
Improve static analysis on AttachEntityListenersListener

### DIFF
--- a/src/Tools/AttachEntityListenersListener.php
+++ b/src/Tools/AttachEntityListenersListener.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 
+use function assert;
 use function ltrim;
 
 /**
@@ -14,16 +16,22 @@ use function ltrim;
  */
 class AttachEntityListenersListener
 {
-    /** @var mixed[][] */
+    /**
+     * @var array<class-string, list<array{
+     *     event: Events::*|null,
+     *     class: class-string,
+     *     method: string|null,
+     * }>>
+     */
     private array $entityListeners = [];
 
     /**
      * Adds an entity listener for a specific entity.
      *
-     * @param string      $entityClass      The entity to attach the listener.
-     * @param string      $listenerClass    The listener class.
-     * @param string|null $eventName        The entity lifecycle event.
-     * @param string|null $listenerCallback The listener callback method or NULL to use $eventName.
+     * @param class-string          $entityClass      The entity to attach the listener.
+     * @param class-string          $listenerClass    The listener class.
+     * @param Events::*|null        $eventName        The entity lifecycle event.
+     * @param non-falsy-string|null $listenerCallback The listener callback method or NULL to use $eventName.
      */
     public function addEntityListener(
         string $entityClass,
@@ -34,7 +42,7 @@ class AttachEntityListenersListener
         $this->entityListeners[ltrim($entityClass, '\\')][] = [
             'event'  => $eventName,
             'class'  => $listenerClass,
-            'method' => $listenerCallback ?: $eventName,
+            'method' => $listenerCallback ?? $eventName,
         ];
     }
 
@@ -53,6 +61,7 @@ class AttachEntityListenersListener
             if ($listener['event'] === null) {
                 EntityListenerBuilder::bindEntityListener($metadata, $listener['class']);
             } else {
+                assert($listener['method'] !== null);
                 $metadata->addEntityListener($listener['event'], $listener['class'], $listener['method']);
             }
         }


### PR DESCRIPTION
Improve static analysis on AttachEntityListenersListener

`$listenerCallback` is supposed to be a method name, so it is safe to
require it is not a falsy string.