### PR TITLE
Deprecate DatabaseDriver

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 3.3
+
+## Deprecate `DatabaseDriver`
+
+The class `Doctrine\ORM\Mapping\Driver\DatabaseDriver` is deprecated without replacement.
+
 # Upgrade to 3.2
 
 ## Deprecate the `NotSupported` exception

--- a/src/Mapping/Driver/DatabaseDriver.php
+++ b/src/Mapping/Driver/DatabaseDriver.php
@@ -35,6 +35,8 @@ use function strtolower;
 /**
  * The DatabaseDriver reverse engineers the mapping metadata from a database.
  *
+ * @deprecated No replacement planned
+ *
  * @link    www.doctrine-project.org
  */
 class DatabaseDriver implements MappingDriver


### PR DESCRIPTION
It was used for the reverse engineering feature, which has been removed.