### PR TITLE
Fix BIGINT validation

### DIFF
--- a/tests/Tests/Models/BigIntegers/BigIntegers.php
+++ b/tests/Tests/Models/BigIntegers/BigIntegers.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\BigIntegers;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class BigIntegers
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /** @ORM\Column(type="bigint") */
+    public int $one = 1;
+
+    /** @ORM\Column(type="bigint") */
+    public string $two = '2';
+
+    /** @ORM\Column(type="bigint") */
+    public float $three = 3.0;
+}

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Tools\SchemaValidator;
+use Doctrine\Tests\Models\BigIntegers\BigIntegers;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\OrmTestCase;
 
@@ -238,6 +239,19 @@ class SchemaValidatorTest extends OrmTestCase
         self::assertEquals(
             ["The target entity 'Doctrine\Tests\ORM\Tools\InvalidMappedSuperClass' specified on Doctrine\Tests\ORM\Tools\InvalidMappedSuperClass#selfWhatever is a mapped superclass. This is not possible since there is no table that a foreign key could refer to."],
             $ce
+        );
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testBigIntProperty(): void
+    {
+        $class = $this->em->getClassMetadata(BigIntegers::class);
+
+        self::assertSame(
+            ['The field \'Doctrine\Tests\Models\BigIntegers\BigIntegers#three\' has the property type \'float\' that differs from the metadata field type \'int|string\' returned by the \'bigint\' DBAL type.'],
+            $this->validator->validateClass($class)
         );
     }
 }


### PR DESCRIPTION
Fixes #11377.

Our schema validation currently fails if we map a `BIGINT` column to a property with an `int` PHP type. While this is technically correct because DBAL 3 hydrates `BIGINT` values as strings, the error is also unnecessarily strict:

The ORM will cast strings returned by DBAL back to `int`, if that's the property type. The value range of `BIGINT` and PHP's int (on 64bit machines) is the same. Storing `BIGINT` values as string is only necessary if we run on 32bit PHP or we deal with `BIGINT UNSIGNED` on MySQL/MariaDB. Both are edge cases a project may validly choose to ignore.

Emitting this error encourages downstream projects to change their property types of `BIGINT` columns from `int` to `string` which is unfortunate given that DBAL 4 moved towards returning integers if possible.