### PR TITLE
Account for inversedBy being a non-falsy-string or null

### DIFF
--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -91,7 +91,7 @@ class ObjectHydrator extends AbstractHydrator
             }
 
             // handle fetch-joined owning side bi-directional one-to-one associations
-            if ($assoc->inversedBy) {
+            if ($assoc->inversedBy !== null) {
                 $class        = $this->getClassMetadata($className);
                 $inverseAssoc = $class->associationMappings[$assoc->inversedBy];
 
@@ -439,7 +439,7 @@ class ObjectHydrator extends AbstractHydrator
                             if ($relation->isOwningSide()) {
                                 // TODO: Just check hints['fetched'] here?
                                 // If there is an inverse mapping on the target class its bidirectional
-                                if ($relation->inversedBy) {
+                                if ($relation->inversedBy !== null) {
                                     $inverseAssoc = $targetClass->associationMappings[$relation->inversedBy];
                                     if ($inverseAssoc->isToOne()) {
                                         $targetClass->reflFields[$inverseAssoc->fieldName]->setValue($element, $parentObject);

--- a/src/Mapping/Builder/ClassMetadataBuilder.php
+++ b/src/Mapping/Builder/ClassMetadataBuilder.php
@@ -288,7 +288,7 @@ class ClassMetadataBuilder
     ): ClassMetadataBuilder {
         $builder = $this->createManyToOne($name, $targetEntity);
 
-        if ($inversedBy) {
+        if ($inversedBy !== null) {
             $builder->inversedBy($inversedBy);
         }
 
@@ -348,7 +348,7 @@ class ClassMetadataBuilder
     ): ClassMetadataBuilder {
         $builder = $this->createOneToOne($name, $targetEntity);
 
-        if ($inversedBy) {
+        if ($inversedBy !== null) {
             $builder->inversedBy($inversedBy);
         }
 
@@ -380,7 +380,7 @@ class ClassMetadataBuilder
     ): ClassMetadataBuilder {
         $builder = $this->createManyToMany($name, $targetEntity);
 
-        if ($inversedBy) {
+        if ($inversedBy !== null) {
             $builder->inversedBy($inversedBy);
         }
 

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -764,7 +764,7 @@ class BasicEntityPersister implements EntityPersister
         $targetClass = $this->em->getClassMetadata($assoc->targetEntity);
 
         if ($assoc->isOwningSide()) {
-            $isInverseSingleValued = $assoc->inversedBy && ! $targetClass->isCollectionValuedAssociation($assoc->inversedBy);
+            $isInverseSingleValued = $assoc->inversedBy !== null && ! $targetClass->isCollectionValuedAssociation($assoc->inversedBy);
 
             // Mark inverse side as fetched in the hints, otherwise the UoW would
             // try to load it in a separate query (remember: to-one inverse sides can not be lazy).

--- a/src/Tools/SchemaValidator.php
+++ b/src/Tools/SchemaValidator.php
@@ -162,7 +162,7 @@ class SchemaValidator
                 }
             }
 
-            if ($assoc->isOwningSide() && $assoc->inversedBy) {
+            if ($assoc->isOwningSide() && $assoc->inversedBy !== null) {
                 if ($targetMetadata->hasField($assoc->inversedBy)) {
                     $ce[] = 'The association ' . $class->name . '#' . $fieldName . ' refers to the inverse side ' .
                             'field ' . $assoc->targetEntity . '#' . $assoc->inversedBy . ' which is not defined as association.';

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2550,7 +2550,7 @@ class UnitOfWork implements PropertyChangedListener
                     $this->originalEntityData[$oid][$field] = $newValue;
                     $class->reflFields[$field]->setValue($entity, $newValue);
 
-                    if ($assoc->inversedBy && $assoc->isOneToOne() && $newValue !== null) {
+                    if ($assoc->inversedBy !== null && $assoc->isOneToOne() && $newValue !== null) {
                         $inverseAssoc = $targetClass->associationMappings[$assoc->inversedBy];
                         $targetClass->reflFields[$inverseAssoc->fieldName]->setValue($newValue, $entity);
                     }


### PR DESCRIPTION
It is supposed to hold the name of a PHP property, and those cannot be falsy strings.