### PR TITLE
Reintroduce PARTIAL, but only for non-object hydration.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -75,9 +75,11 @@ now they throw an exception.
 
 ## BC BREAK: Partial objects are removed
 
-- The `PARTIAL` keyword in DQL no longer exists.
-- `Doctrine\ORM\Query\AST\PartialObjectExpression`is removed.
-- `Doctrine\ORM\Query\SqlWalker::HINT_PARTIAL` and
+WARNING: This was relaxed in ORM 3.2 when partial was re-allowed for array-hydration.
+
+- The `PARTIAL` keyword in DQL no longer exists (reintroduced in ORM 3.2)
+- `Doctrine\ORM\Query\AST\PartialObjectExpression` is removed. (reintroduced in ORM 3.2)
+- `Doctrine\ORM\Query\SqlWalker::HINT_PARTIAL` (reintroduced in ORM 3.2) and
   `Doctrine\ORM\Query::HINT_FORCE_PARTIAL_LOAD` are removed.
 - `Doctrine\ORM\EntityManager*::getPartialReference()` is removed.
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -73,6 +73,7 @@ Advanced Topics
 * :doc:`TypedFieldMapper <reference/typedfieldmapper>`
 * :doc:`Improving Performance <reference/improving-performance>`
 * :doc:`Caching <reference/caching>`
+* :doc:`Partial Hydration <reference/partial-hydration>`
 * :doc:`Change Tracking Policies <reference/change-tracking-policies>`
 * :doc:`Best Practices <reference/best-practices>`
 * :doc:`Metadata Drivers <reference/metadata-drivers>`

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -523,6 +523,25 @@ when the DQL is switched to an arbitrary join.
     - HAVING is applied to the results of a query after
       aggregation (GROUP BY)
 
+
+Partial Hydration Syntax
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default when you run a DQL query in Doctrine and select only a
+subset of the fields for a given entity, you do not receive objects
+back. Instead, you receive only arrays as a flat rectangular result
+set, similar to how you would if you were just using SQL directly
+and joining some data.
+
+If you want to select a partial number of fields for hydration entity in
+the context of array hydration and joins you can use the ``partial`` DQL keyword:
+
+.. code-block:: php
+
+    <?php
+    $query = $em->createQuery('SELECT partial u.{id, username}, partial a.{id, name} FROM CmsUser u JOIN u.articles a');
+    $users = $query->getArrayResult(); // array of partially loaded CmsUser and CmsArticle fields
+
 "NEW" Operator Syntax
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -1647,8 +1666,10 @@ Select Expressions
 
 .. code-block:: php
 
-    SelectExpression        ::= (IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | "(" Subselect ")" | CaseExpression | NewObjectExpression) [["AS"] ["HIDDEN"] AliasResultVariable]
+    SelectExpression        ::= (IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | PartialObjectExpression | "(" Subselect ")" | CaseExpression | NewObjectExpression) [["AS"] ["HIDDEN"] AliasResultVariable]
     SimpleSelectExpression  ::= (StateFieldPathExpression | IdentificationVariable | FunctionDeclaration | AggregateExpression | "(" Subselect ")" | ScalarExpression) [["AS"] AliasResultVariable]
+    PartialObjectExpression ::= "PARTIAL" IdentificationVariable "." PartialFieldSet
+    PartialFieldSet         ::= "{" SimpleStateField {"," SimpleStateField}* "}"
     NewObjectExpression     ::= "NEW" AbstractSchemaName "(" NewObjectArg {"," NewObjectArg}* ")"
     NewObjectArg            ::= ScalarExpression | "(" Subselect ")"
 

--- a/docs/en/reference/partial-hydration.rst
+++ b/docs/en/reference/partial-hydration.rst
@@ -1,0 +1,20 @@
+Partial Hydration
+=================
+
+.. note::
+
+    Creating Partial Objects through DQL was possible in ORM 2,
+    but is only supported for array hydration as of ORM 3 anymore.
+
+Partial hydration of entities is allowed in the array hydrator, when
+only a subset of the fields of an entity are loaded from the database
+and the nested results are still created based on the entity relationship structure.
+
+.. code-block:: php
+
+    <?php
+    $users = $em->createQuery("SELECT PARTIAL u.{id,name}, partial a.{id,street} FROM MyApp\Domain\User u JOIN u.addresses a")
+                ->getArrayResult();
+
+This is a useful optimization when you are not interested in all fields of an entity
+for performance reasons, for example in use-cases for exporting or rendering lots of data.

--- a/docs/en/reference/partial-hydration.rst
+++ b/docs/en/reference/partial-hydration.rst
@@ -4,7 +4,7 @@ Partial Hydration
 .. note::
 
     Creating Partial Objects through DQL was possible in ORM 2,
-    but is only supported for array hydration as of ORM 3 anymore.
+    but is only supported for array hydration as of ORM 3.
 
 Partial hydration of entities is allowed in the array hydrator, when
 only a subset of the fields of an entity are loaded from the database

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -43,6 +43,7 @@
       reference/query-builder
       reference/native-sql
       reference/change-tracking-policies
+      reference/partial-hydration
       reference/attributes-reference
       reference/xml-mapping
       reference/php-mapping

--- a/src/Internal/Hydration/HydrationException.php
+++ b/src/Internal/Hydration/HydrationException.php
@@ -64,4 +64,9 @@ class HydrationException extends Exception implements ORMException
             implode('", "', $discrValues),
         ));
     }
+
+    public static function partialObjectHydrationDisallowed(): self
+    {
+        return new self('Hydration of entity objects is not allowed when DQL PARTIAL keyword is used.');
+    }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -71,6 +71,14 @@ class Query extends AbstractQuery
     public const HINT_REFRESH_ENTITY = 'doctrine.refresh.entity';
 
     /**
+     * The forcePartialLoad query hint forces a particular query to return
+     * partial objects.
+     *
+     * @todo Rename: HINT_OPTIMIZE
+     */
+    public const HINT_FORCE_PARTIAL_LOAD = 'doctrine.forcePartialLoad';
+
+    /**
      * The includeMetaColumns query hint causes meta columns like foreign keys and
      * discriminator columns to be selected and returned as part of the query result.
      *

--- a/src/Query.php
+++ b/src/Query.php
@@ -71,14 +71,6 @@ class Query extends AbstractQuery
     public const HINT_REFRESH_ENTITY = 'doctrine.refresh.entity';
 
     /**
-     * The forcePartialLoad query hint forces a particular query to return
-     * partial objects.
-     *
-     * @todo Rename: HINT_OPTIMIZE
-     */
-    public const HINT_FORCE_PARTIAL_LOAD = 'doctrine.forcePartialLoad';
-
-    /**
      * The includeMetaColumns query hint causes meta columns like foreign keys and
      * discriminator columns to be selected and returned as part of the query result.
      *

--- a/src/Query/AST/PartialObjectExpression.php
+++ b/src/Query/AST/PartialObjectExpression.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+class PartialObjectExpression extends Node
+{
+    /** @param mixed[] $partialFieldSet */
+    public function __construct(
+        public string $identificationVariable,
+        public array $partialFieldSet,
+    ) {
+    }
+}

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -28,6 +28,7 @@ use function array_merge;
 use function assert;
 use function count;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_float;
 use function is_numeric;
@@ -50,6 +51,11 @@ class SqlWalker
     use LockSqlHelper;
 
     public const HINT_DISTINCT = 'doctrine.distinct';
+
+    /**
+     * Used to mark a query as containing a PARTIAL expression, which needs to be known by SLC.
+     */
+    public const HINT_PARTIAL = 'doctrine.partial';
 
     private readonly ResultSetMapping $rsm;
 
@@ -1318,7 +1324,17 @@ class SqlWalker
                 break;
 
             default:
-                $dqlAlias    = $expr;
+                // IdentificationVariable or PartialObjectExpression
+                if ($expr instanceof AST\PartialObjectExpression) {
+                    $this->query->setHint(self::HINT_PARTIAL, true);
+
+                    $dqlAlias        = $expr->identificationVariable;
+                    $partialFieldSet = $expr->partialFieldSet;
+                } else {
+                    $dqlAlias        = $expr;
+                    $partialFieldSet = [];
+                }
+
                 $class       = $this->getMetadataForDqlAlias($dqlAlias);
                 $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
 
@@ -1334,6 +1350,10 @@ class SqlWalker
 
                 // Select all fields from the queried class
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
+                    if ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true)) {
+                        continue;
+                    }
+
                     $tableName = isset($mapping->inherited)
                         ? $this->em->getClassMetadata($mapping->inherited)->getTableName()
                         : $class->getTableName();
@@ -1360,13 +1380,14 @@ class SqlWalker
 
                 // Add any additional fields of subclasses (excluding inherited fields)
                 // 1) on Single Table Inheritance: always, since its marginal overhead
-                // 2) on Class Table Inheritance
+                // 2) on Class Table Inheritance only if partial objects are disallowed,
+                //    since it requires outer joining subtables.
                 foreach ($class->subClasses as $subClassName) {
                     $subClass      = $this->em->getClassMetadata($subClassName);
                     $sqlTableAlias = $this->getSQLTableAlias($subClass->getTableName(), $dqlAlias);
 
                     foreach ($subClass->fieldMappings as $fieldName => $mapping) {
-                        if (isset($mapping->inherited)) {
+                        if (isset($mapping->inherited) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
                             continue;
                         }
 

--- a/src/Query/TokenType.php
+++ b/src/Query/TokenType.php
@@ -77,6 +77,7 @@ enum TokenType: int
     case T_OR       = 242;
     case T_ORDER    = 243;
     case T_OUTER    = 244;
+    case T_PARTIAL  = 245;
     case T_SELECT   = 246;
     case T_SET      = 247;
     case T_SOME     = 248;

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnexpectedAssociationValue;
 use Doctrine\ORM\Id\AssignedGenerator;
+use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Internal\StronglyConnectedComponents;
 use Doctrine\ORM\Internal\TopologicalSort;
@@ -43,6 +44,7 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\ORM\Persisters\Entity\SingleTablePersister;
 use Doctrine\ORM\Proxy\InternalProxy;
+use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
@@ -2353,6 +2355,10 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function createEntity(string $className, array $data, array &$hints = []): object
     {
+        if (isset($hints[SqlWalker::HINT_PARTIAL])) {
+            throw HydrationException::partialObjectHydrationDisallowed();
+        }
+
         $class = $this->em->getClassMetadata($className);
 
         $id     = $this->identifierFlattener->flattenIdentifier($class, $data);

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -109,6 +109,52 @@ class QueryTest extends OrmFunctionalTestCase
         self::assertEquals('Symfony 2', $users[0]->articles[1]->topic);
     }
 
+    public function testJoinPartialArrayHydration(): void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Guilherme';
+        $user->username = 'gblanco';
+        $user->status   = 'developer';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $user->addArticle($article1);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $user->addArticle($article2);
+
+        $this->_em->persist($user);
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('select partial u.{id, username}, partial a.{id, topic} from ' . CmsUser::class . ' u join u.articles a ORDER BY a.topic');
+        $users = $query->getArrayResult();
+
+        $this->assertEquals([
+            [
+                'id' => 13,
+                'username' => 'gblanco',
+                'articles' =>
+                [
+                    [
+                        'id' => 3,
+                        'topic' => 'Doctrine 2',
+                    ],
+                    [
+                        'id' => 4,
+                        'topic' => 'Symfony 2',
+                    ],
+                ],
+            ],
+        ], $users);
+    }
+
     public function testUsingZeroBasedQueryParameterShouldWork(): void
     {
         $user           = new CmsUser();

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -138,16 +138,16 @@ class QueryTest extends OrmFunctionalTestCase
 
         $this->assertEquals([
             [
-                'id' => 13,
+                'id' => $user->id,
                 'username' => 'gblanco',
                 'articles' =>
                 [
                     [
-                        'id' => 3,
+                        'id' => $article1->id,
                         'topic' => 'Doctrine 2',
                     ],
                     [
-                        'id' => 4,
+                        'id' => $article2->id,
                         'topic' => 'Symfony 2',
                     ],
                 ],

--- a/tests/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Tests/ORM/Functional/ValueObjectsTest.php
@@ -218,6 +218,15 @@ class ValueObjectsTest extends OrmFunctionalTestCase
             ->execute();
     }
 
+    public function testPartialDqlWithNonExistentEmbeddableField(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage("no mapped field named 'address.asdfasdf'");
+
+        $this->_em->createQuery('SELECT PARTIAL p.{id,address.asdfasdf} FROM ' . __NAMESPACE__ . '\\DDC93Person p')
+            ->getArrayResult();
+    }
+
     public function testEmbeddableWithInheritance(): void
     {
         $car = new DDC93Car(new DDC93Address('Foo', '12345', 'Asdf'));

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -22,6 +23,7 @@ use PHPUnit\Framework\Attributes\Group;
 class LanguageRecognitionTest extends OrmTestCase
 {
     private EntityManagerInterface $entityManager;
+    private int $hydrationMode = AbstractQuery::HYDRATE_OBJECT;
 
     protected function setUp(): void
     {
@@ -45,6 +47,7 @@ class LanguageRecognitionTest extends OrmTestCase
     {
         $query = $this->entityManager->createQuery($dql);
         $query->setDQL($dql);
+        $query->setHydrationMode($this->hydrationMode);
 
         foreach ($hints as $key => $value) {
             $query->setHint($key, $value);
@@ -525,6 +528,18 @@ class LanguageRecognitionTest extends OrmTestCase
     public function testUnknownAbstractSchemaName(): void
     {
         $this->assertInvalidDQL('SELECT u FROM UnknownClassName u');
+    }
+
+    public function testCorrectPartialObjectLoad(): void
+    {
+        $this->hydrationMode = AbstractQuery::HYDRATE_ARRAY;
+        $this->assertValidDQL('SELECT PARTIAL u.{id,name} FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    public function testIncorrectPartialObjectLoadBecauseOfMissingIdentifier(): void
+    {
+        $this->hydrationMode = AbstractQuery::HYDRATE_ARRAY;
+        $this->assertInvalidDQL('SELECT PARTIAL u.{name} FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
     public function testScalarExpressionInSelect(): void

--- a/tests/Tests/ORM/Query/ParserTest.php
+++ b/tests/Tests/ORM/Query/ParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
@@ -113,6 +114,15 @@ class ParserTest extends OrmTestCase
 
         $this->expectException(QueryException::class);
         $parser->match(TokenType::T_SELECT);
+    }
+
+    public function testPartialExpressionWithObjectHydratorThrows(): void
+    {
+        $this->expectException(HydrationException::class);
+        $this->expectExceptionMessage('Hydration of entity objects is not allowed when DQL PARTIAL keyword is used.');
+
+        $parser = $this->createParser(CmsUser::class);
+        $parser->PartialObjectExpression();
     }
 
     private function createParser(string $dql): Parser

--- a/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -40,6 +40,7 @@ class_exists('Doctrine\\DBAL\\Platforms\\SqlitePlatform');
 class SelectSqlGenerationTest extends OrmTestCase
 {
     private EntityManagerInterface $entityManager;
+    private int $hydrationMode = ORMQuery::HYDRATE_OBJECT;
 
     protected function setUp(): void
     {
@@ -56,6 +57,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         array $queryParams = [],
     ): void {
         $query = $this->entityManager->createQuery($dqlToBeTested);
+        $query->setHydrationMode($this->hydrationMode);
 
         foreach ($queryParams as $name => $value) {
             $query->setParameter($name, $value);
@@ -1330,6 +1332,22 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
+    #[Group('DDC-2519')]
+    public function testPartialWithAssociationIdentifier(): void
+    {
+        $this->hydrationMode = ORMQuery::HYDRATE_ARRAY;
+
+        $this->assertSqlGeneration(
+            'SELECT PARTIAL l.{_source, _target} FROM Doctrine\Tests\Models\Legacy\LegacyUserReference l',
+            'SELECT l0_.iUserIdSource AS iUserIdSource_0, l0_.iUserIdTarget AS iUserIdTarget_1 FROM legacy_users_reference l0_',
+        );
+
+        $this->assertSqlGeneration(
+            'SELECT PARTIAL l.{_description, _source, _target} FROM Doctrine\Tests\Models\Legacy\LegacyUserReference l',
+            'SELECT l0_.description AS description_0, l0_.iUserIdSource AS iUserIdSource_1, l0_.iUserIdTarget AS iUserIdTarget_2 FROM legacy_users_reference l0_',
+        );
+    }
+
     #[Group('DDC-1339')]
     public function testIdentityFunctionInSelectClause(): void
     {
@@ -1400,11 +1418,13 @@ class SelectSqlGenerationTest extends OrmTestCase
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeSingleTableInChildClass(): void
+    public function testInheritanceTypeSingleTableInChildClassWithDisabledForcePartialLoad(): void
     {
+        $this->hydrationMode = ORMQuery::HYDRATE_ARRAY;
+
         $this->assertSqlGeneration(
             'SELECT fc FROM Doctrine\Tests\Models\Company\CompanyFlexContract fc',
-            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5, c0_.salesPerson_id AS salesPerson_id_6 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
         );
     }
 
@@ -1687,6 +1707,22 @@ class SelectSqlGenerationTest extends OrmTestCase
         $this->assertSqlGeneration(
             'SELECT p FROM Doctrine\Tests\Models\CustomType\CustomTypeParent p',
             'SELECT c0_.id AS id_0, -(c0_.customInteger) AS customInteger_1, c0_.child_id AS child_id_2 FROM customtype_parents c0_',
+        );
+    }
+
+    public function testCustomTypeValueSqlForPartialObject(): void
+    {
+        $this->hydrationMode = ORMQuery::HYDRATE_ARRAY;
+
+        if (DBALType::hasType('negative_to_positive')) {
+            DBALType::overrideType('negative_to_positive', NegativeToPositiveType::class);
+        } else {
+            DBALType::addType('negative_to_positive', NegativeToPositiveType::class);
+        }
+
+        $this->assertSqlGeneration(
+            'SELECT partial p.{id, customInteger} FROM Doctrine\Tests\Models\CustomType\CustomTypeParent p',
+            'SELECT c0_.id AS id_0, -(c0_.customInteger) AS customInteger_1 FROM customtype_parents c0_',
         );
     }
 

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Exception\EntityIdentityCollisionException;
+use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -22,6 +23,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Version;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\EntityPersisterMock;
@@ -642,6 +644,15 @@ class UnitOfWorkTest extends OrmTestCase
         $this->expectExceptionMessageMatches('/another object .* was already present for the same ID/');
 
         $this->_unitOfWork->persist($phone2);
+    }
+
+    public function testItThrowsWhenCreateEntityWithSqlWalkerPartialQueryHint(): void
+    {
+        $this->expectException(HydrationException::class);
+        $this->expectExceptionMessage('Hydration of entity objects is not allowed when DQL PARTIAL keyword is used.');
+
+        $hints = [SqlWalker::HINT_PARTIAL => true];
+        $this->_unitOfWork->createEntity(VersionedAssignedIdentifierEntity::class, ['id' => 1], $hints);
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/doctrine/orm/issues/8471#issuecomment-2002116608, `PARTIAL` is re-introduced in 3.2 but only when used with non object hydrators, usefully with array hydration.

This will allow retrieval of partial fields with complex entity dql relationships, example:

```php
    $query = $em->createQuery('SELECT partial u.{id, username}, partial a.{id, name} FROM CmsUser u JOIN u.articles a');
    $users = $query->getArrayResult(); // array of partially loaded CmsUser and CmsArticle fields
```

Todo:
* [x] Test for the partial hydration exception with object hydration mode
* [x] Test for UnitOfWork::createEntity with partial keyword usage.
* [x] Actual test for array hydrator partial usage

Related:
* #11366 
* #8471 