### PR TITLE
Remove doctrine/instantiator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2",
         "doctrine/inflector": "^1.4 || ^2.0",
-        "doctrine/instantiator": "^1.3 || ^2",
         "doctrine/lexer": "^3",
         "doctrine/persistence": "^3.3.1",
         "psr/cache": "^1 || ^2 || ^3",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -324,7 +324,6 @@
       <code><![CDATA[getValue]]></code>
       <code><![CDATA[getValue]]></code>
       <code><![CDATA[getValue]]></code>
-      <code><![CDATA[instantiate]]></code>
       <code><![CDATA[setValue]]></code>
       <code><![CDATA[setValue]]></code>
     </PossiblyNullReference>

--- a/src/Mapping/ReflectionEmbeddedProperty.php
+++ b/src/Mapping/ReflectionEmbeddedProperty.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\Instantiator\Instantiator;
+use ReflectionClass;
 use ReflectionProperty;
 
 /**
@@ -13,17 +13,13 @@ use ReflectionProperty;
  *
  * This way value objects "just work" without UnitOfWork, Persisters or Hydrators
  * needing any changes.
- *
- * TODO: Move this class into Common\Reflection
  */
 final class ReflectionEmbeddedProperty extends ReflectionProperty
 {
-    private Instantiator|null $instantiator = null;
-
     /**
      * @param ReflectionProperty $parentProperty reflection property of the class where the embedded object has to be put
      * @param ReflectionProperty $childProperty  reflection property of the embedded object
-     * @psalm-param class-string $embeddedClass
+     * @param class-string       $embeddedClass
      */
     public function __construct(
         private readonly ReflectionProperty $parentProperty,
@@ -49,9 +45,7 @@ final class ReflectionEmbeddedProperty extends ReflectionProperty
         $embeddedObject = $this->parentProperty->getValue($object);
 
         if ($embeddedObject === null) {
-            $this->instantiator ??= new Instantiator();
-
-            $embeddedObject = $this->instantiator->instantiate($this->embeddedClass);
+            $embeddedObject = (new ReflectionClass($this->embeddedClass))->newInstanceWithoutConstructor();
 
             $this->parentProperty->setValue($object, $embeddedObject);
         }

--- a/tests/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\Instantiator\Instantiator;
 use Doctrine\ORM\Mapping\ReflectionEmbeddedProperty;
 use Doctrine\Tests\Models\Generic\BooleanModel;
 use Doctrine\Tests\Models\Reflection\AbstractEmbeddable;
@@ -13,6 +12,7 @@ use Doctrine\Tests\Models\Reflection\ConcreteEmbeddable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionProperty;
 
 /**
@@ -34,9 +34,7 @@ class ReflectionEmbeddedPropertyTest extends TestCase
     ): void {
         $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass);
 
-        $instantiator = new Instantiator();
-
-        $object = $instantiator->instantiate($parentProperty->getDeclaringClass()->getName());
+        $object = (new ReflectionClass($parentProperty->getDeclaringClass()->getName()))->newInstanceWithoutConstructor();
 
         $embeddedPropertyReflection->setValue($object, 'newValue');
 
@@ -60,11 +58,9 @@ class ReflectionEmbeddedPropertyTest extends TestCase
     ): void {
         $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass);
 
-        $instantiator = new Instantiator();
+        $reflection = new ReflectionClass($parentProperty->getDeclaringClass()->getName());
 
-        self::assertNull($embeddedPropertyReflection->getValue(
-            $instantiator->instantiate($parentProperty->getDeclaringClass()->getName()),
-        ));
+        self::assertNull($embeddedPropertyReflection->getValue($reflection->newInstanceWithoutConstructor()));
     }
 
     /** @return ReflectionProperty[][]|string[][] */


### PR DESCRIPTION
I'd like to remove `doctrine/instantiator` from our dependencies.

I had a chat with @sebastianbergmann the other day and he told me how relieved he was that he could remove `doctrine/instantiator` from PHPUnit's dependencies because `ReflectionClass::newInstanceWithoutConstructor()` has become a drop-in replacement for all of his use-cases. This made me wonder if that weren't also the case for the ORM.

Is there any situation where instantiator would simply call `ReflectionClass::newInstanceWithoutConstructor()`?