### PR TITLE
Deprecate the `\Doctrine\ORM\Query\Parser::setCustomOutputTreeWalker()` method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,12 @@
 Use of the PARTIAL keyword is not deprecated anymore in DQL when used with a hydrator
 that is not creating entities, such as the ArrayHydrator.
 
+## Deprecate `\Doctrine\ORM\Query\Parser::setCustomOutputTreeWalker()`
+
+Use the `\Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER` query hint to set the output walker
+class instead of setting it through the `\Doctrine\ORM\Query\Parser::setCustomOutputTreeWalker()` method
+on the parser instance.
+
 # Upgrade to 2.19
 
 ## Deprecate calling `ClassMetadata::getAssociationMappedByTargetField()` with the owning side of an association

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -203,7 +203,7 @@ class Parser
         Deprecation::trigger(
             'doctrine/orm',
             'https://github.com/doctrine/orm/pull/11641',
-            '%s is deprecated, set the output walker class in a query hint instead',
+            '%s is deprecated, set the output walker class with the \Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER query hint instead',
             __METHOD__
         );
 

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -200,6 +200,13 @@ class Parser
      */
     public function setCustomOutputTreeWalker($className)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/11641',
+            '%s is deprecated, set the output walker class in a query hint instead',
+            __METHOD__
+        );
+
         $this->customOutputWalker = $className;
     }
 

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -51,7 +51,7 @@ class LanguageRecognitionTest extends OrmTestCase
         $parser = new Query\Parser($query);
 
         // We do NOT test SQL output here. That only unnecessarily slows down the tests!
-        $parser->setCustomOutputTreeWalker(NullSqlWalker::class);
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, NullSqlWalker::class);
 
         return $parser->parse();
     }


### PR DESCRIPTION
We use this method only from within one of our own test cases, and I don't see how it would be useful to anybody else outside – it has to be called on the `Parser` instance which exists internally in the `Query` only.

Deprecating and removing it in 4.0 allows for a slight simplification in the `Parser` there, since we do no longer need the field (it can be a local variable).