### PR TITLE
use templating to allow a more flexible type inference in `QueryBuilder::setParameters()` method

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -467,7 +467,9 @@ class QueryBuilder implements Stringable
      *        )));
      * </code>
      *
-     * @psalm-param ArrayCollection<int, Parameter> $parameters
+     * @template TKey of int
+     *
+     * @psalm-param ArrayCollection<TKey, Parameter> $parameters
      *
      * @return $this
      */


### PR DESCRIPTION
fixes https://github.com/doctrine/orm/issues/11451

