### PR TITLE
Move orphan metadata to where it belongs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,10 +40,5 @@ jobs:
         with:
           dependency-versions: "highest"
 
-      - name: "Add orphan metadata where needed"
-        run: |
-          printf '%s\n\n%s\n' ":orphan:" "$(cat docs/en/sidebar.rst)" > docs/en/sidebar.rst
-          printf '%s\n\n%s\n' ":orphan:" "$(cat docs/en/reference/installation.rst)" > docs/en/reference/installation.rst
-
       - name: "Run guides-cli"
         run: "vendor/bin/guides -vvv --no-progress docs/en 2>&1 | grep -v 'No template found for rendering directive' | ( ! grep WARNING )"

--- a/docs/en/reference/installation.rst
+++ b/docs/en/reference/installation.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Installation
 ============
 

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. toc::
 
    .. tocheader:: Tutorials


### PR DESCRIPTION
The goal here was to retain compatibility with doctrine/rst-parser, which is no longer in use in the website.

Needs https://github.com/doctrine/doctrine-website/pull/618