### PR TITLE
Remove implicit casts in FileLock.php

### DIFF
--- a/src/Cache/Region/FileLockRegion.php
+++ b/src/Cache/Region/FileLockRegion.php
@@ -67,7 +67,7 @@ class FileLockRegion implements ConcurrentRegion
         $time    = $this->getLockTime($filename);
         $content = $this->getLockContent($filename);
 
-        if (! $content || ! $time) {
+        if ($content === false || $time) {
             @unlink($filename);
 
             return false;

--- a/src/Cache/Region/FileLockRegion.php
+++ b/src/Cache/Region/FileLockRegion.php
@@ -156,12 +156,10 @@ class FileLockRegion implements ConcurrentRegion
     {
         // The check below is necessary because on some platforms glob returns false
         // when nothing matched (even though no errors occurred)
-        $filenames = glob(sprintf('%s/*.%s', $this->directory, self::LOCK_EXTENSION));
+        $filenames = glob(sprintf('%s/*.%s', $this->directory, self::LOCK_EXTENSION)) ?: [];
 
-        if ($filenames) {
-            foreach ($filenames as $filename) {
-                @unlink($filename);
-            }
+        foreach ($filenames as $filename) {
+            @unlink($filename);
         }
 
         return $this->region->evictAll();

--- a/src/Cache/Region/FileLockRegion.php
+++ b/src/Cache/Region/FileLockRegion.php
@@ -67,7 +67,7 @@ class FileLockRegion implements ConcurrentRegion
         $time    = $this->getLockTime($filename);
         $content = $this->getLockContent($filename);
 
-        if ($content === false || $time) {
+        if ($content === false || $time === false) {
             @unlink($filename);
 
             return false;

--- a/src/Cache/Region/FileLockRegion.php
+++ b/src/Cache/Region/FileLockRegion.php
@@ -176,7 +176,7 @@ class FileLockRegion implements ConcurrentRegion
         $lock     = Lock::createLockRead();
         $filename = $this->getLockFileName($key);
 
-        if (! @file_put_contents($filename, $lock->value, LOCK_EX)) {
+        if (@file_put_contents($filename, $lock->value, LOCK_EX) === false) {
             return null;
         }
 


### PR DESCRIPTION
Commit messages hold justifications.

This is the `Lock` class.

https://github.com/doctrine/orm/blob/d5ba1068038b1e183c3a0a69e999d76dde58186d/src/Cache/Lock.php#L10-L25

Although its constructor is public, it is called exactly once inside `src`, inside `Lock::createLockRead()`. This means `Lock::$value` always contains a non-falsy-string.