### PR TITLE
Allow (Array)ParameterType in QueryBuilder

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\Internal\QueryType;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Parameter;
@@ -428,12 +430,12 @@ class QueryBuilder implements Stringable
      *         ->setParameter('user_id', 1);
      * </code>
      *
-     * @param string|int      $key  The parameter position or name.
-     * @param string|int|null $type ParameterType::* or \Doctrine\DBAL\Types\Type::* constant
+     * @param string|int                                       $key  The parameter position or name.
+     * @param ParameterType|ArrayParameterType|string|int|null $type ParameterType::*, ArrayParameterType::* or \Doctrine\DBAL\Types\Type::* constant
      *
      * @return $this
      */
-    public function setParameter(string|int $key, mixed $value, string|int|null $type = null): static
+    public function setParameter(string|int $key, mixed $value, ParameterType|ArrayParameterType|string|int|null $type = null): static
     {
         $existingParameter = $this->getParameter($key);
 

--- a/tests/Tests/ORM/Functional/QueryParameterTest.php
+++ b/tests/Tests/ORM/Functional/QueryParameterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('GH-11278')]
+final class QueryParameterTest extends OrmFunctionalTestCase
+{
+    private int $userId;
+
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+
+        $user            = new CmsUser();
+        $user->name      = 'John Doe';
+        $user->username  = 'john';
+        $user2           = new CmsUser();
+        $user2->name     = 'Jane Doe';
+        $user2->username = 'jane';
+        $user3           = new CmsUser();
+        $user3->name     = 'Just Bill';
+        $user3->username = 'bill';
+
+        $this->_em->persist($user);
+        $this->_em->persist($user2);
+        $this->_em->persist($user3);
+        $this->_em->flush();
+
+        $this->userId = $user->id;
+
+        $this->_em->clear();
+    }
+
+    public function testParameterTypeInBuilder(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.id = :id')
+            ->setParameter('id', $this->userId, ParameterType::INTEGER)
+            ->getQuery()
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'John Doe']], $result);
+    }
+
+    public function testParameterTypeInQuery(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.id = :id')
+            ->getQuery()
+            ->setParameter('id', $this->userId, ParameterType::INTEGER)
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'John Doe']], $result);
+    }
+
+    public function testDbalTypeStringInBuilder(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.id = :id')
+            ->setParameter('id', $this->userId, Types::INTEGER)
+            ->getQuery()
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'John Doe']], $result);
+    }
+
+    public function testDbalTypeStringInQuery(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.id = :id')
+            ->getQuery()
+            ->setParameter('id', $this->userId, Types::INTEGER)
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'John Doe']], $result);
+    }
+
+    public function testArrayParameterTypeInBuilder(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.username IN (:usernames)')
+            ->orderBy('u.username')
+            ->setParameter('usernames', ['john', 'jane'], ArrayParameterType::STRING)
+            ->getQuery()
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'Jane Doe'], ['name' => 'John Doe']], $result);
+    }
+
+    public function testArrayParameterTypeInQuery(): void
+    {
+        $result = $this->_em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select('u.name')
+            ->where('u.username IN (:usernames)')
+            ->orderBy('u.username')
+            ->getQuery()
+            ->setParameter('usernames', ['john', 'jane'], ArrayParameterType::STRING)
+            ->getArrayResult();
+
+        self::assertSame([['name' => 'Jane Doe'], ['name' => 'John Doe']], $result);
+    }
+}


### PR DESCRIPTION
Replaces #11279, fixes #11278.

This PR continues the work done by @hanishsingla and adds a few tests.

Changing the signature of `QueryBuilder::setParameter()` is technically a BC break, but we cannot fix the bug without breaking BC, I'm afraid. Let's hope nobody overrides the `setParameter()` method of 3.0 yet. 🤞🏻 