### PR TITLE
Allow classname in 'value' attribute of xml discriminator-mapping field

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -375,7 +375,7 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
-    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="orm:type" use="required"/>
     <xs:attribute name="class" type="orm:fqcn" use="required"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>

--- a/tests/Tests/Models/Customer/CustomerType.php
+++ b/tests/Tests/Models/Customer/CustomerType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Customer;
+
+class CustomerType
+{
+    /** @var string */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Tests/Models/Customer/ExternalCustomer.php
+++ b/tests/Tests/Models/Customer/ExternalCustomer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Customer;
+
+final class ExternalCustomer extends CustomerType
+{
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+    }
+}

--- a/tests/Tests/Models/Customer/InternalCustomer.php
+++ b/tests/Tests/Models/Customer/InternalCustomer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Customer;
+
+final class InternalCustomer extends CustomerType
+{
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+    }
+}

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
@@ -24,6 +25,7 @@ use Doctrine\Tests\DbalTypes\CustomIntType;
 use Doctrine\Tests\Models\CMS;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\Company\CompanyContract;
+use Doctrine\Tests\Models\Customer\CustomerType;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\DDC117\DDC117Article;
 use Doctrine\Tests\Models\DDC117\DDC117ArticleDetails;
@@ -1391,6 +1393,20 @@ class ClassMetadataTest extends OrmTestCase
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11309');
 
         $metadata->getAssociationMappedByTargetField('foo');
+    }
+
+    public function testClassNameMappingDiscriminatorValue(): void
+    {
+        $driver     = new XmlDriver(
+            __DIR__ . '/xml',
+            XmlDriver::DEFAULT_FILE_EXTENSION,
+            true
+        );
+        $xmlElement = $driver->getElement(CustomerType::class);
+        self::assertEquals(
+            'Doctrine\Tests\Models\Customer\InternalCustomer',
+            $xmlElement->children()->{'discriminator-map'}->{'discriminator-mapping'}[0]->attributes()['value']
+        );
     }
 }
 

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Customer.CustomerType.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Customer.CustomerType.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Customer\CustomerType" table="customers" inheritance-type="SINGLE_TABLE">
+        <field name="name" column="name"/>
+        <discriminator-column name="type" type="string"/>
+        <discriminator-map>
+            <discriminator-mapping value="Doctrine\Tests\Models\Customer\InternalCustomer" class="Doctrine\Tests\Models\Customer\InternalCustomer" />
+            <discriminator-mapping value="Doctrine\Tests\Models\Customer\ExternalCustomer" class="Doctrine\Tests\Models\Customer\ExternalCustomer" />
+        </discriminator-map>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
fixes https://github.com/doctrine/orm/issues/11449

In relation to https://github.com/doctrine/orm/pull/10630
This PR allows a more loosen validation of the value attribute of discriminator-mapping field, using orm:type in the XSD schema as it was done in the linked pull request.
The test I wrote loads the entity enabling the validation against XSD schema, thus expects no exception to be thrown.