### PR TITLE
Remove guides-specific markup

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,5 +40,10 @@ jobs:
         with:
           dependency-versions: "highest"
 
+      - name: "Add orphan metadata where needed"
+        run: |
+          printf '%s\n\n%s\n' ":orphan:" "$(cat docs/en/sidebar.rst)" > docs/en/sidebar.rst
+          printf '%s\n\n%s\n' ":orphan:" "$(cat docs/en/reference/installation.rst)" > docs/en/reference/installation.rst
+
       - name: "Run guides-cli"
         run: "vendor/bin/guides -vvv --no-progress docs/en 2>&1 | grep -v 'No template found for rendering directive' | ( ! grep WARNING )"

--- a/docs/en/reference/installation.rst
+++ b/docs/en/reference/installation.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Installation
 ============
 

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. toc::
 
    .. tocheader:: Tutorials


### PR DESCRIPTION
doctrine/rst-parser does not appear to support `:orphan:` metadata yet, and renders it verbatim on the website.

Let's move this to the CI job.