### PR TITLE
Fix missing null in phpdocs

### DIFF
--- a/src/Mapping/AssociationOverride.php
+++ b/src/Mapping/AssociationOverride.php
@@ -22,11 +22,11 @@ final class AssociationOverride implements MappingAttribute
     public readonly array|null $inverseJoinColumns;
 
     /**
-     * @param string                       $name               The name of the relationship property whose mapping is being overridden.
-     * @param JoinColumn|array<JoinColumn> $joinColumns
-     * @param JoinColumn|array<JoinColumn> $inverseJoinColumns
-     * @param JoinTable|null               $joinTable          The join table that maps the relationship.
-     * @param string|null                  $inversedBy         The name of the association-field on the inverse-side.
+     * @param string                            $name               The name of the relationship property whose mapping is being overridden.
+     * @param JoinColumn|array<JoinColumn>|null $joinColumns
+     * @param JoinColumn|array<JoinColumn>|null $inverseJoinColumns
+     * @param JoinTable|null                    $joinTable          The join table that maps the relationship.
+     * @param string|null                       $inversedBy         The name of the association-field on the inverse-side.
      * @psalm-param 'LAZY'|'EAGER'|'EXTRA_LAZY'|null $fetch
      */
     public function __construct(

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -78,8 +78,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * Creates a new persistent collection.
      *
-     * @param EntityManagerInterface|null                   $em        The EntityManager the collection will be associated with.
-     * @param ClassMetadata|null                            $typeClass The class descriptor of the entity type of this collection.
+     * @param EntityManagerInterface|null $em        The EntityManager the collection will be associated with.
+     * @param ClassMetadata|null          $typeClass The class descriptor of the entity type of this collection.
      * @psalm-param Collection<TKey, T>&Selectable<TKey, T> $collection The collection elements.
      */
     public function __construct(

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -78,8 +78,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * Creates a new persistent collection.
      *
-     * @param EntityManagerInterface $em        The EntityManager the collection will be associated with.
-     * @param ClassMetadata          $typeClass The class descriptor of the entity type of this collection.
+     * @param EntityManagerInterface|null                   $em        The EntityManager the collection will be associated with.
+     * @param ClassMetadata|null                            $typeClass The class descriptor of the entity type of this collection.
      * @psalm-param Collection<TKey, T>&Selectable<TKey, T> $collection The collection elements.
      */
     public function __construct(


### PR DESCRIPTION
- Native type has those, but phpdocs do not. 
- Detected by https://github.com/shipmonk-rnd/phpstan-rules?tab=readme-ov-file#forbidphpdocnullabilitymismatchwithnativetypehint