### PR TITLE
Remove unused $pkColumns when gathering columns

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -421,18 +421,12 @@ class SchemaTool
      */
     private function gatherColumns(ClassMetadata $class, Table $table): void
     {
-        $pkColumns = [];
-
         foreach ($class->fieldMappings as $mapping) {
             if ($class->isInheritanceTypeSingleTable() && isset($mapping->inherited)) {
                 continue;
             }
 
             $this->gatherColumn($class, $mapping, $table);
-
-            if ($class->isIdentifier($mapping->fieldName)) {
-                $pkColumns[] = $this->quoteStrategy->getColumnName($mapping->fieldName, $class, $this->platform);
-            }
         }
     }
 


### PR DESCRIPTION
**What**
Cleanup

**Context**
Seems to be a leftover from way back:
- https://github.com/doctrine/orm/commit/c697a2d47f3c289276f2f73d741a2b930b0d6eea#diff-8be2a95c816ec2bcf28d186a4f18ef9fa4c48b849da2ae597e9d6d9398ca17f0R298
  - TL;DR: Logic moved from `_gatherColumns` to `getSchemaFromMetadata`

