### PR TITLE
feat: allow setting foreign deferrable key as IMMEDIATE or DEFERRABLE

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -684,7 +684,7 @@ Optional parameters:
    affected entities and should be enforced as such on the database
    constraint level. Defaults to false.
 -  **deferrable**: Determines whether this relation constraint can be deferred. Defaults to false.
--  **deferred**: Determines whether this deferrable relation constraint can be IMMEDIATE or DEFERRED. Defaults to false (IMMEDIATE).
+-  **deferred**: Determines whether this deferrable relation constraint can be INITIALLY IMMEDIATE or INITIALLY DEFERRED. Defaults to false (INITIALLY IMMEDIATE).
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
 -  **onDelete**: Cascade Action (Database-level)

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -684,6 +684,7 @@ Optional parameters:
    affected entities and should be enforced as such on the database
    constraint level. Defaults to false.
 -  **deferrable**: Determines whether this relation constraint can be deferred. Defaults to false.
+-  **deferred**: Determines whether this deferrable relation constraint can be IMMEDIATE or DEFERRED. Defaults to false (IMMEDIATE).
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
 -  **onDelete**: Cascade Action (Database-level)

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -684,7 +684,9 @@ Optional parameters:
    affected entities and should be enforced as such on the database
    constraint level. Defaults to false.
 -  **deferrable**: Determines whether this relation constraint can be deferred. Defaults to false.
--  **deferred**: Determines whether this deferrable relation constraint can be INITIALLY IMMEDIATE or INITIALLY DEFERRED. Defaults to false (INITIALLY IMMEDIATE).
+-  **deferred**: Determines whether this deferrable relation
+   constraint can be ``INITIALLY IMMEDIATE`` or ``INITIALLY DEFERRED``.
+   Defaults to false (``INITIALLY IMMEDIATE``).
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
 -  **onDelete**: Cascade Action (Database-level)

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -691,6 +691,7 @@ class AttributeDriver implements MappingDriver
         $mapping = [
             'name' => $joinColumn->name,
             'deferrable' => $joinColumn->deferrable,
+            'deferred' => $joinColumn->deferred,
             'unique' => $joinColumn->unique,
             'nullable' => $joinColumn->nullable,
             'onDelete' => $joinColumn->onDelete,

--- a/src/Mapping/JoinColumnMapping.php
+++ b/src/Mapping/JoinColumnMapping.php
@@ -14,6 +14,7 @@ final class JoinColumnMapping implements ArrayAccess
     use ArrayAccessImplementation;
 
     public bool|null $deferrable         = null;
+    public bool|null $deferred           = null;
     public bool|null $unique             = null;
     public bool|null $quoted             = null;
     public string|null $fieldName        = null;
@@ -67,7 +68,7 @@ final class JoinColumnMapping implements ArrayAccess
             }
         }
 
-        foreach (['deferrable', 'unique', 'quoted', 'nullable'] as $boolKey) {
+        foreach (['deferrable', 'deferred', 'unique', 'quoted', 'nullable'] as $boolKey) {
             if ($this->$boolKey !== null) {
                 $serialized[] = $boolKey;
             }

--- a/src/Mapping/JoinColumnProperties.php
+++ b/src/Mapping/JoinColumnProperties.php
@@ -11,6 +11,7 @@ trait JoinColumnProperties
         public readonly string|null $name = null,
         public readonly string|null $referencedColumnName = null,
         public readonly bool $deferrable = false,
+        public readonly bool $deferred = false,
         public readonly bool $unique = false,
         public readonly bool|null $nullable = null,
         public readonly mixed $onDelete = null,

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -728,6 +728,10 @@ class SchemaTool
             if (isset($joinColumn->deferrable)) {
                 $fkOptions['deferrable'] = $joinColumn->deferrable;
             }
+
+            if (isset($joinColumn->deferred)) {
+                $fkOptions['deferred'] = $joinColumn->deferred;
+            }
         }
 
         // Prefer unique constraints over implicit simple indexes created for foreign keys.

--- a/tests/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -56,6 +56,7 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
         self::assertCount(1, $fks);
 
         self::assertTrue($fks[0]->getOption('deferrable'));
+        self::assertTrue($fks[0]->getOption('deferred'));
     }
 }
 
@@ -127,6 +128,6 @@ class EntityWithSelfReferencingAssociation
     private int $id;
 
     #[ManyToOne(targetEntity: self::class)]
-    #[JoinColumn(deferrable: true)]
+    #[JoinColumn(deferrable: true, deferred: true)]
     private self $parent;
 }

--- a/tests/Tests/ORM/Mapping/JoinColumnMappingTest.php
+++ b/tests/Tests/ORM/Mapping/JoinColumnMappingTest.php
@@ -18,6 +18,7 @@ final class JoinColumnMappingTest extends TestCase
         $mapping = new JoinColumnMapping('foo', 'id');
 
         $mapping->deferrable           = true;
+        $mapping->deferred             = true;
         $mapping->unique               = true;
         $mapping->quoted               = true;
         $mapping->fieldName            = 'bar';
@@ -31,6 +32,7 @@ final class JoinColumnMappingTest extends TestCase
         assert($resurrectedMapping instanceof JoinColumnMapping);
 
         self::assertTrue($resurrectedMapping->deferrable);
+        self::assertTrue($resurrectedMapping->deferred);
         self::assertSame('foo', $resurrectedMapping->name);
         self::assertTrue($resurrectedMapping->unique);
         self::assertTrue($resurrectedMapping->quoted);


### PR DESCRIPTION
#### Summary
Pass options to FK because of \Doctrine\DBAL\Platforms\PostgreSQLPlatform::getAdvancedForeignKeyOptionsSQL

#### How to use
```
#[ORM\JoinColumn(name: 'customer_id', options: ['deferrable' => true, 'deferred' => true])]
```