### PR TITLE
Address doctrine/persistence 3.3.3 release

### DIFF
--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -74,3 +74,9 @@ parameters:
         -
             message: '#^Call to method injectObjectManager\(\) on an unknown class Doctrine\\Persistence\\ObjectManagerAware\.$#'
             path: src/UnitOfWork.php
+
+        -
+            message: '#contains generic type.*but class.*is not generic#'
+            paths:
+                - src/Mapping/Driver/XmlDriver.php
+                - src/Mapping/Driver/YamlDriver.php

--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -64,3 +64,9 @@ parameters:
 
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
+
+        -
+            message: '#contains generic type.*but class.*is not generic#'
+            paths:
+                - src/Mapping/Driver/XmlDriver.php
+                - src/Mapping/Driver/YamlDriver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -932,13 +932,8 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$metadata->table]]></code>
     </InvalidPropertyAssignmentValue>
-    <InvalidPropertyFetch>
-      <code><![CDATA[$xmlRoot->{'discriminator-column'}]]></code>
-      <code><![CDATA[$xmlRoot->{'discriminator-map'}]]></code>
-    </InvalidPropertyFetch>
     <InvalidReturnStatement>
       <code><![CDATA[$mapping]]></code>
-      <code><![CDATA[$result]]></code>
       <code><![CDATA[[
             'usage'  => $usage,
             'region' => $region,
@@ -962,7 +957,6 @@
       *                   options?: array
       *               }]]></code>
       <code><![CDATA[array{usage: int|null, region?: string}]]></code>
-      <code><![CDATA[loadMappingFile]]></code>
     </InvalidReturnType>
     <MissingParamType>
       <code><![CDATA[$fileExtension]]></code>
@@ -971,15 +965,6 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$metadata]]></code>
     </MoreSpecificImplementedParamType>
-    <NoInterfaceProperties>
-      <code><![CDATA[$xmlRoot->{'discriminator-column'}]]></code>
-      <code><![CDATA[$xmlRoot->{'discriminator-map'}]]></code>
-    </NoInterfaceProperties>
-    <TypeDoesNotContainType>
-      <code><![CDATA[$xmlRoot->getName() === 'embeddable']]></code>
-      <code><![CDATA[$xmlRoot->getName() === 'entity']]></code>
-      <code><![CDATA[$xmlRoot->getName() === 'mapped-superclass']]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/Mapping/Driver/YamlDriver.php">
     <ArgumentTypeCoercion>
@@ -1011,38 +996,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[array{usage: int|null, region: string|null}]]></code>
     </MoreSpecificReturnType>
-    <PossiblyUndefinedMethod>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-    </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$element]]></code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Mapping/Embedded.php">
     <MissingParamType>

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -37,6 +37,8 @@ use function strtoupper;
  * XmlDriver is a metadata driver that enables mapping through XML files.
  *
  * @link        www.doctrine-project.org
+ *
+ * @template-extends FileDriver<SimpleXMLElement>
  */
 class XmlDriver extends FileDriver
 {
@@ -79,7 +81,6 @@ class XmlDriver extends FileDriver
     public function loadMetadataForClass($className, PersistenceClassMetadata $metadata)
     {
         $xmlRoot = $this->getElement($className);
-        assert($xmlRoot instanceof SimpleXMLElement);
 
         if ($xmlRoot->getName() === 'entity') {
             if (isset($xmlRoot['repository-class'])) {
@@ -203,6 +204,7 @@ class XmlDriver extends FileDriver
                     ];
 
                     if (isset($discrColumn['options'])) {
+                        assert($discrColumn['options'] instanceof SimpleXMLElement);
                         $columnDef['options'] = $this->parseOptions($discrColumn['options']->children());
                     }
 
@@ -214,6 +216,7 @@ class XmlDriver extends FileDriver
                 // Evaluate <discriminator-map...>
                 if (isset($xmlRoot->{'discriminator-map'})) {
                     $map = [];
+                    assert($xmlRoot->{'discriminator-map'}->{'discriminator-mapping'} instanceof SimpleXMLElement);
                     foreach ($xmlRoot->{'discriminator-map'}->{'discriminator-mapping'} as $discrMapElement) {
                         $map[(string) $discrMapElement['value']] = (string) $discrMapElement['class'];
                     }

--- a/src/Mapping/Driver/YamlDriver.php
+++ b/src/Mapping/Driver/YamlDriver.php
@@ -31,6 +31,8 @@ use function substr;
  * The YamlDriver reads the mapping metadata from yaml schema files.
  *
  * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
+ *
+ * @template-extends FileDriver<array<string, mixed>>
  */
 class YamlDriver extends FileDriver
 {


### PR DESCRIPTION
`FileDriver` became templatable, and some very wrong phpdoc has been fixed, causing Psalm to better understand the 2 `FileDriver` classes in this project.