### PR TITLE
Allow overriding association's cascade

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -1676,7 +1676,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Sets the association to override association mapping of property for an entity relationship.
      *
-     * @psalm-param array<string, mixed> $overrideMapping
+     * @psalm-param array{joinColumns?: array, inversedBy?: ?string, joinTable?: array, fetch?: ?string, cascade?: string[]} $overrideMapping
      *
      * @throws MappingException
      */
@@ -1710,6 +1710,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         if (isset($overrideMapping['fetch'])) {
             $mapping['fetch'] = $overrideMapping['fetch'];
+        }
+
+        if (isset($overrideMapping['cascade'])) {
+            $mapping['cascade'] = $overrideMapping['cascade'];
         }
 
         switch ($mapping['type']) {

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -870,11 +870,21 @@ class ClassMetadataTest extends OrmTestCase
     {
         $cm = new ClassMetadata(Directory::class);
         $cm->mapManyToOne(['fieldName' => 'parentDirectory', 'targetEntity' => Directory::class, 'cascade' => ['remove'], 'declared' => Directory::class]);
-        $cm->setAssociationOverride('parentDirectory', ['cascade' => '']);
+        $cm->setAssociationOverride('parentDirectory', ['cascade' => ['remove']]);
 
         $mapping = $cm->getAssociationMapping('parentDirectory');
 
         self::assertSame(Directory::class, $mapping->declared);
+    }
+
+    public function testAssociationOverrideCanOverrideCascade(): void
+    {
+        $cm = new ClassMetadata(Directory::class);
+        $cm->mapManyToOne(['fieldName' => 'parentDirectory', 'targetEntity' => Directory::class, 'cascade' => ['remove'], 'declared' => Directory::class]);
+        $cm->setAssociationOverride('parentDirectory', ['cascade' => ['all']]);
+
+        $mapping = $cm->getAssociationMapping('parentDirectory');
+        self::assertSame(['remove', 'persist', 'refresh', 'detach'], $mapping['cascade']);
     }
 
     #[TestGroup('DDC-1955')]


### PR DESCRIPTION
We were badly bitten by `cascade` set on an association we did not expect it to have. The association is dynamically mapped using a `loadClassMetadata` event by a vendor with no way of hooking into it. As we're really careful with persisting stuff I'd like to have an option to remove vendor's cascade and instead take care of it within our codebase.

Additionally I've listed what can actually be overridden as I was surprised it's that limited :) 