### PR TITLE
ci: maintained and stable mariadb version (lts)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -190,7 +190,7 @@ jobs:
           - "default"
           - "3@dev"
         mariadb-version:
-          - "10.9"
+          - "11.4"
         extension:
           - "mysqli"
           - "pdo_mysql"
@@ -204,11 +204,11 @@ jobs:
       mariadb:
         image: "mariadb:${{ matrix.mariadb-version }}"
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: "doctrine_tests"
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes
+          MARIADB_DATABASE: "doctrine_tests"
 
         options: >-
-          --health-cmd "mysqladmin ping --silent"
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
 
         ports:
           - "3306:3306"


### PR DESCRIPTION
Also use MARIADB env names and the healthcheck.sh included in the container.