### PR TITLE
Remove wrong annotation about return type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,11 +171,6 @@ parameters:
 			path: src/Mapping/ClassMetadataFactory.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\:\\:fullyQualifiedClassName\\(\\) should return class\\-string\\|null but returns string\\|null\\.$#"
-			count: 1
-			path: src/Mapping/ClassMetadataInfo.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\NamingStrategy\\:\\:joinColumnName\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 2
 			path: src/Mapping/ClassMetadataInfo.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -607,7 +607,6 @@
     <InvalidPropertyAssignmentValue>
       <code>$definition</code>
       <code><![CDATA[$this->sqlResultSetMappings]]></code>
-      <code><![CDATA[$this->subClasses]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$mapping</code>
@@ -618,16 +617,12 @@
       <code>getReflectionClass</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
-      <code>$className</code>
-      <code>$className</code>
       <code>$columnNames</code>
       <code>$mapping</code>
       <code>$quotedColumnNames</code>
-      <code><![CDATA[$this->namespace . '\\' . $className]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code>FieldMapping</code>
-      <code>class-string|null</code>
       <code><![CDATA[list<string>]]></code>
       <code><![CDATA[list<string>]]></code>
     </MoreSpecificReturnType>

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -3707,7 +3707,6 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string|null $className
      *
      * @return string|null null if the input value is null
-     * @psalm-return class-string|null
      */
     public function fullyQualifiedClassName($className)
     {


### PR DESCRIPTION
Found while working on https://github.com/doctrine/orm/pull/11294

Although this method is guaranteed to return either null or something that can be used as a fully qualified class name, it never actually checks that the class actually exists. Adding such a check breaks several tests, including some that expect a exceptions at some later points in the execution.