### PR TITLE
Run risky code in finally block

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -32,7 +32,6 @@ use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
-use Throwable;
 
 use function array_keys;
 use function class_exists;
@@ -246,18 +245,22 @@ class EntityManager implements EntityManagerInterface
 
         $this->conn->beginTransaction();
 
+        $successful = false;
+
         try {
             $return = $func($this);
 
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
-        } catch (Throwable $e) {
-            $this->close();
-            $this->conn->rollBack();
+            $successful = true;
 
-            throw $e;
+            return $return ?: true;
+        } finally {
+            if (! $successful) {
+                $this->close();
+                $this->conn->rollBack();
+            }
         }
     }
 
@@ -268,18 +271,22 @@ class EntityManager implements EntityManagerInterface
     {
         $this->conn->beginTransaction();
 
+        $successful = false;
+
         try {
             $return = $func($this);
 
             $this->flush();
             $this->conn->commit();
 
-            return $return;
-        } catch (Throwable $e) {
-            $this->close();
-            $this->conn->rollBack();
+            $successful = true;
 
-            throw $e;
+            return $return;
+        } finally {
+            if (! $successful) {
+                $this->close();
+                $this->conn->rollBack();
+            }
         }
     }
 

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -259,7 +259,9 @@ class EntityManager implements EntityManagerInterface
         } finally {
             if (! $successful) {
                 $this->close();
-                $this->conn->rollBack();
+                if ($this->conn->isTransactionActive()) {
+                    $this->conn->rollBack();
+                }
             }
         }
     }
@@ -285,7 +287,9 @@ class EntityManager implements EntityManagerInterface
         } finally {
             if (! $successful) {
                 $this->close();
-                $this->conn->rollBack();
+                if ($this->conn->isTransactionActive()) {
+                    $this->conn->rollBack();
+                }
             }
         }
     }

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -49,7 +49,6 @@ use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
-use Throwable;
 use UnexpectedValueException;
 
 use function array_chunk;
@@ -427,6 +426,8 @@ class UnitOfWork implements PropertyChangedListener
         $conn = $this->em->getConnection();
         $conn->beginTransaction();
 
+        $successful = false;
+
         try {
             // Collection deletions (deletions of complete collections)
             foreach ($this->collectionDeletions as $collectionToDelete) {
@@ -478,16 +479,18 @@ class UnitOfWork implements PropertyChangedListener
 
                 throw new OptimisticLockException('Commit failed', $object);
             }
-        } catch (Throwable $e) {
-            $this->em->close();
 
-            if ($conn->isTransactionActive()) {
-                $conn->rollBack();
+            $successful = true;
+        } finally {
+            if (! $successful) {
+                $this->em->close();
+
+                if ($conn->isTransactionActive()) {
+                    $conn->rollBack();
+                }
+
+                $this->afterTransactionRolledBack();
             }
-
-            $this->afterTransactionRolledBack();
-
-            throw $e;
         }
 
         $this->afterTransactionComplete();


### PR DESCRIPTION
`catch` blocks are not supposed to fail. If you want to do something despite an exception happening, you should do it in a `finally` block.

(finally) Fixes #7545