### PR TITLE
Allow interface parent and traitfor entitylistener

### DIFF
--- a/src/Tools/AttachEntityListenersListener.php
+++ b/src/Tools/AttachEntityListenersListener.php
@@ -57,7 +57,30 @@ class AttachEntityListenersListener
             return;
         }
 
-        foreach ($this->entityListeners[$metadata->name] as $listener) {
+        $tagetEntities = $this->entityListeners[$metadata->name];
+
+        foreach(class_implements($metadata->name, true) as $interface) {
+            echo $interface;
+            if(isset($this->entityListeners[$interface])) {
+                $tagetEntities = array_merge($tagetEntities, $this->entityListeners[$interface]);
+            }
+        }
+
+        foreach(class_parents($metadata->name, true) as $parent) {
+            echo $parent;
+            if(isset($this->entityListeners[$parent])) {
+                $tagetEntities = array_merge($tagetEntities, $this->entityListeners[$parent]);
+            }
+        }
+
+        foreach(class_uses($metadata->name, true) as $trait) {
+            echo $trait;
+            if(isset($this->entityListeners[$trait])) {
+                $tagetEntities = array_merge($tagetEntities, $this->entityListeners[$trait]);
+            }
+        }		
+
+        foreach ($tagetEntities as $listener) {
             if ($listener['event'] === null) {
                 EntityListenerBuilder::bindEntityListener($metadata, $listener['class']);
             } else {

--- a/tests/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -103,6 +103,114 @@ class AttachEntityListenersListenerTest extends OrmTestCase
         self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
     }
 
+    public function testAttachToExistingInterfaceListeners(): void
+    {
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestInterfaceEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::prePersist,
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestBarEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::postPersist,
+            'postPersistHandler',
+        );
+
+        $metadata = $this->factory->getMetadataFor(AttachEntityListenersListenerTestBarEntity::class);
+
+        self::assertArrayHasKey('postPersist', $metadata->entityListeners);
+        self::assertArrayHasKey('prePersist', $metadata->entityListeners);
+
+        self::assertCount(2, $metadata->entityListeners['prePersist']);
+        self::assertCount(2, $metadata->entityListeners['postPersist']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['prePersist'][0]['class']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['prePersist'][1]['class']);
+
+        self::assertEquals('postPersist', $metadata->entityListeners['postPersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postPersist'][0]['class']);
+
+        self::assertEquals('postPersistHandler', $metadata->entityListeners['postPersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
+    }
+
+    public function testAttachToExistingParentListeners(): void
+    {
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestParentEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::prePersist,
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestBarEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::postPersist,
+            'postPersistHandler',
+        );
+
+        $metadata = $this->factory->getMetadataFor(AttachEntityListenersListenerTestBarEntity::class);
+
+        self::assertArrayHasKey('postPersist', $metadata->entityListeners);
+        self::assertArrayHasKey('prePersist', $metadata->entityListeners);
+
+        self::assertCount(2, $metadata->entityListeners['prePersist']);
+        self::assertCount(2, $metadata->entityListeners['postPersist']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['prePersist'][0]['class']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['prePersist'][1]['class']);
+
+        self::assertEquals('postPersist', $metadata->entityListeners['postPersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postPersist'][0]['class']);
+
+        self::assertEquals('postPersistHandler', $metadata->entityListeners['postPersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
+    }
+
+    public function testAttachToExistingTraitListeners(): void
+    {
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestTraitEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::prePersist,
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestBarEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::postPersist,
+            'postPersistHandler',
+        );
+
+        $metadata = $this->factory->getMetadataFor(AttachEntityListenersListenerTestBarEntity::class);
+
+        self::assertArrayHasKey('postPersist', $metadata->entityListeners);
+        self::assertArrayHasKey('prePersist', $metadata->entityListeners);
+
+        self::assertCount(2, $metadata->entityListeners['prePersist']);
+        self::assertCount(2, $metadata->entityListeners['postPersist']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['prePersist'][0]['class']);
+
+        self::assertEquals('prePersist', $metadata->entityListeners['prePersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['prePersist'][1]['class']);
+
+        self::assertEquals('postPersist', $metadata->entityListeners['postPersist'][0]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postPersist'][0]['class']);
+
+        self::assertEquals('postPersistHandler', $metadata->entityListeners['postPersist'][1]['method']);
+        self::assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
+    }
+
     public function testDuplicateEntityListenerException(): void
     {
         $this->expectException(MappingException::class);
@@ -147,6 +255,17 @@ class AttachEntityListenersListenerTest extends OrmTestCase
     }
 }
 
+class AttachEntityListenersListenerTestParentEntity
+{
+}
+
+trait AttachEntityListenersListenerTestTraitEntity
+{
+}
+interface AttachEntityListenersListenerTestInterfaceEntity
+{
+}
+
 #[Entity]
 class AttachEntityListenersListenerTestFooEntity
 {
@@ -159,8 +278,10 @@ class AttachEntityListenersListenerTestFooEntity
 
 #[Entity]
 #[EntityListeners(['AttachEntityListenersListenerTestListener'])]
-class AttachEntityListenersListenerTestBarEntity
+class AttachEntityListenersListenerTestBarEntity extends AttachEntityListenersListenerTestParentEntity implements AttachEntityListenersListenerTestInterfaceEntity
 {
+    use AttachEntityListenersListenerTestTraitEntity;
+
     /** @var int */
     #[Id]
     #[Column(type: 'integer')]


### PR DESCRIPTION
Add possibility to specify an interface, a parent class or a trait in entityClass in addEntityListener function.
With This, in symfony we can write :

```php 
#[AsEntityListener(event: Events::postUpdate, method: 'postUpdate', entity: MyInterface::class)]
#[AsEntityListener(event: Events::postUpdate, method: 'postUpdate', entity: MyTrait::class)]
#[AsEntityListener(event: Events::postUpdate, method: 'postUpdate', entity: MyParent::class)]
```