### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "CI"
+    target-branch: "2.19.x"


### PR DESCRIPTION
Targeting 2.19.x, since we want the updates to bubble up. Since Dependabot has had no effect on doctrine/dbal yet, I suppose that means that "dependabot.yml" must be present on the default branch.