### PR TITLE
Make nullable parameters explicit in generated entities

### DIFF
--- a/src/Tools/EntityGenerator.php
+++ b/src/Tools/EntityGenerator.php
@@ -767,6 +767,9 @@ public function __construct(<params>)
 
             if ($fieldMapping['type'] === 'datetime') {
                 $param = $this->getType($fieldMapping['type']) . ' ' . $param;
+                if (! empty($fieldMapping['nullable'])) {
+                    $param = '?' . $param;
+                }
             }
 
             if (! empty($fieldMapping['nullable'])) {
@@ -1385,6 +1388,9 @@ public function __construct(<params>)
         if ($typeHint && ! isset($types[$typeHint])) {
             $variableType   =  '\\' . ltrim($variableType, '\\');
             $methodTypeHint =  '\\' . $typeHint . ' ';
+            if ($defaultValue === 'null') {
+                $methodTypeHint = '?' . $methodTypeHint;
+            }
         }
 
         $replacements = [


### PR DESCRIPTION
Currently, `EntityGenerator` might generate methods with implicitly nullable parameters like this:

```php
public function setOtherEntity(OtherEntity $other = null) {
```

However, this is deprecated in PHP 8.4 and we need to generate the code like this:

```php
public function setOtherEntity(?OtherEntity $other = null) {
```