### PR TITLE
Fix incorrect exception message for ManyToOne attribute in embeddable class

### DIFF
--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -390,7 +390,7 @@ class AttributeDriver implements MappingDriver
                 $metadata->mapOneToMany($mapping);
             } elseif ($manyToOneAttribute !== null) {
                 if ($metadata->isEmbeddedClass) {
-                    throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\OneToMany::class);
+                    throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\ManyToOne::class);
                 }
 
                 $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);


### PR DESCRIPTION
When a ManyToOne attribute is encountered on an Embeddable class, the exception message reads "Attribute "Doctrine\ORM\Mapping\OneToMany" on embeddable [class] is not allowed.". This should be "Doctrine\ORM\Mapping\ManyToOne" on embeddable [class] is not allowed.".
This pull request solves this issue.