### PR TITLE
Make CountWalker use COUNT(*) when $distinct is explicitly set to false (#11552)

### DIFF
--- a/tests/Tests/ORM/Tools/Pagination/CountWalkerTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/CountWalkerTest.php
@@ -27,6 +27,20 @@ class CountWalkerTest extends PaginationTestCase
         );
     }
 
+    public function testCountQueryWithoutDistinctUsesCountStar(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN p.category c JOIN p.author a',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CountWalker::class]);
+        $query->setHint(CountWalker::HINT_DISTINCT, false);
+
+        self::assertEquals(
+            'SELECT count(*) AS sclr_0 FROM BlogPost b0_ INNER JOIN Category c1_ ON b0_.category_id = c1_.id INNER JOIN Author a2_ ON b0_.author_id = a2_.id',
+            $query->getSQL(),
+        );
+    }
+
     public function testCountQueryMixedResultsWithName(): void
     {
         $query = $this->entityManager->createQuery(


### PR DESCRIPTION
This change makes CountWalker use COUNT(*) instead of COUNT(tbl.id), when the user declared that their query does not need to use (SELECT) DISTINCT, which is commonly the case when there are no JOINs in the query, or when the JOINs are only *ToOne.

Research showed that COUNT(*) allows databases to use index(-only) scans more eagerly from any of the indexed columns, especially when the query is using a WHERE-condition that filters on an indexed column.

Implements #11552.