### PR TITLE
Prevent creation of new MANAGED entity instance by reloading REMOVED entity from database

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1292,6 +1292,8 @@ class UnitOfWork implements PropertyChangedListener
         $eventsToDispatch = [];
 
         foreach ($entities as $entity) {
+            $this->removeFromIdentityMap($entity);
+
             $oid       = spl_object_id($entity);
             $class     = $this->em->getClassMetadata(get_class($entity));
             $persister = $this->getEntityPersister($class->name);
@@ -1666,8 +1668,6 @@ class UnitOfWork implements PropertyChangedListener
         if (! $this->isInIdentityMap($entity)) {
             return;
         }
-
-        $this->removeFromIdentityMap($entity);
 
         unset($this->entityUpdates[$oid]);
 

--- a/tests/Tests/ORM/Functional/Ticket/GH6123Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH6123Test.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH6123Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH6123Entity::class,
+        );
+    }
+
+    public function testLoadingRemovedEntityFromDatabaseDoesNotCreateNewManagedEntityInstance(): void
+    {
+        $entity = new GH6123Entity();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        self::assertSame(UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($entity));
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForDelete($entity));
+
+        $this->_em->remove($entity);
+
+        $freshEntity = $this->loadEntityFromDatabase($entity->id);
+        self::assertSame($entity, $freshEntity);
+
+        self::assertSame(UnitOfWork::STATE_REMOVED, $this->_em->getUnitOfWork()->getEntityState($freshEntity));
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForDelete($freshEntity));
+    }
+
+    public function testRemovedEntityCanBePersistedAgain(): void
+    {
+        $entity = new GH6123Entity();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->remove($entity);
+        self::assertSame(UnitOfWork::STATE_REMOVED, $this->_em->getUnitOfWork()->getEntityState($entity));
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForDelete($entity));
+
+        $this->loadEntityFromDatabase($entity->id);
+
+        $this->_em->persist($entity);
+        self::assertSame(UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($entity));
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForDelete($entity));
+
+        $this->_em->flush();
+    }
+
+    private function loadEntityFromDatabase(int $id): GH6123Entity|null
+    {
+        return $this->_em->createQueryBuilder()
+            ->select('e')
+            ->from(GH6123Entity::class, 'e')
+            ->where('e.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}
+
+#[ORM\Entity]
+class GH6123Entity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[Column(type: Types::INTEGER, nullable: false)]
+    public int $id;
+}

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -413,12 +413,18 @@ class UnitOfWorkTest extends OrmTestCase
         $entity->id = 123;
 
         $this->_unitOfWork->registerManaged($entity, ['id' => 123], []);
+        self::assertSame(UnitOfWork::STATE_MANAGED, $this->_unitOfWork->getEntityState($entity));
+        self::assertFalse($this->_unitOfWork->isScheduledForDelete($entity));
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity));
 
         $this->_unitOfWork->remove($entity);
-        self::assertFalse($this->_unitOfWork->isInIdentityMap($entity));
+        self::assertSame(UnitOfWork::STATE_REMOVED, $this->_unitOfWork->getEntityState($entity));
+        self::assertTrue($this->_unitOfWork->isScheduledForDelete($entity));
+        self::assertTrue($this->_unitOfWork->isInIdentityMap($entity));
 
         $this->_unitOfWork->persist($entity);
+        self::assertSame(UnitOfWork::STATE_MANAGED, $this->_unitOfWork->getEntityState($entity));
+        self::assertFalse($this->_unitOfWork->isScheduledForDelete($entity));
         self::assertTrue($this->_unitOfWork->isInIdentityMap($entity));
     }
 


### PR DESCRIPTION
Fixes #6123, #9463
Replaces: #6126

Current behavior: `EntityManager::remove()` called with MANAGED entity schedules the entity for deletion at a later time, but **immediately** removes it from identity map.

The immediate removal from identity map is problematic. Until the changes are flushed, the entity may get loaded again from database - either directly as part of a query result, or indirectly through a reference from another entity. This leads to the creation of a new entity (proxy) instance that is then added to identity map, i.e. the `UnitOfWork` will have both - MANAGED entity instance in identity map, and REMOVED entity scheduled for deletion.

This leads to all sorts of unexpected behaviors, e.g.:
- unexpected results of `===` entity comparisons
- inconsistent `persist` behavior depending on which of the instances is passed (including indirect through `cascade: persist`)
- MANAGED entity instance remaining in identity map even after flushing the changes to database (executing the delete of the mapped row)

Proposed fix: Postpone the removal from identity map to the time when the scheduled deletes are executed.

This change caused failure of `UnitOfWorkTest::testRemovedAndRePersistedEntitiesAreInTheIdentityMapAndAreNotGarbageCollected()`, which directly asserted the problematic immediate removal from identity map. From the original PR #1338, it seems this is rather an unintended by-product than actually desired behavior. The test was introduced to ensure that REMOVED entity can become MANAGED again (and unscheduled from deletion) by re-persisting it. This functionality does not require the immediate removal from identity map. In fact, the immediate removal from identity map may break it as demonstrated in `GH6123Test::testRemovedEntityCanBePersistedAgain()`.

~Although the PR targets 3.1.x branch, it would be definitely a good candidate for backporting.~ (changed to target 2.19.x)
