### PR TITLE
Guides as dev dependency

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,17 +29,6 @@ jobs:
           coverage: "none"
           php-version: "8.3"
 
-      - name: "Remove existing composer file"
-        run: "rm composer.json"
-
-      - name: "Require phpdocumentor/guides-cli"
-        run: "composer require --dev phpdocumentor/guides-cli --no-update"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: "highest"
-
       - name: "Add orphan metadata where needed"
         run: |
           printf '%s\n\n%s\n' ":orphan:" "$(cat docs/en/sidebar.rst)" > docs/en/sidebar.rst

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpbench/phpbench": "^1.0",
+        "phpdocumentor/guides-cli": "^1.4",
         "phpstan/phpstan": "1.11.1",
         "phpunit/phpunit": "^10.4.0",
         "psr/log": "^1 || ^2 || ^3",


### PR DESCRIPTION
Needs https://github.com/doctrine/doctrine-website/pull/618

Note that there isn't a version of guides which is compatible with PHP 8.1, and I don't want contributors (or us, in the CI) to have to tweak the `composer.json` to be able to install the project so I'm targeting 3.2.x.