### PR TITLE
Let PHPStan detect deprecated usages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         },
         "sort-packages": true
     },
@@ -42,7 +43,9 @@
         "doctrine/annotations": "^1.13 || ^2",
         "doctrine/coding-standard": "^9.0.2 || ^12.0",
         "phpbench/phpbench": "^0.16.10 || ^1.0",
+        "phpstan/extension-installer": "~1.1.0 || ^1.4",
         "phpstan/phpstan": "~1.4.10 || 1.12.6",
+        "phpstan/phpstan-deprecation-rules": "^1",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.7.2",

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -61,6 +61,11 @@ parameters:
             count: 2
             path: src/Mapping/ClassMetadataFactory.php
 
+        - '~^Call to deprecated method getSQLResultCasing\(\) of class Doctrine\\DBAL\\Platforms\\AbstractPlatform\.$~'
+        -
+            message: '~deprecated class Doctrine\\DBAL\\Tools\\Console\\Command\\ImportCommand\:~'
+            path: src/Tools/Console/ConsoleRunner.php
+
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
 

--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -3,6 +3,8 @@ includes:
     - phpstan-params.neon
 
 parameters:
+    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
         # deprecations from doctrine/dbal:3.x
         - '/^Call to an undefined method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getGuidExpression\(\).$/'
@@ -70,3 +72,13 @@ parameters:
             paths:
                 - src/Mapping/Driver/XmlDriver.php
                 - src/Mapping/Driver/YamlDriver.php
+
+        # Extending a deprecated class conditionally to maintain BC
+        -
+            message: '~deprecated class Doctrine\\Persistence\\Mapping\\Driver\\AnnotationDriver\:~'
+            path: src/Mapping/Driver/CompatibilityAnnotationDriver.php
+
+        # We're sniffing for this deprecated class in order to detect Persistence 2
+        -
+            message: '~deprecated class Doctrine\\Common\\Persistence\\PersistentObject\:~'
+            path: src/EntityManager.php

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -558,9 +558,11 @@ abstract class AbstractQuery
 
         // DBAL 2
         if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            // @phpstan-ignore method.deprecated
             if (! $profile->getResultCacheDriver()) {
                 $defaultHydrationCacheImpl = $this->_em->getConfiguration()->getHydrationCache();
                 if ($defaultHydrationCacheImpl) {
+                    // @phpstan-ignore method.deprecated
                     $profile = $profile->setResultCacheDriver(DoctrineProvider::wrap($defaultHydrationCacheImpl));
                 }
             }
@@ -609,9 +611,11 @@ abstract class AbstractQuery
 
         // DBAL 2
         if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            // @phpstan-ignore method.deprecated
             if (! $profile->getResultCacheDriver()) {
                 $defaultResultCacheDriver = $this->_em->getConfiguration()->getResultCache();
                 if ($defaultResultCacheDriver) {
+                    // @phpstan-ignore method.deprecated
                     $profile = $profile->setResultCacheDriver(DoctrineProvider::wrap($defaultResultCacheDriver));
                 }
             }
@@ -677,6 +681,7 @@ abstract class AbstractQuery
             $resultCacheDriver = DoctrineProvider::wrap($resultCache);
 
             $this->_queryCacheProfile = $this->_queryCacheProfile
+                // @phpstan-ignore method.deprecated
                 ? $this->_queryCacheProfile->setResultCacheDriver($resultCacheDriver)
                 : new QueryCacheProfile(0, null, $resultCacheDriver);
 
@@ -780,6 +785,7 @@ abstract class AbstractQuery
 
         // Compatibility for DBAL 2
         if (! method_exists($this->_queryCacheProfile, 'setResultCache')) {
+            // @phpstan-ignore method.deprecated
             $this->_queryCacheProfile = $this->_queryCacheProfile->setResultCacheDriver(DoctrineProvider::wrap($cache));
 
             return $this;
@@ -1235,6 +1241,7 @@ abstract class AbstractQuery
 
         // Support for DBAL 2
         if (! method_exists($this->_hydrationCacheProfile, 'getResultCache')) {
+            // @phpstan-ignore method.deprecated
             $cacheDriver = $this->_hydrationCacheProfile->getResultCacheDriver();
             assert($cacheDriver !== null);
 

--- a/src/Cache/Region.php
+++ b/src/Cache/Region.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\Cache\Exception\CacheException;
 
 /**
  * Defines a contract for accessing a particular named region.
+ *
+ * @phpstan-ignore interface.extendsDeprecatedInterface
  */
 interface Region extends MultiGetRegion
 {

--- a/src/Cache/Region/DefaultRegion.php
+++ b/src/Cache/Region/DefaultRegion.php
@@ -72,6 +72,7 @@ class DefaultRegion implements Region
                 CacheItemPoolInterface::class
             );
 
+            // @phpstan-ignore property.deprecated
             $this->cache         = $cacheItemPool;
             $this->cacheItemPool = CacheAdapter::wrap($cacheItemPool);
         } elseif (! $cacheItemPool instanceof CacheItemPoolInterface) {
@@ -82,6 +83,7 @@ class DefaultRegion implements Region
                 get_debug_type($cacheItemPool)
             ));
         } else {
+            // @phpstan-ignore property.deprecated
             $this->cache         = DoctrineProvider::wrap($cacheItemPool);
             $this->cacheItemPool = $cacheItemPool;
         }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -269,6 +269,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
         );
 
         if (! isset($this->_attributes['entityNamespaces'][$entityNamespaceAlias])) {
+            // @phpstan-ignore staticMethod.deprecatedClass
             throw UnknownEntityNamespace::fromNamespaceAlias($entityNamespaceAlias);
         }
 
@@ -314,6 +315,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         // Compatibility with DBAL 2
         if (! method_exists(parent::class, 'getResultCache')) {
+            // @phpstan-ignore method.deprecated
             $cacheImpl = $this->getResultCacheImpl();
 
             return $cacheImpl ? CacheAdapter::wrap($cacheImpl) : null;
@@ -329,6 +331,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         // Compatibility with DBAL 2
         if (! method_exists(parent::class, 'setResultCache')) {
+            // @phpstan-ignore method.deprecated
             $this->setResultCacheImpl(DoctrineProvider::wrap($cache));
 
             return;

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -96,6 +96,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
                 E_USER_NOTICE
             );
 
+            // @phpstan-ignore method.deprecated
             return $this->wrapped->transactional($func);
         }
 

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -162,8 +162,9 @@ class EntityManager implements EntityManagerInterface
             throw MissingMappingDriverImplementation::create();
         }
 
-        $this->conn         = $conn;
-        $this->config       = $config;
+        $this->conn   = $conn;
+        $this->config = $config;
+        // @phpstan-ignore method.deprecated
         $this->eventManager = $eventManager ?? $conn->getEventManager();
 
         $metadataFactoryClassName = $config->getClassMetadataFactoryName();
@@ -615,6 +616,7 @@ class EntityManager implements EntityManagerInterface
     public function clear($entityName = null)
     {
         if ($entityName !== null && ! is_string($entityName)) {
+            // @phpstan-ignore staticMethod.deprecated
             throw ORMInvalidArgumentException::invalidEntityName($entityName);
         }
 
@@ -1109,6 +1111,7 @@ class EntityManager implements EntityManagerInterface
 
     private function configureLegacyMetadataCache(): void
     {
+        // @phpstan-ignore method.deprecated
         $metadataCache = $this->config->getMetadataCacheImpl();
         if (! $metadataCache) {
             return;

--- a/src/Event/PostLoadEventArgs.php
+++ b/src/Event/PostLoadEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PostLoadEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PostPersistEventArgs.php
+++ b/src/Event/PostPersistEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PostPersistEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PostRemoveEventArgs.php
+++ b/src/Event/PostRemoveEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PostRemoveEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PostUpdateEventArgs.php
+++ b/src/Event/PostUpdateEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PostUpdateEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PrePersistEventArgs.php
+++ b/src/Event/PrePersistEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PrePersistEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PreRemoveEventArgs.php
+++ b/src/Event/PreRemoveEventArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 final class PreRemoveEventArgs extends LifecycleEventArgs
 {
 }

--- a/src/Event/PreUpdateEventArgs.php
+++ b/src/Event/PreUpdateEventArgs.php
@@ -13,6 +13,8 @@ use function sprintf;
 
 /**
  * Class that holds event arguments for a preUpdate event.
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {
@@ -26,6 +28,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      */
     public function __construct($entity, EntityManagerInterface $em, array &$changeSet)
     {
+        // @phpstan-ignore staticMethod.deprecatedClass
         parent::__construct($entity, $em);
 
         $this->entityChangeSet = &$changeSet;

--- a/src/Exception/ORMException.php
+++ b/src/Exception/ORMException.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\ORMException as BaseORMException;
 
 /**
  * Should become an interface in 3.0
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class ORMException extends BaseORMException
 {

--- a/src/Id/AbstractIdGenerator.php
+++ b/src/Id/AbstractIdGenerator.php
@@ -73,6 +73,7 @@ abstract class AbstractIdGenerator
             throw new InvalidArgumentException('Unsupported entity manager implementation.');
         }
 
+        // @phpstan-ignore method.deprecated
         return $this->generate($em, $entity);
     }
 

--- a/src/Internal/CriteriaOrderings.php
+++ b/src/Internal/CriteriaOrderings.php
@@ -22,6 +22,7 @@ trait CriteriaOrderings
     private static function getCriteriaOrderings(Criteria $criteria): array
     {
         if (! method_exists(Criteria::class, 'orderings')) {
+            // @phpstan-ignore method.deprecated
             return $criteria->getOrderings();
         }
 

--- a/src/Mapping/Builder/ClassMetadataBuilder.php
+++ b/src/Mapping/Builder/ClassMetadataBuilder.php
@@ -172,6 +172,8 @@ class ClassMetadataBuilder
     /**
      * Adds named query.
      *
+     * @deprecated
+     *
      * @param string $name
      * @param string $dqlQuery
      *

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -558,6 +558,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedQueries as $name => $query) {
             if (! isset($subClass->namedQueries[$name])) {
+                // @phpstan-ignore method.deprecated
                 $subClass->addNamedQuery(
                     [
                         'name'  => $query['name'],
@@ -575,6 +576,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedNativeQueries as $name => $query) {
             if (! isset($subClass->namedNativeQueries[$name])) {
+                // @phpstan-ignore method.deprecated
                 $subClass->addNamedNativeQuery(
                     [
                         'name'              => $query['name'],
@@ -637,7 +639,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 $platform     = $this->getTargetPlatform();
 
                 // Platforms that do not have native IDENTITY support need a sequence to emulate this behaviour.
-                /** @psalm-suppress UndefinedClass, InvalidClass */
+                /** @psalm-suppress UndefinedClass, InvalidClass */ // @phpstan-ignore method.deprecated
                 if (! $platform instanceof MySQLPlatform && ! $platform instanceof SqlitePlatform && ! $platform instanceof SQLServerPlatform && $platform->usesSequenceEmulatedIdentityColumns()) {
                     Deprecation::trigger(
                         'doctrine/orm',
@@ -654,8 +656,9 @@ DEPRECATION
                     $columnName     = $class->getSingleIdentifierColumnName();
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
                     $sequencePrefix = $class->getSequencePrefix($this->getTargetPlatform());
-                    $sequenceName   = $this->getTargetPlatform()->getIdentitySequenceName($sequencePrefix, $columnName);
-                    $definition     = [
+                    // @phpstan-ignore method.deprecated
+                    $sequenceName = $this->getTargetPlatform()->getIdentitySequenceName($sequencePrefix, $columnName);
+                    $definition   = [
                         'sequenceName' => $this->truncateSequenceName($sequenceName),
                     ];
 
@@ -711,6 +714,7 @@ DEPRECATION
                 $class->setIdGenerator(new AssignedGenerator());
                 break;
 
+            // @phpstan-ignore classConstant.deprecated
             case ClassMetadata::GENERATOR_TYPE_UUID:
                 Deprecation::trigger(
                     'doctrine/orm',
@@ -718,6 +722,7 @@ DEPRECATION
                     'Mapping for %s: the "UUID" id generator strategy is deprecated with no replacement',
                     $class->name
                 );
+                // @phpstan-ignore new.deprecated
                 $class->setIdGenerator(new UuidGenerator());
                 break;
 

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -1405,6 +1405,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getColumnName($fieldName)
     {
+        // @phpstan-ignore property.deprecated
         return $this->columnNames[$fieldName] ?? $fieldName;
     }
 
@@ -1659,6 +1660,7 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['quoted']     = true;
         }
 
+        // @phpstan-ignore property.deprecated
         $this->columnNames[$mapping['fieldName']] = $mapping['columnName'];
 
         if (isset($this->fieldNames[$mapping['columnName']]) || ($this->discriminatorColumn && $this->discriminatorColumn['name'] === $mapping['columnName'])) {
@@ -1683,6 +1685,7 @@ class ClassMetadataInfo implements ClassMetadata
             }
         }
 
+        // @phpstan-ignore method.deprecated
         if (Type::hasType($mapping['type']) && Type::getType($mapping['type'])->canRequireSQLConversion()) {
             if (isset($mapping['id']) && $mapping['id'] === true) {
                  throw MappingException::sqlConversionNotAllowedForIdentifiers($this->name, $mapping['fieldName'], $mapping['type']);
@@ -2576,6 +2579,7 @@ class ClassMetadataInfo implements ClassMetadata
 
         unset($this->fieldMappings[$fieldName]);
         unset($this->fieldNames[$mapping['columnName']]);
+        // @phpstan-ignore property.deprecated
         unset($this->columnNames[$mapping['fieldName']]);
 
         $overrideMapping = $this->validateAndCompleteFieldMapping($overrideMapping);
@@ -2699,6 +2703,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     private function isInheritanceType(int $type): bool
     {
+        // @phpstan-ignore classConstant.deprecated
         if ($type === self::INHERITANCE_TYPE_TABLE_PER_CLASS) {
             Deprecation::trigger(
                 'doctrine/orm',
@@ -2710,6 +2715,7 @@ class ClassMetadataInfo implements ClassMetadata
         return $type === self::INHERITANCE_TYPE_NONE ||
                 $type === self::INHERITANCE_TYPE_SINGLE_TABLE ||
                 $type === self::INHERITANCE_TYPE_JOINED ||
+                // @phpstan-ignore classConstant.deprecated
                 $type === self::INHERITANCE_TYPE_TABLE_PER_CLASS;
     }
 
@@ -2766,8 +2772,9 @@ class ClassMetadataInfo implements ClassMetadata
     public function addInheritedFieldMapping(array $fieldMapping)
     {
         $this->fieldMappings[$fieldMapping['fieldName']] = $fieldMapping;
-        $this->columnNames[$fieldMapping['fieldName']]   = $fieldMapping['columnName'];
-        $this->fieldNames[$fieldMapping['columnName']]   = $fieldMapping['fieldName'];
+        // @phpstan-ignore property.deprecated
+        $this->columnNames[$fieldMapping['fieldName']] = $fieldMapping['columnName'];
+        $this->fieldNames[$fieldMapping['columnName']] = $fieldMapping['fieldName'];
 
         if (isset($fieldMapping['generated'])) {
             $this->requiresFetchAfterChange = true;
@@ -3859,6 +3866,7 @@ class ClassMetadataInfo implements ClassMetadata
         if ($schemaName) {
             $sequencePrefix = $schemaName . '.' . $tableName;
 
+            // @phpstan-ignore method.deprecated
             if (! $platform->supportsSchemas() && $platform->canEmulateSchemas()) {
                 $sequencePrefix = $schemaName . '__' . $tableName;
             }

--- a/src/Mapping/DefaultQuoteStrategy.php
+++ b/src/Mapping/DefaultQuoteStrategy.php
@@ -42,6 +42,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
         if (! empty($class->table['schema'])) {
             $tableName = $class->table['schema'] . '.' . $class->table['name'];
 
+            // @phpstan-ignore method.deprecated
             if (! $platform->supportsSchemas() && $platform->canEmulateSchemas()) {
                 $tableName = $class->table['schema'] . '__' . $class->table['name'];
             }
@@ -90,7 +91,8 @@ class DefaultQuoteStrategy implements QuoteStrategy
         $schema = '';
 
         if (isset($association['joinTable']['schema'])) {
-            $schema  = $association['joinTable']['schema'];
+            $schema = $association['joinTable']['schema'];
+            // @phpstan-ignore method.deprecated
             $schema .= ! $platform->supportsSchemas() && $platform->canEmulateSchemas() ? '__' : '.';
         }
 

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -65,6 +65,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
         $this->reader = new AttributeReader();
         $this->addPaths($paths);
 
+        // @phpstan-ignore property.deprecated
         if ($this->entityAnnotationClasses !== self::ENTITY_ATTRIBUTE_CLASSES) {
             Deprecation::trigger(
                 'doctrine/orm',
@@ -114,6 +115,7 @@ class AttributeDriver extends CompatibilityAnnotationDriver
 
         foreach ($classAttributes as $a) {
             $attr = $a instanceof RepeatableAttributeCollection ? $a[0] : $a;
+            // @phpstan-ignore property.deprecated
             if (isset($this->entityAnnotationClasses[get_class($attr)])) {
                 return false;
             }

--- a/src/Mapping/Driver/SimplifiedYamlDriver.php
+++ b/src/Mapping/Driver/SimplifiedYamlDriver.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
  * YamlDriver that additionally looks for mapping information in a global file.
  *
  * @deprecated This class is being removed from the ORM and won't have any replacement
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class SimplifiedYamlDriver extends YamlDriver
 {

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -122,6 +122,7 @@ class XmlDriver extends FileDriver
         // Evaluate named queries
         if (isset($xmlRoot->{'named-queries'})) {
             foreach ($xmlRoot->{'named-queries'}->{'named-query'} ?? [] as $namedQueryElement) {
+                // @phpstan-ignore method.deprecated
                 $metadata->addNamedQuery(
                     [
                         'name'  => (string) $namedQueryElement['name'],
@@ -134,6 +135,7 @@ class XmlDriver extends FileDriver
         // Evaluate native named queries
         if (isset($xmlRoot->{'named-native-queries'})) {
             foreach ($xmlRoot->{'named-native-queries'}->{'named-native-query'} ?? [] as $nativeQueryElement) {
+                // @phpstan-ignore method.deprecated
                 $metadata->addNamedNativeQuery(
                     [
                         'name'              => isset($nativeQueryElement['name']) ? (string) $nativeQueryElement['name'] : null,
@@ -489,6 +491,7 @@ class XmlDriver extends FileDriver
                         /** @psalm-suppress DeprecatedConstant */
                         $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
                             ? (string) $orderByField['direction']
+                            // @phpstan-ignore classConstant.deprecated
                             : (class_exists(Order::class) ? (Order::Ascending)->value : Criteria::ASC);
                     }
 
@@ -618,6 +621,7 @@ class XmlDriver extends FileDriver
                         /** @psalm-suppress DeprecatedConstant */
                         $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
                             ? (string) $orderByField['direction']
+                            // @phpstan-ignore classConstant.deprecated
                             : (class_exists(Order::class) ? (Order::Ascending)->value : Criteria::ASC);
                     }
 

--- a/src/Mapping/MappingAttribute.php
+++ b/src/Mapping/MappingAttribute.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-/** A marker interface for mapping attributes. */
+/**
+ * A marker interface for mapping attributes.
+ *
+ * @phpstan-ignore interface.extendsDeprecatedInterface
+ */
 interface MappingAttribute extends Annotation
 {
 }

--- a/src/Persisters/Entity/JoinedSubclassPersister.php
+++ b/src/Persisters/Entity/JoinedSubclassPersister.php
@@ -250,6 +250,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // If the database platform supports FKs, just
         // delete the row from the root table. Cascades do the rest.
+        // @phpstan-ignore method.deprecated
         if ($this->platform->supportsForeignKeyConstraints()) {
             $rootClass = $this->em->getClassMetadata($this->class->rootEntityName);
             $rootTable = $this->quoteStrategy->getTableName($rootClass, $this->platform);

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -173,6 +173,7 @@ EOPHP;
             $this->isLazyGhostObjectEnabled = false;
 
             $proxyGenerator = new ProxyGenerator($proxyDir, $proxyNs);
+            // @phpstan-ignore classConstant.deprecatedInterface
             $proxyGenerator->setPlaceholder('baseProxyInterface', LegacyProxy::class);
 
             parent::__construct($proxyGenerator, $em->getMetadataFactory(), $autoGenerate);

--- a/src/Query.php
+++ b/src/Query.php
@@ -344,6 +344,7 @@ class Query extends AbstractQuery
 
         $cache = method_exists(QueryCacheProfile::class, 'getResultCache')
             ? $this->_queryCacheProfile->getResultCache()
+            // @phpstan-ignore method.deprecated
             : $this->_queryCacheProfile->getResultCacheDriver();
 
         assert($cache !== null);

--- a/src/Query/AST/InListExpression.php
+++ b/src/Query/AST/InListExpression.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 class InListExpression extends InExpression
 {
     /** @var non-empty-list<mixed> */
@@ -15,6 +16,7 @@ class InListExpression extends InExpression
         $this->literals = $literals;
         $this->not      = $not;
 
+        // @phpstan-ignore staticMethod.deprecatedClass
         parent::__construct($expression);
     }
 }

--- a/src/Query/AST/InSubselectExpression.php
+++ b/src/Query/AST/InSubselectExpression.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+/** @phpstan-ignore class.extendsDeprecatedClass */
 class InSubselectExpression extends InExpression
 {
     /** @var Subselect */
@@ -14,6 +15,7 @@ class InSubselectExpression extends InExpression
         $this->subselect = $subselect;
         $this->not       = $not;
 
+        // @phpstan-ignore staticMethod.deprecatedClass
         parent::__construct($expression);
     }
 }

--- a/src/Query/AST/IndexBy.php
+++ b/src/Query/AST/IndexBy.php
@@ -23,6 +23,7 @@ class IndexBy extends Node
 
     public function __construct(PathExpression $singleValuedPathExpression)
     {
+        // @phpstan-ignore property.deprecated
         $this->singleValuedPathExpression = $this->simpleStateFieldPathExpression = $singleValuedPathExpression;
     }
 

--- a/src/Query/Exec/AbstractSqlExecutor.php
+++ b/src/Query/Exec/AbstractSqlExecutor.php
@@ -39,6 +39,7 @@ abstract class AbstractSqlExecutor
 
     public function __construct()
     {
+        // @phpstan-ignore property.deprecated
         $this->_sqlStatements = &$this->sqlStatements;
     }
 
@@ -93,10 +94,13 @@ abstract class AbstractSqlExecutor
 
     public function __wakeup(): void
     {
+        // @phpstan-ignore property.deprecated
         if ($this->_sqlStatements !== null && $this->sqlStatements === null) {
+            // @phpstan-ignore property.deprecated
             $this->sqlStatements = $this->_sqlStatements;
         }
 
+        // @phpstan-ignore property.deprecated
         $this->_sqlStatements = &$this->sqlStatements;
     }
 }

--- a/src/Query/Lexer.php
+++ b/src/Query/Lexer.php
@@ -84,7 +84,11 @@ class Lexer extends AbstractLexer
     public const T_CLOSE_CURLY_BRACE = TokenType::T_CLOSE_CURLY_BRACE;
 
     // All tokens that are identifiers or keywords that could be considered as identifiers should be >= 100
-    /** @deprecated No Replacement planned. */
+    /**
+     * @deprecated No Replacement planned.
+     *
+     * @phpstan-ignore classConstant.deprecated
+     */
     public const T_ALIASED_NAME = TokenType::T_ALIASED_NAME;
 
     /** @deprecated use {@see TokenType::T_FULLY_QUALIFIED_NAME} */
@@ -341,6 +345,7 @@ class Lexer extends AbstractLexer
                         $value
                     );
 
+                    // @phpstan-ignore classConstant.deprecated
                     return TokenType::T_ALIASED_NAME;
                 }
 

--- a/src/Query/ParameterTypeInferer.php
+++ b/src/Query/ParameterTypeInferer.php
@@ -8,10 +8,12 @@ use BackedEnum;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Types;
 
+use function class_exists;
 use function current;
 use function is_array;
 use function is_bool;
@@ -67,9 +69,17 @@ class ParameterTypeInferer
                 $firstValue = $firstValue->value;
             }
 
+            if (! class_exists(ArrayParameterType::class)) {
+                return is_int($firstValue)
+                    // @phpstan-ignore classConstant.deprecated
+                    ? Connection::PARAM_INT_ARRAY
+                    // @phpstan-ignore classConstant.deprecated
+                    : Connection::PARAM_STR_ARRAY;
+            }
+
             return is_int($firstValue)
-                ? Connection::PARAM_INT_ARRAY
-                : Connection::PARAM_STR_ARRAY;
+                ? ArrayParameterType::INTEGER
+                : ArrayParameterType::STRING;
         }
 
         return ParameterType::STRING;

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -981,6 +981,7 @@ class Parser
             return $this->lexer->token->value;
         }
 
+        // @phpstan-ignore classConstant.deprecated
         $this->match(TokenType::T_ALIASED_NAME);
 
         assert($this->lexer->token !== null);
@@ -2577,6 +2578,8 @@ class Parser
      *         AST\InstanceOfExpression|
      *         AST\LikeExpression|
      *         AST\NullComparisonExpression)
+     *
+     * @phpstan-ignore return.deprecatedClass
      */
     public function SimpleConditionalExpression()
     {

--- a/src/Query/TreeWalkerAdapter.php
+++ b/src/Query/TreeWalkerAdapter.php
@@ -806,6 +806,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
 
     final protected function getMetadataForDqlAlias(string $dqlAlias): ClassMetadata
     {
+        // @phpstan-ignore method.deprecated
         $metadata = $this->_getQueryComponents()[$dqlAlias]['metadata'] ?? null;
 
         if ($metadata === null) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -86,6 +86,7 @@ class QueryBuilder
      *
      * @var int
      * @psalm-var self::SELECT|self::DELETE|self::UPDATE
+     * @phpstan-ignore classConstant.deprecated
      */
     private $type = self::SELECT;
 
@@ -94,6 +95,7 @@ class QueryBuilder
      *
      * @var int
      * @psalm-var self::STATE_*
+     * @phpstan-ignore classConstant.deprecated
      */
     private $state = self::STATE_CLEAN;
 
@@ -342,25 +344,30 @@ class QueryBuilder
      */
     public function getDQL()
     {
+        // @phpstan-ignore classConstant.deprecated
         if ($this->dql !== null && $this->state === self::STATE_CLEAN) {
             return $this->dql;
         }
 
         switch ($this->type) {
+            // @phpstan-ignore classConstant.deprecated
             case self::DELETE:
                 $dql = $this->getDQLForDelete();
                 break;
 
+            // @phpstan-ignore classConstant.deprecated
             case self::UPDATE:
                 $dql = $this->getDQLForUpdate();
                 break;
 
+            // @phpstan-ignore classConstant.deprecated
             case self::SELECT:
             default:
                 $dql = $this->getDQLForSelect();
                 break;
         }
 
+        // @phpstan-ignore classConstant.deprecated
         $this->state = self::STATE_CLEAN;
         $this->dql   = $dql;
 
@@ -422,6 +429,7 @@ class QueryBuilder
         } else {
             // Should never happen with correct joining order. Might be
             // thoughtful to throw exception instead.
+            // @phpstan-ignore method.deprecated
             $rootAlias = $this->getRootAlias();
         }
 
@@ -743,6 +751,7 @@ class QueryBuilder
             $newDqlPart = [];
 
             foreach ($dqlPart as $k => $v) {
+                // @phpstan-ignore method.deprecated
                 $k = is_numeric($k) ? $this->getRootAlias() : $k;
 
                 $newDqlPart[$k] = $v;
@@ -763,6 +772,7 @@ class QueryBuilder
             $this->dqlParts[$dqlPartName] = $isMultiple ? [$dqlPart] : $dqlPart;
         }
 
+        // @phpstan-ignore classConstant.deprecated
         $this->state = self::STATE_DIRTY;
 
         return $this;
@@ -785,6 +795,7 @@ class QueryBuilder
      */
     public function select($select = null)
     {
+        // @phpstan-ignore classConstant.deprecated
         $this->type = self::SELECT;
 
         if (empty($select)) {
@@ -816,7 +827,8 @@ class QueryBuilder
 
         if ($this->dqlParts['distinct'] !== $flag) {
             $this->dqlParts['distinct'] = $flag;
-            $this->state                = self::STATE_DIRTY;
+            // @phpstan-ignore classConstant.deprecated
+            $this->state = self::STATE_DIRTY;
         }
 
         return $this;
@@ -839,6 +851,7 @@ class QueryBuilder
      */
     public function addSelect($select = null)
     {
+        // @phpstan-ignore classConstant.deprecated
         $this->type = self::SELECT;
 
         if (empty($select)) {
@@ -868,6 +881,7 @@ class QueryBuilder
      */
     public function delete($delete = null, $alias = null)
     {
+        // @phpstan-ignore classConstant.deprecated
         $this->type = self::DELETE;
 
         if (! $delete) {
@@ -903,6 +917,7 @@ class QueryBuilder
      */
     public function update($update = null, $alias = null)
     {
+        // @phpstan-ignore classConstant.deprecated
         $this->type = self::UPDATE;
 
         if (! $update) {
@@ -1528,7 +1543,8 @@ class QueryBuilder
     public function resetDQLPart($part)
     {
         $this->dqlParts[$part] = is_array($this->dqlParts[$part]) ? [] : null;
-        $this->state           = self::STATE_DIRTY;
+        // @phpstan-ignore classConstant.deprecated
+        $this->state = self::STATE_DIRTY;
 
         return $this;
     }

--- a/src/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/src/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -71,6 +71,7 @@ EOT
 
         $cacheDriver = null;
         if (! $cache) {
+            // @phpstan-ignore method.deprecated
             $cacheDriver = $em->getConfiguration()->getQueryCacheImpl();
 
             if (! $cacheDriver) {

--- a/src/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/src/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -63,8 +63,9 @@ EOT
     {
         $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
 
-        $em          = $this->getEntityManager($input);
-        $cache       = $em->getConfiguration()->getResultCache();
+        $em    = $this->getEntityManager($input);
+        $cache = $em->getConfiguration()->getResultCache();
+        // @phpstan-ignore method.deprecated
         $cacheDriver = method_exists(Configuration::class, 'getResultCacheImpl') ? $em->getConfiguration()->getResultCacheImpl() : null;
 
         if (! $cacheDriver && ! $cache) {

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -71,6 +71,7 @@ final class ConsoleRunner
         if ($helperSetOrProvider instanceof HelperSet) {
             $cli->setHelperSet($helperSetOrProvider);
 
+            // @phpstan-ignore new.deprecated
             $helperSetOrProvider = new HelperSetManagerProvider($helperSetOrProvider);
         }
 
@@ -83,6 +84,7 @@ final class ConsoleRunner
     public static function addCommands(Application $cli, ?EntityManagerProvider $entityManagerProvider = null): void
     {
         if ($entityManagerProvider === null) {
+            // @phpstan-ignore new.deprecated
             $entityManagerProvider = new HelperSetManagerProvider($cli->getHelperSet());
         }
 
@@ -95,6 +97,7 @@ final class ConsoleRunner
         $cli->addCommands(
             [
                 // DBAL Commands
+                // @phpstan-ignore new.deprecated
                 new DBALConsole\Command\ReservedWordsCommand($connectionProvider),
                 new DBALConsole\Command\RunSqlCommand($connectionProvider),
 
@@ -108,11 +111,16 @@ final class ConsoleRunner
                 new Command\SchemaTool\CreateCommand($entityManagerProvider),
                 new Command\SchemaTool\UpdateCommand($entityManagerProvider),
                 new Command\SchemaTool\DropCommand($entityManagerProvider),
+                // @phpstan-ignore new.deprecated
                 new Command\EnsureProductionSettingsCommand($entityManagerProvider),
+                // @phpstan-ignore new.deprecated
                 new Command\ConvertDoctrine1SchemaCommand(),
+                // @phpstan-ignore new.deprecated
                 new Command\GenerateRepositoriesCommand($entityManagerProvider),
+                // @phpstan-ignore new.deprecated
                 new Command\GenerateEntitiesCommand($entityManagerProvider),
                 new Command\GenerateProxiesCommand($entityManagerProvider),
+                // @phpstan-ignore new.deprecated
                 new Command\ConvertMappingCommand($entityManagerProvider),
                 new Command\RunDqlCommand($entityManagerProvider),
                 new Command\ValidateSchemaCommand($entityManagerProvider),

--- a/src/Tools/Export/Driver/AnnotationExporter.php
+++ b/src/Tools/Export/Driver/AnnotationExporter.php
@@ -16,6 +16,8 @@ use function str_replace;
  * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
  *
  * @link    www.doctrine-project.org
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class AnnotationExporter extends AbstractExporter
 {

--- a/src/Tools/Export/Driver/PhpExporter.php
+++ b/src/Tools/Export/Driver/PhpExporter.php
@@ -23,6 +23,8 @@ use const PHP_EOL;
  * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
  *
  * @link    www.doctrine-project.org
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class PhpExporter extends AbstractExporter
 {

--- a/src/Tools/Export/Driver/XmlExporter.php
+++ b/src/Tools/Export/Driver/XmlExporter.php
@@ -21,6 +21,8 @@ use function uasort;
  * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
  *
  * @link    www.doctrine-project.org
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class XmlExporter extends AbstractExporter
 {

--- a/src/Tools/Export/Driver/YamlExporter.php
+++ b/src/Tools/Export/Driver/YamlExporter.php
@@ -16,6 +16,8 @@ use function count;
  * @deprecated 2.7 This class is being removed from the ORM and won't have any replacement
  *
  * @link    www.doctrine-project.org
+ *
+ * @phpstan-ignore class.extendsDeprecatedClass
  */
 class YamlExporter extends AbstractExporter
 {

--- a/src/Tools/Pagination/LimitSubqueryWalker.php
+++ b/src/Tools/Pagination/LimitSubqueryWalker.php
@@ -74,6 +74,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
             return;
         }
 
+        // @phpstan-ignore method.deprecated
         $queryComponents = $this->_getQueryComponents();
         foreach ($AST->orderByClause->orderByItems as $item) {
             if ($item->expression instanceof PathExpression) {

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -84,6 +84,7 @@ class SchemaTool
         $this->quoteStrategy = $em->getConfiguration()->getQuoteStrategy();
         $this->schemaManager = method_exists(Connection::class, 'createSchemaManager')
             ? $em->getConnection()->createSchemaManager()
+            // @phpstan-ignore method.deprecated
             : $em->getConnection()->getSchemaManager();
     }
 
@@ -311,6 +312,7 @@ class SchemaTool
                         $table->setPrimaryKey($pkColumns);
                     }
                 }
+            // @phpstan-ignore method.deprecated
             } elseif ($class->isInheritanceTypeTablePerClass()) {
                 throw NotSupported::create();
             } else {
@@ -412,7 +414,9 @@ class SchemaTool
                 return ! $asset->isInDefaultNamespace($schema->getName());
             };
 
+            // @phpstan-ignore method.deprecated
             if (array_filter($schema->getSequences() + $schema->getTables(), $filter) && ! $this->platform->canEmulateSchemas()) {
+                // @phpstan-ignore method.deprecated, new.deprecated
                 $schema->visit(new RemoveNamespacedAssets());
             }
         }
@@ -989,10 +993,12 @@ class SchemaTool
         $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
         if ($saveMode) {
+            // @phpstan-ignore method.deprecated
             return $schemaDiff->toSaveSql($this->platform);
         }
 
         if (! method_exists(AbstractPlatform::class, 'getAlterSchemaSQL')) {
+            // @phpstan-ignore method.deprecated
             return $schemaDiff->toSql($this->platform);
         }
 


### PR DESCRIPTION
We want to shift responsibilities from Psalm over to PHPStan. This PR enables PHPStan to sniff for deprecated code usages. I've reviewed all the errors reported by the new rules and ignored most of them via inline annotations.