### PR TITLE
Fix fromMappingArray definition

### DIFF
--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -20,10 +20,6 @@ parameters:
             message: '~^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getArrayBindingType\(\) never returns .* so it can be removed from the return type\.$~'
             path: src/Persisters/Entity/BasicEntityPersister.php
 
-        -
-            message: '~^Unreachable statement \- code above always terminates\.$~'
-            path: src/Mapping/AssociationMapping.php
-
         - '~^Class Doctrine\\DBAL\\Platforms\\SQLitePlatform not found\.$~'
 
         # To be removed in 4.0

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,10 +20,6 @@ parameters:
             message: '~^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getArrayBindingType\(\) never returns .* so it can be removed from the return type\.$~'
             path: src/Persisters/Entity/BasicEntityPersister.php
 
-        -
-            message: '~^Unreachable statement \- code above always terminates\.$~'
-            path: src/Mapping/AssociationMapping.php
-
         # Compatibility with DBAL 3
         # See https://github.com/doctrine/dbal/pull/3480
         -

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -302,6 +302,10 @@
       <code><![CDATA[$mapping]]></code>
       <code><![CDATA[$mapping]]></code>
       <code><![CDATA[$mapping]]></code>
+      <code><![CDATA[$mapping]]></code>
+      <code><![CDATA[$mapping]]></code>
+      <code><![CDATA[$mapping]]></code>
+      <code><![CDATA[$mapping]]></code>
       <code><![CDATA[$overrideMapping]]></code>
     </InvalidArgument>
     <InvalidNullableReturnType>

--- a/src/Mapping/AssociationMapping.php
+++ b/src/Mapping/AssociationMapping.php
@@ -27,7 +27,7 @@ abstract class AssociationMapping implements ArrayAccess
     /**
      * The fetching strategy to use for the association, usually defaults to FETCH_LAZY.
      *
-     * @var ClassMetadata::FETCH_*
+     * @var ClassMetadata::FETCH_*|null
      */
     public int|null $fetch = null;
 
@@ -96,13 +96,26 @@ abstract class AssociationMapping implements ArrayAccess
     }
 
     /**
+     * @param mixed[] $mappingArray
      * @psalm-param array{
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
      *     joinTable?: mixed[]|null,
      *     type?: int,
-     *     isOwningSide: bool, ...} $mappingArray
+     *     isOwningSide: bool,
+     * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): static
     {

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -1152,7 +1152,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     fieldName?: string,
      *     columnName?: string,
      *     id?: bool,
-     *     generated?: int,
+     *     generated?: self::GENERATED_*,
      *     enumType?: class-string,
      * } $mapping The field mapping to validate & complete.
      *

--- a/src/Mapping/EmbeddedClassMapping.php
+++ b/src/Mapping/EmbeddedClassMapping.php
@@ -49,10 +49,12 @@ final class EmbeddedClassMapping implements ArrayAccess
 
     /**
      * @psalm-param array{
-     *    class: class-string,
-     *    columnPrefix?: false|string|null,
-     *    declaredField?: string|null,
-     *    originalField?: string|null
+     *     class: class-string,
+     *     columnPrefix?: false|string|null,
+     *     declaredField?: string|null,
+     *     originalField?: string|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
      * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): self

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -26,7 +26,7 @@ final class FieldMapping implements ArrayAccess
     public bool|null $notInsertable      = null;
     public bool|null $notUpdatable       = null;
     public string|null $columnDefinition = null;
-    /** @psalm-var ClassMetadata::GENERATED_* */
+    /** @psalm-var ClassMetadata::GENERATED_*|null */
     public int|null $generated = null;
     /** @var class-string<BackedEnum>|null */
     public string|null $enumType = null;
@@ -83,7 +83,34 @@ final class FieldMapping implements ArrayAccess
     ) {
     }
 
-    /** @param array{type: string, fieldName: string, columnName: string} $mappingArray */
+    /**
+     * @param array<string, mixed> $mappingArray
+     * @psalm-param array{
+     *     type: string,
+     *     fieldName: string,
+     *     columnName: string,
+     *     length?: int|null,
+     *     id?: bool|null,
+     *     nullable?: bool|null,
+     *     notInsertable?: bool|null,
+     *     notUpdatable?: bool|null,
+     *     columnDefinition?: string|null,
+     *     generated?: ClassMetadata::GENERATED_*|null,
+     *     enumType?: string|null,
+     *     precision?: int|null,
+     *     scale?: int|null,
+     *     unique?: bool|null,
+     *     inherited?: string|null,
+     *     originalClass?: string|null,
+     *     originalField?: string|null,
+     *     quoted?: bool|null,
+     *     declared?: string|null,
+     *     declaredField?: string|null,
+     *     options?: array<string, mixed>|null,
+     *     version?: bool|null,
+     *     default?: string|int|null,
+     * } $mappingArray
+     */
     public static function fromMappingArray(array $mappingArray): self
     {
         $mapping = new self(

--- a/src/Mapping/JoinColumnMapping.php
+++ b/src/Mapping/JoinColumnMapping.php
@@ -31,7 +31,17 @@ final class JoinColumnMapping implements ArrayAccess
 
     /**
      * @param array<string, mixed> $mappingArray
-     * @psalm-param array{name: string, referencedColumnName: string, ...} $mappingArray
+     * @psalm-param array{
+     *     name: string,
+     *     referencedColumnName: string,
+     *     unique?: bool|null,
+     *     quoted?: bool|null,
+     *     fieldName?: string|null,
+     *     onDelete?: string|null,
+     *     columnDefinition?: string|null,
+     *     nullable?: bool|null,
+     *     options?: array<string, mixed>|null,
+     * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): self
     {

--- a/src/Mapping/JoinTableMapping.php
+++ b/src/Mapping/JoinTableMapping.php
@@ -35,10 +35,10 @@ final class JoinTableMapping implements ArrayAccess
      * @param mixed[] $mappingArray
      * @psalm-param array{
      *    name: string,
-     *    quoted?: bool,
+     *    quoted?: bool|null,
      *    joinColumns?: mixed[],
      *    inverseJoinColumns?: mixed[],
-     *    schema?: string,
+     *    schema?: string|null,
      *    options?: array<string, mixed>
      * } $mappingArray
      */

--- a/src/Mapping/ManyToManyOwningSideMapping.php
+++ b/src/Mapping/ManyToManyOwningSideMapping.php
@@ -41,9 +41,21 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
      *     joinTable?: mixed[]|null,
      *     type?: int,
-     *     isOwningSide: bool, ...} $mappingArray
+     *     isOwningSide: bool,
+     * } $mappingArray
      */
     public static function fromMappingArrayAndNamingStrategy(array $mappingArray, NamingStrategy $namingStrategy): self
     {

--- a/src/Mapping/OneToManyAssociationMapping.php
+++ b/src/Mapping/OneToManyAssociationMapping.php
@@ -12,9 +12,21 @@ final class OneToManyAssociationMapping extends ToManyInverseSideMapping
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
      *     joinTable?: mixed[]|null,
      *     type?: int,
-     *     isOwningSide: bool, ...} $mappingArray
+     *     isOwningSide: bool,
+     * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): static
     {
@@ -33,9 +45,21 @@ final class OneToManyAssociationMapping extends ToManyInverseSideMapping
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
      *     joinTable?: mixed[]|null,
      *     type?: int,
-     *     isOwningSide: bool, ...} $mappingArray
+     *     isOwningSide: bool,
+     * } $mappingArray
      */
     public static function fromMappingArrayAndName(array $mappingArray, string $name): static
     {

--- a/src/Mapping/ToOneInverseSideMapping.php
+++ b/src/Mapping/ToOneInverseSideMapping.php
@@ -13,8 +13,21 @@ abstract class ToOneInverseSideMapping extends InverseSideMapping
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
+     *     joinTable?: mixed[]|null,
+     *     type?: int,
      *     isOwningSide: bool,
-     *     } $mappingArray
+     * } $mappingArray
      */
     public static function fromMappingArrayAndName(
         array $mappingArray,

--- a/src/Mapping/ToOneOwningSideMapping.php
+++ b/src/Mapping/ToOneOwningSideMapping.php
@@ -31,8 +31,22 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
+     *     joinTable?: mixed[]|null,
+     *     type?: int,
+     *     isOwningSide: bool,
      *     joinColumns?: mixed[]|null,
-     *     isOwningSide: bool, ...} $mappingArray
+     * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): static
     {
@@ -64,8 +78,22 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
      *     fieldName: string,
      *     sourceEntity: class-string,
      *     targetEntity: class-string,
+     *     cascade?: list<'persist'|'remove'|'detach'|'refresh'|'all'>,
+     *     fetch?: ClassMetadata::FETCH_*|null,
+     *     inherited?: class-string|null,
+     *     declared?: class-string|null,
+     *     cache?: array<mixed>|null,
+     *     id?: bool|null,
+     *     isOnDeleteCascade?: bool|null,
+     *     originalClass?: class-string|null,
+     *     originalField?: string|null,
+     *     orphanRemoval?: bool,
+     *     unique?: bool|null,
+     *     joinTable?: mixed[]|null,
+     *     type?: int,
+     *     isOwningSide: bool,
      *     joinColumns?: mixed[]|null,
-     *     isOwningSide: bool, ...} $mappingArray
+     * } $mappingArray
      */
     public static function fromMappingArrayAndName(
         array $mappingArray,


### PR DESCRIPTION
Hi,

Kinda similar to https://github.com/doctrine/orm/pull/11226 @greg0ire @derrabus 

I got a psalm error because `FieldMapping::fromMappingArray` does not accept `nullable` key.
This was because the array param was missing lot of keys.

I tried to fix the phpdoc of every fromMappingArray keys by looking at all the property of the class and allow them as array keys in the `$mappingArray` parameter.

Thanks.