### PR TITLE
Remove unused test group

### DIFF
--- a/tests/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -249,7 +249,6 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         self::assertEquals(1600000, $result[3]['op']);
     }
 
-    /** @group test */
     public function testOperatorDiv(): void
     {
         $result = $this->_em->createQuery('SELECT m, (m.salary/0.5) AS op FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')


### PR DESCRIPTION
During a review of another PR I found this remnant of a phpunit group, that looks like it wasn't supposed to be pushed/merged into ORM. The group name is too generic and and there's only one with that name.