### PR TITLE
Remove quotes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,4 +381,4 @@ jobs:
         with:
           directory: reports
         env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
In the case of a pull request made from a fork, secrets are not accessible, and this resolved to null.
The codecov action seems to interpret null as no secret provided, while it interprets the empty string as an invalid token, making the whole tokenless upload invalid.