### PR TITLE
Allow named Arguments to be passed to Dto

### DIFF
--- a/src/Exception/DuplicateFieldException.php
+++ b/src/Exception/DuplicateFieldException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use LogicException;
+
+use function sprintf;
+
+class DuplicateFieldException extends LogicException implements ORMException
+{
+    public static function create(string $argName, string $columnName): self
+    {
+        return new self(sprintf('Name "%s" for "%s" already in use.', $argName, $columnName));
+    }
+}

--- a/src/Exception/NoMatchingPropertyException.php
+++ b/src/Exception/NoMatchingPropertyException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use LogicException;
+
+use function sprintf;
+
+class NoMatchingPropertyException extends LogicException implements ORMException
+{
+    public static function create(string $property): self
+    {
+        return new self(sprintf('Column name "%s" does not match any property name. Consider aliasing it to the name of an existing property.', $property));
+    }
+}

--- a/src/Query/ResultSetMapping.php
+++ b/src/Query/ResultSetMapping.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
-use function array_merge;
 use function count;
 
 /**
@@ -549,27 +548,6 @@ class ResultSetMapping
         if ($type) {
             $this->typeMappings[$columnName] = $type;
         }
-
-        return $this;
-    }
-
-    public function addNewObjectAsArgument(string|int $alias, string|int $objOwner, int $objOwnerIdx): static
-    {
-        $owner = [
-            'ownerIndex' => $objOwner,
-            'argIndex' => $objOwnerIdx,
-        ];
-
-        if (! isset($this->nestedNewObjectArguments[$owner['ownerIndex']])) {
-            $this->nestedNewObjectArguments[$alias] = $owner;
-
-            return $this;
-        }
-
-        $this->nestedNewObjectArguments = array_merge(
-            [$alias => $owner],
-            $this->nestedNewObjectArguments,
-        );
 
         return $this;
     }

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1510,6 +1510,7 @@ class SqlWalker
                     $this->newObjectStack[] = [$objIndex, $argIndex];
                     $sqlSelectExpressions[] = $e->dispatch($this);
                     array_pop($this->newObjectStack);
+                    $this->rsm->nestedNewObjectArguments[$columnAlias] = ['ownerIndex' => $objIndex, 'argIndex' => $argIndex];
                     break;
 
                 case $e instanceof AST\Subselect:
@@ -1563,10 +1564,6 @@ class SqlWalker
                 'objIndex'  => $objIndex,
                 'argIndex'  => $argIndex,
             ];
-
-            if ($objOwner !== null && $objOwnerIdx !== null) {
-                $this->rsm->addNewObjectAsArgument($objIndex, $objOwner, $objOwnerIdx);
-            }
         }
 
         return implode(', ', $sqlSelectExpressions);

--- a/src/Query/TokenType.php
+++ b/src/Query/TokenType.php
@@ -89,4 +89,5 @@ enum TokenType: int
     case T_WHEN     = 254;
     case T_WHERE    = 255;
     case T_WITH     = 256;
+    case T_NAMED    = 257;
 }

--- a/tests/Tests/Models/CMS/CmsAddressDTONamedArgs.php
+++ b/tests/Tests/Models/CMS/CmsAddressDTONamedArgs.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+class CmsAddressDTONamedArgs
+{
+    public function __construct(
+        public string|null $country = null,
+        public string|null $city = null,
+        public string|null $zip = null,
+        public CmsAddressDTO|string|null $address = null,
+    ) {
+    }
+}

--- a/tests/Tests/Models/CMS/CmsUserDTONamedArgs.php
+++ b/tests/Tests/Models/CMS/CmsUserDTONamedArgs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+class CmsUserDTONamedArgs
+{
+    public function __construct(
+        public string|null $name = null,
+        public string|null $email = null,
+        public string|null $address = null,
+        public int|null $phonenumbers = null,
+        public CmsAddressDTO|null $addressDto = null,
+        public CmsAddressDTONamedArgs|null $addressDtoNamedArgs = null,
+    ) {
+    }
+}

--- a/tests/Tests/Models/CMS/CmsUserDTOVariadicArg.php
+++ b/tests/Tests/Models/CMS/CmsUserDTOVariadicArg.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+class CmsUserDTOVariadicArg
+{
+    public string|null $name      = null;
+    public string|null $email     = null;
+    public string|null $address   = null;
+    public int|null $phonenumbers = null;
+
+    public function __construct(...$args)
+    {
+        $this->name         = $args['name'] ?? null;
+        $this->email        = $args['email'] ?? null;
+        $this->phonenumbers = $args['phonenumbers'] ?? null;
+        $this->address      = $args['address'] ?? null;
+    }
+}

--- a/tests/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -102,21 +102,4 @@ class ResultSetMappingTest extends OrmTestCase
 
         self::assertTrue($this->_rsm->hasIndexBy('lu'));
     }
-
-    public function testNewObjectNestedArgumentsDeepestLeavesShouldComeFirst(): void
-    {
-        $this->_rsm->addNewObjectAsArgument('objALevel2', 'objALevel1', 0);
-        $this->_rsm->addNewObjectAsArgument('objALevel3', 'objALevel2', 1);
-        $this->_rsm->addNewObjectAsArgument('objBLevel3', 'objBLevel2', 0);
-        $this->_rsm->addNewObjectAsArgument('objBLevel2', 'objBLevel1', 1);
-
-        $expectedArgumentMapping = [
-            'objALevel3' => ['ownerIndex' => 'objALevel2', 'argIndex' => 1],
-            'objALevel2' => ['ownerIndex' => 'objALevel1', 'argIndex' => 0],
-            'objBLevel3' => ['ownerIndex' => 'objBLevel2', 'argIndex' => 0],
-            'objBLevel2' => ['ownerIndex' => 'objBLevel1', 'argIndex' => 1],
-        ];
-
-        self::assertSame($expectedArgumentMapping, $this->_rsm->nestedNewObjectArguments);
-    }
 }


### PR DESCRIPTION
Allow to change argument order or use variadic argument in dto constructor.

When Dto implements (empty) interface WithNamedArguments, ObjectHydrator will pass an associated key<>value argument to Dto constructor.
Dto can use named arguments or a variadic argument to put values in their properties.

Final Goal (to do after) is to allow `select NEW ItemDto(item.*) FROM App\Entity\Item as item`


updated with with the nested New operator PR.