### PR TITLE
Fix sqlWalker::walkSimpleArithmeticExpression phpdoc

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -331,21 +331,6 @@ parameters:
 			path: src/Query/AST/Functions/DateSubFunction.php
 
 		-
-			message: "#^Parameter \\#1 \\$simpleArithmeticExpr of method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkSimpleArithmeticExpression\\(\\) expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\SimpleArithmeticExpression, Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node given\\.$#"
-			count: 1
-			path: src/Query/AST/Functions/LengthFunction.php
-
-		-
-			message: "#^Parameter \\#1 \\$simpleArithmeticExpr of method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkSimpleArithmeticExpression\\(\\) expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\SimpleArithmeticExpression, Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node given\\.$#"
-			count: 1
-			path: src/Query/AST/Functions/LowerFunction.php
-
-		-
-			message: "#^Parameter \\#1 \\$simpleArithmeticExpr of method Doctrine\\\\ORM\\\\Query\\\\SqlWalker\\:\\:walkSimpleArithmeticExpression\\(\\) expects Doctrine\\\\ORM\\\\Query\\\\AST\\\\SimpleArithmeticExpression, Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node given\\.$#"
-			count: 1
-			path: src/Query/AST/Functions/UpperFunction.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\AST\\\\IndexBy\\:\\:dispatch\\(\\) should return string but returns void\\.$#"
 			count: 1
 			path: src/Query/AST/IndexBy.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1577,11 +1577,6 @@
       <code><![CDATA[$assoc['joinColumns']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="src/Query/AST/Functions/LengthFunction.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->stringPrimary]]></code>
-    </ArgumentTypeCoercion>
-  </file>
   <file src="src/Query/AST/Functions/LocateFunction.php">
     <PossiblyInvalidArgument>
       <code><![CDATA[$this->simpleArithmeticExpression]]></code>
@@ -1589,11 +1584,6 @@
     <PossiblyInvalidPropertyAssignmentValue>
       <code><![CDATA[$parser->SimpleArithmeticExpression()]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
-  </file>
-  <file src="src/Query/AST/Functions/LowerFunction.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->stringPrimary]]></code>
-    </ArgumentTypeCoercion>
   </file>
   <file src="src/Query/AST/Functions/ModFunction.php">
     <PossiblyInvalidPropertyAssignmentValue>
@@ -1621,11 +1611,6 @@
       <code><![CDATA[$parser->SimpleArithmeticExpression()]]></code>
       <code><![CDATA[$parser->SimpleArithmeticExpression()]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
-  </file>
-  <file src="src/Query/AST/Functions/UpperFunction.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->stringPrimary]]></code>
-    </ArgumentTypeCoercion>
   </file>
   <file src="src/Query/AST/GeneralCaseExpression.php">
     <ParamNameMismatch>
@@ -2131,9 +2116,6 @@
     <NoValue>
       <code>$expression</code>
     </NoValue>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$aggExpression->pathExpression]]></code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$AST->whereClause]]></code>
       <code><![CDATA[$AST->whereClause]]></code>

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -2588,7 +2588,7 @@ class SqlWalker implements TreeWalker
     /**
      * Walks down an SimpleArithmeticExpression AST node, thereby generating the appropriate SQL.
      *
-     * @param AST\SimpleArithmeticExpression $simpleArithmeticExpr
+     * @param AST\Node|string $simpleArithmeticExpr
      *
      * @return string
      *


### PR DESCRIPTION
Compatibility with ORM 2 & 3 is not always easy with the different phpdoc/typehint on SQLWalker (and static analysis).

`walkSimpleArithmeticExpression` phpdoc only accepts `SimpleArithmeticExpression` on 2.x but in fact support a wilder type Node|string ; and the type was updated on 3.x branch.

I took the typehint from the 3.x branch https://github.com/doctrine/orm/blob/2a250b5814de192a23438c0a43e15da7e77890a7/src/Query/SqlWalker.php#L2127 to update the phpdoc on 2.x branch.

This also fixes 7 baselines entries