### PR TITLE
Detect invalid `indexBy` configuration in the SchemaValidator

### DIFF
--- a/tests/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\DbalTypes\CustomIdObjectType;
 use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
 use Doctrine\Tests\DbalTypes\UpperCaseStringType;
+use Doctrine\Tests\ORM\Functional\Ticket\GH11608\GH11608Test;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -52,6 +53,18 @@ class SchemaValidatorTest extends OrmFunctionalTestCase
         $modelSets = [];
 
         foreach (array_keys(self::$modelSets) as $modelSet) {
+
+            /**
+             * GH11608 Tests whether the Schema validator picks up on invalid mapping. The entities are intentionally
+             * invalid, and so for the purpose of this test case, those entities should be ignored.
+             *
+             * @see GH11608Test
+             * @see https://github.com/doctrine/orm/issues/11608
+             */
+            if ($modelSet === GH11608Test::class) {
+                continue;
+            }
+
             $modelSets[$modelSet] = [$modelSet];
         }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/ConnectingEntity.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/ConnectingEntity.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH11608;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+#[Entity]
+class ConnectingEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int $id;
+
+    #[ManyToOne(inversedBy: 'validRightSideEntities')]
+    #[JoinColumn(nullable: false)]
+    public LeftSideEntity $validLeftSideMappedByAssociation;
+
+    #[ManyToOne(inversedBy: 'invalidRightSideEntities')]
+    #[JoinColumn(nullable: false)]
+    public LeftSideEntity $invalidLeftSideMappedByAssociation;
+
+    #[ManyToOne(inversedBy: 'validConnections')]
+    #[JoinColumn(nullable: false)]
+    public LeftSideEntity $validLeftSideMappedByColumn;
+
+    #[ManyToOne(inversedBy: 'invalidConnections')]
+    #[JoinColumn(nullable: false)]
+    public LeftSideEntity $invalidLeftSideMappedByColumn;
+
+    #[ManyToOne(inversedBy: 'leftSideEntities')]
+    #[JoinColumn(name: 'right_side_id', nullable: false)]
+    public RightSideEntity $rightSide;
+
+    #[Column(type: 'text', nullable: false)]
+    public string $arbitraryValue;
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH11608;
+
+use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
+use Doctrine\ORM\Tools\SchemaValidator;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH11608Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useModelSet(self::class);
+        $this->_em->getConfiguration()->setNamingStrategy(new UnderscoreNamingStrategy());
+    }
+
+    public function testOneToManyIndexByErrorDetected(): void
+    {
+        $validator = new SchemaValidator($this->_em);
+
+        $errors = $validator->validateClass($this->_em->getClassMetadata(LeftSideEntity::class));
+
+        self::assertCount(2, $errors);
+
+        self::assertStringContainsStringIgnoringCase('invalidRightSideEntities is indexed by a field right_side_id_that_doesnt_exist', $errors[0]);
+        self::assertStringContainsStringIgnoringCase('invalidConnections is indexed by a field arbitrary_value_that_doesnt_exist', $errors[1]);
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
@@ -7,12 +7,17 @@ namespace Doctrine\Tests\ORM\Functional\Ticket\GH11608;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function var_dump;
 
 class GH11608Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->useModelSet(self::class);
         $this->_em->getConfiguration()->setNamingStrategy(new UnderscoreNamingStrategy());
     }
@@ -27,5 +32,22 @@ class GH11608Test extends OrmFunctionalTestCase
 
         self::assertStringContainsStringIgnoringCase('invalidRightSideEntities is indexed by a field right_side_id_that_doesnt_exist', $errors[0]);
         self::assertStringContainsStringIgnoringCase('invalidConnections is indexed by a field arbitrary_value_that_doesnt_exist', $errors[1]);
+    }
+
+    #[DataProvider('provideValidEntitiesCauseNoErrors')]
+    public function testValidEntitiesCauseNoErrors(string $className): void
+    {
+        $validator = new SchemaValidator($this->_em);
+
+        $errors = $validator->validateClass($this->_em->getClassMetadata($className));
+
+        var_dump($errors);
+        self::assertEmpty($errors);
+    }
+
+    public static function provideValidEntitiesCauseNoErrors(): Generator
+    {
+        yield [ConnectingEntity::class];
+        yield [RightSideEntity::class];
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/GH11608Test.php
@@ -41,7 +41,6 @@ class GH11608Test extends OrmFunctionalTestCase
 
         $errors = $validator->validateClass($this->_em->getClassMetadata($className));
 
-        var_dump($errors);
         self::assertEmpty($errors);
     }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/LeftSideEntity.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/LeftSideEntity.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH11608;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class LeftSideEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int $id;
+
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'validLeftSideMappedByAssociation', indexBy: 'right_side_id')]
+    public Collection $validRightSideEntities;
+
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'invalidLeftSideMappedByAssociation', indexBy: 'right_side_id_that_doesnt_exist')]
+    public Collection $invalidRightSideEntities;
+
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'validLeftSideMappedByColumn', indexBy: 'arbitrary_value')]
+    public Collection $validConnections;
+
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'invalidLeftSideMappedByColumn', indexBy: 'arbitrary_value_that_doesnt_exist')]
+    public Collection $invalidConnections;
+
+    public function __construct()
+    {
+        $this->validRightSideEntities   = new ArrayCollection();
+        $this->invalidRightSideEntities = new ArrayCollection();
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/RightSideEntity.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/RightSideEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH11608;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class RightSideEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int $id;
+
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'rightSide', indexBy: 'left_side_id')]
+    public Collection $leftSideEntities;
+
+    public function __construct()
+    {
+        $this->leftSideEntities = new ArrayCollection();
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH11608/RightSideEntity.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11608/RightSideEntity.php
@@ -20,7 +20,7 @@ class RightSideEntity
     #[GeneratedValue]
     public int $id;
 
-    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'rightSide', indexBy: 'left_side_id')]
+    #[OneToMany(targetEntity: ConnectingEntity::class, mappedBy: 'rightSide', indexBy: 'id')]
     public Collection $leftSideEntities;
 
     public function __construct()

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -167,6 +167,7 @@ use Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKe
 use Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity;
 use Doctrine\Tests\Models\VersionedManyToOne\Article;
 use Doctrine\Tests\Models\VersionedManyToOne\Category;
+use Doctrine\Tests\ORM\Functional\Ticket\GH11608;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Count;
@@ -482,6 +483,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'issue9300' => [
             Models\Issue9300\Issue9300Child::class,
             Models\Issue9300\Issue9300Parent::class,
+        ],
+        GH11608\GH11608Test::class => [
+            GH11608\LeftSideEntity::class,
+            GH11608\RightSideEntity::class,
+            GH11608\ConnectingEntity::class,
         ],
     ];
 


### PR DESCRIPTION
Fixes #11608 