### PR TITLE
Remove vendor prefix of PHPDoc referencing class-string

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -305,7 +305,7 @@
       <code><![CDATA[$persister->loadById($sortedId)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[?T]]></code>
+      <code><![CDATA[T|null]]></code>
     </InvalidReturnType>
     <MissingReturnType>
       <code><![CDATA[wrapInTransaction]]></code>

--- a/src/Cache/AssociationCacheEntry.php
+++ b/src/Cache/AssociationCacheEntry.php
@@ -21,15 +21,13 @@ class AssociationCacheEntry implements CacheEntry
      * The entity class name
      *
      * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     public $class;
 
     /**
-     * @param string               $class      The entity class.
+     * @param class-string         $class      The entity class.
      * @param array<string, mixed> $identifier The entity identifier.
-     * @psalm-param class-string $class
      */
     public function __construct($class, array $identifier)
     {

--- a/src/Cache/CollectionCacheKey.php
+++ b/src/Cache/CollectionCacheKey.php
@@ -26,8 +26,7 @@ class CollectionCacheKey extends CacheKey
      * The owner entity class
      *
      * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     public $entityClass;
 
@@ -40,10 +39,9 @@ class CollectionCacheKey extends CacheKey
     public $association;
 
     /**
-     * @param string               $entityClass     The entity class.
+     * @param class-string         $entityClass     The entity class.
      * @param string               $association     The field name that represents the association.
      * @param array<string, mixed> $ownerIdentifier The identifier of the owning entity.
-     * @psalm-param class-string $entityClass
      */
     public function __construct($entityClass, $association, array $ownerIdentifier)
     {

--- a/src/Cache/EntityCacheEntry.php
+++ b/src/Cache/EntityCacheEntry.php
@@ -25,15 +25,13 @@ class EntityCacheEntry implements CacheEntry
      * The entity class name
      *
      * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     public $class;
 
     /**
-     * @param string              $class The entity class.
+     * @param class-string        $class The entity class.
      * @param array<string,mixed> $data  The entity data.
-     * @psalm-param class-string $class
      */
     public function __construct($class, array $data)
     {

--- a/src/Cache/EntityCacheKey.php
+++ b/src/Cache/EntityCacheKey.php
@@ -26,15 +26,13 @@ class EntityCacheKey extends CacheKey
      * The entity class name
      *
      * @readonly Public only for performance reasons, it should be considered immutable.
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     public $entityClass;
 
     /**
-     * @param string               $entityClass The entity class name. In a inheritance hierarchy it should always be the root entity class.
+     * @param class-string         $entityClass The entity class name. In a inheritance hierarchy it should always be the root entity class.
      * @param array<string, mixed> $identifier  The entity identifier
-     * @psalm-param class-string $entityClass
      */
     public function __construct($entityClass, array $identifier)
     {

--- a/src/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/src/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -254,9 +254,8 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     /**
      * @deprecated This method is not used anymore.
      *
-     * @param string $targetEntity
-     * @param object $element
-     * @psalm-param class-string $targetEntity
+     * @param class-string $targetEntity
+     * @param object       $element
      *
      * @return void
      */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -687,8 +687,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name
      *
-     * @return string|callable|null
-     * @psalm-return class-string|callable|null
+     * @return class-string|callable|null
      */
     public function getCustomNumericFunction($name)
     {
@@ -705,7 +704,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * Any previously added numeric functions are discarded.
      *
-     * @psalm-param array<string, class-string> $functions The map of custom
+     * @param array<string, class-string> $functions The map of custom
      *                                                     DQL numeric functions.
      *
      * @return void
@@ -740,8 +739,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name
      *
-     * @return string|callable|null
-     * @psalm-return class-string|callable|null
+     * @return class-string|callable|null
      */
     public function getCustomDatetimeFunction($name)
     {
@@ -807,8 +805,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $modeName The hydration mode name.
      *
-     * @return string|null The hydrator class name.
-     * @psalm-return class-string<AbstractHydrator>|null
+     * @return class-string<AbstractHydrator>|null The hydrator class name.
      */
     public function getCustomHydrationMode($modeName)
     {
@@ -818,9 +815,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Adds a custom hydration mode.
      *
-     * @param string $modeName The hydration mode name.
-     * @param string $hydrator The hydrator class name.
-     * @psalm-param class-string<AbstractHydrator> $hydrator
+     * @param string                         $modeName The hydration mode name.
+     * @param class-string<AbstractHydrator> $hydrator The hydrator class name.
      *
      * @return void
      */
@@ -832,8 +828,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Sets a class metadata factory.
      *
-     * @param string $cmfName
-     * @psalm-param class-string $cmfName
+     * @param class-string $cmfName
      *
      * @return void
      */
@@ -842,10 +837,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
         $this->_attributes['classMetadataFactoryName'] = $cmfName;
     }
 
-    /**
-     * @return string
-     * @psalm-return class-string
-     */
+    /** @return class-string */
     public function getClassMetadataFactoryName()
     {
         if (! isset($this->_attributes['classMetadataFactoryName'])) {
@@ -858,9 +850,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Adds a filter to the list of possible filters.
      *
-     * @param string $name      The name of the filter.
-     * @param string $className The class name of the filter.
-     * @psalm-param class-string<SQLFilter> $className
+     * @param string                  $name      The name of the filter.
+     * @param class-string<SQLFilter> $className The class name of the filter.
      *
      * @return void
      */
@@ -874,9 +865,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name The name of the filter.
      *
-     * @return string|null The class name of the filter, or null if it is not
-     *  defined.
-     * @psalm-return class-string<SQLFilter>|null
+     * @return class-string<SQLFilter>|null The class name of the filter,
+     *                                      or null if it is not defined.
      */
     public function getFilterClassName($name)
     {
@@ -886,8 +876,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Sets default repository class.
      *
-     * @param string $className
-     * @psalm-param class-string<EntityRepository> $className
+     * @param class-string<EntityRepository> $className
      *
      * @return void
      *
@@ -915,8 +904,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Get default repository class.
      *
-     * @return string
-     * @psalm-return class-string<EntityRepository>
+     * @return class-string<EntityRepository>
      */
     public function getDefaultRepositoryClassName()
     {

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -50,7 +50,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
+     * @param class-string<T> $className
      *
      * @psalm-return EntityRepository<T>
      *

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -30,7 +30,6 @@ use Doctrine\ORM\Query\FilterCollection;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\MappingException;
-use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Throwable;
 
@@ -407,25 +406,23 @@ class EntityManager implements EntityManagerInterface
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string   $className   The class name of the entity to find.
-     * @param mixed    $id          The identity of the entity to find.
-     * @param int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
-     *    or NULL if no specific lock mode should be used
-     *    during the search.
-     * @param int|null $lockVersion The version of the entity to find when using
-     * optimistic locking.
-     * @psalm-param class-string<T> $className
+     * @param class-string<T> $className   The class name of the entity to find.
+     * @param mixed           $id          The identity of the entity to find.
+     * @param int|null        $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
+     *                                     or NULL if no specific lock mode should be used
+     *                                     during the search.
+     * @param int|null        $lockVersion The version of the entity to find when using
+     *                                     optimistic locking.
      * @psalm-param LockMode::*|null $lockMode
      *
-     * @return object|null The entity instance or NULL if the entity can not be found.
-     * @psalm-return ?T
+     * @return T|null The entity instance or NULL if the entity can not be found.
      *
      * @throws OptimisticLockException
      * @throws ORMInvalidArgumentException
      * @throws TransactionRequiredException
      * @throws ORMException
      *
-     * @template T
+     * @template T of object
      */
     public function find($className, $id, $lockMode = null, $lockVersion = null)
     {
@@ -803,11 +800,9 @@ class EntityManager implements EntityManagerInterface
     /**
      * Gets the repository for an entity class.
      *
-     * @param string $entityName The name of the entity.
-     * @psalm-param class-string<T> $entityName
+     * @param class-string<T> $entityName The name of the entity.
      *
-     * @return ObjectRepository|EntityRepository The repository class.
-     * @psalm-return EntityRepository<T>
+     * @return EntityRepository<T> The repository class.
      *
      * @template T of object
      */

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -29,9 +29,9 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
+     * @param class-string<T> $className
      *
-     * @psalm-return EntityRepository<T>
+     * @return EntityRepository<T>
      *
      * @template T of object
      */
@@ -172,12 +172,10 @@ interface EntityManagerInterface extends ObjectManager
      * Gets a reference to the entity identified by the given type and identifier
      * without actually loading it, if the entity is not yet loaded.
      *
-     * @param string $entityName The name of the entity type.
-     * @param mixed  $id         The entity identifier.
-     * @psalm-param class-string<T> $entityName
+     * @param class-string<T> $entityName The name of the entity type.
+     * @param mixed           $id         The entity identifier.
      *
-     * @return object|null The entity reference.
-     * @psalm-return T|null
+     * @return T|null The entity reference.
      *
      * @throws ORMException
      *
@@ -202,12 +200,10 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @deprecated 2.7 This method is being removed from the ORM and won't have any replacement
      *
-     * @param string $entityName The name of the entity type.
-     * @param mixed  $identifier The entity identifier.
-     * @psalm-param class-string<T> $entityName
+     * @param class-string<T> $entityName The name of the entity type.
+     * @param mixed           $identifier The entity identifier.
      *
-     * @return object|null The (partial) entity reference
-     * @psalm-return T|null
+     * @return T|null The (partial) entity reference
      *
      * @template T
      */
@@ -337,7 +333,7 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param string|class-string<T> $className
+     * @param string|class-string<T> $className
      *
      * @return Mapping\ClassMetadata
      * @psalm-return ($className is class-string<T> ? Mapping\ClassMetadata<T> : Mapping\ClassMetadata<object>)

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -42,8 +42,7 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * @internal This property will be private in 3.0, call {@see getEntityName()} instead.
      *
-     * @var string
-     * @psalm-var class-string<T>
+     * @var class-string<T>
      */
     protected $_entityName;
 
@@ -287,10 +286,7 @@ class EntityRepository implements ObjectRepository, Selectable
         ));
     }
 
-    /**
-     * @return string
-     * @psalm-return class-string<T>
-     */
+    /** @return class-string<T> */
     protected function getEntityName()
     {
         return $this->_entityName;

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -273,7 +273,7 @@ class ObjectHydrator extends AbstractHydrator
     }
 
     /**
-     * @psalm-param class-string $className
+     * @param class-string $className
      * @psalm-param array<string, mixed> $data
      *
      * @return mixed

--- a/src/Mapping/Builder/ClassMetadataBuilder.php
+++ b/src/Mapping/Builder/ClassMetadataBuilder.php
@@ -218,11 +218,11 @@ class ClassMetadataBuilder
     /**
      * Sets the discriminator column details.
      *
-     * @param string $name
-     * @param string $type
-     * @param int    $length
-     * @psalm-param class-string<BackedEnum>|null $enumType
-     * @psalm-param array<string, mixed> $options
+     * @param string                        $name
+     * @param string                        $type
+     * @param int                           $length
+     * @param class-string<BackedEnum>|null $enumType
+     * @param array<string, mixed>          $options
      *
      * @return $this
      */

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -420,7 +420,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * Gets the lower-case short name of a class.
      *
-     * @psalm-param class-string $className
+     * @param class-string $className
      */
     private function getShortName(string $className): string
     {
@@ -850,8 +850,10 @@ DEPRECATION
      */
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
-        /** @psalm-var class-string */
-        return $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
+        /** @var class-string $classString */
+        $classString = $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
+
+        return $classString;
     }
 
     /**

--- a/src/Mapping/ClassMetadataInfo.php
+++ b/src/Mapping/ClassMetadataInfo.php
@@ -257,8 +257,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * READ-ONLY: The name of the entity class.
      *
-     * @var string
-     * @psalm-var class-string<T>
+     * @var class-string<T>
      */
     public $name;
 
@@ -275,8 +274,7 @@ class ClassMetadataInfo implements ClassMetadata
      * hierarchy. If the entity is not part of a mapped inheritance hierarchy this is the same
      * as {@link $name}.
      *
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     public $rootEntityName;
 
@@ -300,8 +298,7 @@ class ClassMetadataInfo implements ClassMetadata
      * The name of the custom repository class used for the entity class.
      * (Optional).
      *
-     * @var string|null
-     * @psalm-var ?class-string<EntityRepository>
+     * @var class-string<EntityRepository>|null
      */
     public $customRepositoryClassName;
 
@@ -323,7 +320,7 @@ class ClassMetadataInfo implements ClassMetadata
      * READ-ONLY: The names of the parent <em>entity</em> classes (ancestors), starting with the
      * nearest one and ending with the root entity class.
      *
-     * @psalm-var list<class-string>
+     * @var list<class-string>
      */
     public $parentClasses = [];
 
@@ -350,7 +347,7 @@ class ClassMetadataInfo implements ClassMetadata
      * For subclasses of such root entities, the list can be reused/passed downwards, it only needs to
      * be filtered accordingly (only keep remaining subclasses)
      *
-     * @psalm-var list<class-string>
+     * @var list<class-string>
      */
     public $subClasses = [];
 
@@ -548,9 +545,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see discriminatorColumn
      *
-     * @var array<int|string, string>
-     *
-     * @psalm-var array<int|string, class-string>
+     * @var array<int|string, class-string>
      */
     public $discriminatorMap = [];
 
@@ -811,8 +806,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Initializes a new ClassMetadata instance that will hold the object-relational mapping
      * metadata of the class with the given name.
      *
-     * @param string $entityName The name of the entity class the new instance is used for.
-     * @psalm-param class-string<T> $entityName
+     * @param class-string<T> $entityName The name of the entity class the new instance is used for.
      */
     public function __construct($entityName, ?NamingStrategy $namingStrategy = null, ?TypedFieldMapper $typedFieldMapper = null)
     {
@@ -2426,7 +2420,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Assumes that the class names in the passed array are in the order:
      * directParent -> directParentParent -> directParentParentParent ... -> root.
      *
-     * @psalm-param list<class-string> $classNames
+     * @param list<class-string> $classNames
      *
      * @return void
      */
@@ -3024,8 +3018,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Registers a custom repository class for the entity class.
      *
-     * @param string|null $repositoryClassName The class name of the custom mapper.
-     * @psalm-param class-string<EntityRepository>|null $repositoryClassName
+     * @param class-string<EntityRepository>|null $repositoryClassName The class name of the custom mapper.
      *
      * @return void
      */
@@ -3562,8 +3555,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $assocName
      *
-     * @return string
-     * @psalm-return class-string
+     * @return class-string
      *
      * @throws InvalidArgumentException
      */
@@ -3883,7 +3875,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
     }
 
-    /** @psalm-param class-string $class */
+    /** @param class-string $class */
     private function getAccessibleProperty(ReflectionService $reflService, string $class, string $field): ?ReflectionProperty
     {
         $reflectionProperty = $reflService->getAccessibleProperty($class, $field);

--- a/src/Mapping/DefaultEntityListenerResolver.php
+++ b/src/Mapping/DefaultEntityListenerResolver.php
@@ -17,7 +17,7 @@ use function trim;
  */
 class DefaultEntityListenerResolver implements EntityListenerResolver
 {
-    /** @psalm-var array<class-string, object> Map to store entity listener instances. */
+    /** @var array<class-string, object> Map to store entity listener instances. */
     private $instances = [];
 
     /**

--- a/src/Mapping/Driver/AnnotationDriver.php
+++ b/src/Mapping/Driver/AnnotationDriver.php
@@ -47,10 +47,7 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
      */
     protected $reader;
 
-    /**
-     * @var int[]
-     * @psalm-var array<class-string, int>
-     */
+    /** @var array<class-string, int> */
     protected $entityAnnotationClasses = [
         Mapping\Entity::class => 1,
         Mapping\MappedSuperclass::class => 2,
@@ -89,8 +86,8 @@ class AnnotationDriver extends CompatibilityAnnotationDriver
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
-     * @psalm-param ClassMetadata<T> $metadata
+     * @param class-string<T>  $className
+     * @param ClassMetadata<T> $metadata
      *
      * @template T of object
      */

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -127,8 +127,8 @@ class AttributeDriver extends CompatibilityAnnotationDriver
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
-     * @psalm-param ClassMetadata<T> $metadata
+     * @param class-string<T>  $className
+     * @param ClassMetadata<T> $metadata
      *
      * @template T of object
      */

--- a/src/Mapping/Driver/DatabaseDriver.php
+++ b/src/Mapping/Driver/DatabaseDriver.php
@@ -185,8 +185,8 @@ class DatabaseDriver implements MappingDriver
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
-     * @psalm-param ClassMetadata<T> $metadata
+     * @param class-string<T>  $className
+     * @param ClassMetadata<T> $metadata
      *
      * @template T of object
      */
@@ -533,7 +533,7 @@ class DatabaseDriver implements MappingDriver
     /**
      * Returns the mapped class name for a table if it exists. Otherwise return "classified" version.
      *
-     * @psalm-return class-string
+     * @return class-string
      */
     private function getClassNameForTable(string $tableName): string
     {

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -73,8 +73,8 @@ class XmlDriver extends FileDriver
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
-     * @psalm-param ClassMetadata<T> $metadata
+     * @param class-string<T>  $className
+     * @param ClassMetadata<T> $metadata
      *
      * @template T of object
      */
@@ -971,19 +971,19 @@ class XmlDriver extends FileDriver
 
         if (isset($xmlElement->entity)) {
             foreach ($xmlElement->entity as $entityElement) {
-                /** @psalm-var class-string $entityName */
+                /** @var class-string $entityName */
                 $entityName          = (string) $entityElement['name'];
                 $result[$entityName] = $entityElement;
             }
         } elseif (isset($xmlElement->{'mapped-superclass'})) {
             foreach ($xmlElement->{'mapped-superclass'} as $mappedSuperClass) {
-                /** @psalm-var class-string $className */
+                /** @var class-string $className */
                 $className          = (string) $mappedSuperClass['name'];
                 $result[$className] = $mappedSuperClass;
             }
         } elseif (isset($xmlElement->embeddable)) {
             foreach ($xmlElement->embeddable as $embeddableElement) {
-                /** @psalm-var class-string $embeddableName */
+                /** @var class-string $embeddableName */
                 $embeddableName          = (string) $embeddableElement['name'];
                 $result[$embeddableName] = $embeddableElement;
             }

--- a/src/Mapping/Driver/YamlDriver.php
+++ b/src/Mapping/Driver/YamlDriver.php
@@ -63,8 +63,8 @@ class YamlDriver extends FileDriver
     /**
      * {@inheritDoc}
      *
-     * @psalm-param class-string<T> $className
-     * @psalm-param ClassMetadata<T> $metadata
+     * @param class-string<T>  $className
+     * @param ClassMetadata<T> $metadata
      *
      * @template T of object
      */

--- a/src/Mapping/Entity.php
+++ b/src/Mapping/Entity.php
@@ -18,8 +18,7 @@ use Doctrine\ORM\EntityRepository;
 final class Entity implements MappingAttribute
 {
     /**
-     * @var string|null
-     * @psalm-var class-string<EntityRepository<T>>|null
+     * @var class-string<EntityRepository<T>>|null
      * @readonly
      */
     public $repositoryClass;

--- a/src/Mapping/MappedSuperclass.php
+++ b/src/Mapping/MappedSuperclass.php
@@ -17,13 +17,12 @@ use Doctrine\ORM\EntityRepository;
 final class MappedSuperclass implements MappingAttribute
 {
     /**
-     * @var string|null
-     * @psalm-var class-string<EntityRepository>|null
+     * @var class-string<EntityRepository>|null
      * @readonly
      */
     public $repositoryClass;
 
-    /** @psalm-param class-string<EntityRepository>|null $repositoryClass */
+    /** @param class-string<EntityRepository>|null $repositoryClass */
     public function __construct(?string $repositoryClass = null)
     {
         $this->repositoryClass = $repositoryClass;

--- a/src/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/src/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -33,8 +33,7 @@ final class ReflectionPropertiesGetter
     }
 
     /**
-     * @param string $className
-     * @psalm-param class-string $className
+     * @param class-string $className
      *
      * @return ReflectionProperty[] indexed by property internal name
      */
@@ -57,7 +56,7 @@ final class ReflectionPropertiesGetter
     }
 
     /**
-     * @psalm-param class-string $className
+     * @param class-string $className
      *
      * @return ReflectionClass[]
      * @psalm-return list<ReflectionClass<object>>

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -51,7 +51,7 @@ class Parser
 {
     /**
      * @readonly Maps BUILT-IN string function names to AST class names.
-     * @psalm-var array<string, class-string<Functions\FunctionNode>>
+     * @var array<string, class-string<Functions\FunctionNode>>
      */
     private static $stringFunctions = [
         'concat'    => Functions\ConcatFunction::class,
@@ -64,7 +64,7 @@ class Parser
 
     /**
      * @readonly Maps BUILT-IN numeric function names to AST class names.
-     * @psalm-var array<string, class-string<Functions\FunctionNode>>
+     * @var array<string, class-string<Functions\FunctionNode>>
      */
     private static $numericFunctions = [
         'length'    => Functions\LengthFunction::class,
@@ -87,7 +87,7 @@ class Parser
 
     /**
      * @readonly Maps BUILT-IN datetime function names to AST class names.
-     * @psalm-var array<string, class-string<Functions\FunctionNode>>
+     * @var array<string, class-string<Functions\FunctionNode>>
      */
     private static $datetimeFunctions = [
         'current_date'      => Functions\CurrentDateFunction::class,
@@ -162,7 +162,7 @@ class Parser
     /**
      * Any additional custom tree walkers that modify the AST.
      *
-     * @psalm-var list<class-string<TreeWalker>>
+     * @var list<class-string<TreeWalker>>
      */
     private $customTreeWalkers = [];
 
@@ -193,8 +193,7 @@ class Parser
      * Sets a custom tree walker that produces output.
      * This tree walker will be run last over the AST, after any other walkers.
      *
-     * @param string $className
-     * @psalm-param class-string<SqlWalker> $className
+     * @param class-string<SqlWalker> $className
      *
      * @return void
      */
@@ -206,8 +205,7 @@ class Parser
     /**
      * Adds a custom tree walker for modifying the AST.
      *
-     * @param string $className
-     * @psalm-param class-string<TreeWalker> $className
+     * @param class-string<TreeWalker> $className
      *
      * @return void
      */

--- a/src/Query/ResultSetMapping.php
+++ b/src/Query/ResultSetMapping.php
@@ -41,7 +41,7 @@ class ResultSetMapping
      * Maps alias names to class names.
      *
      * @ignore
-     * @psalm-var array<string, class-string>
+     * @var array<string, class-string>
      */
     public $aliasMap = [];
 
@@ -137,7 +137,7 @@ class ResultSetMapping
      * Map from column names to class names that declare the field the column is mapped to.
      *
      * @ignore
-     * @psalm-var array<string, class-string>
+     * @var array<string, class-string>
      */
     public $declaringClasses = [];
 
@@ -172,12 +172,11 @@ class ResultSetMapping
     /**
      * Adds an entity result to this ResultSetMapping.
      *
-     * @param string      $class       The class name of the entity.
-     * @param string      $alias       The alias for the class. The alias must be unique among all entity
-     *                                 results or joined entity results within this ResultSetMapping.
-     * @param string|null $resultAlias The result alias with which the entity result should be
-     *                                 placed in the result structure.
-     * @psalm-param class-string $class
+     * @param class-string $class       The class name of the entity.
+     * @param string       $alias       The alias for the class. The alias must be unique among all entity
+     *                                  results or joined entity results within this ResultSetMapping.
+     * @param string|null  $resultAlias The result alias with which the entity result should be
+     *                                  placed in the result structure.
      *
      * @return $this
      *
@@ -316,15 +315,14 @@ class ResultSetMapping
     /**
      * Adds a field to the result that belongs to an entity or joined entity.
      *
-     * @param string      $alias          The alias of the root entity or joined entity to which the field belongs.
-     * @param string      $columnName     The name of the column in the SQL result set.
-     * @param string      $fieldName      The name of the field on the declaring class.
-     * @param string|null $declaringClass The name of the class that declares/owns the specified field.
-     *                                    When $alias refers to a superclass in a mapped hierarchy but
-     *                                    the field $fieldName is defined on a subclass, specify that here.
-     *                                    If not specified, the field is assumed to belong to the class
-     *                                    designated by $alias.
-     * @psalm-param class-string|null $declaringClass
+     * @param string            $alias          The alias of the root entity or joined entity to which the field belongs.
+     * @param string            $columnName     The name of the column in the SQL result set.
+     * @param string            $fieldName      The name of the field on the declaring class.
+     * @param class-string|null $declaringClass The name of the class that declares/owns the specified field.
+     *                                          When $alias refers to a superclass in a mapped hierarchy but
+     *                                          the field $fieldName is defined on a subclass, specify that here.
+     *                                          If not specified, the field is assumed to belong to the class
+     *                                          designated by $alias.
      *
      * @return $this
      *
@@ -349,12 +347,11 @@ class ResultSetMapping
     /**
      * Adds a joined entity result.
      *
-     * @param string $class       The class name of the joined entity.
-     * @param string $alias       The unique alias to use for the joined entity.
-     * @param string $parentAlias The alias of the entity result that is the parent of this joined result.
-     * @param string $relation    The association field that connects the parent entity result
-     *                            with the joined entity result.
-     * @psalm-param class-string $class
+     * @param class-string $class       The class name of the joined entity.
+     * @param string       $alias       The unique alias to use for the joined entity.
+     * @param string       $parentAlias The alias of the entity result that is the parent of this joined result.
+     * @param string       $relation    The association field that connects the parent entity result
+     *                                  with the joined entity result.
      *
      * @return $this
      *
@@ -539,7 +536,7 @@ class ResultSetMapping
         return $this->fieldMappings[$columnName];
     }
 
-    /** @psalm-return array<string, class-string> */
+    /** @return array<string, class-string> */
     public function getAliasMap()
     {
         return $this->aliasMap;

--- a/src/Query/ResultSetMappingBuilder.php
+++ b/src/Query/ResultSetMappingBuilder.php
@@ -77,12 +77,10 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds a root entity and all of its fields to the result set.
      *
-     * @param string   $class          The class name of the root entity.
-     * @param string   $alias          The unique alias to use for the root entity.
-     * @param string[] $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
-     * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
-     * @psalm-param class-string $class
-     * @psalm-param array<string, string> $renamedColumns
+     * @param class-string          $class          The class name of the root entity.
+     * @param string                $alias          The unique alias to use for the root entity.
+     * @param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param int|null              $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
      * @psalm-param self::COLUMN_RENAMING_*|null $renameMode
      *
      * @return void
@@ -99,15 +97,13 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds a joined entity and all of its fields to the result set.
      *
-     * @param string   $class          The class name of the joined entity.
-     * @param string   $alias          The unique alias to use for the joined entity.
-     * @param string   $parentAlias    The alias of the entity result that is the parent of this joined result.
-     * @param string   $relation       The association field that connects the parent entity result
-     *                                 with the joined entity result.
-     * @param string[] $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
-     * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
-     * @psalm-param class-string $class
-     * @psalm-param array<string, string> $renamedColumns
+     * @param class-string          $class          The class name of the joined entity.
+     * @param string                $alias          The unique alias to use for the joined entity.
+     * @param string                $parentAlias    The alias of the entity result that is the parent of this joined result.
+     * @param string                $relation       The association field that connects the parent entity result
+     *                                              with the joined entity result.
+     * @param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param int|null              $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
      * @psalm-param self::COLUMN_RENAMING_*|null $renameMode
      *
      * @return void
@@ -228,12 +224,11 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * This depends on the renaming mode selected by the user.
      *
-     * @psalm-param class-string $className
+     * @param class-string $className
      * @psalm-param self::COLUMN_RENAMING_* $mode
      * @psalm-param array<string, string> $customRenameColumns
      *
      * @return string[]
-     * @psalm-return array<array-key, string>
      */
     private function getColumnAliasMap(
         string $className,

--- a/src/Query/TreeWalkerChain.php
+++ b/src/Query/TreeWalkerChain.php
@@ -23,8 +23,7 @@ class TreeWalkerChain implements TreeWalker
     /**
      * The tree walkers.
      *
-     * @var string[]
-     * @psalm-var list<class-string<TreeWalker>>
+     * @var list<class-string<TreeWalker>>
      */
     private $walkers = [];
 
@@ -81,8 +80,7 @@ class TreeWalkerChain implements TreeWalker
     /**
      * Adds a tree walker to the chain.
      *
-     * @param string $walkerClass The class of the walker to instantiate.
-     * @psalm-param class-string<TreeWalker> $walkerClass
+     * @param class-string<TreeWalker> $walkerClass The class of the walker to instantiate.
      *
      * @return void
      */

--- a/src/Query/TreeWalkerChainIterator.php
+++ b/src/Query/TreeWalkerChainIterator.php
@@ -49,10 +49,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
         $this->parserResult    = $parserResult;
     }
 
-    /**
-     * @return string|false
-     * @psalm-return class-string<TreeWalker>|false
-     */
+    /** @return class-string<TreeWalker>|false */
     #[ReturnTypeWillChange]
     public function rewind()
     {

--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -131,8 +131,7 @@ EOT
     /**
      * Return all mapped entity class names
      *
-     * @return string[]
-     * @psalm-return class-string[]
+     * @return class-string[]
      */
     private function getMappedEntities(EntityManagerInterface $entityManager): array
     {

--- a/src/Tools/ConvertDoctrine1Schema.php
+++ b/src/Tools/ConvertDoctrine1Schema.php
@@ -91,8 +91,8 @@ class ConvertDoctrine1Schema
     }
 
     /**
-     * @param mixed[] $mappingInformation
-     * @psalm-param class-string $className
+     * @param class-string $className
+     * @param mixed[]      $mappingInformation
      */
     private function convertToClassMetadataInfo(
         string $className,

--- a/src/Tools/EntityRepositoryGenerator.php
+++ b/src/Tools/EntityRepositoryGenerator.php
@@ -31,7 +31,7 @@ use const DIRECTORY_SEPARATOR;
  */
 class EntityRepositoryGenerator
 {
-    /** @psalm-var class-string|null */
+    /** @var class-string|null */
     private $repositoryName;
 
     /** @var string */
@@ -80,7 +80,7 @@ class <className> extends <repositoryName>
     /**
      * Generates the namespace, if class do not have namespace, return empty string instead.
      *
-     * @psalm-param class-string $fullClassName
+     * @param class-string $fullClassName
      */
     private function getClassNamespace(string $fullClassName): string
     {
@@ -90,7 +90,7 @@ class <className> extends <repositoryName>
     /**
      * Generates the class name
      *
-     * @psalm-param class-string $fullClassName
+     * @param class-string $fullClassName
      */
     private function generateClassName(string $fullClassName): string
     {
@@ -108,7 +108,7 @@ class <className> extends <repositoryName>
     /**
      * Generates the namespace statement, if class do not have namespace, return empty string instead.
      *
-     * @psalm-param class-string $fullClassName The full repository class name.
+     * @param class-string $fullClassName The full repository class name.
      */
     private function generateEntityRepositoryNamespace(string $fullClassName): string
     {

--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -209,7 +209,7 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * Appends a custom tree walker to the tree walkers hint.
      *
-     * @psalm-param class-string $walkerClass
+     * @param class-string $walkerClass
      */
     private function appendTreeWalker(Query $query, string $walkerClass): void
     {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -127,8 +127,7 @@ class UnitOfWork implements PropertyChangedListener
      * Since all classes in a hierarchy must share the same identifier set,
      * we always take the root class name of the hierarchy.
      *
-     * @var mixed[]
-     * @psalm-var array<class-string, array<string, object>>
+     * @var array<class-string, array<string, object>>
      */
     private $identityMap = [];
 
@@ -175,7 +174,7 @@ class UnitOfWork implements PropertyChangedListener
      * This is only used for entities with a change tracking policy of DEFERRED_EXPLICIT.
      * Keys are object ids (spl_object_id).
      *
-     * @psalm-var array<class-string, array<int, mixed>>
+     * @var array<class-string, array<int, mixed>>
      */
     private $scheduledForSynchronization = [];
 
@@ -313,7 +312,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Map of Entity Class-Names and corresponding IDs that should eager loaded when requested.
      *
-     * @psalm-var array<class-string, array<string, mixed>>
+     * @var array<class-string, array<string, mixed>>
      */
     private $eagerLoadingEntities = [];
 
@@ -2907,11 +2906,9 @@ EXCEPTION
      *
      * Internal note: Highly performance-sensitive method.
      *
-     * @param string  $className The name of the entity class.
-     * @param mixed[] $data      The data for the entity.
-     * @param mixed[] $hints     Any hints to account for during reconstitution/lookup of the entity.
-     * @psalm-param class-string $className
-     * @psalm-param array<string, mixed> $hints
+     * @param class-string         $className The name of the entity class.
+     * @param mixed[]              $data      The data for the entity.
+     * @param array<string, mixed> $hints     Any hints to account for during reconstitution/lookup of the entity.
      *
      * @return object The managed entity instance.
      *
@@ -3349,7 +3346,7 @@ EXCEPTION
     /**
      * Gets the identity map of the UnitOfWork.
      *
-     * @psalm-return array<class-string, array<string, object>>
+     * @return array<class-string, array<string, object>>
      */
     public function getIdentityMap()
     {
@@ -3449,9 +3446,8 @@ EXCEPTION
      * Tries to find an entity with the given identifier in the identity map of
      * this UnitOfWork.
      *
-     * @param mixed  $id            The entity identifier to look for.
-     * @param string $rootClassName The name of the root class of the mapped entity hierarchy.
-     * @psalm-param class-string $rootClassName
+     * @param mixed        $id            The entity identifier to look for.
+     * @param class-string $rootClassName The name of the root class of the mapped entity hierarchy.
      *
      * @return object|false Returns the entity with the specified identifier if it exists in
      *                      this UnitOfWork, FALSE otherwise.
@@ -3503,8 +3499,7 @@ EXCEPTION
     /**
      * Gets the EntityPersister for an Entity.
      *
-     * @param string $entityName The name of the Entity.
-     * @psalm-param class-string $entityName
+     * @param class-string $entityName The name of the Entity.
      *
      * @return EntityPersister
      */

--- a/tests/StaticAnalysis/Mapping/class-metadata-constructor.php
+++ b/tests/StaticAnalysis/Mapping/class-metadata-constructor.php
@@ -10,9 +10,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 class MetadataGenerator
 {
     /**
-     * @psalm-param class-string<T> $entityName
+     * @param class-string<T> $entityName
      *
-     * @psalm-return ClassMetadata<T>
+     * @return ClassMetadata<T>
      */
     public function createMetadata(string $entityName): ClassMetadata
     {

--- a/tests/StaticAnalysis/get-metadata.php
+++ b/tests/StaticAnalysis/get-metadata.php
@@ -15,18 +15,15 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 abstract class GetMetadata
 {
-    /**
-     * @param string|object $class
-     * @psalm-param class-string|object $class
-     */
+    /** @param class-string|object $class */
     abstract public function getEntityManager($class): EntityManagerInterface;
 
     /**
-     * @psalm-param class-string<TObject> $class
+     * @param class-string<TObject> $class
      *
-     * @psalm-return ClassMetadata<TObject>
+     * @return ClassMetadata<TObject>
      *
-     * @psalm-template TObject of object
+     * @template TObject of object
      */
     public function __invoke(string $class): ClassMetadata
     {

--- a/tests/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -40,7 +40,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
     /**
      * @param string[] $classNames
      *
-     * @psalm-return array<class-string, ClassMetadata>
+     * @return array<class-string, ClassMetadata>
      */
     protected function extractClassMetadata(array $classNames): array
     {

--- a/tests/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Tests/ORM/Functional/PostLoadEventTest.php
@@ -296,7 +296,7 @@ class PostLoadListenerCheckAssociationsArePopulated
 
 class PostLoadListenerLoadEntityInEventHandler
 {
-    /** @psalm-var array<class-string, int> */
+    /** @var array<class-string, int> */
     private $firedByClasses = [];
 
     public function postLoad(PostLoadEventArgs $event): void

--- a/tests/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -56,7 +56,7 @@ class DDC1884Test extends OrmFunctionalTestCase
     /**
      * @psalm-return array{Car, Car, Car, Car}
      *
-     * @psalm-var class-string<Car> $class
+     * @var class-string<Car> $class
      */
     private function createCars(string $class): array
     {
@@ -87,7 +87,7 @@ class DDC1884Test extends OrmFunctionalTestCase
     /**
      * @psalm-return array{Driver, Driver}
      *
-     * @psalm-var class-string<Driver> $class
+     * @var class-string<Driver> $class
      */
     private function createDrivers(string $class): array
     {

--- a/tests/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -134,7 +134,7 @@ class AnnotationDriverTest extends MappingDriverTestCase
         return $this->createAnnotationDriver();
     }
 
-    /** @psalm-var class-string<object> $entityClassName */
+    /** @var class-string<object> $entityClassName */
     protected function ensureIsLoaded(string $entityClassName): void
     {
         new $entityClassName();
@@ -241,7 +241,7 @@ class AnnotationDriverTest extends MappingDriverTestCase
     }
 
     /**
-     * @psalm-param class-string $class
+     * @param class-string $class
      *
      * @dataProvider provideDiscriminatorColumnTestcases
      */

--- a/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -561,13 +561,13 @@ final class Cube extends Shape
 /* Test subject class with overridden factory method for mocking purposes */
 class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
 {
-    /** @psalm-var array<class-string<object>, ClassMetadata> */
+    /** @var array<class-string<object>, ClassMetadata> */
     private $mockMetadata = [];
 
-    /** @psalm-var list<class-string<object>> */
+    /** @var list<class-string<object>> */
     private $requestedClasses = [];
 
-    /** @psalm-param class-string<object> $className */
+    /** @param class-string<object> $className */
     protected function newClassMetadataInstance($className): ClassMetadata
     {
         $this->requestedClasses[] = $className;
@@ -581,7 +581,7 @@ class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
         return $this->mockMetadata[$className];
     }
 
-    /** @psalm-param class-string<object> $className */
+    /** @param class-string<object> $className */
     public function setMetadataForClass(string $className, ClassMetadata $metadata): void
     {
         $this->mockMetadata[$className] = $metadata;

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -94,7 +94,7 @@ abstract class MappingDriverTestCase extends OrmTestCase
     abstract protected function loadDriver(): MappingDriver;
 
     /**
-     * @psalm-param class-string<object> $entityClassName
+     * @param class-string<object> $entityClassName
      */
     public function createClassMetadata(
         string $entityClassName,

--- a/tests/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -108,10 +108,9 @@ class DefaultRepositoryFactoryTest extends TestCase
     }
 
     /**
-     * @psalm-param class-string<TEntity> $className
+     * @param class-string<TEntity> $className
      *
-     * @return ClassMetadata&MockObject
-     * @psalm-return ClassMetadata<TEntity>&MockObject
+     * @return ClassMetadata<TEntity>&MockObject
      *
      * @template TEntity of object
      */

--- a/tests/Tests/PHPUnitCompatibility/MockBuilderCompatibilityTools.php
+++ b/tests/Tests/PHPUnitCompatibility/MockBuilderCompatibilityTools.php
@@ -11,10 +11,10 @@ use function method_exists;
 trait MockBuilderCompatibilityTools
 {
     /**
-     * @param list<string> $onlyMethods
-     * @psalm-param class-string<TMockedType> $className
+     * @param class-string<TMockedType> $className
+     * @param list<string>              $onlyMethods
      *
-     * @psalm-return MockBuilder<TMockedType>
+     * @return MockBuilder<TMockedType>
      *
      * @template TMockedType of object
      */

--- a/tests/Tests/TestUtil.php
+++ b/tests/Tests/TestUtil.php
@@ -170,14 +170,14 @@ class TestUtil
         }
 
         $evm = $conn->getEventManager();
-        /** @psalm-var class-string<EventSubscriber> $subscriberClass */
+        /** @var class-string<EventSubscriber> $subscriberClass */
         foreach (explode(',', $GLOBALS['db_event_subscribers']) as $subscriberClass) {
             $subscriberInstance = new $subscriberClass();
             $evm->addEventSubscriber($subscriberInstance);
         }
     }
 
-    /** @psalm-return array<string, mixed> */
+    /** @return array<string, mixed> */
     private static function getPrivilegedConnectionParameters(): array
     {
         if (isset($GLOBALS['privileged_db_driver'])) {


### PR DESCRIPTION
By now, all static analyzers and IDEs should know what a `class-string<Something>` means, so let's remove the vendor prefix in those cases.