### PR TITLE
Change the lock mode in the "Aggregate Fields" cookbook (aggregate-fields.rst) article.

### DIFF
--- a/docs/en/cookbook/aggregate-fields.rst
+++ b/docs/en/cookbook/aggregate-fields.rst
@@ -352,7 +352,7 @@ the database using a FOR UPDATE.
     use Bank\Entities\Account;
     use Doctrine\DBAL\LockMode;
 
-    $account = $em->find(Account::class, $accId, LockMode::PESSIMISTIC_READ);
+    $account = $em->find(Account::class, $accId, LockMode::PESSIMISTIC_WRITE);
 
 Keeping Updates and Deletes in Sync
 -----------------------------------


### PR DESCRIPTION
Change `PESSIMISTIC_READ` to `PESSIMISTIC_WRITE` because otherwise the solution to the race condition at the bottom of the article would allow concurrent reads, which would not solve the presented race condition problem.

Please correct me if I'm wrong because I might be.