### PR TITLE
Added a new manager to manage multiple entity manager instances

### DIFF
--- a/src/Tools/Console/EntityManagerProvider/MultipleManagerProvider.php
+++ b/src/Tools/Console/EntityManagerProvider/MultipleManagerProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console\EntityManagerProvider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\UnknownManagerException;
+
+final class MultipleManagerProvider implements EntityManagerProvider
+{
+	/**
+	 * @param array<string, EntityManagerInterface> $managers
+	 */
+	public function __construct(
+		private readonly array $managers,
+        private readonly string $defaultManagerName = 'default',
+	) {
+	}
+
+	public function getDefaultManager(): EntityManagerInterface
+	{
+        if (array_key_exists($this->defaultManagerName, $this->managers)) {
+            return $this->managers[$this->defaultManagerName];
+        } else {
+            throw UnknownManagerException::unknownManager($this->defaultManagerName, $this->getManagerNames());
+        }
+	}
+
+	public function getManager(string $name): EntityManagerInterface
+	{
+		$managerNamesAvailable = $this->getManagerNames();
+		if (in_array($name, $managerNamesAvailable)) {
+			return $this->managers[$name];
+		} else {
+			throw UnknownManagerException::unknownManager($name, $managerNamesAvailable);
+		}
+	}
+
+	private function getManagerNames(): array
+	{
+		return array_keys($this->managers);
+	}
+}


### PR DESCRIPTION
Hi,

I encountered a problem with the console, I would have liked to be able to pass several instances of the entity manager.
Currently, only one instance can be passed using `SingleManagerProvider` class.

Here is a new implementation of the `MultipleManagerProvider` class.
It allows you to obtain several instances of the `Entity manager` within a console application.

Here is how it could be instantiated:

```php
#!/usr/bin/env php
<?php
use Doctrine\ORM\Tools\Console\ConsoleRunner;
use Doctrine\ORM\Tools\Console\EntityManagerProvider\MultipleManagerProvider;

$em1 = GetEntityManager();
$em2 = GetEntityManager();

$commands = [
    // If you want to add your own custom console commands,
    // you can do so here.
];

$multipleManagerProvider = new MultipleManagerProvider(['em1' => $em1, 'em2' => $em2]);
ConsoleRunner::run($multipleManagerProvider, $commands);
```

It's now possible to execute the binary with the argument `--em=em1 `or `--em=em2`