### PR TITLE
Deprecate obsolete and unnecessary properties from Table attribute (#11351)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,12 @@
 
 That option behaves as a no-op, and is deprecated. It will be removed in 4.0.
 
+## Deprecate properties `$indexes` and `$uniqueConstraints` of `Doctrine\ORM\Mapping\Table`
+
+The properties `$indexes` and `$uniqueConstraints` have been deprecated since they had no effect at all.
+The preferred way of defining indices and unique constraints is by
+using the `\Doctrine\ORM\Mapping\UniqueConstraint` and `\Doctrine\ORM\Mapping\Index` attributes.
+
 # Upgrade to 3.1
 
 ## Deprecate `Doctrine\ORM\Mapping\ReflectionEnumProperty`

--- a/src/Mapping/Table.php
+++ b/src/Mapping/Table.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;
+use Doctrine\Deprecations\Deprecation;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Table implements MappingAttribute
@@ -21,5 +22,24 @@ final class Table implements MappingAttribute
         public readonly array|null $uniqueConstraints = null,
         public readonly array $options = [],
     ) {
+        if ($this->indexes !== null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/11357',
+                'Providing the property $indexes on %s does not have any effect and will be removed in Doctrine ORM 4.0. Please use the %s attribute instead.',
+                self::class,
+                Index::class,
+            );
+        }
+
+        if ($this->uniqueConstraints !== null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/11357',
+                'Providing the property $uniqueConstraints on %s does not have any effect and will be removed in Doctrine ORM 4.0. Please use the %s attribute instead.',
+                self::class,
+                UniqueConstraint::class,
+            );
+        }
     }
 }

--- a/tests/Tests/ORM/Mapping/TableMappingTest.php
+++ b/tests/Tests/ORM/Mapping/TableMappingTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Mapping\Table;
+use PHPUnit\Framework\TestCase;
+
+final class TableMappingTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testDeprecationOnIndexesPropertyIsTriggered(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');
+
+        new Table(indexes: []);
+    }
+
+    public function testDeprecationOnUniqueConstraintsPropertyIsTriggered(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');
+
+        new Table(uniqueConstraints: []);
+    }
+}


### PR DESCRIPTION
The properties `indexes` and `uniqueConstraints` were used by the `AnnotationDriver` but were never implemented for the `AttributeDriver`. Since the `AnnotationDriver` doesn't exist anymore these can become deprecated and will then be removed afterwards.