### PR TITLE
Add error handling when misuse of find() with array values

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1565,10 +1565,6 @@ class UnitOfWork implements PropertyChangedListener
             ' ',
             array_map(
                 static function (mixed $value): Stringable|int|float|string|bool {
-                    if ($value instanceof BackedEnum) {
-                        $value = $value->value;
-                    }
-
                     if (! is_scalar($value) && ! ($value instanceof Stringable)) {
                         throw new UnexpectedValueException(sprintf(
                             'Unexpected identifier value: Expecting scalar or Stringable, got %s.',

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -66,6 +66,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_object;
+use function is_scalar;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -1560,15 +1561,21 @@ class UnitOfWork implements PropertyChangedListener
      */
     final public static function getIdHashByIdentifier(array $identifier): string
     {
-        foreach ($identifier as $k => $value) {
-            if ($value instanceof BackedEnum) {
-                $identifier[$k] = $value->value;
-            }
-        }
-
         return implode(
             ' ',
-            $identifier,
+            array_map(
+                static function (mixed $value): Stringable|int|float|string|bool {
+                    if (! is_scalar($value) && ! ($value instanceof Stringable)) {
+                        throw new UnexpectedValueException(sprintf(
+                            'Unexpected identifier value: Expecting scalar or Stringable, got %s.',
+                            get_debug_type($value),
+                        ));
+                    }
+
+                    return $value;
+                },
+                $identifier,
+            ),
         );
     }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1565,6 +1565,10 @@ class UnitOfWork implements PropertyChangedListener
             ' ',
             array_map(
                 static function (mixed $value): Stringable|int|float|string|bool {
+                    if ($value instanceof BackedEnum) {
+                        $value = $value->value;
+                    }
+
                     if (! is_scalar($value) && ! ($value instanceof Stringable)) {
                         throw new UnexpectedValueException(sprintf(
                             'Unexpected identifier value: Expecting scalar or Stringable, got %s.',

--- a/tests/Tests/ORM/Functional/IdentifierFunctionalTest.php
+++ b/tests/Tests/ORM/Functional/IdentifierFunctionalTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use UnexpectedValueException;
+
+class IdentifierFunctionalTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+    }
+
+    public function testIdentifierArrayValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Unexpected identifier value: Expecting scalar or Stringable, got array.');
+        $this->_em->find(CmsUser::class, ['id' => ['array']]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4.x
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #11236

### Issue
When we *(inexpertly)* use `$em->find(...)` with array values in identifer, it returns a PHP warning..
See all details and how to reproduce it in the issue : https://github.com/doctrine/orm/issues/11236.

### Solution
In this PR
 - Add some DX with an exception explaining the problem, to avoid PHP warning
 - Add tests

### Notes
This PR is a copy of [this PR](https://github.com/doctrine/orm/pull/11237) who has been re-targeted to branch `3.1.x`