### PR TITLE
Cache null/empty returns for findOneBy

### DIFF
--- a/src/Cache/DefaultQueryCache.php
+++ b/src/Cache/DefaultQueryCache.php
@@ -85,7 +85,11 @@ class DefaultQueryCache implements QueryCache
         $generateKeys = static fn (array $entry): EntityCacheKey => new EntityCacheKey($cm->rootEntityName, $entry['identifier']);
 
         $cacheKeys = new CollectionCacheEntry(array_map($generateKeys, $cacheEntry->result));
-        $entries   = $region->getMultiple($cacheKeys) ?? [];
+        $entries   = $region->getMultiple($cacheKeys);
+        
+        if ($entries === null) {
+            return null;
+        }
 
         // @TODO - move to cache hydration component
         foreach ($cacheEntry->result as $index => $entry) {

--- a/src/Cache/DefaultQueryCache.php
+++ b/src/Cache/DefaultQueryCache.php
@@ -86,7 +86,7 @@ class DefaultQueryCache implements QueryCache
 
         $cacheKeys = new CollectionCacheEntry(array_map($generateKeys, $cacheEntry->result));
         $entries   = $region->getMultiple($cacheKeys);
-        
+
         if ($entries === null) {
             return null;
         }

--- a/src/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/src/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -311,7 +311,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
             if (empty($result)) {
                 return null;
-            } 
+            }
 
             return $result[0];
         }

--- a/src/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/src/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -309,16 +309,20 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         if ($result !== null) {
             $this->cacheLogger?->queryCacheHit($this->regionName, $queryKey);
 
+            if (empty($result)) {
+                return null;
+            } 
+
             return $result[0];
         }
 
         $result = $this->persister->load($criteria, $entity, $assoc, $hints, $lockMode, $limit, $orderBy);
 
         if ($result === null) {
-            return null;
+            $cached = $queryCache->put($queryKey, $rsm, []);
+        } else {
+            $cached = $queryCache->put($queryKey, $rsm, [$result]);
         }
-
-        $cached = $queryCache->put($queryKey, $rsm, [$result]);
 
         $this->cacheLogger?->queryCacheMiss($this->regionName, $queryKey);
 

--- a/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -446,7 +446,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertCount(2, $result2);
 
         self::assertEquals(5, $this->secondLevelCacheLogger->getPutCount());
-        self::assertEquals(3, $this->secondLevelCacheLogger->getMissCount());
+        self::assertEquals(2, $this->secondLevelCacheLogger->getMissCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionPutCount($this->getDefaultQueryRegionName()));
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionMissCount($this->getDefaultQueryRegionName()));
 


### PR DESCRIPTION
On 'findOneBy' calls which return no an empty result set from the persister, null values are not cached.
This makes it so that repeat calls of 'findOneBy' with the same criteria, always hit the database.

The changes introduced in this commit make the AbstractEntityPersister cache the empty result set in the region, so that repeat calls do not hit the database again.

The existing mechanism to invalidate the query cache is sufficient; any persist/update performed to the region will invalidate it, exactly how it happens for non-empty result sets.

This is also more in-line with the way 'loadByCriteria' and 'loadAll' behave.

Fixes #11563