### PR TITLE
Precise EntityRepository::count return type

### DIFF
--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -131,6 +131,7 @@ class EntityRepository implements ObjectRepository, Selectable
      * @psalm-param array<string, mixed> $criteria
      *
      * @return int The cardinality of the objects that match the given criteria.
+     * @psalm-return 0|positive-int
      *
      * @todo Add this method to `ObjectRepository` interface in the next major release
      */

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -835,7 +835,10 @@ class BasicEntityPersister implements EntityPersister
             ? $this->expandCriteriaParameters($criteria)
             : $this->expandParameters($criteria);
 
-        return (int) $this->conn->executeQuery($sql, $params, $types)->fetchOne();
+        $count = (int) $this->conn->executeQuery($sql, $params, $types)->fetchOne();
+        assert($count >= 0);
+
+        return $count;
     }
 
     /**

--- a/src/Persisters/Entity/EntityPersister.php
+++ b/src/Persisters/Entity/EntityPersister.php
@@ -125,6 +125,8 @@ interface EntityPersister
      * Count entities (optionally filtered by a criteria)
      *
      * @param mixed[]|Criteria $criteria
+     *
+     * @psalm-return 0|positive-int
      */
     public function count(array|Criteria $criteria = []): int;
 


### PR DESCRIPTION
Such PR was introduced on PHPStan side https://github.com/phpstan/phpstan-doctrine/pull/604/files

Either it's false, either it's true and should be directly added to the ORM code.
I already saw multiple `@psalm-return 0|positive-int` occurences, so I used the same syntax.

Psalm does not understand that in the `BasicEntityPersister`, `'SELECT COUNT(*) ...` returns a positive int ; should I add the error to the baseline or typehint the result in a temporary variable ? (WDY prefer @greg0ire)