### PR TITLE
Fix the initialization of lazy-ghost proxies with postLoad listeners

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -447,7 +447,7 @@ EOPHP;
             foreach ($reflector->getProperties($filter) as $property) {
                 $name = $property->name;
 
-                if ($property->isStatic() || (($class->hasField($name) || $class->hasAssociation($name)) && ! isset($identifiers[$name]))) {
+                if ($property->isStatic() || ! isset($identifiers[$name])) {
                     continue;
                 }
 

--- a/tests/Tests/Models/GH11524/GH11524Entity.php
+++ b/tests/Tests/Models/GH11524/GH11524Entity.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh11524_entities")
+ */
+class GH11524Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int|null
+     */
+    public $id = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH11524Relation")
+     * @ORM\JoinColumn(name="relation_id", referencedColumnName="id", nullable=true)
+     *
+     * @var GH11524Relation|null
+     */
+    public $relation = null;
+}

--- a/tests/Tests/Models/GH11524/GH11524Listener.php
+++ b/tests/Tests/Models/GH11524/GH11524Listener.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Event\PostLoadEventArgs;
+
+class GH11524Listener
+{
+    public function postLoad(PostloadEventArgs $eventArgs): void
+    {
+        $object = $eventArgs->getObject();
+
+        if (!$object instanceof GH11524Relation) {
+            return;
+        }
+
+        $object->setCurrentLocale('en');
+    }
+}

--- a/tests/Tests/Models/GH11524/GH11524Relation.php
+++ b/tests/Tests/Models/GH11524/GH11524Relation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Mapping as ORM;
+use LogicException;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh11524_relations")
+ */
+class GH11524Relation
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int|null
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string|null
+     */
+    private $currentLocale;
+
+    public function setCurrentLocale(string $locale): void
+    {
+        $this->currentLocale = $locale;
+    }
+
+    public function getTranslation(): string
+    {
+        if ($this->currentLocale === null) {
+            throw new LogicException('The current locale must be set to retrieve translation.');
+        }
+
+        return 'fake';
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH11524Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11524Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Events;
+use Doctrine\Persistence\Proxy;
+use Doctrine\Tests\Models\GH11524\GH11524Entity;
+use Doctrine\Tests\Models\GH11524\GH11524Listener;
+use Doctrine\Tests\Models\GH11524\GH11524Relation;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH11524Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH11524Entity::class,
+            GH11524Relation::class
+        );
+
+        $this->_em->getEventManager()->addEventListener(Events::postLoad, new GH11524Listener());
+    }
+
+    public function testPostLoadCalledOnProxy(): void
+    {
+        $relation = new GH11524Relation();
+        $relation->name = 'test';
+        $this->_em->persist($relation);
+
+        $entity = new GH11524Entity();
+        $entity->relation = $relation;
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $reloadedEntity = $this->_em->find(GH11524Entity::class, $entity->id);
+
+        $reloadedRelation = $reloadedEntity->relation;
+
+        $this->assertInstanceOf(Proxy::class, $reloadedRelation, 'The reloaded relation must be a proxy');
+        $this->assertFalse($reloadedRelation->__isInitialized());
+
+        $this->assertSame('fake', $reloadedRelation->getTranslation(), 'The property set by the postLoad listener must get initialized on usage.');
+    }
+}


### PR DESCRIPTION
PostLoad listeners might initialize values for transient properties, so the proxy should not skip initialization when using transient properties.

Closes https://github.com/doctrine/orm/issues/11524