### PR TITLE
Fix the support for custom parameter types in native queries

### DIFF
--- a/src/NativeQuery.php
+++ b/src/NativeQuery.php
@@ -50,7 +50,15 @@ class NativeQuery extends AbstractQuery
         $types      = [];
 
         foreach ($this->getParameters() as $parameter) {
-            $name  = $parameter->getName();
+            $name = $parameter->getName();
+
+            if ($parameter->typeWasSpecified()) {
+                $parameters[$name] = $parameter->getValue();
+                $types[$name]      = $parameter->getType();
+
+                continue;
+            }
+
             $value = $this->processParameterValue($parameter->getValue());
             $type  = $parameter->getValue() === $value
                 ? $parameter->getType()

--- a/tests/Tests/ORM/Query/NativeQueryTest.php
+++ b/tests/Tests/ORM/Query/NativeQueryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query;
+
+use DateTime;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Tests\Mocks\EntityManagerMock;
+use Doctrine\Tests\OrmTestCase;
+
+class NativeQueryTest extends OrmTestCase
+{
+    /** @var EntityManagerMock */
+    protected $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getTestEntityManager();
+    }
+
+    public function testValuesAreNotBeingResolvedForSpecifiedParameterTypes(): void
+    {
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+
+        $this->entityManager->setUnitOfWork($unitOfWork);
+
+        $unitOfWork
+            ->expects(self::never())
+            ->method('getSingleIdentifierValue');
+
+        $rsm = new ResultSetMapping();
+
+        $query = $this->entityManager->createNativeQuery('SELECT d.* FROM date_time_model d WHERE d.datetime = :value', $rsm);
+
+        $query->setParameter('value', new DateTime(), Types::DATETIME_MUTABLE);
+
+        self::assertEmpty($query->getResult());
+    }
+}


### PR DESCRIPTION
The Query class (used for DQL queries) takes care of using the value and type as is when a type was specified for a parameter instead of going through the default processing of values.
The NativeQuery class was missing the equivalent check, making the custom type work only if the default processing of values does not convert the value to a different one.