### PR TITLE
Extend `AttributeDriver` to count in defined indices and unique constraints on `Table` attribute

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1078,6 +1078,8 @@ Required parameters:
 Optional parameters:
 
 -  **schema**: Name of the schema the table lies in.
+-  **indexes**: A array with instances of :ref:`#[Index] <attrref_index>`
+-  **uniqueConstraints**: A array with instances of :ref:`#[UniqueConstraint] <attrref_uniqueconstraint>`
 
 Example:
 
@@ -1085,11 +1087,30 @@ Example:
 
     <?php
     use Doctrine\ORM\Mapping\Entity;
+    use Doctrine\ORM\Mapping\Index;
     use Doctrine\ORM\Mapping\Table;
+    use Doctrine\ORM\Mapping\UniqueConstraint;
 
     #[Entity]
     #[Table(name: "user", schema: "schema_name")]
     class User { }
+
+    #[Entity]
+    #[Table(
+        name: "contact",
+        schema: "schema_name",
+        indexes: [
+            new Index(['some_column_1'], name: 'some_name_1'),
+            new Index(['some_column_2'], name: 'some_name_2'),
+        ],
+        uniqueConstraints: [
+            new UniqueConstraint('some_unique_constraint', ['some_column_3']),
+        ],
+    )]
+    class Contact
+    {
+        // [...]
+    }
 
 .. _attrref_uniqueconstraint:
 

--- a/tests/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\MappingAttribute;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as PersistenceAnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Tests\ORM\Mapping\Fixtures\AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute;
 use Doctrine\Tests\ORM\Mapping\Fixtures\AttributeEntityWithNestedJoinColumns;
 use stdClass;
 
@@ -115,6 +116,8 @@ class AttributeDriverTest extends MappingDriverTestCase
         self::assertFalse($driver->isTransient(AttributeEntityWithoutOriginalParents::class));
 
         self::assertFalse($driver->isTransient(AttributeEntityStartingWithRepeatableAttributes::class));
+
+        self::assertFalse($driver->isTransient(AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute::class));
     }
 
     public function testLegacyInheritance(): void
@@ -163,7 +166,36 @@ class AttributeDriverTest extends MappingDriverTestCase
             $metadata->associationMappings['assoc']['joinTable']['inverseJoinColumns']
         );
     }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testTableAttributeWithIndicesAndUniqueConstraints(): void
+    {
+        $factory = $this->createClassMetadataFactory();
+
+        $metadata = $factory->getMetadataFor(AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute::class);
+
+        self::assertEquals(
+            [
+                'bar' => [
+                    'columns' => [0 => 'id'],
+                ],
+            ],
+            $metadata->table['indexes']
+        );
+
+        self::assertEquals(
+            [
+                'foo' => [
+                    'columns' => [0 => 'id'],
+                ],
+            ],
+            $metadata->table['uniqueConstraints']
+        );
+    }
 }
+
 
 #[ORM\Entity]
 #[ORM\UniqueConstraint(name: 'foo', columns: ['id'])]

--- a/tests/Tests/ORM/Mapping/Fixtures/AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute.php
+++ b/tests/Tests/ORM/Mapping/Fixtures/AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(
+    indexes: [new ORM\Index(name: 'bar', columns: ['id'])],
+    uniqueConstraints: [new ORM\UniqueConstraint(name: 'foo', columns: ['id'])],
+)]
+class AttributeEntityWithIndicesAndUniqueConstraintInTableAttribute
+{
+    /** @var int */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public $id;
+}


### PR DESCRIPTION
This allows defining indices and unique constraints through the `Table` attribute which already provides these properties but which aren't respected by the `AttributeDriver`.

Fixes #11351 