### PR TITLE
Fix SchemaTool::getSchemaFromMetadata() uniqueConstraint without a predefined name

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -365,7 +365,7 @@ class SchemaTool
 
             if (isset($class->table['uniqueConstraints'])) {
                 foreach ($class->table['uniqueConstraints'] as $indexName => $indexData) {
-                    $uniqIndex = new Index(is_numeric($indexName) ? null : $indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
+                    $uniqIndex = new Index('tmp__' . $indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
 
                     foreach ($table->getIndexes() as $tableIndexName => $tableIndex) {
                         $method = method_exists($tableIndex, 'isFulfilledBy') ? 'isFulfilledBy' : 'isFullfilledBy';

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -365,7 +365,7 @@ class SchemaTool
 
             if (isset($class->table['uniqueConstraints'])) {
                 foreach ($class->table['uniqueConstraints'] as $indexName => $indexData) {
-                    $uniqIndex = new Index($indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
+                    $uniqIndex = new Index(is_numeric($indexName) ? null : $indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
 
                     foreach ($table->getIndexes() as $tableIndexName => $tableIndex) {
                         $method = method_exists($tableIndex, 'isFulfilledBy') ? 'isFulfilledBy' : 'isFullfilledBy';

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -580,19 +580,30 @@ class IndexByFieldEntity
     public $fieldName;
 }
 
-#[UniqueConstraint(columns: ['field', 'anotherField'])]
-#[Entity]
+/**
+ * @Entity
+ * @Table(uniqueConstraints={@UniqueConstraint(columns={"field", "anotherField"})})
+ */
 class GH11314Entity
 {
-    #[Id]
-    #[Column]
-    private int $id;
+    /**
+     * @Column(type="integer")
+     * @Id
+     * @var int
+     */
+    private $id;
 
-    #[Column(name: 'field', type: 'string')]
-    private string $field;
+    /**
+     * @Column(name="field", type="string")
+     * @var string
+     */
+    private $field;
 
-    #[Column(name: 'anotherField', type: 'string')]
-    private string $anotherField;
+    /**
+     * @Column(name="anotherField", type="string")
+     * @var string
+     */
+    private $anotherField;
 }
 
 class IncorrectIndexByFieldEntity

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -374,6 +374,27 @@ class SchemaToolTest extends OrmTestCase
         self::assertTrue($schema->hasTable('first_entity'), 'Table first_entity should exist.');
         self::assertFalse($schema->hasTable('second_entity'), 'Table second_entity should not exist.');
     }
+
+    #[Group('11314')]
+    public function testLoadUniqueConstraintWithoutName(): void
+    {
+        $em     = $this->getTestEntityManager();
+        $entity = $em->getClassMetadata(GH11314Entity::class);
+
+        $schemaTool = new SchemaTool($em);
+        $schema     = $schemaTool->getSchemaFromMetadata([$entity]);
+
+        self::assertTrue($schema->hasTable('GH11314Entity'));
+
+        $tableEntity = $schema->getTable('GH11314Entity');
+
+        self::assertTrue($tableEntity->hasIndex('uniq_2d81a3ed5bf54558875f7fd5'));
+
+        $tableIndex = $tableEntity->getIndex('uniq_2d81a3ed5bf54558875f7fd5');
+
+        self::assertTrue($tableIndex->isUnique());
+        self::assertSame(['field', 'anotherField'], $tableIndex->getColumns());
+    }
 }
 
 /**
@@ -557,6 +578,21 @@ class IndexByFieldEntity
      * @Column
      */
     public $fieldName;
+}
+
+#[UniqueConstraint(columns: ['field', 'anotherField'])]
+#[Entity]
+class GH11314Entity
+{
+    #[Id]
+    #[Column]
+    private int $id;
+
+    #[Column(name: 'field', type: 'string')]
+    private string $field;
+
+    #[Column(name: 'anotherField', type: 'string')]
+    private string $anotherField;
 }
 
 class IncorrectIndexByFieldEntity


### PR DESCRIPTION
### Bug Report

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| BC Break    | no
| Version     | 3.0.x

#### Summary

SchemaTool can't correctly read a UniqueConstraint when it doesn't have a name specified.

#### Current behavior

If a unique constraint is specified for a table without a defined name i.e.: `#[ORM\UniqueConstraint(fields: ['field', 'anotherField'])]`, the reading fails due to a type missmatch [here](https://github.com/doctrine/orm/blob/2a250b5814de192a23438c0a43e15da7e77890a7/src/Tools/SchemaTool.php#L340). In such a case the `$indexName` is an integer but it should be null. This is correctly applied [here](https://github.com/doctrine/orm/blob/2a250b5814de192a23438c0a43e15da7e77890a7/src/Tools/SchemaTool.php#L349)

#### How to reproduce

<!--
Provide steps to reproduce the bug.
If possible, also add a code snippet with relevant configuration, entity mappings, DQL etc.
Adding a failing Unit or Functional Test would help us a lot - you can submit one in a Pull Request separately, referencing this bug report.
-->

Add a `#[ORM\UniqueConstraint(fields: ['field', 'anotherField'])]` to any entity and try to dump SQL. You will get

```
In Index.php line 42:
                                                                                                                                                                                          
  Doctrine\DBAL\Schema\Index::__construct(): Argument #1 ($name) must be of type ?string, int given, called in vendor/doctrine/orm/src/Tools/SchemaTool.php on line 340
```

#### Expected behavior

<!-- What was the expected (correct) behavior? -->

The unique constraint should be loaded correctly and a unique name should be generated for it automatically.