### PR TITLE
Discriminator value could be an integer

### DIFF
--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -30,6 +30,7 @@ use function count;
 use function implode;
 use function is_array;
 use function is_float;
+use function is_int;
 use function is_numeric;
 use function is_string;
 use function preg_match;
@@ -384,7 +385,9 @@ class SqlWalker
             $values = [];
 
             if ($class->discriminatorValue !== null) { // discriminators can be 0
-                $values[] = $conn->quote($class->discriminatorValue);
+                $values[] = $class->getDiscriminatorColumn()->type === 'integer' && is_int($class->discriminatorValue)
+                    ? $class->discriminatorValue
+                    : $conn->quote((string) $class->discriminatorValue);
             }
 
             foreach ($class->subClasses as $subclassName) {
@@ -396,7 +399,9 @@ class SqlWalker
                     continue;
                 }
 
-                $values[] = $conn->quote((string) $subclassMetadata->discriminatorValue);
+                $values[] = $subclassMetadata->getDiscriminatorColumn()->type === 'integer' && is_int($subclassMetadata->discriminatorValue)
+                    ? $subclassMetadata->discriminatorValue
+                    : $conn->quote((string) $subclassMetadata->discriminatorValue);
             }
 
             if ($values !== []) {

--- a/tests/Tests/ORM/Functional/Ticket/GH11341Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11341Test.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class GH11341Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            IntegerBaseClass::class,
+            IntegerFooEntity::class,
+            IntegerBarEntity::class,
+            StringAsIntBaseClass::class,
+            StringAsIntFooEntity::class,
+            StringAsIntBarEntity::class,
+            StringBaseClass::class,
+            StringFooEntity::class,
+            StringBarEntity::class,
+        ]);
+    }
+
+    public static function dqlStatements(): Generator
+    {
+        yield ['SELECT e FROM ' . IntegerBaseClass::class . ' e', '/WHERE [a-z]0_.type IN \(1, 2\)$/'];
+        yield ['SELECT e FROM ' . IntegerFooEntity::class . ' e', '/WHERE [a-z]0_.type IN \(1\)$/'];
+        yield ['SELECT e FROM ' . IntegerBarEntity::class . ' e', '/WHERE [a-z]0_.type IN \(2\)$/'];
+        yield ['SELECT e FROM ' . StringAsIntBaseClass::class . ' e', '/WHERE [a-z]0_.type IN \(\'1\', \'2\'\)$/'];
+        yield ['SELECT e FROM ' . StringAsIntFooEntity::class . ' e', '/WHERE [a-z]0_.type IN \(\'1\'\)$/'];
+        yield ['SELECT e FROM ' . StringAsIntBarEntity::class . ' e', '/WHERE [a-z]0_.type IN \(\'2\'\)$/'];
+        yield ['SELECT e FROM ' . StringBaseClass::class . ' e', '/WHERE [a-z]0_.type IN \(\'1\', \'2\'\)$/'];
+        yield ['SELECT e FROM ' . StringFooEntity::class . ' e', '/WHERE [a-z]0_.type IN \(\'1\'\)$/'];
+        yield ['SELECT e FROM ' . StringBarEntity::class . ' e', '/WHERE [a-z]0_.type IN \(\'2\'\)$/'];
+    }
+
+    #[DataProvider('dqlStatements')]
+    public function testDiscriminatorValue(string $dql, string $expectedDiscriminatorValues): void
+    {
+        $query = $this->_em->createQuery($dql);
+        $sql   = $query->getSQL();
+
+        self::assertMatchesRegularExpression($expectedDiscriminatorValues, $sql);
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'integer_discriminator')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'integer')]
+#[ORM\DiscriminatorMap([
+    1 => IntegerFooEntity::class,
+    2 => IntegerBarEntity::class,
+])]
+class IntegerBaseClass
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\Column(type: 'integer')]
+    private int|null $id = null;
+}
+
+#[ORM\Entity]
+class IntegerFooEntity extends IntegerBaseClass
+{
+}
+
+#[ORM\Entity]
+class IntegerBarEntity extends IntegerBaseClass
+{
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'string_as_int_discriminator')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap([
+    1 => StringAsIntFooEntity::class,
+    2 => StringAsIntBarEntity::class,
+])]
+class StringAsIntBaseClass
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\Column(type: 'integer')]
+    private int|null $id = null;
+}
+
+#[ORM\Entity]
+class StringAsIntFooEntity extends StringAsIntBaseClass
+{
+}
+
+#[ORM\Entity]
+class StringAsIntBarEntity extends StringAsIntBaseClass
+{
+}
+
+
+#[ORM\Entity]
+#[ORM\Table(name: 'string_discriminator')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap([
+    '1' => StringFooEntity::class,
+    '2' => StringBarEntity::class,
+])]
+class StringBaseClass
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\Column(type: 'integer')]
+    private int|null $id = null;
+}
+
+#[ORM\Entity]
+class StringFooEntity extends StringBaseClass
+{
+}
+
+#[ORM\Entity]
+class StringBarEntity extends StringBaseClass
+{
+}


### PR DESCRIPTION
The same as
```
399:    $values[] = $conn->quote((string) $subclassMetadata->discriminatorValue);
```

Without casting a TypeError is raised.