### PR TITLE
Fetching entities with Composite Key Relations and null values

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2467,10 +2467,7 @@ class UnitOfWork implements PropertyChangedListener
                             } else {
                                 $associatedId[$targetClass->fieldNames[$targetColumn]] = $joinColumnValue;
                             }
-                        } elseif (
-                            $targetClass->containsForeignIdentifier
-                            && in_array($targetClass->getFieldForColumn($targetColumn), $targetClass->identifier, true)
-                        ) {
+                        } elseif (in_array($targetClass->getFieldForColumn($targetColumn), $targetClass->identifier, true)) {
                             // the missing key is part of target's entity primary key
                             $associatedId = [];
                             break;

--- a/tests/Tests/Models/CompositeKeyRelations/CustomerClass.php
+++ b/tests/Tests/Models/CompositeKeyRelations/CustomerClass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CompositeKeyRelations;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class CustomerClass
+{
+    #[Column(type: 'string')]
+    #[Id]
+    public string $companyCode;
+
+    #[Column(type: 'string')]
+    #[Id]
+    public string $code;
+
+    #[Column(type: 'string')]
+    public string $name;
+}

--- a/tests/Tests/Models/CompositeKeyRelations/InvoiceClass.php
+++ b/tests/Tests/Models/CompositeKeyRelations/InvoiceClass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CompositeKeyRelations;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+#[Entity]
+class InvoiceClass
+{
+    #[Column(type: 'string')]
+    #[Id]
+    public string $companyCode;
+
+    #[Column(type: 'string')]
+    #[Id]
+    public string $invoiceNumber;
+
+    #[ManyToOne(targetEntity: CustomerClass::class)]
+    #[JoinColumn(name: 'companyCode', referencedColumnName: 'companyCode')]
+    #[JoinColumn(name: 'customerCode', referencedColumnName: 'code')]
+    public CustomerClass|null $customer;
+
+    #[Column(type: 'string', nullable: true)]
+    public string|null $customerCode;
+}

--- a/tests/Tests/ORM/Functional/CompositeKeyRelationsTest.php
+++ b/tests/Tests/ORM/Functional/CompositeKeyRelationsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass;
+use Doctrine\Tests\Models\CompositeKeyRelations\InvoiceClass;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class CompositeKeyRelationsTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('compositekeyrelations');
+
+        parent::setUp();
+    }
+
+    public function testFindEntityWithNotNullRelation(): void
+    {
+        $this->_em->getConnection()->insert('CustomerClass', [
+            'companyCode' => 'AA',
+            'code' => 'CUST1',
+            'name' => 'Customer 1',
+        ]);
+
+        $this->_em->getConnection()->insert('InvoiceClass', [
+            'companyCode' => 'AA',
+            'invoiceNumber' => 'INV1',
+            'customerCode' => 'CUST1',
+        ]);
+
+        $entity = $this->findEntity('AA', 'INV1');
+        self::assertSame('AA', $entity->companyCode);
+        self::assertSame('INV1', $entity->invoiceNumber);
+        self::assertInstanceOf(CustomerClass::class, $entity->customer);
+        self::assertSame('Customer 1', $entity->customer->name);
+    }
+
+    public function testFindEntityWithNullRelation(): void
+    {
+        $this->_em->getConnection()->insert('InvoiceClass', [
+            'companyCode' => 'BB',
+            'invoiceNumber' => 'INV1',
+        ]);
+
+        $entity = $this->findEntity('BB', 'INV1');
+        self::assertSame('BB', $entity->companyCode);
+        self::assertSame('INV1', $entity->invoiceNumber);
+        self::assertNull($entity->customer);
+    }
+
+    private function findEntity(string $companyCode, string $invoiceNumber): InvoiceClass
+    {
+        return $this->_em->find(
+            InvoiceClass::class,
+            ['companyCode' => $companyCode, 'invoiceNumber' => $invoiceNumber],
+        );
+    }
+}

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -73,6 +73,7 @@ use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\SingleChildClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\SingleRootClass;
+use Doctrine\Tests\Models\CompositeKeyRelations;
 use Doctrine\Tests\Models\CustomType\CustomIdObjectTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomIdObjectTypeParent;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
@@ -348,6 +349,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             JoinedChildClass::class,
             SingleRootClass::class,
             SingleChildClass::class,
+        ],
+        'compositekeyrelations' => [
+            CompositeKeyRelations\InvoiceClass::class,
+            CompositeKeyRelations\CustomerClass::class,
         ],
         'taxi' => [
             PaidRide::class,


### PR DESCRIPTION
Recreation of #8425 as it was closed but never actually resolved and the issues still persist.

Description from the previous PR (Background):
---


In our database design we are using entities with composite keys, and we are using composite keys relations between entities.

Let say we have the following entities with Primary Keys (PK):

- `Company` (PK: `company_code`)
- `Customer` (PK composite: `company_code` + `customer_code`)
- `Invoice` (PK composite: `company_code` + `invoice_code`)

and the following relations in `Invoice`:
 - to `Company` (using `company_code`), not nullable
 - to `Customer` (using composite key `company_code` + `customer_code`), nullable

Now we have `company_code` (not null) but no `customer_code` (null).
We want to fetch `Invoice` entity, so that we get not null `Company`, and null `Customer`.

The problem is that loading `Invoice` with null `Customer` is not working - we are getting the following exception:

```
Exception: [Doctrine\Common\Proxy\Exception\OutOfBoundsException] Missing value for primary key code on Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass
```

This PR provide a fix, to load the `Customer` in the described case.
The change is pretty simply, and no other tests are affected.


NOTE: Loading `Company` is not a problem as it is using relation on just one column (not a composite key). The description includes it just for completeness of the example.


Workaround
---

We have discovered that we could use one of these workarounds - but both are not perfect:

- do not use null field, use instead empty value (empty string)
- use fetch=EAGER, what might be not efficient and actually might be not needed



Solution
---

The solution proposed in this PR is very minimal - just removal od one of the condition, which seems to be not covered, and I couldn't find track why it has been even added there.  Based on the example provided in this PR, the removed condition seems to be invalid.

PR contains two commits:
- tests with failing scenario
- fix for the presented issue


Additional considerations
---

The following comment confused me a lot:
https://github.com/doctrine/orm/blob/9d4f54b9a476f13479c3845350b12c466873fc42/src/UnitOfWork.php#L2456

and I did additional investigation if the proposed solution here is correct.
In the below we are removing just first part of the condition:
https://github.com/doctrine/orm/blob/9d4f54b9a476f13479c3845350b12c466873fc42/src/UnitOfWork.php#L2470-L2476
and I was wonder if the target entity could/should know if it is a part of a FK somewhere else - and I can't even see the reason behind that, so I believe this is the correct fix as it is the case when the filed "is part of target's entity primary key".

Hope it all makes sense and we can get it in. Thanks 🙌 