### PR TITLE
Fix eager fetch composite foreign key

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -61,6 +61,7 @@ use function array_merge;
 use function array_sum;
 use function array_values;
 use function assert;
+use function count;
 use function current;
 use function func_get_arg;
 use function func_num_args;
@@ -3162,8 +3163,10 @@ EXCEPTION
                     $reflField->setValue($entity, $pColl);
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
-                        $isIteration = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];
-                        if ($assoc['type'] === ClassMetadata::ONE_TO_MANY && ! $isIteration && ! $targetClass->isIdentifierComposite && ! isset($assoc['indexBy'])) {
+                        $isIteration           = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];
+                        $isForeignKeyComposite = count($targetClass->getAssociationMapping($assoc['mappedBy'])['joinColumns']) > 1;
+
+                        if ($assoc['type'] === ClassMetadata::ONE_TO_MANY && ! $isIteration && ! $isForeignKeyComposite && ! isset($assoc['indexBy'])) {
                             $this->scheduleCollectionForBatchLoading($pColl, $class);
                         } else {
                             $this->loadCollection($pColl);

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3164,7 +3164,7 @@ EXCEPTION
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
                         $isIteration           = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];
-                        $isForeignKeyComposite = count($targetClass->getAssociationMapping($assoc['mappedBy'])['joinColumns']) > 1;
+                        $isForeignKeyComposite = $targetClass->hasAssociation($assoc['mappedBy']) && count($targetClass->getAssociationMapping($assoc['mappedBy'])['joinColumns'] ?? []) > 1;
 
                         if ($assoc['type'] === ClassMetadata::ONE_TO_MANY && ! $isIteration && ! $isForeignKeyComposite && ! isset($assoc['indexBy'])) {
                             $this->scheduleCollectionForBatchLoading($pColl, $class);

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/RootEntity.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/RootEntity.php
@@ -37,11 +37,19 @@ class RootEntity
      */
     private $secondLevel;
 
+    /**
+     * @ORM\OneToMany(mappedBy="root", targetEntity=SecondLevelWithoutCompositePrimaryKey::class, fetch="EAGER")
+     *
+     * @var Collection<int, SecondLevelWithoutCompositePrimaryKey>
+     */
+    private $anotherSecondLevel;
+
     public function __construct(int $id, string $other)
     {
-        $this->otherKey    = $other;
-        $this->secondLevel = new ArrayCollection();
-        $this->id          = $id;
+        $this->otherKey           = $other;
+        $this->secondLevel        = new ArrayCollection();
+        $this->anotherSecondLevel = new ArrayCollection();
+        $this->id                 = $id;
     }
 
     public function getId(): ?int

--- a/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevelWithoutCompositePrimaryKey.php
+++ b/tests/Tests/Models/EagerFetchedCompositeOneToMany/SecondLevelWithoutCompositePrimaryKey.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\EagerFetchedCompositeOneToMany;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class SecondLevelWithoutCompositePrimaryKey
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer", nullable=false)
+     *
+     * @var int|null
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=RootEntity::class, inversedBy="anotherSecondLevel")
+     * @ORM\JoinColumns({
+     *      @ORM\JoinColumn(name="root_id", referencedColumnName="id"),
+     *      @ORM\JoinColumn(name="root_other_key", referencedColumnName="other_key")
+     *  })
+     *
+     * @var RootEntity
+     */
+    private $root;
+
+    public function __construct(RootEntity $upper)
+    {
+        $this->root = $upper;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
+++ b/tests/Tests/ORM/Functional/EagerFetchOneToManyWithCompositeKeyTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\RootEntity;
 use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\SecondLevel;
+use Doctrine\Tests\Models\EagerFetchedCompositeOneToMany\SecondLevelWithoutCompositePrimaryKey;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 final class EagerFetchOneToManyWithCompositeKeyTest extends OrmFunctionalTestCase
@@ -13,7 +14,7 @@ final class EagerFetchOneToManyWithCompositeKeyTest extends OrmFunctionalTestCas
     /** @ticket 11154 */
     public function testItDoesNotThrowAnExceptionWhenTriggeringALoad(): void
     {
-        $this->setUpEntitySchema([RootEntity::class, SecondLevel::class]);
+        $this->setUpEntitySchema([RootEntity::class, SecondLevel::class, SecondLevelWithoutCompositePrimaryKey::class]);
 
         $a1 = new RootEntity(1, 'A');
 


### PR DESCRIPTION
I think https://github.com/doctrine/orm/pull/11289 did not completely fix problem for eager fetch.
Change in that PR checked if primary key of target class is composite but that does not matter when loading collection by foreign key.
It should check if foreign key on target class is composite.

Fix from that PR did not work for me because i had entity with regular autogenerated id (single column), but foreign key referenced entity with composite primary key, like `SecondLevelWithoutCompositePrimaryKey` in this PR.

Checking if foreign key is composite fixed the problem for me.