### PR TITLE
Refator array_map into simple loop for performance

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1781,18 +1781,15 @@ EXCEPTION
      */
     final public static function getIdHashByIdentifier(array $identifier): string
     {
+        foreach ($identifier as $k => $value) {
+            if ($value instanceof BackedEnum) {
+                $identifier[$k] = $value->value;
+            }
+        }
+
         return implode(
             ' ',
-            array_map(
-                static function ($value) {
-                    if ($value instanceof BackedEnum) {
-                        return $value->value;
-                    }
-
-                    return $value;
-                },
-                $identifier
-            )
+            $identifier,
         );
     }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1789,7 +1789,7 @@ EXCEPTION
 
         return implode(
             ' ',
-            $identifier,
+            $identifier
         );
     }
 


### PR DESCRIPTION
Alternative to more complex performance refactoring in #11316 

This already reduces performance overhead measured by Tideways by 56%. It shows again how expensive array_map is vs a simple foreach in performance sensitive code path.

<img width="650" alt="Bildschirmfoto 2024-03-02 um 17 35 22" src="https://github.com/doctrine/orm/assets/26936/54cfacb4-1004-4a91-bee7-1f4fe95741ae">

Related to https://github.com/doctrine/orm/issues/11087