### PR TITLE
Issue with single table inheritance and association keys

### DIFF
--- a/tests/Tests/Models/IssueKanbanBOX/EntityA.php
+++ b/tests/Tests/Models/IssueKanbanBOX/EntityA.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+
+#[Entity]
+class EntityA extends VersionedEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    public int $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    #[OneToOne(targetEntity: EntityVersion::class, cascade: ['persist'])]
+    #[JoinColumn(name: 'id', referencedColumnName: 'entityId', nullable: true, onDelete: 'CASCADE')]
+    protected EntityVersion|null $version = null;
+
+    protected function createVersion(string $version): EntityVersion
+    {
+        return new EntityAVersion($this->id, $version);
+    }
+}

--- a/tests/Tests/Models/IssueKanbanBOX/EntityAVersion.php
+++ b/tests/Tests/Models/IssueKanbanBOX/EntityAVersion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class EntityAVersion extends EntityVersion
+{
+}

--- a/tests/Tests/Models/IssueKanbanBOX/EntityB.php
+++ b/tests/Tests/Models/IssueKanbanBOX/EntityB.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+
+#[Entity]
+class EntityB extends VersionedEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    public int $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    #[OneToOne(targetEntity: EntityBVersion::class)]
+    #[JoinColumn(name: 'id', referencedColumnName: 'entityId')]
+    protected EntityVersion|null $version = null;
+
+    protected function createVersion(string $version): EntityVersion
+    {
+        return new EntityBVersion($this->id, $version);
+    }
+}

--- a/tests/Tests/Models/IssueKanbanBOX/EntityBVersion.php
+++ b/tests/Tests/Models/IssueKanbanBOX/EntityBVersion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class EntityBVersion extends EntityVersion
+{
+}

--- a/tests/Tests/Models/IssueKanbanBOX/EntityVersion.php
+++ b/tests/Tests/Models/IssueKanbanBOX/EntityVersion.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'entity_version')]
+#[Entity]
+#[InheritanceType('SINGLE_TABLE')]
+#[DiscriminatorMap([EntityA::class => EntityAVersion::class, EntityB::class => EntityBVersion::class])]
+#[DiscriminatorColumn(name: 'entityType', type: 'string')]
+abstract class EntityVersion
+{
+    /** @var class-string  */
+    #[Id]
+    public $entityType;
+
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    public $entityId;
+
+    /** @var string */
+    #[Column(type: 'string')]
+    public $version;
+
+    public function __construct(
+        int $entityId,
+        string $version,
+    ) {
+        $this->entityType = static::class;
+        $this->entityId   = $entityId;
+        $this->version    = $version;
+    }
+
+    public function setVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+}

--- a/tests/Tests/Models/IssueKanbanBOX/VersionedEntity.php
+++ b/tests/Tests/Models/IssueKanbanBOX/VersionedEntity.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\IssueKanbanBOX;
+
+use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\Persistence\Proxy;
+use ReflectionProperty;
+
+abstract class VersionedEntity
+{
+    protected EntityVersion|null $version = null;
+
+    abstract protected function createVersion(string $version): EntityVersion;
+
+    public function setVersion(string $version): void
+    {
+        //$this->ensureJoinedEntityPropertyInitialized($this, 'version');
+
+        if ($this->version === null) {
+            $this->version = $this->createVersion($version);
+
+            return;
+        }
+
+        $this->version->version = $version;
+    }
+
+    public function getVersion(): string|null
+    {
+        //$this->ensureJoinedEntityPropertyInitialized($this, 'version');
+
+        return $this->version?->version;
+    }
+
+    private function ensureJoinedEntityPropertyInitialized(object $entity, string $propertyName): void
+    {
+        $reflection = new ReflectionProperty($entity, $propertyName);
+        $value      = $reflection->getValue($entity);
+        if (! ($value instanceof Proxy)) {
+            return;
+        }
+
+        try {
+            $value->__load();
+        } catch (EntityNotFoundException) {
+            $reflection->setValue($entity, null);
+        }
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/IssueKanbanBOXTest.php
+++ b/tests/Tests/ORM/Functional/Ticket/IssueKanbanBOXTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\IssueKanbanBOX\EntityA;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class IssueKanbanBOXTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('issueKanbanBOX');
+
+        parent::setUp();
+    }
+
+    public function testEntityVersion(): void
+    {
+        $entityA = new EntityA(1);
+        $this->_em->persist($entityA);
+        $this->_em->flush();
+        $this->_em->clear();
+        $dbRetrievedEntityA = $this->_em->getRepository(EntityA::class)->find(1);
+        self::assertNull($dbRetrievedEntityA->getVersion());
+    }
+}

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -483,6 +483,13 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue9300\Issue9300Child::class,
             Models\Issue9300\Issue9300Parent::class,
         ],
+        'issueKanbanBOX' => [
+            Models\IssueKanbanBOX\EntityVersion::class,
+            Models\IssueKanbanBOX\EntityAVersion::class,
+            Models\IssueKanbanBOX\EntityBVersion::class,
+            Models\IssueKanbanBOX\EntityA::class,
+            Models\IssueKanbanBOX\EntityB::class,
+        ],
     ];
 
     /** @param class-string ...$models */


### PR DESCRIPTION
Having a one to one join with a single table inheritance entity i have issues when the proxy __load results in not having an associated tuple in the joined table.
The given exception is:
```
Doctrine\ORM\Exception\EntityIdentityCollisionException: While adding an entity of class KanbanBOX\Core\Card\Domain\Model\CardVersion with an ID hash of "256" to the identity map,
another object of class DoctrineProxies\__CG__\KanbanBOX\Core\Card\Domain\Model\CardVersion was already present for the same ID. This exception
is a safeguard against an internal inconsistency - IDs should uniquely map to
entity object instances. This problem may occur if:

- you use application-provided IDs and reuse ID values;
- database-provided IDs are reassigned after truncating the database without
clearing the EntityManager;
- you might have been using EntityManager#getReference() to create a reference
for a nonexistent ID that was subsequently (by the RDBMS) assigned to another
entity.

Otherwise, it might be an ORM-internal inconsistency, please report it.
```

I'm having problems simulating my issue in Doctrine/ORM testing environment since the test is creating a FOREIGN KEY based on mapping that makes the test fail.
In our real scenario we have a database first approach so we don't really have foreign key constraints.