### PR TITLE
Fix psalm errors: remove override of template type

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -462,9 +462,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Internal/Hydration/ObjectHydrator.php">
-    <InvalidArgument>
-      <code><![CDATA[$element]]></code>
-    </InvalidArgument>
     <PossiblyFalseArgument>
       <code><![CDATA[$index]]></code>
     </PossiblyFalseArgument>

--- a/src/LazyCriteriaCollection.php
+++ b/src/LazyCriteriaCollection.php
@@ -76,11 +76,11 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
     }
 
     /**
-     * {@inheritDoc}
-     *
      * Do an optimized search of an element
      *
-     * @template TMaybeContained
+     * @param mixed $element The element to search for.
+     *
+     * @return bool TRUE if the collection contains $element, FALSE otherwise.
      */
     public function contains($element)
     {

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -412,11 +412,6 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         return parent::containsKey($key);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @template TMaybeContained
-     */
     public function contains($element): bool
     {
         if (! $this->initialized && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {


### PR DESCRIPTION
See https://github.com/doctrine/collections/issues/368 for the same issue in doctrine/collections which has been fixed there.

The issue happened when using ->contains(). Running psalm emitted

  > InvalidArgument - Argument 1 of Doctrine\ORM\PersistentCollection::contains
  > expects
  > TMaybeContained:fn-doctrine\common\collections\readablecollection::contains
  > as mixed, but … provided.

We should either not define @template TMaybeContained or re-define the psalm docblock from ReadableCollection completely.

Repairing the docblock necessitates an update to the psalm baseline: one "known issue" is no longer an issue and could thus be removed.