### PR TITLE
Performance Optimization for computing id hashes.

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -477,7 +477,7 @@ class EntityManager implements EntityManagerInterface
 
         $unitOfWork = $this->getUnitOfWork();
 
-        $entity = $unitOfWork->tryGetById($sortedId, $class->rootEntityName);
+        $entity = $unitOfWork->tryGetByIdWithClass($sortedId, $class);
 
         // Check identity map first
         if ($entity !== false) {
@@ -548,7 +548,7 @@ class EntityManager implements EntityManagerInterface
             throw UnrecognizedIdentifierFields::fromClassAndFieldNames($class->name, array_keys($id));
         }
 
-        $entity = $this->unitOfWork->tryGetById($sortedId, $class->rootEntityName);
+        $entity = $this->unitOfWork->tryGetByIdWithClass($sortedId, $class);
 
         // Check identity map first, if its already in there just return it.
         if ($entity !== false) {
@@ -579,7 +579,7 @@ class EntityManager implements EntityManagerInterface
         );
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
-        $entity = $this->unitOfWork->tryGetById($identifier, $class->rootEntityName);
+        $entity = $this->unitOfWork->tryGetByIdWithClass($identifier, $class);
 
         // Check identity map first, if its already in there just return it.
         if ($entity !== false) {

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -284,7 +284,7 @@ class ObjectHydrator extends AbstractHydrator
         $class = $this->_metadataCache[$className];
 
         if ($class->isIdentifierComposite) {
-            $idHash = UnitOfWork::getIdHashByIdentifier(
+            $idHash = $class->idHashing->getIdHashByIdentifier(
                 array_map(
                     /** @return mixed */
                     static function (string $fieldName) use ($data, $class) {

--- a/src/Internal/IdHashing/ComplexIdHashing.php
+++ b/src/Internal/IdHashing/ComplexIdHashing.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\IdHashing;
+
+use BackedEnum;
+
+use function array_map;
+use function implode;
+
+class ComplexIdHashing implements IdHashing
+{
+    public function getIdHashByIdentifier(array $identifier): string
+    {
+        return implode(
+            ' ',
+            array_map(
+                static function ($value) {
+                    if ($value instanceof BackedEnum) {
+                        return $value->value;
+                    }
+
+                    return $value;
+                },
+                $identifier
+            )
+        );
+    }
+}

--- a/src/Internal/IdHashing/ComplexIdHashing.php
+++ b/src/Internal/IdHashing/ComplexIdHashing.php
@@ -11,6 +11,9 @@ use function implode;
 
 class ComplexIdHashing implements IdHashing
 {
+    /**
+     * @param mixed[] $identifier
+     */
     public function getIdHashByIdentifier(array $identifier): string
     {
         return implode(

--- a/src/Internal/IdHashing/IdHashing.php
+++ b/src/Internal/IdHashing/IdHashing.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\IdHashing;
+
+/**
+ * Turn an array of identifier values into a hash that can be used as a key in an array.
+ *
+ * This is required for various lookups in the UnitOfWork and adjecent APIs.
+ */
+interface IdHashing
+{
+    public function getIdHashByIdentifier(array $identifier): string;
+}

--- a/src/Internal/IdHashing/IdHashing.php
+++ b/src/Internal/IdHashing/IdHashing.php
@@ -11,5 +11,8 @@ namespace Doctrine\ORM\Internal\IdHashing;
  */
 interface IdHashing
 {
+    /**
+     * @param mixed[] $identifier
+     */
     public function getIdHashByIdentifier(array $identifier): string;
 }

--- a/src/Internal/IdHashing/SingleElementIdHashing.php
+++ b/src/Internal/IdHashing/SingleElementIdHashing.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\IdHashing;
+
+use function array_key_first;
+
+class SingleElementIdHashing implements IdHashing
+{
+    public function getIdHashByIdentifier(array $identifier): string
+    {
+        $key = array_key_first($identifier);
+        if (! isset($identifier[$key])) {
+            return ''; // WHY?
+        }
+
+        return $identifier[$key];
+    }
+}

--- a/src/Internal/IdHashing/SingleElementIdHashing.php
+++ b/src/Internal/IdHashing/SingleElementIdHashing.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\IdHashing;
 
-use function array_key_first;
+use function implode;
 
 class SingleElementIdHashing implements IdHashing
 {
+    /**
+     * @param mixed[] $identifier
+     */
     public function getIdHashByIdentifier(array $identifier): string
     {
         return implode(' ', $identifier);

--- a/src/Internal/IdHashing/SingleElementIdHashing.php
+++ b/src/Internal/IdHashing/SingleElementIdHashing.php
@@ -10,11 +10,6 @@ class SingleElementIdHashing implements IdHashing
 {
     public function getIdHashByIdentifier(array $identifier): string
     {
-        $key = array_key_first($identifier);
-        if (! isset($identifier[$key])) {
-            return ''; // WHY?
-        }
-
-        return $identifier[$key];
+        return implode(' ', $identifier);
     }
 }

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -14,6 +14,9 @@ use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ORM\Cache\Exception\NonCacheableEntityAssociation;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Id\AbstractIdGenerator;
+use Doctrine\ORM\Internal\IdHashing\ComplexIdHashing;
+use Doctrine\ORM\Internal\IdHashing\IdHashing;
+use Doctrine\ORM\Internal\IdHashing\SingleElementIdHashing;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ReflectionService;
 use InvalidArgumentException;
@@ -807,6 +810,9 @@ class ClassMetadataInfo implements ClassMetadata
     /** @var TypedFieldMapper $typedFieldMapper */
     private $typedFieldMapper;
 
+    /** @var IdHashing */
+    public $idHashing;
+
     /**
      * Initializes a new ClassMetadata instance that will hold the object-relational mapping
      * metadata of the class with the given name.
@@ -1092,6 +1098,9 @@ class ClassMetadataInfo implements ClassMetadata
         // Restore ReflectionClass and properties
         $this->reflClass    = $reflService->getClass($this->name);
         $this->instantiator = $this->instantiator ?: new Instantiator();
+        $this->idHashing    = count($this->identifier) === 1 && ! isset($this->fieldMappings[$this->identifier[0]]['enumType'])
+            ? new SingleElementIdHashing()
+            : new ComplexIdHashing();
 
         $parentReflFields = [];
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1867,7 +1867,7 @@ EXCEPTION
                 }
 
                 // Last try before db lookup: check the identity map.
-                if ($this->tryGetById($id, $class->rootEntityName)) {
+                if ($this->tryGetByIdWithClass($id, $class)) {
                     return self::STATE_DETACHED;
                 }
 
@@ -1884,7 +1884,7 @@ EXCEPTION
                 // the last resort: a db lookup
 
                 // Last try before db lookup: check the identity map.
-                if ($this->tryGetById($id, $class->rootEntityName)) {
+                if ($this->tryGetByIdWithClass($id, $class)) {
                     return self::STATE_DETACHED;
                 }
 
@@ -2238,7 +2238,7 @@ EXCEPTION
                     ? $this->identifierFlattener->flattenIdentifier($class, $id)
                     : $id;
 
-                $managedCopy = $this->tryGetById($flatId, $class->rootEntityName);
+                $managedCopy = $this->tryGetByIdWithClass($flatId, $class);
 
                 if ($managedCopy) {
                     // We have the entity in-memory already, just make sure its not removed.
@@ -3442,6 +3442,18 @@ EXCEPTION
     }
 
     /**
+     * @param mixed $id
+     * @param ClassMetadata $classMetadata
+     * @return false|mixed|object
+     */
+    public function tryGetByIdWithClass($id, $classMetadata)
+    {
+        $idHash = $classMetadata->idHashing->getIdHashByIdentifier((array) $id);
+
+        return $this->identityMap[$classMetadata->rootEntityName][$idHash] ?? false;
+    }
+
+    /**
      * Schedules an entity for dirty-checking at commit-time.
      *
      * @param object $entity The entity to schedule for dirty-checking.
@@ -3892,7 +3904,7 @@ EXCEPTION
                                 $targetClass = $this->em->getClassMetadata($assoc2['targetEntity']);
                                 $relatedId   = $targetClass->getIdentifierValues($other);
 
-                                $other = $this->tryGetById($relatedId, $targetClass->name);
+                                $other = $this->tryGetByIdWithClass($relatedId, $targetClass);
 
                                 if (! $other) {
                                     if ($targetClass->subClasses) {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3442,8 +3442,9 @@ EXCEPTION
     }
 
     /**
-     * @param mixed $id
+     * @param mixed         $id
      * @param ClassMetadata $classMetadata
+     *
      * @return false|mixed|object
      */
     public function tryGetByIdWithClass($id, $classMetadata)

--- a/tests/Tests/ORM/Functional/Ticket/GH7869Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7869Test.php
@@ -55,7 +55,7 @@ class GH7869Test extends OrmTestCase
         $uow->clear();
         $uow->triggerEagerLoads();
 
-        self::assertSame(4, $em->getClassMetadataCalls);
+        self::assertSame(6, $em->getClassMetadataCalls);
     }
 }
 


### PR DESCRIPTION
In 09b4a75ed3ec3d67f805f6ccc22399997c31f022 we introduced an API `UnitOfWork::getIdHashByIdentifier` that added a significant amount of function calls over the previous inline `implode` to support backed enums as identifiers.

This PR moves ID hashing into a strategy pattern, moving the object to `ClassMetadata` instances of each entity, getting the previous performance almost back (+ the dynamic call). 

I hope this will significantly improve performance of the 80% identifier that is a simple, single numeric identifier. 

Here are the results from two traces compaed with Tideways using the lazy ghost performance project discussed in #11087 that runs `EntityManager::getReference`, hitting the ID hashing code significantly for 100.000 objects.

| Old Call  | Old Time | New Call | New Time |
| ------------- | ------------- | ------------- | ------------- |
| `UnitOfWork::getIdHashByIdentifier` | 46.75 ms  | `SingleElementIdHashing::getIdHashByIdentifier` | 15.3 ms |
| `UnitOfWork::tryGetById` | 33.01 ms | `UnitOfWork::tryGetByIdWithClass` | 16.1 ms |

<img width="640" alt="Bildschirmfoto 2024-02-28 um 22 22 28" src="https://github.com/doctrine/orm/assets/26936/c315b9f2-e3d9-4f0e-9ef5-30e210f70268">

While not life-changing, this hit accrues, especially in test-suites working with fixtures.