### PR TITLE
Do not use batch loading for collections with composite identifier

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3169,9 +3169,9 @@ EXCEPTION
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
                         $isIteration = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];
-                        if (! $isIteration && $assoc['type'] === ClassMetadata::ONE_TO_MANY) {
+                        if ($assoc['type'] === ClassMetadata::ONE_TO_MANY && ! $isIteration && ! $targetClass->isIdentifierComposite) {
                             $this->scheduleCollectionForBatchLoading($pColl, $class);
-                        } elseif (($isIteration && $assoc['type'] === ClassMetadata::ONE_TO_MANY) || $assoc['type'] === ClassMetadata::MANY_TO_MANY) {
+                        } else {
                             $this->loadCollection($pColl);
                             $pColl->takeSnapshot();
                         }

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/RootEntity.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/RootEntity.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\EagerFetchedCompositeOneToMany;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="eager_composite_join_root")
+ */
+class RootEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", nullable=false)
+     *
+     * @var int|null
+     */
+    private $id = null;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", nullable=false, name="other_key")
+     *
+     * @var string
+     */
+    private $otherKey;
+
+    /**
+     * @ORM\OneToMany(mappedBy="root", targetEntity=SecondLevel::class, fetch="EAGER")
+     *
+     * @var Collection<int, SecondLevel>
+     */
+    private $secondLevel;
+
+    public function __construct(int $id, string $other)
+    {
+        $this->otherKey    = $other;
+        $this->secondLevel = new ArrayCollection();
+        $this->id          = $id;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOtherKey(): string
+    {
+        return $this->otherKey;
+    }
+}

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
@@ -33,8 +33,8 @@ class SecondLevel
     /**
      * @ORM\ManyToOne(targetEntity=RootEntity::class, inversedBy="secondLevel")
      * @ORM\JoinColumns({
-     *      @ORM\JoinColumn(name="root_other_key", referencedColumnName="other_key"),
-     *      @ORM\JoinColumn(name="root_id", referencedColumnName="id")
+     *      @ORM\JoinColumn(name="root_id", referencedColumnName="id"),
+     *      @ORM\JoinColumn(name="root_other_key", referencedColumnName="other_key")
      *  })
      *
      * @var RootEntity

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
@@ -18,14 +18,6 @@ class SecondLevel
      *
      * @var int|null
      */
-    private $id = null;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer", nullable=false)
-     *
-     * @var int|null
-     */
     private $upperId;
 
     /**
@@ -39,17 +31,16 @@ class SecondLevel
     /**
      * @ORM\ManyToOne(targetEntity=RootEntity::class, inversedBy="secondLevel")
      * @ORM\JoinColumns({
-     *      @ORM\JoinColumn(name="other_key", referencedColumnName="other_key"),
-     *      @ORM\JoinColumn(name="upper_id", referencedColumnName="id")
+     *      @ORM\JoinColumn(name="root_other_key", referencedColumnName="other_key"),
+     *      @ORM\JoinColumn(name="root_id", referencedColumnName="id")
      *  })
      *
      * @var RootEntity
      */
     private $root;
 
-    public function __construct(int $id, RootEntity $upper)
+    public function __construct(RootEntity $upper)
     {
-        $this->id       = $id;
         $this->upperId  = $upper->getId();
         $this->otherKey = $upper->getOtherKey();
         $this->root     = $upper;

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
@@ -8,7 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="eager_composite_join_second_level")
+ * @ORM\Table(name="eager_composite_join_second_level", indexes={
+ *     @ORM\Index(name="root_other_key_idx", columns={"root_other_key", "root_id"})
+ * })
  */
 class SecondLevel
 {

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevel.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\EagerFetchedCompositeOneToMany;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="eager_composite_join_second_level")
+ */
+class SecondLevel
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", nullable=false)
+     *
+     * @var int|null
+     */
+    private $id = null;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", nullable=false)
+     *
+     * @var int|null
+     */
+    private $upperId;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", nullable=false, name="other_key")
+     *
+     * @var string
+     */
+    private $otherKey;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=RootEntity::class, inversedBy="secondLevel")
+     * @ORM\JoinColumns({
+     *      @ORM\JoinColumn(name="other_key", referencedColumnName="other_key"),
+     *      @ORM\JoinColumn(name="upper_id", referencedColumnName="id")
+     *  })
+     *
+     * @var RootEntity
+     */
+    private $root;
+
+    public function __construct(int $id, RootEntity $upper)
+    {
+        $this->id       = $id;
+        $this->upperId  = $upper->getId();
+        $this->otherKey = $upper->getOtherKey();
+        $this->root     = $upper;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
+++ b/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\RootEntity;
+use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\SecondLevel;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 final class EagerFetchOneToManyWithCompositeKeyTest extends OrmFunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        $this->useModelSet('eager_fetched_composite_one_to_many');
-
-        parent::setUp();
-    }
-
     /** @ticket 11154 */
     public function testItDoesNotThrowAnExceptionWhenTriggeringALoad(): void
     {
+        $this->setUpEntitySchema([RootEntity::class, SecondLevel::class]);
+
         $a1 = new RootEntity(1, 'A');
 
         $this->_em->persist($a1);

--- a/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
+++ b/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\RootEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class EagerFetchOneToManyWithCompositeKeyTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('eager_fetched_composite_one_to_many');
+
+        parent::setUp();
+    }
+
+    /** @ticket 11154 */
+    public function testItDoesNotThrowAnExceptionWhenTriggeringALoad(): void
+    {
+        $a1 = new RootEntity(1, 'A');
+
+        $this->_em->persist($a1);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        self::assertCount(1, $this->_em->getRepository(RootEntity::class)->findAll());
+    }
+}

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -342,10 +342,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue9300\Issue9300Child::class,
             Models\Issue9300\Issue9300Parent::class,
         ],
-        'eager_fetched_composite_one_to_many' => [
-            Models\EagerFetchedCompositeOneToMany\RootEntity::class,
-            Models\EagerFetchedCompositeOneToMany\SecondLevel::class,
-        ],
     ];
 
     /** @param class-string ...$models */
@@ -673,11 +669,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM issue5989_persons');
             $conn->executeStatement('DELETE FROM issue5989_employees');
             $conn->executeStatement('DELETE FROM issue5989_managers');
-        }
-
-        if (isset($this->_usedModelSets['eager_fetched_composite_one_to_many'])) {
-            $conn->executeStatement('DELETE FROM eager_composite_join_second_level');
-            $conn->executeStatement('DELETE FROM eager_composite_join_root');
         }
 
         $this->_em->clear();

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -342,6 +342,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue9300\Issue9300Child::class,
             Models\Issue9300\Issue9300Parent::class,
         ],
+        'eager_fetched_composite_one_to_many' => [
+            Models\EagerFetchedCompositeOneToMany\RootEntity::class,
+            Models\EagerFetchedCompositeOneToMany\SecondLevel::class,
+        ],
     ];
 
     /** @param class-string ...$models */
@@ -669,6 +673,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM issue5989_persons');
             $conn->executeStatement('DELETE FROM issue5989_employees');
             $conn->executeStatement('DELETE FROM issue5989_managers');
+        }
+
+        if (isset($this->_usedModelSets['eager_fetched_composite_one_to_many'])) {
+            $conn->executeStatement('DELETE FROM eager_composite_join_second_level');
+            $conn->executeStatement('DELETE FROM eager_composite_join_root');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
In 2.17 EAGER fetched OneToMany associations stopped working, if they have multiple join columns due to #8391.

Loads for these associations will trigger a `MessingPositionalParameter` exception "Positional parameter at index 1 does not have a bound value".

This test case should reproduce this issue (https://github.com/doctrine/orm/pull/11154), so it can be fixed.

The PR changes eager loading for target associations with composite identifier not to use batch loading anymore, falling back to the original behavior before #8391. It also cleans up the conditions here after they were made more complex than necessary with #11082 

Related:
* #8391 
* #11082
* #11154 

Fixes #11154 