### PR TITLE
Add the proper void return type on the __load method of proxies

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -387,12 +387,18 @@ EOPHP;
         $code = substr($code, 7 + (int) strpos($code, "\n{"));
         $code = substr($code, 0, (int) strpos($code, "\n}"));
         $code = str_replace('LazyGhostTrait;', str_replace("\n    ", "\n", 'LazyGhostTrait {
-            initializeLazyObject as __load;
+            initializeLazyObject as private;
             setLazyObjectAsInitialized as public __setInitialized;
             isLazyObjectInitialized as private;
             createLazyGhost as private;
             resetLazyObject as private;
-        }'), $code);
+        }
+
+        public function __load(): void
+        {
+            $this->initializeLazyObject();
+        }
+        '), $code);
 
         return $code;
     }


### PR DESCRIPTION
When using ghost objects, the method was leaking a `static` return type due to the way it was implemented, which is incompatible with the native return type that will be added in doctrine/persistence v4.