### PR TITLE
fix: Quote custom types correctly in SQLFilter

### DIFF
--- a/src/Query/Filter/SQLFilter.php
+++ b/src/Query/Filter/SQLFilter.php
@@ -106,7 +106,7 @@ abstract class SQLFilter implements Stringable
             throw FilterException::cannotConvertListParameterIntoSingleValue($name);
         }
 
-        return $this->em->getConnection()->quote((string) $this->parameters[$name]['value']);
+        return $this->em->getConnection()->quote((string) $this->parameters[$name]['value'], $this->parameters[$name]['type']);
     }
 
     /**

--- a/src/Query/Filter/SQLFilter.php
+++ b/src/Query/Filter/SQLFilter.php
@@ -132,7 +132,7 @@ abstract class SQLFilter implements Stringable
         $connection = $this->em->getConnection();
 
         $quoted = array_map(
-            static fn (mixed $value): string => $connection->quote((string) $value),
+            static fn (mixed $value): string => $connection->quote((string) $value, $param['type']),
             $param['value'],
         );
 


### PR DESCRIPTION
This enables the connection to quote the parameters correctly according to the type definition.

## My scenario: 

* Symfony 7.1 app 
* `doctrine/dbal:3.8.2`
* `doctrine/orm:3.2.1`, currently updating from `doctrine/orm:2.19.5`
* I am using the `UlidType` from the doctrine bridge (using `symfony/ulid` underneath) as primary key to the `Organization` entity

## My problem:

I'm using a SQLFilter to permanently set the ulid of the organization permanently for users. After updating `doctrine/orm`, I got an exception that the format of the query parameter wouldn't conform to the expectation of the database.

## My solution

On investigation, I found that the SQLFilter doesn't use the column type to quote the value correctly. This change is supposed to ensure that the correct quoting is done