### PR TITLE
Translate comment into code and annotations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.1
 
+## Deprecate passing null to `ClassMetadata::fullyQualifiedClassName()`
+
+Passing `null` to `Doctrine\ORM\ClassMetadata::fullyQualifiedClassName()` is
+deprecated and will no longer be possible in 4.0.
+
 ## Deprecate array access
 
 Using array access on instances of the following classes is deprecated:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -290,11 +290,6 @@
       <code>$repositoryClassName</code>
     </ArgumentTypeCoercion>
   </file>
-  <file src="src/Mapping/Builder/EntityListenerBuilder.php">
-    <PossiblyNullArgument>
-      <code>$class</code>
-    </PossiblyNullArgument>
-  </file>
   <file src="src/Mapping/ClassMetadata.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->columnNames]]></code>
@@ -322,8 +317,6 @@
       <code>$entity</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code>$class</code>
-      <code>$className</code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$mapping['targetEntity']]]></code>
       <code><![CDATA[$parentReflFields[$embeddedClass->declaredField]]]></code>

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Mapping;
 use BackedEnum;
 use BadMethodCallException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ORM\Cache\Exception\NonCacheableEntityAssociation;
@@ -2003,6 +2004,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      */
     public function setCustomRepositoryClass(string|null $repositoryClassName): void
     {
+        if ($repositoryClassName === null) {
+            $this->customRepositoryClassName = null;
+
+            return;
+        }
+
         $this->customRepositoryClassName = $this->fullyQualifiedClassName($repositoryClassName);
     }
 
@@ -2475,6 +2482,13 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public function fullyQualifiedClassName(string|null $className): string|null
     {
         if ($className === null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/11294',
+                'Passing null to %s is deprecated and will not be supported in Doctrine ORM 4.0',
+                __METHOD__,
+            );
+
             return null;
         }
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2464,11 +2464,18 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         return $assoc->mappedBy;
     }
 
-    /** @return string|null null if the input value is null */
+    /**
+     * @param C $className
+     *
+     * @return string|null null if and only if the input value is null
+     * @psalm-return (C is class-string ? class-string : (C is string ? string : null))
+     *
+     * @template C of string|null
+     */
     public function fullyQualifiedClassName(string|null $className): string|null
     {
-        if (empty($className)) {
-            return $className;
+        if ($className === null) {
+            return null;
         }
 
         if (! str_contains($className, '\\') && $this->namespace) {
@@ -2511,12 +2518,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             throw MappingException::missingEmbeddedClass($mapping['fieldName']);
         }
 
-        $fqcn = $this->fullyQualifiedClassName($mapping['class']);
-
-        assert($fqcn !== null);
-
         $this->embeddedClasses[$mapping['fieldName']] = EmbeddedClassMapping::fromMappingArray([
-            'class' => $fqcn,
+            'class' => $this->fullyQualifiedClassName($mapping['class']),
             'columnPrefix' => $mapping['columnPrefix'] ?? null,
             'declaredField' => $mapping['declaredField'] ?? null,
             'originalField' => $mapping['originalField'] ?? null,

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use ArrayObject;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -66,6 +67,8 @@ require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 
 class ClassMetadataTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     public function testClassMetadataInstanceSerialization(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
@@ -1051,6 +1054,15 @@ class ClassMetadataTest extends OrmTestCase
             EXCEPTION);
 
         $metadata->addLifecycleCallback('foo', 'bar');
+    }
+
+    public function testGettingAnFQCNForNullIsDeprecated(): void
+    {
+        $metadata = new ClassMetadata(self::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11294');
+
+        $metadata->fullyQualifiedClassName(null);
     }
 }
 


### PR DESCRIPTION
The phpdoc comment for the return type of
`ClassMetadata::fullyQualifiedClassName()` says that the return type will be null if the input value is null. I have made it more precise by using "if and only if", made the null check more strict and translated that into template annotations. Also, since we say we return a class-string, I've asserted that.