### PR TITLE
Catch Rollback Driver Exception

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -440,7 +440,11 @@ class UnitOfWork implements PropertyChangedListener
             $this->em->close();
 
             if ($conn->isTransactionActive()) {
-                $conn->rollBack();
+                try {
+                    $conn->rollBack();
+                } catch (Exception) {
+                    // Swallow, the real exception is the commit exception
+                }
             }
 
             $this->afterTransactionRolledBack();


### PR DESCRIPTION
Adds a try/catch when rolling back after an exception during UnitOfWork commit, so exception is not lost.

Currently the connection driver could throw an exception on rollback (eg. if the exception causes there to be no active transaction) which results in the driver exception propagating to the caller, and the commit Throwable being lost. Instead here, the rollback exception is swallowed so the original commit exception can be thrown to the caller.

I'm not sure what the best behaviour is here, so please advise. I've also not added any tests yet as it looked like I'd need to do some wrangling on the mocks being used, so wanted to at least check this was a reasonable idea before spending time on it.