### PR TITLE
[GH-8471] undeprecate partials completly

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,10 +8,12 @@ change in behavior.
 
 Progress on this is tracked at https://github.com/doctrine/orm/issues/11624 .
 
-## PARTIAL DQL syntax is undeprecated for non-object hydration
+## PARTIAL DQL syntax is undeprecated 
 
-Use of the PARTIAL keyword is not deprecated anymore in DQL when used with a hydrator
-that is not creating entities, such as the ArrayHydrator.
+Use of the PARTIAL keyword is not deprecated anymore in DQL, because we will be
+able to support PARTIAL objects with PHP 8.4 Lazy Objects and
+Symfony/VarExporter in a better way. When we decided to remove this feature
+these two abstractions did not exist yet.
 
 ## Deprecate `\Doctrine\ORM\Query\Parser::setCustomOutputTreeWalker()`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,10 @@ able to support PARTIAL objects with PHP 8.4 Lazy Objects and
 Symfony/VarExporter in a better way. When we decided to remove this feature
 these two abstractions did not exist yet.
 
+WARNING: If you want to upgrade to 3.x and still use PARTIAL keyword in DQL
+with array or object hydrators, then you have to directly migrate to ORM 3.3.x or higher.
+PARTIAL keyword in DQL is not available in 3.0, 3.1 and 3.2 of ORM.
+
 ## Deprecate `\Doctrine\ORM\Query\Parser::setCustomOutputTreeWalker()`
 
 Use the `\Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER` query hint to set the output walker

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1852,14 +1852,6 @@ class Parser
      */
     public function PartialObjectExpression()
     {
-        if ($this->query->getHydrationMode() === Query::HYDRATE_OBJECT) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8471',
-                'PARTIAL syntax in DQL is deprecated for object hydration.'
-            );
-        }
-
         $this->match(TokenType::T_PARTIAL);
 
         $partialFieldSet = [];

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2920,15 +2920,6 @@ EXCEPTION
      */
     public function createEntity($className, array $data, &$hints = [])
     {
-        if (isset($hints[SqlWalker::HINT_PARTIAL])) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8471',
-                'Partial Objects are deprecated for object hydration (here entity %s)',
-                $className
-            );
-        }
-
         $class = $this->em->getClassMetadata($className);
 
         $id     = $this->identifierFlattener->flattenIdentifier($class, $data);

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -41,7 +41,6 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\ORM\Persisters\Entity\SingleTablePersister;
 use Doctrine\ORM\Proxy\InternalProxy;
-use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\NotifyPropertyChanged;


### PR DESCRIPTION
This undeprecates SELECT PARTIAL DQL queries. `EntityManager::getPartialReference` is still deprecated, since it will be indistinguishable from `EntityManager::getReference` in the future.

Related:
* #8471
* #11365
* #10985 