### PR TITLE
SchemaValidator: Changing mapping of BIGINT to string|int

### DIFF
--- a/src/Tools/SchemaValidator.php
+++ b/src/Tools/SchemaValidator.php
@@ -39,6 +39,7 @@ use function implode;
 use function in_array;
 use function interface_exists;
 use function is_a;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -49,11 +50,29 @@ use function sprintf;
 class SchemaValidator
 {
     /**
-     * It maps built-in Doctrine types to PHP types
+     * Map built-in Doctrine DBAL 3 types to PHP types
+     */
+    private const BUILTIN_TYPES_MAP_DBAL3 = [
+        AsciiStringType::class => 'string',
+        BigIntType::class => 'string',
+        BooleanType::class => 'bool',
+        DecimalType::class => 'string',
+        FloatType::class => 'float',
+        GuidType::class => 'string',
+        IntegerType::class => 'int',
+        JsonType::class => 'array',
+        SimpleArrayType::class => 'array',
+        SmallIntType::class => 'int',
+        StringType::class => 'string',
+        TextType::class => 'string',
+    ];
+
+    /**
+     * Map built-in Doctrine DBAL 4+ types to PHP types
      */
     private const BUILTIN_TYPES_MAP = [
         AsciiStringType::class => 'string',
-        BigIntType::class => 'string',
+        BigIntType::class => 'string|int',
         BooleanType::class => 'bool',
         DecimalType::class => 'string',
         FloatType::class => 'float',
@@ -436,6 +455,10 @@ class SchemaValidator
     {
         $typeName = $type::class;
 
-        return self::BUILTIN_TYPES_MAP[$typeName] ?? null;
+        if (method_exists(BigIntType::class, 'getName')) { // DBAL 3
+            return self::BUILTIN_TYPES_MAP_DBAL3[$typeName] ?? null;
+        } else { // DBAL 4+
+            return self::BUILTIN_TYPES_MAP[$typeName] ?? null;
+        }
     }
 }

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\BigIntType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -29,6 +31,8 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+
+use function method_exists;
 
 class SchemaValidatorTest extends OrmTestCase
 {
@@ -227,6 +231,47 @@ class SchemaValidatorTest extends OrmTestCase
             ["The target entity 'Doctrine\Tests\ORM\Tools\InvalidMappedSuperClass' specified on Doctrine\Tests\ORM\Tools\InvalidMappedSuperClass#selfWhatever is a mapped superclass. This is not possible since there is no table that a foreign key could refer to."],
             $ce,
         );
+    }
+
+    public function testBigintMappedToStringInt(): void
+    {
+        $class = $this->em->getClassMetadata(BigintMappedToStringInt::class);
+        $ce    = $this->validator->validateClass($class);
+
+        $this->assertEquals([], $ce); // Same for DBAL 3 and 4+
+    }
+
+    public function testBigintMappedToInt(): void
+    {
+        $class = $this->em->getClassMetadata(BigintMappedToInt::class);
+        $ce    = $this->validator->validateClass($class);
+
+        if (method_exists(BigIntType::class, 'getName')) { // DBAL 3
+            $this->assertEquals(
+                ["The field 'Doctrine\Tests\ORM\Tools\BigintMappedToInt#bigint' has the property type 'int' that differs from the metadata field type 'string' returned by the 'bigint' DBAL type."],
+                $ce,
+            );
+        } else { // DBAL 4+
+            $this->assertEquals(
+                ["The field 'Doctrine\Tests\ORM\Tools\BigintMappedToInt#bigint' has the property type 'int' that differs from the metadata field type 'string|int' returned by the 'bigint' DBAL type."],
+                $ce,
+            );
+        }
+    }
+
+    public function testBigintMappedToString(): void
+    {
+        $class = $this->em->getClassMetadata(BigintMappedToString::class);
+        $ce    = $this->validator->validateClass($class);
+
+        if (method_exists(BigIntType::class, 'getName')) { // DBAL 3
+            $this->assertEquals([], $ce);
+        } else { // DBAL 4+
+            $this->assertEquals(
+                ["The field 'Doctrine\Tests\ORM\Tools\BigintMappedToString#bigint' has the property type 'string' that differs from the metadata field type 'string|int' returned by the 'bigint' DBAL type."],
+                $ce,
+            );
+        }
     }
 }
 
@@ -546,4 +591,40 @@ class InvalidMappedSuperClass
     /** @psalm-var Collection<int, self> */
     #[ManyToMany(targetEntity: 'InvalidMappedSuperClass', mappedBy: 'invalid')]
     private $selfWhatever;
+}
+
+#[Entity]
+class BigintMappedToStringInt
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    private int $id;
+
+    #[Column(type: Types::BIGINT)]
+    private string|int $bigint;
+}
+
+#[Entity]
+class BigintMappedToInt
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    private int $id;
+
+    #[Column(type: Types::BIGINT)]
+    private int $bigint;
+}
+
+#[Entity]
+class BigintMappedToString
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    private int $id;
+
+    #[Column(type: Types::BIGINT)]
+    private string $bigint;
 }


### PR DESCRIPTION
Closes https://github.com/doctrine/orm/issues/11377
Follow-up of https://github.com/doctrine/orm/pull/11396

I just copied the `const`, so it can be deleted again easily, once DBAL 3 is no longer supported.

* How can I check DBAL 3 in the test?
* Besides that, is the test enough or should I test more scenarios (positive *and* negative)?