### PR TITLE
Use templating to allow a more flexible type inference in `QueryBuilder::setParameters()` method

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -467,9 +467,11 @@ class QueryBuilder implements Stringable
      *        )));
      * </code>
      *
-     * @psalm-param ArrayCollection<int, Parameter> $parameters
+     * @psalm-param ArrayCollection<TKey, Parameter> $parameters
      *
      * @return $this
+     *
+     * @template TKey of int
      */
     public function setParameters(ArrayCollection $parameters): static
     {


### PR DESCRIPTION
fixes https://github.com/doctrine/orm/issues/11451