### PR TITLE
Allow array again in QueryBuilder::setParameters()

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -464,12 +464,23 @@ class QueryBuilder implements Stringable
      *        )));
      * </code>
      *
-     * @psalm-param ArrayCollection<int, Parameter> $parameters
+     * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
      *
      * @return $this
      */
-    public function setParameters(ArrayCollection $parameters): static
+    public function setParameters(ArrayCollection|array $parameters): static
     {
+        if (is_array($parameters)) {
+            /** @psalm-var ArrayCollection<int, Parameter> $parameterCollection */
+            $parameterCollection = new ArrayCollection();
+
+            foreach ($parameters as $key => $value) {
+                $parameterCollection->add(new Parameter($key, $value));
+            }
+
+            $parameters = $parameterCollection;
+        }
+
         $this->parameters = $parameters;
 
         return $this;

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -669,6 +669,17 @@ class QueryBuilderTest extends OrmTestCase
         $qb->setParameters($parameters);
 
         self::assertEquals($parameters, $qb->getQuery()->getParameters());
+
+        $qb->setParameters([]);
+
+        self::assertEquals(new ArrayCollection(), $qb->getQuery()->getParameters());
+
+        $qb->setParameters([
+            'username' => 'jwage',
+            'username2' => 'jonwage',
+        ]);
+
+        self::assertEquals($parameters, $qb->getQuery()->getParameters());
     }
 
     public function testGetParameters(): void


### PR DESCRIPTION
Fixes BC-break from #9490.

This would otherwise be an undocumented BC-break in ORM 3.0.

This works in 2.x: 

```
        $qb = $this->entityManager->createQueryBuilder();
        $qb->setParameters([
            'username' => 'jwage',
            'username2' => 'jonwage',
        ]);
```

But it doesn't work any longer in 3.0.