### PR TITLE
Update advanced-field-value-conversion-using-custom-mapping-types.rst

### DIFF
--- a/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
+++ b/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
@@ -134,7 +134,7 @@ Now we're going to create the ``point`` type and implement all required methods.
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
             if ($value instanceof Point) {
-                $value = sprintf('POINT(%F %F)', $value->getLongitude(), $value->getLatitude());
+                $value = sprintf('POINT(%F %F)', $value->getLatitude(), $value->getLongitude());
             }
 
             return $value;


### PR DESCRIPTION
In the `convertToDatabaseValue` was the ordering of the latitude and the longitude not right. Switched the two to the right place