### PR TITLE
Add note about `Query::HINT_INCLUDE_META_COLUMNS` for custom hydrators

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1370,6 +1370,9 @@ userland:
 -  ``Query::HINT_CUSTOM_TREE_WALKERS`` - An array of additional
    ``Doctrine\ORM\Query\TreeWalker`` instances that are attached to
    the DQL query parsing process.
+-  ``Query::HINT_INCLUDE_META_COLUMNS`` - A boolean that causes 
+   meta columns like foreign keys and discriminator columns to be 
+   selected and returned as part of the query result.
 
 Query Cache (DQL Query Only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hey !

I was trying to create a custom hydrator that handle everything the same as `ObjectHydrator` and I was not understanding WHY I don't have meta columns when using my hydrator while `ObjectHydrator` had them.
After some search I found: https://github.com/doctrine/orm/blob/3.1.x/src/Query/SqlWalker.php#L647-L648 that forces meta columns when using `ObjectHydrator` but for any other hydrator you have to pass the hint.

So I added a note about that hint in the custom hydrator documentation so people knows about this :wink: 