### PR TITLE
Add ClassMetadataFactoryInterface to allow switching implementation

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -154,6 +154,7 @@
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
         <exclude-pattern>src/EntityManagerInterface.php</exclude-pattern>
+        <exclude-pattern>src/Mapping/ClassMetadataFactoryInterface.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,22 +96,22 @@ parameters:
 			path: src/Cache/TimestampQueryCacheValidator.php
 
 		-
-			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ORM\\\\Decorator\\\\EntityManagerDecorator\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
+			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactoryInterface\\) of method Doctrine\\\\ORM\\\\Decorator\\\\EntityManagerDecorator\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
 			count: 1
 			path: src/Decorator/EntityManagerDecorator.php
 
 		-
-			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ORM\\\\Decorator\\\\EntityManagerDecorator\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManagerDecorator\\<Doctrine\\\\ORM\\\\EntityManagerInterface\\>\\:\\:getMetadataFactory\\(\\)$#"
+			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactoryInterface\\) of method Doctrine\\\\ORM\\\\Decorator\\\\EntityManagerDecorator\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManagerDecorator\\<Doctrine\\\\ORM\\\\EntityManagerInterface\\>\\:\\:getMetadataFactory\\(\\)$#"
 			count: 1
 			path: src/Decorator/EntityManagerDecorator.php
 
 		-
-			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
+			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactoryInterface\\) of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
 			count: 1
 			path: src/EntityManager.php
 
 		-
-			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
+			message: "#^Return type \\(Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactoryInterface\\) of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
 			count: 1
 			path: src/EntityManagerInterface.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -168,7 +168,7 @@
       <code><![CDATA[$this->metadataFactory]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[ClassMetadataFactory]]></code>
+      <code><![CDATA[ClassMetadataFactoryInterface]]></code>
     </InvalidReturnType>
     <PossiblyNullArgument>
       <code><![CDATA[$config->getProxyDir()]]></code>

--- a/src/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/src/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
@@ -27,7 +27,7 @@ use function count;
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
     protected UnitOfWork $uow;
-    protected ClassMetadataFactory $metadataFactory;
+    protected ClassMetadataFactoryInterface $metadataFactory;
     protected ClassMetadata $sourceEntity;
     protected ClassMetadata $targetEntity;
 

--- a/src/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/src/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -20,7 +20,7 @@ use Doctrine\ORM\Cache\TimestampRegion;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
@@ -35,7 +35,7 @@ use function sha1;
 abstract class AbstractEntityPersister implements CachedEntityPersister
 {
     protected UnitOfWork $uow;
-    protected ClassMetadataFactory $metadataFactory;
+    protected ClassMetadataFactoryInterface $metadataFactory;
 
     /** @var mixed[] */
     protected array $queuedCache = [];

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,10 +6,12 @@ namespace Doctrine\ORM;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Cache\CacheConfiguration;
+use Doctrine\ORM\Exception\InvalidClassMetadataFactory;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\Mapping\DefaultEntityListenerResolver;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
@@ -25,6 +27,7 @@ use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use LogicException;
 use Psr\Cache\CacheItemPoolInterface;
+use ReflectionClass;
 
 use function class_exists;
 use function is_a;
@@ -375,6 +378,11 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function setClassMetadataFactoryName(string $cmfName): void
     {
+        $reflectionClass = new ReflectionClass($cmfName);
+        if (! $reflectionClass->implementsInterface(ClassMetadataFactoryInterface::class)) {
+            throw InvalidClassMetadataFactory::create($cmfName);
+        }
+
         $this->attributes['classMetadataFactoryName'] = $cmfName;
     }
 

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\NativeQuery;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query;
@@ -42,7 +42,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
         return $this->wrapped->getRepository($className);
     }
 
-    public function getMetadataFactory(): ClassMetadataFactory
+    public function getMetadataFactory(): ClassMetadataFactoryInterface
     {
         return $this->wrapped->getMetadataFactory();
     }

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnrecognizedIdentifierFields;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\Expr;
@@ -63,7 +63,7 @@ class EntityManager implements EntityManagerInterface
     /**
      * The metadata factory, used to retrieve the ORM metadata of entity classes.
      */
-    private ClassMetadataFactory $metadataFactory;
+    private ClassMetadataFactoryInterface $metadataFactory;
 
     /**
      * The UnitOfWork used to coordinate object-level transactions.
@@ -154,7 +154,7 @@ class EntityManager implements EntityManagerInterface
         return $this->conn;
     }
 
-    public function getMetadataFactory(): ClassMetadataFactory
+    public function getMetadataFactory(): ClassMetadataFactoryInterface
     {
         return $this->metadataFactory;
     }

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\FilterCollection;
@@ -40,7 +40,7 @@ interface EntityManagerInterface extends ObjectManager
      */
     public function getConnection(): Connection;
 
-    public function getMetadataFactory(): ClassMetadataFactory;
+    public function getMetadataFactory(): ClassMetadataFactoryInterface;
 
     /**
      * Gets an ExpressionBuilder used for object-oriented construction of query expressions.

--- a/src/Exception/InvalidClassMetadataFactory.php
+++ b/src/Exception/InvalidClassMetadataFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
+use LogicException;
+
+use function sprintf;
+
+class InvalidClassMetadataFactory extends LogicException implements ConfigurationException
+{
+    public static function create(string $className): self
+    {
+        return new self(sprintf("Invalid class metadata factory class '%s'. It must be a %s.", $className, ClassMetadataFactoryInterface::class));
+    }
+}

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -48,7 +48,7 @@ use function substr;
  *
  * @extends AbstractClassMetadataFactory<ClassMetadata>
  */
-class ClassMetadataFactory extends AbstractClassMetadataFactory
+class ClassMetadataFactory extends AbstractClassMetadataFactory implements ClassMetadataFactoryInterface
 {
     private EntityManagerInterface|null $em       = null;
     private AbstractPlatform|null $targetPlatform = null;
@@ -69,18 +69,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $this->em = $em;
     }
 
-    /**
-     * @param A $maybeOwningSide
-     *
-     * @return (A is ManyToManyAssociationMapping ? ManyToManyOwningSideMapping : (
-     *     A is OneToOneAssociationMapping ? OneToOneOwningSideMapping : (
-     *     A is OneToManyAssociationMapping ? ManyToOneAssociationMapping : (
-     *     A is ManyToOneAssociationMapping ? ManyToOneAssociationMapping :
-     *     ManyToManyOwningSideMapping|OneToOneOwningSideMapping|ManyToOneAssociationMapping
-     * ))))
-     *
-     * @template A of AssociationMapping
-     */
     final public function getOwningSide(AssociationMapping $maybeOwningSide): OwningSideMapping
     {
         if ($maybeOwningSide instanceof OwningSideMapping) {

--- a/src/Mapping/ClassMetadataFactoryInterface.php
+++ b/src/Mapping/ClassMetadataFactoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use Psr\Cache\CacheItemPoolInterface;
+
+/** @template-extends ClassMetadataFactory<ClassMetadata> */
+interface ClassMetadataFactoryInterface extends ClassMetadataFactory
+{
+    /**
+     * Sets the cache for created metadata.
+     */
+    public function setCache(CacheItemPoolInterface $cache): void;
+
+    /**
+     * Sets the entity manager owning the factory.
+     */
+    public function setEntityManager(EntityManagerInterface $em): void;
+
+    /**
+     * @param A $maybeOwningSide
+     *
+     * @return (A is ManyToManyAssociationMapping ? ManyToManyOwningSideMapping : (
+     *     A is OneToOneAssociationMapping ? OneToOneOwningSideMapping : (
+     *     A is OneToManyAssociationMapping ? ManyToOneAssociationMapping : (
+     *     A is ManyToOneAssociationMapping ? ManyToOneAssociationMapping :
+     *     ManyToManyOwningSideMapping|OneToOneOwningSideMapping|ManyToOneAssociationMapping
+     * ))))
+     *
+     * @template A of AssociationMapping
+     */
+    public function getOwningSide(AssociationMapping $maybeOwningSide): OwningSideMapping;
+}

--- a/tests/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\NativeQuery;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query;
@@ -45,7 +45,7 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
         );
     }
 
-    public function getMetadataFactory(): ClassMetadataFactory
+    public function getMetadataFactory(): ClassMetadataFactoryInterface
     {
         return $this->realEntityManager->getMetadataFactory();
     }

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Exception\InvalidClassMetadataFactory;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Mapping as MappingNamespace;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
@@ -16,6 +17,7 @@ use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
+use Doctrine\Tests\ORM\Mapping\ClassMetadataFactoryTestSubject;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
@@ -147,8 +149,12 @@ class ConfigurationTest extends TestCase
     public function testSetGetClassMetadataFactoryName(): void
     {
         self::assertSame(MappingNamespace\ClassMetadataFactory::class, $this->configuration->getClassMetadataFactoryName());
+        $this->configuration->setClassMetadataFactoryName(ClassMetadataFactoryTestSubject::class);
+        self::assertSame(ClassMetadataFactoryTestSubject::class, $this->configuration->getClassMetadataFactoryName());
+
+        $this->expectException(InvalidClassMetadataFactory::class);
+        $this->expectExceptionMessage('Invalid class metadata factory class \'Doctrine\Tests\ORM\ConfigurationTest\'. It must be a Doctrine\ORM\Mapping\ClassMetadataFactoryInterface.');
         $this->configuration->setClassMetadataFactoryName(self::class);
-        self::assertSame(self::class, $this->configuration->getClassMetadataFactoryName());
     }
 
     public function testAddGetFilters(): void

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
@@ -92,7 +93,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
         return $class;
     }
 
-    protected function createClassMetadataFactory(EntityManagerInterface|null $em = null): ClassMetadataFactory
+    protected function createClassMetadataFactory(EntityManagerInterface|null $em = null): ClassMetadataFactoryInterface
     {
         $driver  = $this->loadDriver();
         $em    ??= $this->getTestEntityManager();


### PR DESCRIPTION
### New Feature

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | no
| BC Break    | no

#### Summary

Fixes #11496

This PR introduces a new `ClassMetadataFactoryInterface` interface and changes the type-hints to allow switching implementation of the factory in configuration.
