### PR TITLE
Create postGenerateComparisonSchema event

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -1003,8 +1003,8 @@ postGenerateSchema
 ~~~~~~~~~~~~~~~~~~
 
 This event is fired after the schema instance was successfully built and before SQL queries are generated from the
-schema information of ``Doctrine\DBAL\Schema\Schema``. It allows to access the full object representation of the database schema
-and the EntityManager.
+schema information of ``Doctrine\DBAL\Schema\Schema``. It allows to access the full object representation of the schema
+and the EntityManager as mapped by the metadata attributes.
 
 .. code-block:: php
 
@@ -1019,6 +1019,32 @@ and the EntityManager.
     class TestEventListener
     {
         public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs)
+        {
+            $schema = $eventArgs->getSchema();
+            $em = $eventArgs->getEntityManager();
+        }
+    }
+
+postGenerateComparisonSchema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This event is fired after the schema instance was successfully built and before SQL queries are generated from the
+schema information of ``Doctrine\DBAL\Schema\Schema``. It allows to access the full object representation of the schema
+as it is introspected from the database platform.
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Tools\ToolEvents;
+    use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+    $test = new TestEventListener();
+    $evm = $em->getEventManager();
+    $evm->addEventListener(ToolEvents::postGenerateComparisonSchema, $test);
+
+    class TestEventListener
+    {
+        public function postGenerateComparisonSchema(GenerateSchemaEventArgs $eventArgs)
         {
             $schema = $eventArgs->getSchema();
             $em = $eventArgs->getEntityManager();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -40,10 +40,6 @@ parameters:
             message: '~^Parameter #1 \$command of method Symfony\\Component\\Console\\Application::add\(\) expects Symfony\\Component\\Console\\Command\\Command, Doctrine\\DBAL\\Tools\\Console\\Command\\ReservedWordsCommand given\.$~'
             path: src/Tools/Console/ConsoleRunner.php
 
-        -
-            message: '~Strict comparison using \=\=\= between callable\(\)\: mixed and null will always evaluate to false\.~'
-            path: src/Tools/SchemaTool.php
-
         # To be removed in 4.0
         -
             message: '#Negated boolean expression is always false\.#'

--- a/src/Tools/ToolEvents.php
+++ b/src/Tools/ToolEvents.php
@@ -20,4 +20,11 @@ class ToolEvents
      * The EventArgs contain the EntityManager and the created Schema instance.
      */
     public const postGenerateSchema = 'postGenerateSchema';
+
+    /**
+     * The postGenerateComparisonSchema event is triggered in SchemaTool#createSchemaForComparison()
+     * after a schema is generated from the current database state.
+     * The EventArgs contain the EntityManager and the created Schema instance.
+     */
+    public const postGenerateComparisonSchema = 'postGenerateComparisonSchema';
 }


### PR DESCRIPTION
Schemas generated from metadata cause the event `ToolEvents::postGenerateSchema` to be triggered in the method `SchemaTool::getSchemaFromMetadata`. It would be helpful to do the same for schemas generated for comparison in `SchemaTool::createSchemaForComparison`. This PR introduces the new event `ToolEvents::postGenerateComparisonSchema`. 

PR relates to an attempt to fix doctrine/migrations#1406. It is a requirement of doctrine/migrations#1418 and doctrine/DoctrineMigrationsBundle#529.