### PR TITLE
Fix matching lazy collections with enums criteria

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -667,16 +667,6 @@
       <code><![CDATA[[UnitOfWork::HINT_DEFEREAGERLOAD => true]]]></code>
       <code><![CDATA[[UnitOfWork::HINT_DEFEREAGERLOAD => true]]]></code>
     </InvalidArgument>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$newValue]]></code>
-      <code><![CDATA[[$params, $types]]]></code>
-      <code><![CDATA[[$sqlParams, $sqlTypes]]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array]]></code>
-      <code><![CDATA[array]]></code>
-      <code><![CDATA[list<mixed>]]></code>
-    </MoreSpecificReturnType>
     <PossiblyNullReference>
       <code><![CDATA[getValue]]></code>
       <code><![CDATA[getValue]]></code>

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -260,7 +260,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $params = array_merge($params, ...$paramsValues);
-        unset($paramsValues);
 
         $tableName = $this->quoteStrategy->getTableName($targetClass, $this->platform);
         $joinTable = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -15,10 +15,12 @@ use Doctrine\ORM\Mapping\InverseSideMapping;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
+use Doctrine\ORM\Persisters\Traits\ResolveValuesHelper;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_fill;
+use function array_merge;
 use function array_pop;
 use function assert;
 use function count;
@@ -32,6 +34,8 @@ use function sprintf;
  */
 class ManyToManyPersister extends AbstractCollectionPersister
 {
+    use ResolveValuesHelper;
+
     public function delete(PersistentCollection $collection): void
     {
         $mapping = $this->getMapping($collection);
@@ -249,7 +253,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $whereClauses[] = sprintf('te.%s %s NULL', $field, $operator === Comparison::EQ ? 'IS' : 'IS NOT');
             } else {
                 $whereClauses[] = sprintf('te.%s %s ?', $field, $operator);
-                $params[]       = $value;
+                $params         = array_merge($params, $this->getValues($value));
                 $paramTypes[]   = PersisterHelper::getTypeOfField($name, $targetClass, $this->em)[0];
             }
         }

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -242,7 +242,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $paramTypes[]   = PersisterHelper::getTypeOfColumn($value, $ownerMetadata, $this->em);
         }
 
-        $parameters = $this->expandCriteriaParameters($criteria);
+        $parameters   = $this->expandCriteriaParameters($criteria);
         $paramsValues = [];
 
         foreach ($parameters as $parameter) {

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -243,6 +243,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $parameters = $this->expandCriteriaParameters($criteria);
+        $paramsValues = [];
 
         foreach ($parameters as $parameter) {
             [$name, $value, $operator] = $parameter;
@@ -253,10 +254,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $whereClauses[] = sprintf('te.%s %s NULL', $field, $operator === Comparison::EQ ? 'IS' : 'IS NOT');
             } else {
                 $whereClauses[] = sprintf('te.%s %s ?', $field, $operator);
-                $params         = array_merge($params, $this->getValues($value));
+                $paramsValues[] = $this->getValues($value);
                 $paramTypes[]   = PersisterHelper::getTypeOfField($name, $targetClass, $this->em)[0];
             }
         }
+
+        $params = array_merge($params, ...$paramsValues);
+        unset($paramsValues);
 
         $tableName = $this->quoteStrategy->getTableName($targetClass, $this->platform);
         $joinTable = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Persisters\Entity;
 
-use BackedEnum;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Order;
@@ -31,7 +30,7 @@ use Doctrine\ORM\Persisters\Exception\InvalidOrientation;
 use Doctrine\ORM\Persisters\Exception\UnrecognizedField;
 use Doctrine\ORM\Persisters\SqlExpressionVisitor;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
-use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
+use Doctrine\ORM\Persisters\Traits\ResolveValuesHelper;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -53,7 +52,6 @@ use function assert;
 use function count;
 use function implode;
 use function is_array;
-use function is_object;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -99,6 +97,7 @@ use function trim;
 class BasicEntityPersister implements EntityPersister
 {
     use LockSqlHelper;
+    use ResolveValuesHelper;
 
     /** @var array<string,string> */
     private static array $comparisonMap = [
@@ -1910,62 +1909,6 @@ class BasicEntityPersister implements EntityPersister
             ParameterType::INTEGER => ArrayParameterType::INTEGER,
             ParameterType::ASCII => ArrayParameterType::ASCII,
         };
-    }
-
-    /**
-     * Retrieves the parameters that identifies a value.
-     *
-     * @return mixed[]
-     */
-    private function getValues(mixed $value): array
-    {
-        if (is_array($value)) {
-            $newValue = [];
-
-            foreach ($value as $itemValue) {
-                $newValue = array_merge($newValue, $this->getValues($itemValue));
-            }
-
-            return [$newValue];
-        }
-
-        return $this->getIndividualValue($value);
-    }
-
-    /**
-     * Retrieves an individual parameter value.
-     *
-     * @psalm-return list<mixed>
-     */
-    private function getIndividualValue(mixed $value): array
-    {
-        if (! is_object($value)) {
-            return [$value];
-        }
-
-        if ($value instanceof BackedEnum) {
-            return [$value->value];
-        }
-
-        $valueClass = DefaultProxyClassNameResolver::getClass($value);
-
-        if ($this->em->getMetadataFactory()->isTransient($valueClass)) {
-            return [$value];
-        }
-
-        $class = $this->em->getClassMetadata($valueClass);
-
-        if ($class->isIdentifierComposite) {
-            $newValue = [];
-
-            foreach ($class->getIdentifierValues($value) as $innerValue) {
-                $newValue = array_merge($newValue, $this->getValues($innerValue));
-            }
-
-            return $newValue;
-        }
-
-        return [$this->em->getUnitOfWork()->getSingleIdentifierValue($value)];
     }
 
     public function exists(object $entity, Criteria|null $extraConditions = null): bool

--- a/src/Persisters/Traits/ResolveValuesHelper.php
+++ b/src/Persisters/Traits/ResolveValuesHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Persisters\Traits;
+
+use BackedEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
+
+use function array_merge;
+use function is_array;
+use function is_object;
+
+trait ResolveValuesHelper
+{
+    protected EntityManagerInterface $em;
+
+    /**
+     * Retrieves the parameters that identifies a value.
+     *
+     * @return mixed[]
+     */
+    private function getValues(mixed $value): array
+    {
+        if (is_array($value)) {
+            $newValue = [];
+
+            foreach ($value as $itemValue) {
+                $newValue = array_merge($newValue, $this->getValues($itemValue));
+            }
+
+            return [$newValue];
+        }
+
+        return $this->getIndividualValue($value);
+    }
+
+    /**
+     * Retrieves an individual parameter value.
+     *
+     * @psalm-return list<mixed>
+     */
+    private function getIndividualValue(mixed $value): array
+    {
+        if (! is_object($value)) {
+            return [$value];
+        }
+
+        if ($value instanceof BackedEnum) {
+            return [$value->value];
+        }
+
+        $valueClass = DefaultProxyClassNameResolver::getClass($value);
+
+        if ($this->em->getMetadataFactory()->isTransient($valueClass)) {
+            return [$value];
+        }
+
+        $class = $this->em->getClassMetadata($valueClass);
+
+        if ($class->isIdentifierComposite) {
+            $newValue = [];
+
+            foreach ($class->getIdentifierValues($value) as $innerValue) {
+                $newValue = array_merge($newValue, $this->getValues($innerValue));
+            }
+
+            return $newValue;
+        }
+
+        return [$this->em->getUnitOfWork()->getSingleIdentifierValue($value)];
+    }
+}

--- a/src/Persisters/Traits/ResolveValuesHelper.php
+++ b/src/Persisters/Traits/ResolveValuesHelper.php
@@ -17,7 +17,7 @@ trait ResolveValuesHelper
     /**
      * Retrieves the parameters that identifies a value.
      *
-     * @return mixed[]
+     * @psalm-return list<mixed>
      */
     private function getValues(mixed $value): array
     {

--- a/src/Persisters/Traits/ResolveValuesHelper.php
+++ b/src/Persisters/Traits/ResolveValuesHelper.php
@@ -11,9 +11,7 @@ use function array_merge;
 use function is_array;
 use function is_object;
 
-/**
- * @internal
- */
+/** @internal */
 trait ResolveValuesHelper
 {
     /**

--- a/src/Persisters/Traits/ResolveValuesHelper.php
+++ b/src/Persisters/Traits/ResolveValuesHelper.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Traits;
 
 use BackedEnum;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 
 use function array_merge;
 use function is_array;
 use function is_object;
 
+/**
+ * @internal
+ */
 trait ResolveValuesHelper
 {
-    protected EntityManagerInterface $em;
-
     /**
      * Retrieves the parameters that identifies a value.
      *
@@ -24,13 +24,13 @@ trait ResolveValuesHelper
     private function getValues(mixed $value): array
     {
         if (is_array($value)) {
-            $newValue = [];
+            $newValues = [];
 
             foreach ($value as $itemValue) {
-                $newValue = array_merge($newValue, $this->getValues($itemValue));
+                $newValues[] = $this->getValues($itemValue);
             }
 
-            return [$newValue];
+            return [array_merge(...$newValues)];
         }
 
         return $this->getIndividualValue($value);
@@ -60,13 +60,13 @@ trait ResolveValuesHelper
         $class = $this->em->getClassMetadata($valueClass);
 
         if ($class->isIdentifierComposite) {
-            $newValue = [];
+            $newValues = [];
 
             foreach ($class->getIdentifierValues($value) as $innerValue) {
-                $newValue = array_merge($newValue, $this->getValues($innerValue));
+                $newValues[] = $this->getValues($innerValue);
             }
 
-            return $newValue;
+            return array_merge(...$newValues);
         }
 
         return [$this->em->getUnitOfWork()->getSingleIdentifierValue($value)];

--- a/tests/Tests/Models/Enums/Book.php
+++ b/tests/Tests/Models/Enums/Book.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'books')]
+class Book
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[ManyToOne(targetEntity: Library::class, inversedBy: 'books')]
+    #[JoinColumn(name: 'library_id', referencedColumnName: 'id')]
+    public Library $library;
+
+    #[Column(enumType: BookColor::class)]
+    public BookColor $bookColor;
+
+    #[ManyToMany(targetEntity: BookCategory::class, mappedBy: 'books')]
+    public Collection $categories;
+
+    public function __construct()
+    {
+        $this->categories = new ArrayCollection();
+    }
+
+    public function setLibrary(Library $library): void
+    {
+        $this->library = $library;
+    }
+
+    public function addCategory(BookCategory $bookCategory): void
+    {
+        $this->categories->add($bookCategory);
+        $bookCategory->addBook($this);
+    }
+}

--- a/tests/Tests/Models/Enums/BookCategory.php
+++ b/tests/Tests/Models/Enums/BookCategory.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\Enums;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -40,13 +39,5 @@ class BookCategory
     public function getBooks(): Collection
     {
         return $this->books;
-    }
-
-    public function getBooksWithColor(BookColor $bookColor): Collection
-    {
-        $criteria = Criteria::create()
-            ->andWhere(Criteria::expr()->eq('bookColor', $bookColor));
-
-        return $this->books->matching($criteria);
     }
 }

--- a/tests/Tests/Models/Enums/BookCategory.php
+++ b/tests/Tests/Models/Enums/BookCategory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+#[Entity]
+class BookCategory
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int $id;
+
+    #[Column]
+    public string $name;
+
+    #[ManyToMany(targetEntity: Book::class, inversedBy: 'categories')]
+    public Collection $books;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+
+    public function addBook(Book $book): void
+    {
+        $this->books->add($book);
+    }
+
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function getBooksWithColor(BookColor $bookColor): Collection
+    {
+        $criteria = Criteria::create()
+            ->andWhere(Criteria::expr()->eq('bookColor', $bookColor));
+
+        return $this->books->matching($criteria);
+    }
+}

--- a/tests/Tests/Models/Enums/BookColor.php
+++ b/tests/Tests/Models/Enums/BookColor.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+enum BookColor: string
+{
+    case RED  = 'red';
+    case BLUE = 'blue';
+}

--- a/tests/Tests/Models/Enums/Library.php
+++ b/tests/Tests/Models/Enums/Library.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\Enums;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -27,14 +26,6 @@ class Library
     public function __construct()
     {
         $this->books = new ArrayCollection();
-    }
-
-    public function getBooksWithColor(BookColor $bookColor): Collection
-    {
-        $criteria = Criteria::create()
-            ->andWhere(Criteria::expr()->eq('bookColor', $bookColor));
-
-        return $this->books->matching($criteria);
     }
 
     public function getBooks(): Collection

--- a/tests/Tests/Models/Enums/Library.php
+++ b/tests/Tests/Models/Enums/Library.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class Library
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[OneToMany(targetEntity: Book::class, mappedBy: 'library')]
+    public Collection $books;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+
+    public function getBooksWithColor(BookColor $bookColor): Collection
+    {
+        $criteria = Criteria::create()
+            ->andWhere(Criteria::expr()->eq('bookColor', $bookColor));
+
+        return $this->books->matching($criteria);
+    }
+
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function addBook(Book $book): void
+    {
+        $this->books->add($book);
+        $book->setLibrary($this);
+    }
+}

--- a/tests/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Tests/ORM/Functional/EnumTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -78,7 +80,6 @@ class EnumTest extends OrmFunctionalTestCase
         $this->_em->persist($card2);
         $this->_em->flush();
 
-        unset($card1, $card2);
         $this->_em->clear();
 
         /** @var list<Card> $foundCards */
@@ -406,7 +407,6 @@ class EnumTest extends OrmFunctionalTestCase
         $this->_em->persist($card2);
         $this->_em->flush();
 
-        unset($card1, $card2);
         $this->_em->clear();
 
         /** @var list<Card> $foundCards */
@@ -542,12 +542,15 @@ EXCEPTION
         $this->_em->flush();
         $libraryId = $library->id;
 
-        unset($library, $redBook, $blueBook);
-
         $this->_em->clear();
 
         $library = $this->_em->find(Library::class, $libraryId);
-        $this->assertCount(1, $library->getBooksWithColor(BookColor::RED));
+
+        $redBooks = $library->books->matching(
+            Criteria::create()->andWhere(Criteria::expr()->eq('bookColor', BookColor::RED)),
+        );
+
+        $this->assertCount(1, $redBooks);
     }
 
     public function testEnumInitializedCollectionMatchingWithOneToMany(): void
@@ -571,8 +574,6 @@ EXCEPTION
         $this->_em->flush();
         $libraryId = $library->id;
 
-        unset($library, $redBook, $blueBook);
-
         $this->_em->clear();
 
         $library = $this->_em->find(Library::class, $libraryId);
@@ -581,7 +582,11 @@ EXCEPTION
         // Load books collection first
         $this->assertCount(2, $library->getBooks());
 
-        $this->assertCount(1, $library->getBooksWithColor(BookColor::RED));
+        $redBooks = $library->books->matching(
+            Criteria::create()->andWhere(Criteria::expr()->eq('bookColor', BookColor::RED)),
+        );
+
+        $this->assertCount(1, $redBooks);
     }
 
     public function testEnumLazyCollectionMatchingWithManyToMany(): void
@@ -612,10 +617,14 @@ EXCEPTION
         $thrillerCategoryId = $thrillerCategory->id;
 
         $this->_em->clear();
-        unset($thrillerCategory, $fantasyCategory, $blueBook, $redBook);
 
         $thrillerCategory = $this->_em->find(BookCategory::class, $thrillerCategoryId);
-        $this->assertCount(1, $thrillerCategory->getBooksWithColor(BookColor::RED));
+
+        $redBooks = $thrillerCategory->books->matching(
+            Criteria::create()->andWhere(Criteria::expr()->eq('bookColor', BookColor::RED)),
+        );
+
+        $this->assertCount(1, $redBooks);
     }
 
     public function testEnumInitializedCollectionMatchingWithManyToMany(): void
@@ -646,7 +655,6 @@ EXCEPTION
         $thrillerCategoryId = $thrillerCategory->id;
 
         $this->_em->clear();
-        unset($thrillerCategory, $fantasyCategory, $blueBook, $redBook);
 
         $thrillerCategory = $this->_em->find(BookCategory::class, $thrillerCategoryId);
         $this->assertInstanceOf(BookCategory::class, $thrillerCategory);
@@ -654,6 +662,10 @@ EXCEPTION
         // Load books collection first
         $this->assertCount(2, $thrillerCategory->getBooks());
 
-        $this->assertCount(1, $thrillerCategory->getBooksWithColor(BookColor::RED));
+        $redBooks = $thrillerCategory->books->matching(
+            Criteria::create()->andWhere(Criteria::expr()->eq('bookColor', BookColor::RED)),
+        );
+
+        $this->assertCount(1, $redBooks);
     }
 }

--- a/tests/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Tests/ORM/Functional/EnumTest.php
@@ -12,9 +12,13 @@ use Doctrine\ORM\Query\Expr\Func;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\DataTransferObjects\DtoWithArrayOfEnums;
 use Doctrine\Tests\Models\DataTransferObjects\DtoWithEnum;
+use Doctrine\Tests\Models\Enums\Book;
+use Doctrine\Tests\Models\Enums\BookCategory;
+use Doctrine\Tests\Models\Enums\BookColor;
 use Doctrine\Tests\Models\Enums\Card;
 use Doctrine\Tests\Models\Enums\CardWithDefault;
 use Doctrine\Tests\Models\Enums\CardWithNullable;
+use Doctrine\Tests\Models\Enums\Library;
 use Doctrine\Tests\Models\Enums\Product;
 use Doctrine\Tests\Models\Enums\Quantity;
 use Doctrine\Tests\Models\Enums\Scale;
@@ -515,5 +519,96 @@ EXCEPTION
         $card = $this->_em->find(CardWithDefault::class, $cardId);
 
         self::assertSame(Suit::Hearts, $card->suit);
+    }
+
+    public function testEnumCollectionMatchingWithOneToMany(): void
+    {
+        $this->setUpEntitySchema([Book::class, Library::class]);
+
+        $redBook            = new Book();
+        $redBook->bookColor = BookColor::RED;
+
+        $blueBook            = new Book();
+        $blueBook->bookColor = BookColor::BLUE;
+
+        $library = new Library();
+        $library->addBook($blueBook);
+        $library->addBook($redBook);
+
+        $this->_em->persist($library);
+        $this->_em->persist($blueBook);
+        $this->_em->persist($redBook);
+
+        $this->_em->flush();
+        $libraryId = $library->id;
+
+        unset($library, $redBook, $blueBook);
+
+        $this->_em->clear();
+
+        // Case 1: load collection first, then use matching()
+
+        $library = $this->_em->find(Library::class, $libraryId);
+        $this->assertInstanceOf(Library::class, $library);
+
+        // Load books collection first
+        $this->assertCount(2, $library->getBooks());
+
+        $this->assertCount(1, $library->getBooksWithColor(BookColor::RED));
+
+        $this->_em->clear();
+
+        // Case 2: use matching() with uninitialized collection
+
+        $library = $this->_em->find(Library::class, $libraryId);
+        $this->assertCount(1, $library->getBooksWithColor(BookColor::RED));
+    }
+
+    public function testEnumCollectionMatchingWithManyToMany(): void
+    {
+        $this->setUpEntitySchema([Book::class, BookCategory::class, Library::class]);
+
+        $thrillerCategory       = new BookCategory();
+        $thrillerCategory->name = 'thriller';
+
+        $fantasyCategory       = new BookCategory();
+        $fantasyCategory->name = 'fantasy';
+
+        $redBook = new Book();
+        $redBook->addCategory($fantasyCategory);
+        $redBook->addCategory($thrillerCategory);
+        $redBook->bookColor = BookColor::RED;
+
+        $blueBook = new Book();
+        $blueBook->addCategory($thrillerCategory);
+        $blueBook->bookColor = BookColor::BLUE;
+
+        $this->_em->persist($thrillerCategory);
+        $this->_em->persist($fantasyCategory);
+        $this->_em->persist($blueBook);
+        $this->_em->persist($redBook);
+
+        $this->_em->flush();
+        $thrillerCategoryId = $thrillerCategory->id;
+
+        $this->_em->clear();
+        unset($thrillerCategory, $fantasyCategory, $blueBook, $redBook);
+
+        // Case 1: load collection first, then use matching()
+
+        $thrillerCategory = $this->_em->find(BookCategory::class, $thrillerCategoryId);
+        $this->assertInstanceOf(BookCategory::class, $thrillerCategory);
+
+        // Load books collection first
+        $this->assertCount(2, $thrillerCategory->getBooks());
+
+        $this->assertCount(1, $thrillerCategory->getBooksWithColor(BookColor::RED));
+
+        $this->_em->clear();
+
+        // Case 2: use matching() with uninitialized collection
+
+        $thrillerCategory = $this->_em->find(BookCategory::class, $thrillerCategoryId);
+        $this->assertCount(1, $thrillerCategory->getBooksWithColor(BookColor::RED));
     }
 }


### PR DESCRIPTION
Fix issue #11481 

I identified some duplicated code between the `BasicEntityPersister` and the `ManyToManyPersister`, like the method `expandCriteriaParameters`.
Because I don't want to create side effects, I just factorized two methods : `getValues` and `getIndividualValue` into a trait.

Thanks for your review !