### PR TITLE
Prepare PHP 8.4 support: Prevent property hooks from being used

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -166,6 +166,11 @@ parameters:
 			path: src/Mapping/ClassMetadataFactory.php
 
 		-
+			message: "#^Call to an undefined method ReflectionProperty\\:\\:getHooks\\(\\)\\.$#"
+			count: 1
+			path: src/Mapping/ClassMetadataInfo.php
+
+		-
 			message: "#^Method Doctrine\\\\ORM\\\\Mapping\\\\NamingStrategy\\:\\:joinColumnName\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 2
 			path: src/Mapping/ClassMetadataInfo.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -713,6 +713,9 @@
       <code><![CDATA[joinColumnName]]></code>
       <code><![CDATA[joinColumnName]]></code>
     </TooManyArguments>
+    <UndefinedMethod>
+      <code><![CDATA[getHooks]]></code>
+    </UndefinedMethod>
   </file>
   <file src="src/Mapping/ColumnResult.php">
     <MissingConstructor>

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -3879,7 +3879,7 @@ class ClassMetadataInfo implements ClassMetadata
     private function getAccessibleProperty(ReflectionService $reflService, string $class, string $field): ?ReflectionProperty
     {
         $reflectionProperty = $reflService->getAccessibleProperty($class, $field);
-        if ($reflectionProperty !== null && \PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
+        if ($reflectionProperty !== null && PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
             $declaringClass = $reflectionProperty->class;
             if ($declaringClass !== $class) {
                 $reflectionProperty = $reflService->getAccessibleProperty($declaringClass, $field);
@@ -3890,8 +3890,8 @@ class ClassMetadataInfo implements ClassMetadata
             }
         }
 
-        if (\PHP_VERSION_ID >= 80400 && count($reflectionProperty->getHooks()) > 0) {
-            throw new LogicException("Doctrine ORM does not support property hooks in this version. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.");
+        if (PHP_VERSION_ID >= 80400 && count($reflectionProperty->getHooks()) > 0) {
+            throw new LogicException('Doctrine ORM does not support property hooks in this version. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.');
         }
 
         return $reflectionProperty;

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -3890,7 +3890,7 @@ class ClassMetadataInfo implements ClassMetadata
             }
         }
 
-        if (PHP_VERSION_ID >= 80400 && count($reflectionProperty->getHooks()) > 0) {
+        if (PHP_VERSION_ID >= 80400 && $reflectionProperty !== NULL && count($reflectionProperty->getHooks()) > 0) {
             throw new LogicException('Doctrine ORM does not support property hooks in this version. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.');
         }
 

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -3890,7 +3890,7 @@ class ClassMetadataInfo implements ClassMetadata
             }
         }
 
-        if (PHP_VERSION_ID >= 80400 && $reflectionProperty !== NULL && count($reflectionProperty->getHooks()) > 0) {
+        if (PHP_VERSION_ID >= 80400 && $reflectionProperty !== null && count($reflectionProperty->getHooks()) > 0) {
             throw new LogicException('Doctrine ORM does not support property hooks in this version. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.');
         }
 

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -3879,7 +3879,7 @@ class ClassMetadataInfo implements ClassMetadata
     private function getAccessibleProperty(ReflectionService $reflService, string $class, string $field): ?ReflectionProperty
     {
         $reflectionProperty = $reflService->getAccessibleProperty($class, $field);
-        if ($reflectionProperty !== null && PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
+        if ($reflectionProperty !== null && \PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
             $declaringClass = $reflectionProperty->class;
             if ($declaringClass !== $class) {
                 $reflectionProperty = $reflService->getAccessibleProperty($declaringClass, $field);
@@ -3888,6 +3888,10 @@ class ClassMetadataInfo implements ClassMetadata
             if ($reflectionProperty !== null) {
                 $reflectionProperty = new ReflectionReadonlyProperty($reflectionProperty);
             }
+        }
+
+        if (\PHP_VERSION_ID >= 80400 && count($reflectionProperty->getHooks()) > 0) {
+            throw new LogicException("Doctrine ORM does not support property hooks in this version. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.");
         }
 
         return $reflectionProperty;


### PR DESCRIPTION
Property hooks must be explicitly supported by new code, due to them having to use setRawValue/getRawValue to access the right representation for storing in the database. 

For now we prevent property hooks from being used at all so that users will not run into potential BC breaks once property hooks support ships.

Related:
* #11624 