### PR TITLE
fix: non-managed properties should trigger proxy load

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -447,7 +447,7 @@ EOPHP;
             foreach ($reflector->getProperties($filter) as $property) {
                 $name = $property->name;
 
-                if ($property->isStatic() || (($class->hasField($name) || $class->hasAssociation($name)) && ! isset($identifiers[$name]))) {
+                if ($property->isStatic() || ! isset($identifiers[$name])) {
                     continue;
                 }
 

--- a/tests/Tests/Models/Product/Product.php
+++ b/tests/Tests/Models/Product/Product.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Product;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class Product
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column()
+     * @ORM\GeneratedValue
+     */
+    #[ORM\Id]
+    #[ORM\Column()]
+    #[ORM\GeneratedValue]
+    private int $id = 42;
+
+    /**
+     * @ORM\Column()
+     */
+    #[ORM\Column()]
+    private string $name;
+
+    private ?string $image = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    public function setImage(string $image): void
+    {
+        $this->image = $image;
+    }
+}

--- a/tests/Tests/Models/Product/Product.php
+++ b/tests/Tests/Models/Product/Product.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\Column()
      * @ORM\GeneratedValue
@@ -20,7 +21,7 @@ class Product
     #[ORM\Id]
     #[ORM\Column()]
     #[ORM\GeneratedValue]
-    private int $id = 42;
+    private $id = 42;
 
     /**
      * @ORM\Column()

--- a/tests/Tests/Models/Product/Product.php
+++ b/tests/Tests/Models/Product/Product.php
@@ -24,12 +24,16 @@ class Product
     private $id = 42;
 
     /**
+     * @var string
      * @ORM\Column()
      */
     #[ORM\Column()]
-    private string $name;
+    private $name;
 
-    private ?string $image = null;
+    /**
+     * @var string|null
+     */
+    private $image = null;
 
     public function __construct(string $name)
     {

--- a/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -132,10 +132,10 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $reference = $this->_em->getReference(LifecycleCallbackTestEntity::class, $id);
-        self::assertFalse($reference->postLoadCallbackInvoked);
+        self::assertFalse(LifecycleCallbackTestEntity::$staticPostLoadCallbackInvoked);
 
         $reference->getValue(); // trigger proxy load
-        self::assertTrue($reference->postLoadCallbackInvoked);
+        self::assertTrue(LifecycleCallbackTestEntity::$staticPostLoadCallbackInvoked);
     }
 
     /** @group DDC-958 */
@@ -495,6 +495,9 @@ class LifecycleCallbackTestEntity
     public $postLoadCallbackInvoked = false;
 
     /** @var bool */
+    public static $staticPostLoadCallbackInvoked = false;
+
+    /** @var bool */
     public $postLoadCascaderNotNull = false;
 
     /** @var bool */
@@ -546,8 +549,9 @@ class LifecycleCallbackTestEntity
     /** @PostLoad */
     public function doStuffOnPostLoad(): void
     {
-        $this->postLoadCallbackInvoked = true;
-        $this->postLoadCascaderNotNull = isset($this->cascader);
+        $this->postLoadCallbackInvoked       = true;
+        self::$staticPostLoadCallbackInvoked = true;
+        $this->postLoadCascaderNotNull       = isset($this->cascader);
     }
 
     /** @PreUpdate */

--- a/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -47,6 +47,8 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
+        LifecycleCallbackTestEntity::$staticPostLoadCallbackInvoked = false;
+
         $this->createSchemaForModels(
             LifecycleCallbackEventArgEntity::class,
             LifecycleCallbackTestEntity::class,

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -249,7 +249,7 @@ class ProxyFactoryTest extends OrmTestCase
 
         $classMetaData = $this->emMock->getClassMetadata(Product::class);
 
-        $persister  = $this
+        $persister = $this
             ->getMockBuilder(BasicEntityPersister::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -260,7 +260,7 @@ class ProxyFactoryTest extends OrmTestCase
             ->expects(self::atLeastOnce())
             ->method('loadById')
             ->with(self::equalTo($identifier))
-            ->will(self::returnValue($product));
+            ->willReturn($product);
 
         $persister
             ->expects(self::atLeastOnce())


### PR DESCRIPTION
After the move to lazy ghost, properties not managed by Doctrine no longer trigger proxy initialization.

This new behavior impacts things like file uploads that rely on `postLoad` event handler. Accessing a file upload property does not trigger the load, so the upload property is incorrectly null, unless the consumer first triggers the load by accessing another property first (or explicitly call `__load`).

This PR restores the behavior of legacy proxy, and should resolve the aforementioned issue.

