### PR TITLE
Prototype for ReflectionClass::newLazyGhost

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,6 +40,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dbal-version:
           - "default"
         extension:

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -212,7 +212,7 @@ EOPHP;
             });
 
             foreach ($identifier as $idField => $value) {
-                $classMetadata->reflFields[$idField]->setRawValueWithoutInitialization($proxy, $value);
+                $classMetadata->reflFields[$idField]->setRawValueWithoutLazyInitialization($proxy, $value);
             }
 
             return $proxy;

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -212,11 +212,7 @@ EOPHP;
             });
 
             foreach ($identifier as $idField => $value) {
-                // why only here and not in other proxies?
-                if (! empty($classMetadata->fieldMappings[$idField]['enumType'])) {
-                    $value = $classMetadata->fieldMappings[$idField]['enumType']::from($value);
-                }
-                $classMetadata->reflFields[$idField]->setRawValueWithoutLazyInitialization($proxy, $value);
+                $classMetadata->reflFields[$idField]->setValue($proxy, $value);
             }
 
             return $proxy;

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -212,7 +212,7 @@ EOPHP;
             });
 
             foreach ($identifier as $idField => $value) {
-                $classMetadata->reflFields[$idField]->setValue($proxy, $value);
+                $classMetadata->reflFields[$idField]->setRawValueWithoutInitialization($proxy, $value);
             }
 
             return $proxy;

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -212,6 +212,10 @@ EOPHP;
             });
 
             foreach ($identifier as $idField => $value) {
+                // why only here and not in other proxies?
+                if (! empty($classMetadata->fieldMappings[$idField]['enumType'])) {
+                    $value = $classMetadata->fieldMappings[$idField]['enumType']::from($value);
+                }
                 $classMetadata->reflFields[$idField]->setRawValueWithoutLazyInitialization($proxy, $value);
             }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3732,8 +3732,8 @@ EXCEPTION
      */
     public function isUninitializedObject($obj): bool
     {
-        if (PHP_VERSION_ID >= 80400) {
-            return (new ReflectionObject($obj))->isUninitializedLazyObject($obj);
+        if (PHP_VERSION_ID >= 80400 && !($obj instanceof Collection)) {
+            return $this->em->getClassMetadata(get_class($obj))->reflClass->isUninitializedLazyObject($obj);
         }
 
         return $obj instanceof InternalProxy && ! $obj->__isInitialized();

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -49,6 +49,7 @@ use Doctrine\Persistence\ObjectManagerAware;
 use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
 use InvalidArgumentException;
+use ReflectionObject;
 use RuntimeException;
 use Throwable;
 use UnexpectedValueException;
@@ -3715,6 +3716,11 @@ EXCEPTION
         if ($obj instanceof PersistentCollection) {
             $obj->initialize();
         }
+
+        if (PHP_VERSION_ID >= 80400) {
+            $reflection = new ReflectionObject($obj);
+            $reflection->initializeLazyObject($obj);
+        }
     }
 
     /**
@@ -3726,6 +3732,10 @@ EXCEPTION
      */
     public function isUninitializedObject($obj): bool
     {
+        if (PHP_VERSION_ID >= 80400) {
+            return $this->em->getClassMetadata(get_class($obj))->reflClass->isUninitializedLazyObject($obj);
+        }
+
         return $obj instanceof InternalProxy && ! $obj->__isInitialized();
     }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -818,11 +818,7 @@ class UnitOfWork implements PropertyChangedListener
 
                         $newValue = clone $actualValue;
                         $newValue->setOwner($entity, $assoc);
-                        if (PHP_VERSION_ID >= 80400) {
-                            $class->reflFields[$propName]->setRawValueWithoutLazyInitialization($entity, $newValue);
-                        } else {
-                            $class->reflFields[$propName]->setValue($entity, $newValue);
-                        }
+                        $class->reflFields[$propName]->setValue($entity, $newValue);
                     }
                 }
 
@@ -2994,11 +2990,7 @@ EXCEPTION
 
         foreach ($data as $field => $value) {
             if (isset($class->fieldMappings[$field])) {
-                if (PHP_VERSION_ID >= 80400) {
-                    $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $value);
-                } else {
-                    $class->reflFields[$field]->setValue($entity, $value);
-                }
+                $class->reflFields[$field]->setValue($entity, $value);
             }
         }
 
@@ -3040,34 +3032,21 @@ EXCEPTION
                         if (isset($data[$field]) && is_object($data[$field]) && isset($this->entityStates[spl_object_id($data[$field])])) {
                             $this->originalEntityData[$oid][$field] = $data[$field];
 
-                            if (PHP_VERSION_ID >= 80400) {
-                                $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $data[$field]);
-                                $targetClass->reflFields[$assoc['mappedBy']]->setRawValueWithoutLazyInitialization($data[$field], $entity);
-                            } else {
-                                $class->reflFields[$field]->setValue($entity, $data[$field]);
-                                $targetClass->reflFields[$assoc['mappedBy']]->setValue($data[$field], $entity);
-                            }
+                            $class->reflFields[$field]->setValue($entity, $data[$field]);
+                            $targetClass->reflFields[$assoc['mappedBy']]->setValue($data[$field], $entity);
 
                             continue 2;
                         }
 
                         // Inverse side of x-to-one can never be lazy
-                        if (PHP_VERSION_ID >= 80400) {
-                            $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity));
-                        } else {
-                            $class->reflFields[$field]->setValue($entity, $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity));
-                        }
+                        $class->reflFields[$field]->setValue($entity, $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity));
 
                         continue 2;
                     }
 
                     // use the entity association
                     if (isset($data[$field]) && is_object($data[$field]) && isset($this->entityStates[spl_object_id($data[$field])])) {
-                        if (PHP_VERSION_ID >= 80400) {
-                            $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $data[$field]);
-                        } else {
-                            $class->reflFields[$field]->setValue($entity, $data[$field]);
-                        }
+                        $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
                         break;
@@ -3098,11 +3077,7 @@ EXCEPTION
 
                     if (! $associatedId) {
                         // Foreign key is NULL
-                        if (PHP_VERSION_ID >= 80400) {
-                            $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, null);
-                        } else {
-                            $class->reflFields[$field]->setValue($entity, null);
-                        }
+                        $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
                         break;
@@ -3168,19 +3143,11 @@ EXCEPTION
                     }
 
                     $this->originalEntityData[$oid][$field] = $newValue;
-                    if (PHP_VERSION_ID >= 80400) {
-                        $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $newValue);
-                    } else {
-                        $class->reflFields[$field]->setValue($entity, $newValue);
-                    }
+                    $class->reflFields[$field]->setValue($entity, $newValue);
 
                     if ($assoc['inversedBy'] && $assoc['type'] & ClassMetadata::ONE_TO_ONE && $newValue !== null) {
                         $inverseAssoc = $targetClass->associationMappings[$assoc['inversedBy']];
-                        if (PHP_VERSION_ID >= 80400) {
-                            $targetClass->reflFields[$inverseAssoc['fieldName']]->setRawValueWithoutLazyInitialization($newValue, $entity);
-                        } else {
-                            $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($newValue, $entity);
-                        }
+                        $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($newValue, $entity);
                     }
 
                     break;
@@ -3195,11 +3162,7 @@ EXCEPTION
                     if (isset($data[$field]) && $data[$field] instanceof PersistentCollection) {
                         $data[$field]->setOwner($entity, $assoc);
 
-                        if (PHP_VERSION_ID >= 80400) {
-                            $class->reflFields[$field]->setRawValueWithoutLazyInitialization($entity, $data[$field]);
-                        } else {
-                            $class->reflFields[$field]->setValue($entity, $data[$field]);
-                        }
+                        $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
                         break;
@@ -3211,11 +3174,7 @@ EXCEPTION
                     $pColl->setInitialized(false);
 
                     $reflField = $class->reflFields[$field];
-                    if (PHP_VERSION_ID >= 80400) {
-                        $reflField->setRawValueWithoutLazyInitialization($entity, $pColl);
-                    } else {
-                        $reflField->setValue($entity, $pColl);
-                    }
+                    $reflField->setValue($entity, $pColl);
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
                         $isIteration = isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION];

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2954,7 +2954,11 @@ EXCEPTION
             }
 
             if ($this->isUninitializedObject($entity)) {
-                $entity->__setInitialized(true);
+                if (PHP_VERSION_ID >= 80400) {
+                    $class->reflClass->markLazyObjectAsInitialized($entity);
+                } else {
+                    $entity->__setInitialized(true);
+                }
             } else {
                 if (
                     ! isset($hints[Query::HINT_REFRESH])

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3733,7 +3733,7 @@ EXCEPTION
     public function isUninitializedObject($obj): bool
     {
         if (PHP_VERSION_ID >= 80400) {
-            return $this->em->getClassMetadata(get_class($obj))->reflClass->isUninitializedLazyObject($obj);
+            return (new ReflectionObject($obj))->isUninitializedLazyObject($obj);
         }
 
         return $obj instanceof InternalProxy && ! $obj->__isInitialized();

--- a/tests/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -575,7 +575,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        self::assertFalse($groupRef->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($groupRef));
 
         $this->_em->clear();
 

--- a/tests/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -540,7 +540,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        self::assertFalse($userRef->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($userRef));
 
         $this->_em->clear();
 

--- a/tests/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Tests/ORM/Functional/MergeProxiesTest.php
@@ -151,7 +151,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         self::assertTrue($this->isUninitializedObject($proxy1));
         self::assertTrue($this->isUninitializedObject($proxy2));
 
-        $proxy1->__load();
+        $this->initializeObject($proxy1);
 
         self::assertCount(
             1,
@@ -219,7 +219,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
             'Loading the merged instance was done via the second entity manager'
         );
 
-        $unManagedProxy->__load();
+        $this->initializeObject($unManagedProxy);
 
         self::assertCount(
             1,

--- a/tests/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Tests/ORM/Functional/MergeProxiesTest.php
@@ -164,7 +164,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
             'No queries were executed on the second entity manager, as it is unrelated with the first proxy'
         );
 
-        $proxy2->__load();
+        $this->initializeObject($proxy2);
 
         self::assertCount(
             1,

--- a/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -34,6 +34,10 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
+        if (PHP_VERSION_ID >= 80400) {
+            self::markTestSkipped('This test is not necessary for PHP 8.4 using Lazy Objects.');
+        }
+
         $this->createSchemaForModels(
             CmsUser::class,
             CmsTag::class,

--- a/tests/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -248,7 +248,6 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         assert($entity instanceof ECommerceProduct);
         $className = DefaultProxyClassNameResolver::getClass($entity);
 
-        self::assertInstanceOf(InternalProxy::class, $entity);
         self::assertTrue($this->isUninitializedObject($entity));
         self::assertEquals(ECommerceProduct::class, $className);
 
@@ -257,7 +256,8 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace('\\', '', $restName) . '.php';
         self::assertTrue(file_exists($proxyFileName), 'Proxy file name cannot be found generically.');
 
-        $entity->__load();
+        $this->initializeObject($entity);
+
         self::assertFalse($this->isUninitializedObject($entity));
     }
 }

--- a/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Cache\QueryCacheKey;
-use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\Cache\Attraction;
@@ -938,7 +937,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state1->getCountry());
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertEquals($countryName, $state1->getCountry()->getName());
         self::assertEquals($stateId, $state1->getId());
 
@@ -956,7 +954,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state2->getCountry());
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertEquals($countryName, $state2->getCountry()->getName());
         self::assertEquals($stateId, $state2->getId());
     }
@@ -1030,7 +1027,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertInstanceOf(City::class, $state1->getCities()->get(0));
         self::assertInstanceOf(State::class, $state1->getCities()->get(0)->getState());
         self::assertSame($state1, $state1->getCities()->get(0)->getState());
@@ -1047,7 +1043,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertInstanceOf(City::class, $state2->getCities()->get(0));
         self::assertInstanceOf(State::class, $state2->getCities()->get(0)->getState());
         self::assertSame($state2, $state2->getCities()->get(0)->getState());

--- a/tests/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -56,11 +56,11 @@ class DDC1238Test extends OrmFunctionalTestCase
 
         $user2 = $this->_em->getReference(DDC1238User::class, $userId);
 
-        //$user->__load();
+        //$this->>initializeObject($user);
 
         self::assertIsInt($user->getId(), 'Even if a proxy is detached, it should still have an identifier');
 
-        $user2->__load();
+        $this->initializeObject($user2);
 
         self::assertIsInt($user2->getId(), 'The managed instance still has an identifier');
     }

--- a/tests/Tests/ORM/Functional/Ticket/DDC1734Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1734Test.php
@@ -76,8 +76,11 @@ class DDC1734Test extends OrmFunctionalTestCase
         self::assertEquals('Foo', $unserializedProxy->getName(), 'The entity is broken');
     }
 
-    /** @param object $object */
-    private function getProxy($object): InternalProxy
+    /**
+     * @param object $object
+     * @return object
+     */
+    private function getProxy($object)
     {
         $metadataFactory = $this->_em->getMetadataFactory();
         $className       = get_class($object);

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -982,4 +982,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     {
         return $this->_em->getUnitOfWork()->isUninitializedObject($entity);
     }
+
+    final protected function initializeObject($entity): void
+    {
+        $this->_em->getUnitOfWork()->initializeObject($entity);
+    }
 }


### PR DESCRIPTION
All failures left are due to the problem that on PHP 8.4 `setRawValueWithoutInitialization` should be called.

This requires deep changes to doctrine/persistence that are required to make this working.

