### PR TITLE
Deprecate the NotSupported exception

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.2
 
+## Deprecate the `NotSupported` exception
+
+The class `Doctrine\ORM\Exception\NotSupported` is deprecated without replacement.
+
 ## Deprecate remaining `Serializable` implementation
 
 Relying on `SequenceGenerator` implementing the `Serializable` is deprecated

--- a/src/Exception/NotSupported.php
+++ b/src/Exception/NotSupported.php
@@ -8,6 +8,7 @@ use LogicException;
 
 use function sprintf;
 
+/** @deprecated */
 final class NotSupported extends LogicException implements ORMException
 {
     public static function create(): self


### PR DESCRIPTION
Another thing we should've removed in 3.0. 🙈 

All usages have been removed in the process of removing functionality relates to deprecated DBAL 2 and Persistence 2 features. We may chose to un-deprecate the class in the future, should we need it. But right now, we don't raise that exception anywhere, so we might as well remove it.