### PR TITLE
Fix cloning entities

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1502,7 +1502,9 @@
       <code><![CDATA[__wakeup]]></code>
     </UndefinedInterfaceMethod>
     <UndefinedMethod>
-      <code><![CDATA[self::createLazyGhost($initializer, $skippedProperties)]]></code>
+      <code><![CDATA[self::createLazyGhost(static function (InternalProxy $object) use ($initializer, $identifier): void {
+                $initializer($object, $identifier);
+            }, $skippedProperties)]]></code>
     </UndefinedMethod>
     <UnresolvableInclude>
       <code><![CDATA[require $fileName]]></code>

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -354,15 +354,14 @@ EOPHP;
     /**
      * Creates a closure capable of initializing a proxy
      *
-     * @return Closure(InternalProxy, InternalProxy):void
+     * @return Closure(InternalProxy, array):void
      *
      * @throws EntityNotFoundException
      */
     private function createLazyInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister, IdentifierFlattener $identifierFlattener): Closure
     {
-        return static function (InternalProxy $proxy) use ($entityPersister, $classMetadata, $identifierFlattener): void {
-            $identifier = $classMetadata->getIdentifierValues($proxy);
-            $original   = $entityPersister->loadById($identifier);
+        return static function (InternalProxy $proxy, array $identifier) use ($entityPersister, $classMetadata, $identifierFlattener): void {
+            $original = $entityPersister->loadById($identifier);
 
             if ($original === null) {
                 throw EntityNotFoundException::fromClassNameAndIdentifier(
@@ -378,7 +377,7 @@ EOPHP;
             $class = $entityPersister->getClassMetadata();
 
             foreach ($class->getReflectionProperties() as $property) {
-                if (! $class->hasField($property->name) && ! $class->hasAssociation($property->name)) {
+                if (isset($identifier[$property->name]) || ! $class->hasField($property->name) && ! $class->hasAssociation($property->name)) {
                     continue;
                 }
 
@@ -468,7 +467,9 @@ EOPHP;
         $identifierFields = array_intersect_key($class->getReflectionProperties(), $identifiers);
 
         $proxyFactory = Closure::bind(static function (array $identifier) use ($initializer, $skippedProperties, $identifierFields, $className): InternalProxy {
-            $proxy = self::createLazyGhost($initializer, $skippedProperties);
+            $proxy = self::createLazyGhost(static function (InternalProxy $object) use ($initializer, $identifier): void {
+                $initializer($object, $identifier);
+            }, $skippedProperties);
 
             foreach ($identifierFields as $idField => $reflector) {
                 if (! isset($identifier[$idField])) {

--- a/tests/Tests/Models/ECommerce/ECommerceProduct2.php
+++ b/tests/Tests/Models/ECommerce/ECommerceProduct2.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ECommerce;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * ECommerceProduct2
+ * Resets the id when being cloned.
+ *
+ * @Entity
+ * @Table(name="ecommerce_products",indexes={@Index(name="name_idx", columns={"name"})})
+ */
+class ECommerceProduct2
+{
+    /**
+     * @var int|null
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Column(type="string", length=50, nullable=true)
+     */
+    private $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function __clone()
+    {
+        $this->id   = null;
+        $this->name = 'Clone of ' . $this->name;
+    }
+}

--- a/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -58,7 +58,7 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     public function testPersistUpdate(): void
     {
         // Considering case (a)
-        $proxy = $this->_em->getProxyFactory()->getProxy(CmsUser::class, ['id' => 123]);
+        $proxy = $this->_em->getProxyFactory()->getProxy(CmsUser::class, ['id' => $this->user->getId()]);
 
         $proxy->id       = null;
         $proxy->username = 'ocra';

--- a/tests/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
+use Doctrine\Tests\Models\ECommerce\ECommerceProduct2;
 use Doctrine\Tests\Models\ECommerce\ECommerceShipping;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -110,6 +111,24 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         // domain logic, Product::__clone sets isCloned public property
         self::assertTrue($clone->isCloned);
         self::assertFalse($entity->isCloned);
+    }
+
+    public function testCloneProxyWithResetId(): void
+    {
+        $id = $this->createProduct();
+
+        $entity = $this->_em->getReference(ECommerceProduct2::class, $id);
+        assert($entity instanceof ECommerceProduct2);
+
+        $clone = clone $entity;
+        assert($clone instanceof ECommerceProduct2);
+
+        self::assertEquals($id, $entity->getId());
+        self::assertEquals('Doctrine Cookbook', $entity->getName());
+
+        self::assertFalse($this->_em->contains($clone));
+        self::assertNull($clone->getId());
+        self::assertEquals('Clone of Doctrine Cookbook', $clone->getName());
     }
 
     /** @group DDC-733 */


### PR DESCRIPTION
Fix #11455

When initializing a proxy, the current identifier of the entity was used to load from the DB.

This breaks eg when `__clone` sets the id to null before setting other properties to null also: that second "set" triggers initialization, yet because the id was just set to null before, the ORM triggers a SELECT with no WHERE (!?)

This is also happening when changing the id outside of `__clone` before setting any other properties - that's why the `testPersistUpdate` case needs to be updated: id `123` doesn't exist in the DB, yet this was shadowed by the `$proxy->id = null;` line, which triggered a SELECT with no WHERE, leading to the proxy being hydrated with whatever first row was returned by that SELECT.

Now, we consistently initialize the proxy with the identifier it was created with.