### PR TITLE
Add a test case for join columns on the inverse side of a 1:1 assoc

### DIFF
--- a/tests/Tests/Models/Jedi/JediKnight.php
+++ b/tests/Tests/Models/Jedi/JediKnight.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Jedi;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'jedi_knights')]
+class JediKnight
+{
+    #[ORM\Column]
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column(length: 100)]
+    public string $name;
+
+    #[ORM\OneToOne(inversedBy: 'padawan')]
+    #[ORM\JoinColumn(name: 'master_id')]
+    public self|null $master = null;
+
+    #[ORM\OneToOne(mappedBy: 'master')]
+    #[ORM\JoinColumn(name: 'padawan_id')]
+    public self|null $padawan = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Tests/ORM/Functional/OneToOneBidirectionalPersistedTest.php
+++ b/tests/Tests/ORM/Functional/OneToOneBidirectionalPersistedTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\Tests\Models\Jedi\JediKnight;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class OneToOneBidirectionalPersistedTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('jedi');
+
+        parent::setUp();
+    }
+
+    public function testInverseColumnIsPopulated(): void
+    {
+        $master  = new JediKnight('Obi-Wan Kenobi');
+        $padawan = new JediKnight('Anakin Skywalker');
+
+        $padawan->master = $master;
+        $master->padawan = $padawan;
+
+        $this->_em->persist($master);
+        $this->_em->persist($padawan);
+        $this->_em->flush();
+
+        $tableContent = $this->_em->getConnection()->fetchAllAssociative(
+            'SELECT id, name, master_id, padawan_id FROM jedi_knights WHERE id IN (:ids) ORDER BY name',
+            ['ids' => [$master->id, $padawan->id]],
+            ['ids' => ArrayParameterType::INTEGER],
+        );
+
+        self::assertSame(
+            [
+                ['id' => $padawan->id, 'name' => 'Anakin Skywalker', 'master_id' => $master->id, 'padawan_id' => null],
+                ['id' => $master->id, 'name' => 'Obi-Wan Kenobi', 'master_id' => null, 'padawan_id' => $padawan->id],
+            ],
+            $tableContent,
+        );
+    }
+}

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -479,6 +479,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue9300\Issue9300Child::class,
             Models\Issue9300\Issue9300Parent::class,
         ],
+        'jedi' => [
+            Models\Jedi\JediKnight::class,
+        ],
     ];
 
     /** @param class-string ...$models */
@@ -806,6 +809,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM issue5989_persons');
             $conn->executeStatement('DELETE FROM issue5989_employees');
             $conn->executeStatement('DELETE FROM issue5989_managers');
+        }
+
+        if (isset($this->_usedModelSets['jedi'])) {
+            $conn->executeStatement('DELETE FROM jedi_knights');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
See #11299 for the same test on the 2.18.x branch.

In a project, I've stumbled across a "feature" which we seemed to have removed, but I don't know if it was on purpose. The entity model contained a bidirectional `OneToOne` relation with a `JoinColumn` declared on the inverse side. That join column was actually added to the schema by the ORM and it was even possible to have it persist the ID of the foreign record.

In 3.0, this is not possible anymore, but it's mainly prevented by the metadata model.

I'm opening this issue to clarify if we have removed this feature on purpose or if we have simply forgotten it while developing the new metadata mapping classes.

cc @greg0ire 