### PR TITLE
Using an integer as discriminator value with ORM v3

### DIFF
--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -2251,8 +2251,10 @@ class SqlWalker
             $discriminators += HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($metadata, $this->em);
         }
 
-        foreach (array_keys($discriminators) as $dis) {
-            $sqlParameterList[] = $this->conn->quote($dis);
+        foreach (array_keys($discriminators) as $discriminatorValue) {
+            $sqlParameterList[] = $rootClass->getDiscriminatorColumn()->type === 'integer' && is_int($discriminatorValue)
+                ? $discriminatorValue
+                : $this->conn->quote((string) $discriminatorValue);
         }
 
         return '(' . implode(', ', $sqlParameterList) . ')';


### PR DESCRIPTION
This fixes a bug that occurred when configuring integers as discriminator values and using DQL instanceOf function in the queries. Doctrine throws a type error whenever the application generates these queries.

Related to https://github.com/doctrine/orm/pull/11425