### PR TITLE
Intial event commit id support

### DIFF
--- a/src/Event/CommitEventIdAware.php
+++ b/src/Event/CommitEventIdAware.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+/**
+ * Allows for discerning from which commit did the event come from.
+ *
+ * Nullability left as a fallback for old events, custom ones or unable to discern.
+ */
+interface CommitEventIdAware
+{
+    public function getCommitEventId(): ?string;
+}

--- a/src/Event/OnFlushEventArgs.php
+++ b/src/Event/OnFlushEventArgs.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Event;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Provides event arguments for the preFlush event.
@@ -15,8 +16,23 @@ use Doctrine\Persistence\Event\ManagerEventArgs;
  *
  * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class OnFlushEventArgs extends ManagerEventArgs
+class OnFlushEventArgs extends ManagerEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct(ObjectManager $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
+
     /**
      * Retrieve associated EntityManager.
      *

--- a/src/Event/PostFlushEventArgs.php
+++ b/src/Event/PostFlushEventArgs.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Event;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Provides event arguments for the postFlush event.
@@ -15,8 +16,23 @@ use Doctrine\Persistence\Event\ManagerEventArgs;
  *
  * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class PostFlushEventArgs extends ManagerEventArgs
+class PostFlushEventArgs extends ManagerEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct(ObjectManager $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
+
     /**
      * Retrieves associated EntityManager.
      *

--- a/src/Event/PostPersistEventArgs.php
+++ b/src/Event/PostPersistEventArgs.php
@@ -4,6 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-final class PostPersistEventArgs extends LifecycleEventArgs
+use Doctrine\ORM\EntityManagerInterface;
+
+final class PostPersistEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct($object, EntityManagerInterface $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($object, $objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
 }

--- a/src/Event/PostRemoveEventArgs.php
+++ b/src/Event/PostRemoveEventArgs.php
@@ -4,6 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-final class PostRemoveEventArgs extends LifecycleEventArgs
+use Doctrine\ORM\EntityManagerInterface;
+
+final class PostRemoveEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct($object, EntityManagerInterface $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = null;
+
+        parent::__construct($object, $objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
 }

--- a/src/Event/PostUpdateEventArgs.php
+++ b/src/Event/PostUpdateEventArgs.php
@@ -4,6 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-final class PostUpdateEventArgs extends LifecycleEventArgs
+use Doctrine\ORM\EntityManagerInterface;
+
+final class PostUpdateEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct($object, EntityManagerInterface $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($object, $objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
 }

--- a/src/Event/PreFlushEventArgs.php
+++ b/src/Event/PreFlushEventArgs.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Event;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Provides event arguments for the preFlush event.
@@ -15,8 +16,23 @@ use Doctrine\Persistence\Event\ManagerEventArgs;
  *
  * @extends ManagerEventArgs<EntityManagerInterface>
  */
-class PreFlushEventArgs extends ManagerEventArgs
+class PreFlushEventArgs extends ManagerEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct(ObjectManager $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
+
     /**
      * @deprecated 2.13. Use {@see getObjectManager} instead.
      *

--- a/src/Event/PrePersistEventArgs.php
+++ b/src/Event/PrePersistEventArgs.php
@@ -4,6 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-final class PrePersistEventArgs extends LifecycleEventArgs
+use Doctrine\ORM\EntityManagerInterface;
+
+final class PrePersistEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct($object, EntityManagerInterface $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($object, $objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
 }

--- a/src/Event/PreRemoveEventArgs.php
+++ b/src/Event/PreRemoveEventArgs.php
@@ -4,6 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
-final class PreRemoveEventArgs extends LifecycleEventArgs
+use Doctrine\ORM\EntityManagerInterface;
+
+final class PreRemoveEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
+    public function __construct($object, EntityManagerInterface $objectManager, ?string $commitEventId = null)
+    {
+        $this->commitEventId = $commitEventId;
+
+        parent::__construct($object, $objectManager);
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
+    }
 }

--- a/src/Event/PreUpdateEventArgs.php
+++ b/src/Event/PreUpdateEventArgs.php
@@ -14,8 +14,11 @@ use function sprintf;
 /**
  * Class that holds event arguments for a preUpdate event.
  */
-class PreUpdateEventArgs extends LifecycleEventArgs
+class PreUpdateEventArgs extends LifecycleEventArgs implements CommitEventIdAware
 {
+    /** @var string|null */
+    private $commitEventId = null;
+
     /** @var array<string, array{mixed, mixed}|PersistentCollection> */
     private $entityChangeSet;
 
@@ -24,11 +27,17 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      * @param mixed[][] $changeSet
      * @psalm-param array<string, array{mixed, mixed}|PersistentCollection> $changeSet
      */
-    public function __construct($entity, EntityManagerInterface $em, array &$changeSet)
+    public function __construct($entity, EntityManagerInterface $em, array &$changeSet, ?string $commitEventId = null)
     {
         parent::__construct($entity, $em);
 
         $this->entityChangeSet = &$changeSet;
+        $this->commitEventId   = $commitEventId;
+    }
+
+    public function getCommitEventId(): ?string
+    {
+        return $this->commitEventId;
     }
 
     /**


### PR DESCRIPTION
Hey,

This is a draft with an idea for discerning which UoW commit we're running the events for.
The idea behind this is that as of now I'm unable to detect what is the "context" for the events being sent. As such, it is not possible to properly queue things with PostFlush in our event library [here](https://github.com/dualmediaspzoo/symfony-doctrine-event-converter-bundle).

I'd like to be able to detect the context the events are running in, as I might delay dispatching of symfony events until PostFlush occurs. As of now, any events which fit the criteria will be added to a dispatch queue, which once ran will trigger more events, which then may in turn trigger more events... etc etc.
The point is not to stop this behavior, but rather to detect the correct order of dispatching of said events, for which I'd need the functionality below.

I would appriciate all and any feedback, along with information if you'd consider adding said feature, should it be done to your satisfaction. For now, this is simply an idea, might also be in the incorrect branch, but I don't think it's a BC break? (though it might be because of the additional parameter)?

The CommitEventId logic could be simplified a bit by modifying the event in persistence, but I'm not sure that's a great idea.

PS. Isn't PrePersist called too early? Shouldn't it be called during UoW->Commit?