### PR TITLE
Remove older versions from the docs

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -94,42 +94,6 @@
             "branchName": "2.10.x",
             "slug": "2.10",
             "maintained": false
-        },
-        {
-            "name": "2.9",
-            "branchName": "2.9.x",
-            "slug": "2.9",
-            "maintained": false
-        },
-        {
-            "name": "2.8",
-            "branchName": "2.8.x",
-            "slug": "2.8",
-            "maintained": false
-        },
-        {
-            "name": "2.7",
-            "branchName": "2.7",
-            "slug": "2.7",
-            "maintained": false
-        },
-        {
-            "name": "2.6",
-            "branchName": "2.6",
-            "slug": "2.6",
-            "maintained": false
-        },
-        {
-            "name": "2.5",
-            "branchName": "2.5",
-            "slug": "2.5",
-            "maintained": false
-        },
-        {
-            "name": "2.4",
-            "branchName": "2.4",
-            "slug": "2.4",
-            "maintained": false
         }
     ]
 }


### PR DESCRIPTION
The Algolia indexes and records are currently above 90%. A quick way to reduce the amount is to drop older versions from the docs of ORM that are unmaintained for a long time. This PR will drop all versions < 2.10 from the docs.