### PR TITLE
Improve lazy ghost performance by avoiding self-referencing closure

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1492,6 +1492,7 @@
       <code><![CDATA[getValue]]></code>
       <code><![CDATA[setAccessible]]></code>
       <code><![CDATA[setValue]]></code>
+      <code><![CDATA[setValue]]></code>
     </PossiblyNullReference>
     <TypeDoesNotContainType>
       <code><![CDATA[$autoGenerate < 0]]></code>
@@ -1501,13 +1502,8 @@
       <code><![CDATA[__wakeup]]></code>
     </UndefinedInterfaceMethod>
     <UndefinedMethod>
-      <code><![CDATA[self::createLazyGhost(static function (InternalProxy $object) use ($initializer, &$proxy): void {
-                $initializer($object, $proxy);
-            }, $skippedProperties)]]></code>
+      <code><![CDATA[self::createLazyGhost($initializer, $skippedProperties)]]></code>
     </UndefinedMethod>
-    <UndefinedVariable>
-      <code><![CDATA[$proxy]]></code>
-    </UndefinedVariable>
     <UnresolvableInclude>
       <code><![CDATA[require $fileName]]></code>
     </UnresolvableInclude>

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -65,7 +65,7 @@ class ProxyFactoryTest extends OrmTestCase
     {
         $identifier = ['id' => 42];
         $proxyClass = 'Proxies\__CG__\Doctrine\Tests\Models\ECommerce\ECommerceFeature';
-        $persister  = $this->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['load'])
+        $persister  = $this->getMockBuilderWithOnlyMethods(BasicEntityPersister::class, ['loadById'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -75,8 +75,8 @@ class ProxyFactoryTest extends OrmTestCase
 
         $persister
             ->expects(self::atLeastOnce())
-            ->method('load')
-            ->with(self::equalTo($identifier), self::isInstanceOf($proxyClass))
+            ->method('loadById')
+            ->with(self::equalTo($identifier))
             ->will(self::returnValue($proxy));
 
         $proxy->getDescription();


### PR DESCRIPTION
This is based on @nicolas-grekas work in https://github.com/doctrine/orm/issues/11087#issuecomment-1994002826

It refactors the lazy initializer to avoid the self-referencing closure, which caused memory problems and pressure on garbage collection.