### PR TITLE
EntityGenerator lifecycle callbacks

### DIFF
--- a/src/Tools/EntityGenerator.php
+++ b/src/Tools/EntityGenerator.php
@@ -1421,11 +1421,12 @@ public function __construct(<params>)
     }
 
     /**
-     * @param string[] $events
+     * @param string|string[] $name
+     * @param string          $methodName
      *
      * @return string
      */
-    protected function generateLifecycleCallbackMethod(array $events, string $methodName, ClassMetadataInfo $metadata)
+    protected function generateLifecycleCallbackMethod($name, $methodName, ClassMetadataInfo $metadata)
     {
         if ($this->hasMethod($methodName, $metadata)) {
             return '';
@@ -1437,7 +1438,7 @@ public function __construct(<params>)
             function ($event) {
                 return $this->annotationsPrefix . ucfirst($event);
             },
-            $events
+            is_array($name) ? $name : [$name]
         );
         $replacements     = [
             '<name>'        => implode("\n * @", $eventAnnotations),

--- a/src/Tools/EntityGenerator.php
+++ b/src/Tools/EntityGenerator.php
@@ -1419,7 +1419,7 @@ public function __construct(<params>)
             return '';
         }
 
-        $this->staticReflection[$metadata->name]['methods'][] = $methodName;
+        $this->staticReflection[$metadata->name]['methods'][] = strtolower($methodName);
 
         $replacements = [
             '<name>'        => $this->annotationsPrefix . ucfirst($name),

--- a/src/Tools/EntityGenerator.php
+++ b/src/Tools/EntityGenerator.php
@@ -1278,20 +1278,22 @@ public function __construct(<params>)
         $lifecycleEventsByCallback = [];
         foreach ($metadata->lifecycleCallbacks as $event => $callbacks) {
             foreach ($callbacks as $callback) {
-                $callbackCaseInsensitive = $callback; 
-                foreach(array_keys($lifecycleEventsByCallback) as $key) {
-                    if(strtolower($key) === strtolower($callback)) {
+                $callbackCaseInsensitive = $callback;
+                foreach (array_keys($lifecycleEventsByCallback) as $key) {
+                    if (strtolower($key) === strtolower($callback)) {
                         $callbackCaseInsensitive = $key;
                         break;
                     }
                 }
+
                 $lifecycleEventsByCallback[$callbackCaseInsensitive][] = $event;
             }
         }
+
         foreach ($lifecycleEventsByCallback as $callback => $events) {
             $methods[] = $this->generateLifecycleCallbackMethod($events, $callback, $metadata);
         }
-//        var_dump($methods);
+
         return implode("\n\n", array_filter($methods));
     }
 
@@ -1419,8 +1421,7 @@ public function __construct(<params>)
     }
 
     /**
-     * @param array $events
-     * @param string $methodName
+     * @param string[] $events
      *
      * @return string
      */
@@ -1438,7 +1439,7 @@ public function __construct(<params>)
             },
             $events
         );
-        $replacements = [
+        $replacements     = [
             '<name>'        => implode("\n * @", $eventAnnotations),
             '<methodName>'  => $methodName,
         ];

--- a/tests/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -46,6 +46,9 @@ use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @runTestsInSeparateProcesses 
+ */
 class EntityGeneratorTest extends OrmTestCase
 {
     /** @var EntityGenerator */
@@ -112,6 +115,8 @@ class EntityGeneratorTest extends OrmTestCase
             ]
         );
         $metadata->addLifecycleCallback('loading', 'postLoad');
+        $metadata->addLifecycleCallback('logChange', 'prePersist');
+        $metadata->addLifecycleCallback('logChange', 'preRemove');
         $metadata->addLifecycleCallback('willBeRemoved', 'preRemove');
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
@@ -282,7 +287,7 @@ class EntityGeneratorTest extends OrmTestCase
         $reflClass = new ReflectionClass($metadata->name);
 
         self::assertCount(6, $reflClass->getProperties());
-        self::assertCount(15, $reflClass->getMethods());
+        self::assertCount(16, $reflClass->getMethods());
 
         self::assertEquals('published', $book->getStatus());
 
@@ -453,6 +458,7 @@ class EntityGeneratorTest extends OrmTestCase
 
         self::assertTrue($reflClass->hasMethod('loading'), 'Check for postLoad lifecycle callback.');
         self::assertTrue($reflClass->hasMethod('willBeRemoved'), 'Check for preRemove lifecycle callback.');
+        self::assertTrue($reflClass->hasMethod('logChange'), 'Check for prePersist and preRemove lifecycle callback.');
     }
 
     public function testLoadMetadata(): void

--- a/tests/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -46,9 +46,6 @@ use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
-/**
- * @runTestsInSeparateProcesses 
- */
 class EntityGeneratorTest extends OrmTestCase
 {
     /** @var EntityGenerator */

--- a/tests/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -114,6 +114,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata->addLifecycleCallback('loading', 'postLoad');
         $metadata->addLifecycleCallback('logChange', 'prePersist');
         $metadata->addLifecycleCallback('logChange', 'preRemove');
+        $metadata->addLifecycleCallback('logchange', 'preUpdate');
         $metadata->addLifecycleCallback('willBeRemoved', 'preRemove');
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
 
@@ -475,7 +476,7 @@ class EntityGeneratorTest extends OrmTestCase
 
         self::assertEquals($cm->columnNames, $metadata->columnNames);
         self::assertEquals($cm->getTableName(), $metadata->getTableName());
-        self::assertEquals($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
+        self::assertEqualsIgnoringCase($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
         self::assertEquals($cm->identifier, $metadata->identifier);
         self::assertEquals($cm->idGenerator, $metadata->idGenerator);
         self::assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
@@ -516,7 +517,7 @@ class EntityGeneratorTest extends OrmTestCase
 
         self::assertEquals($cm->columnNames, $metadata->columnNames);
         self::assertEquals($cm->getTableName(), $metadata->getTableName());
-        self::assertEquals($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
+        self::assertEqualsIgnoringCase($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
         self::assertEquals($cm->identifier, $metadata->identifier);
         self::assertEquals($cm->idGenerator, $metadata->idGenerator);
         self::assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);


### PR DESCRIPTION
This PR addresses a problem in the Entity Generator. when adding the same lifecycle event callback to two or more lifecycle events the generator will create a stub for each event each with the same method name. This results in fatal 'Cannot redeclare' errors. This Problem occurred only if the callback name contains uppercase letters.

this PR intends to fix this issue by updating the EntityGenerator to allow the same callback to be triggered by multiple event. 