### PR TITLE
GH11551 - fix OneToManyPersister::deleteEntityCollection case where single-inheritence table parent entity is targetEntity.

### DIFF
--- a/src/Persisters/Collection/OneToManyPersister.php
+++ b/src/Persisters/Collection/OneToManyPersister.php
@@ -13,10 +13,13 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Utility\PersisterHelper;
 
+use function array_fill;
+use function array_keys;
 use function array_merge;
 use function array_reverse;
 use function array_values;
 use function assert;
+use function count;
 use function implode;
 use function is_int;
 use function is_string;
@@ -194,9 +197,12 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         if ($targetClass->isInheritanceTypeSingleTable()) {
             $discriminatorColumn = $targetClass->getDiscriminatorColumn();
-            $statement          .= ' AND ' . $discriminatorColumn['name'] . ' = ?';
-            $parameters[]        = $targetClass->discriminatorValue;
-            $types[]             = $discriminatorColumn['type'];
+            $discriminatorValues = $targetClass->discriminatorValue ? [$targetClass->discriminatorValue] : array_keys($targetClass->discriminatorMap);
+            $statement          .= ' AND ' . $discriminatorColumn['name'] . ' IN (' . implode(', ', array_fill(0, count($discriminatorValues), '?')) . ')';
+            foreach ($discriminatorValues as $discriminatorValue) {
+                $parameters[] = $discriminatorValue;
+                $types[]      =  $discriminatorColumn['type'];
+            }
         }
 
         $numAffected = $this->conn->executeStatement($statement, $parameters, $types);

--- a/src/Persisters/Collection/OneToManyPersister.php
+++ b/src/Persisters/Collection/OneToManyPersister.php
@@ -201,7 +201,7 @@ class OneToManyPersister extends AbstractCollectionPersister
             $statement          .= ' AND ' . $discriminatorColumn['name'] . ' IN (' . implode(', ', array_fill(0, count($discriminatorValues), '?')) . ')';
             foreach ($discriminatorValues as $discriminatorValue) {
                 $parameters[] = $discriminatorValue;
-                $types[]      =  $discriminatorColumn['type'];
+                $types[]      = $discriminatorColumn['type'];
             }
         }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH11501Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11501Test.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH11501Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH11501AbstractTestEntity::class,
+            GH11501TestEntityOne::class,
+            GH11501TestEntityTwo::class,
+            GH11501TestEntityHolder::class,
+        ]);
+    }
+
+    /**
+     * @throws ORMException
+     */
+    public function testDeleteOneToManyCollectionWithSingleTableInheritance(): void
+    {
+        $testEntityOne    = new GH11501TestEntityOne();
+        $testEntityTwo    = new GH11501TestEntityTwo();
+        $testEntityHolder = new GH11501TestEntityHolder();
+
+        $testEntityOne->testEntityHolder = $testEntityHolder;
+        $testEntityHolder->testEntities->add($testEntityOne);
+
+        $testEntityTwo->testEntityHolder = $testEntityHolder;
+        $testEntityHolder->testEntities->add($testEntityTwo);
+
+        $em = $this->getEntityManager();
+        $em->persist($testEntityOne);
+        $em->persist($testEntityTwo);
+        $em->persist($testEntityHolder);
+        $em->flush();
+
+        $testEntityHolder->testEntities = new ArrayCollection();
+        $em->persist($testEntityHolder);
+        $em->flush();
+        $em->refresh($testEntityHolder);
+
+        static::assertEmpty($testEntityHolder->testEntities->toArray(), 'All records should have been deleted');
+    }
+}
+
+
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="one_to_many_single_table_inheritance_test_entities_parent_join")
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({"test_entity_one"="GH11501TestEntityOne", "test_entity_two"="GH11501TestEntityTwo"})
+ */
+class GH11501AbstractTestEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH11501TestEntityHolder", inversedBy="testEntities")
+     * @ORM\JoinColumn(name="test_entity_holder_id", referencedColumnName="id")
+     *
+     * @var GH11501TestEntityHolder
+     */
+    public $testEntityHolder;
+}
+
+
+/** @ORM\Entity */
+class GH11501TestEntityOne extends GH11501AbstractTestEntity
+{
+}
+
+/** @ORM\Entity */
+class GH11501TestEntityTwo extends GH11501AbstractTestEntity
+{
+}
+
+/** @ORM\Entity */
+class GH11501TestEntityHolder
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH11501AbstractTestEntity", mappedBy="testEntityHolder", orphanRemoval=true)
+     *
+     * @var Collection
+     */
+    public $testEntities;
+
+    public function __construct()
+    {
+        $this->testEntities = new ArrayCollection();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/doctrine/orm/issues/11551

When using the parent entity for a single-inheritence table as the targetEntity for a property, the discriminator value should be all of the values in the discriminator map.

OneToManyPersister::deleteEntityCollection has been amended to reflect this.