### PR TITLE
Psalmify QueryBuilder, Query and EntityRepository.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -201,7 +201,7 @@ parameters:
 			path: src/Proxy/ProxyFactory.php
 
 		-
-			message: "#^Parameter \\#2 \\$sqlParams of method Doctrine\\\\ORM\\\\Query\\:\\:evictResultSetCache\\(\\) expects array\\<string, mixed\\>, array\\<int, mixed\\> given\\.$#"
+			message: "#^Parameter \\#2 \\$sqlParams of method Doctrine\\\\ORM\\\\Query<T>\\:\\:evictResultSetCache\\(\\) expects array\\<string, mixed\\>, array\\<int, mixed\\> given\\.$#"
 			count: 1
 			path: src/Query.php
 
@@ -271,7 +271,7 @@ parameters:
 			path: src/Query/SqlWalker.php
 
 		-
-			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, non\\-empty\\-array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
+			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder<T>\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, non\\-empty\\-array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
 			count: 2
 			path: src/QueryBuilder.php
 

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -44,6 +44,8 @@ use function sha1;
  * Base contract for ORM queries. Base class for Query and NativeQuery.
  *
  * @link    www.doctrine-project.org
+ *
+ * @template T
  */
 abstract class AbstractQuery
 {
@@ -683,6 +685,12 @@ abstract class AbstractQuery
      * Alias for execute(null, $hydrationMode = HYDRATE_OBJECT).
      *
      * @psalm-param string|AbstractQuery::HYDRATE_* $hydrationMode
+     *
+     * @psalm-return (
+     *    $hydrationMode is self::HYDRATE_OBJECT|null
+     *    ? array<array-key, T>
+     *    : mixed
+     * )
      */
     public function getResult(string|int $hydrationMode = self::HYDRATE_OBJECT): mixed
     {
@@ -730,6 +738,12 @@ abstract class AbstractQuery
      *
      * @psalm-param string|AbstractQuery::HYDRATE_*|null $hydrationMode
      *
+     * @psalm-return (
+     *    $hydrationMode is self::HYDRATE_OBJECT|null
+     *    ? null|T
+     *    : mixed
+     * )
+     *
      * @throws NonUniqueResultException
      */
     public function getOneOrNullResult(string|int|null $hydrationMode = null): mixed
@@ -764,6 +778,12 @@ abstract class AbstractQuery
      * If there is no result, a NoResultException is thrown.
      *
      * @psalm-param string|AbstractQuery::HYDRATE_*|null $hydrationMode
+     *
+     * @psalm-return (
+     *    $hydrationMode is self::HYDRATE_OBJECT|null
+     *    ? T
+     *    : mixed
+     * )
      *
      * @throws NonUniqueResultException If the query result is not unique.
      * @throws NoResultException        If the query returned no result.

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -740,7 +740,7 @@ abstract class AbstractQuery
      *
      * @psalm-return (
      *    $hydrationMode is self::HYDRATE_OBJECT|null
-     *    ? null|T
+     *    ? T|null
      *    : mixed
      * )
      *

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -49,6 +49,8 @@ class EntityRepository implements ObjectRepository, Selectable
 
     /**
      * Creates a new QueryBuilder instance that is prepopulated for this entity name.
+     *
+     * @return QueryBuilder<T>
      */
     public function createQueryBuilder(string $alias, string|null $indexBy = null): QueryBuilder
     {

--- a/src/NativeQuery.php
+++ b/src/NativeQuery.php
@@ -16,6 +16,7 @@ use function ksort;
  * Represents a native SQL query.
  *
  * @final
+ * @extends AbstractQuery<mixed>
  */
 class NativeQuery extends AbstractQuery
 {

--- a/src/Query.php
+++ b/src/Query.php
@@ -39,7 +39,6 @@ use function stripos;
  *
  * @template T
  * @extends AbstractQuery<T>
- *
  * @final
  */
 class Query extends AbstractQuery

--- a/src/Query.php
+++ b/src/Query.php
@@ -37,6 +37,9 @@ use function stripos;
 /**
  * A Query object represents a DQL query.
  *
+ * @template T
+ * @extends AbstractQuery<T>
+ *
  * @final
  */
 class Query extends AbstractQuery

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -38,6 +38,8 @@ use function substr;
 /**
  * This class is responsible for building DQL query strings via an object oriented
  * PHP interface.
+ *
+ * @template T
  */
 class QueryBuilder implements Stringable
 {
@@ -251,6 +253,8 @@ class QueryBuilder implements Stringable
      *     $q = $qb->getQuery();
      *     $results = $q->execute();
      * </code>
+     *
+     * @psalm-return Query<T>
      */
     public function getQuery(): Query
     {
@@ -613,6 +617,9 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @psalm-this-out self<mixed>
+     * @psalm-return self<mixed>
      */
     public function select(mixed ...$select): static
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -617,9 +617,11 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     * @psalm-return static<mixed>
+     * @phpstan-return $this<mixed>
      *
-     * @psalm-this-out self<mixed>
-     * @psalm-return self<mixed>
+     * @psalm-this-out static<mixed>
+     * @phpstan-this-out $this<mixed>
      */
     public function select(mixed ...$select): static
     {

--- a/tests/StaticAnalysis/query-builder.php
+++ b/tests/StaticAnalysis/query-builder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM;
+
+class Cat
+{
+}
+
+/** @extends EntityRepository<Cat> */
+class CatRepository extends EntityRepository
+{
+}
+
+/** @return array<array-key, Cat> */
+function getResultAsEntities(CatRepository $catRepository): array
+{
+    return $catRepository->createQueryBuilder('c')->getQuery()->getResult();
+}
+
+function getOneOrNullEntity(CatRepository $catRepository): Cat|null
+{
+    return $catRepository->createQueryBuilder('c')->getQuery()->getOneOrNullResult();
+}
+
+function getSingleEntity(CatRepository $catRepository): Cat
+{
+    return $catRepository->createQueryBuilder('c')->getQuery()->getSingleResult();
+}
+
+/**
+ * Once QueryBuilder::select is called, all results will be mixed. User must manually assert returned type.
+ *
+ * @see QueryBuilder::select()
+ */
+function getMixedResults(CatRepository $catRepository): mixed
+{
+    return $catRepository->createQueryBuilder('c')
+        ->select('c.id')
+        ->getQuery()->getResult();
+}
+
+function getMixedOrNullResult(CatRepository $catRepository): mixed
+{
+    return $catRepository->createQueryBuilder('c')
+        ->select('c.id')
+        ->getQuery()->getOneOrNullResult();
+}
+
+function getMixedResult(CatRepository $catRepository): mixed
+{
+    return $catRepository->createQueryBuilder('c')
+        ->select('c.id')
+        ->getQuery()->getSingleResult();
+}


### PR DESCRIPTION
Added templates for QueryBuilder, Query and EntityRepository. 

---

With repository defined like:

```php
/** 
 * @extends EntityRepository<Product> 
 */
class ProductRepository extends EntityRepository{}
```
Using it:

```php
$qb = $productRepository->createQueryBuilder('p'); // QueryBuilder<Product>
$query = $qb->getQuery(); // Query<Product>

$query->getResults(); // array<array-key, Product>
$query->getOneOrNullResult(); // Product|null
$query->getSingleResult(); // Product
```

If at any point user makes a call to `QueryBuilder::select`, it will be converted to `mixed` via `@psalm-this-out self<mixed>`. For example:

```php
$qb = $productRepository->createQueryBuilder('p'); // QueryBuilder<Product>
$qb->select('p.name'); // QueryBuilder<mixed>
$query = $qb->getQuery(); // Query<mixed>

$query->getResults(); // mixed
```

---

The reasoning is that almost all queries are done with object hydration and this would help in later processing. Custom `select` will break out of static analysis and it is up to user to [assert](https://github.com/webmozarts/assert) returned results.