### PR TITLE
Inherits index from MappedSuperclass

### DIFF
--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -40,6 +40,7 @@ use function explode;
 use function get_class;
 use function in_array;
 use function is_a;
+use function is_numeric;
 use function is_subclass_of;
 use function str_contains;
 use function strlen;
@@ -541,7 +542,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         foreach (['uniqueConstraints', 'indexes'] as $indexType) {
             if (isset($parentClass->table[$indexType])) {
                 foreach ($parentClass->table[$indexType] as $indexName => $index) {
-                    if (\is_numeric($indexName)) {
+                    if (is_numeric($indexName)) {
                         // Always add indices without a name
                         $subClass->table[$indexType][] = $index;
 

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -541,6 +541,13 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         foreach (['uniqueConstraints', 'indexes'] as $indexType) {
             if (isset($parentClass->table[$indexType])) {
                 foreach ($parentClass->table[$indexType] as $indexName => $index) {
+                    if (\is_numeric($indexName)) {
+                        // Always add indices without a name
+                        $subClass->table[$indexType][] = $index;
+
+                        continue;
+                    }
+
                     if (isset($subClass->table[$indexType][$indexName])) {
                         continue; // Let the inheriting table override indices
                     }

--- a/tests/Tests/Models/InheritsIndexFromMappedSuperclass/Cat.php
+++ b/tests/Tests/Models/InheritsIndexFromMappedSuperclass/Cat.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\InheritsIndexFromMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="cats",indexes={@Index(columns={"lives"}), @Index(name="composite_idx", columns={"name", "label", "lives"})})
+ */
+class Cat extends Pet
+{
+    /**
+     * @var int
+     * @Column(type="integer")
+     */
+    public $lives;
+}

--- a/tests/Tests/Models/InheritsIndexFromMappedSuperclass/Pet.php
+++ b/tests/Tests/Models/InheritsIndexFromMappedSuperclass/Pet.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\InheritsIndexFromMappedSuperclass;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @MappedSuperclass
+ * @Table(indexes={@Index(columns={"name"}), @Index(name="composite_idx", columns={"name", "label"})})
+ */
+abstract class Pet
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $label;
+}

--- a/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -36,6 +36,7 @@ use Doctrine\Tests\Mocks\MetadataDriverMock;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\DDC4006\DDC4006User;
+use Doctrine\Tests\Models\InheritsIndexFromMappedSuperclass\Cat;
 use Doctrine\Tests\Models\JoinedInheritanceType\AnotherChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\RootClass;
@@ -520,6 +521,21 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $userMetadata = $cmf->getMetadataFor(DDC4006User::class);
 
         self::assertTrue($userMetadata->isIdGeneratorIdentity());
+    }
+
+    public function testInheritsIndexFromMappedSuperclass(): void
+    {
+        $cmf    = new ClassMetadataFactory();
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/InheritsIndexFromMappedSuperclass/']);
+        $em     = $this->createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $userMetadata = $cmf->getMetadataFor(Cat::class);
+
+        self::assertCount(3, $userMetadata->table['indexes']);
+        self::assertSame('lives', $userMetadata->table['indexes'][0]['columns'][0]);
+        self::assertSame(['name', 'label', 'lives'], $userMetadata->table['indexes']['composite_idx']['columns']);
+        self::assertSame('name', $userMetadata->table['indexes'][1]['columns'][0]);
     }
 
     public function testInvalidSubClassCase(): void

--- a/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -530,12 +530,12 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $em     = $this->createEntityManager($driver);
         $cmf->setEntityManager($em);
 
-        $userMetadata = $cmf->getMetadataFor(Cat::class);
+        $catMetadata = $cmf->getMetadataFor(Cat::class);
 
-        self::assertCount(3, $userMetadata->table['indexes']);
-        self::assertSame('lives', $userMetadata->table['indexes'][0]['columns'][0]);
-        self::assertSame(['name', 'label', 'lives'], $userMetadata->table['indexes']['composite_idx']['columns']);
-        self::assertSame('name', $userMetadata->table['indexes'][1]['columns'][0]);
+        self::assertCount(3, $catMetadata->table['indexes']);
+        self::assertSame('lives', $catMetadata->table['indexes'][0]['columns'][0]);
+        self::assertSame(['name', 'label', 'lives'], $catMetadata->table['indexes']['composite_idx']['columns']);
+        self::assertSame('name', $catMetadata->table['indexes'][1]['columns'][0]);
     }
 
     public function testInvalidSubClassCase(): void


### PR DESCRIPTION
When the parent table has indexes without names, they are not inherited.

Fix for https://github.com/doctrine/orm/issues/5928