### PR TITLE
[GH-8471] reintroduce partial

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -73,6 +73,7 @@ Advanced Topics
 * :doc:`TypedFieldMapper <reference/typedfieldmapper>`
 * :doc:`Improving Performance <reference/improving-performance>`
 * :doc:`Caching <reference/caching>`
+* :doc:`Partial Objects <reference/partial-objects>`
 * :doc:`Change Tracking Policies <reference/change-tracking-policies>`
 * :doc:`Best Practices <reference/best-practices>`
 * :doc:`Metadata Drivers <reference/metadata-drivers>`

--- a/docs/en/reference/partial-objects.rst
+++ b/docs/en/reference/partial-objects.rst
@@ -1,0 +1,98 @@
+Partial Objects
+===============
+
+
+.. note::
+
+    Creating Partial Objects through DQL is deprecated and
+    will be removed in the future, use data transfer object
+    support in DQL instead. (\ `Details
+    <https://github.com/doctrine/orm/issues/8471>`_)
+
+A partial object is an object whose state is not fully initialized
+after being reconstituted from the database and that is
+disconnected from the rest of its data. The following section will
+describe why partial objects are problematic and what the approach
+of Doctrine2 to this problem is.
+
+.. note::
+
+    The partial object problem in general does not apply to
+    methods or queries where you do not retrieve the query result as
+    objects. Examples are: ``Query#getArrayResult()``,
+    ``Query#getScalarResult()``, ``Query#getSingleScalarResult()``,
+    etc.
+
+.. warning::
+
+    Use of partial objects is tricky. Fields that are not retrieved
+    from the database will not be updated by the UnitOfWork even if they
+    get changed in your objects. You can only promote a partial object
+    to a fully-loaded object by calling ``EntityManager#refresh()``
+    or a DQL query with the refresh flag.
+
+
+What is the problem?
+--------------------
+
+In short, partial objects are problematic because they are usually
+objects with broken invariants. As such, code that uses these
+partial objects tends to be very fragile and either needs to "know"
+which fields or methods can be safely accessed or add checks around
+every field access or method invocation. The same holds true for
+the internals, i.e. the method implementations, of such objects.
+You usually simply assume the state you need in the method is
+available, after all you properly constructed this object before
+you pushed it into the database, right? These blind assumptions can
+quickly lead to null reference errors when working with such
+partial objects.
+
+It gets worse with the scenario of an optional association (0..1 to
+1). When the associated field is NULL, you don't know whether this
+object does not have an associated object or whether it was simply
+not loaded when the owning object was loaded from the database.
+
+These are reasons why many ORMs do not allow partial objects at all
+and instead you always have to load an object with all its fields
+(associations being proxied). One secure way to allow partial
+objects is if the programming language/platform allows the ORM tool
+to hook deeply into the object and instrument it in such a way that
+individual fields (not only associations) can be loaded lazily on
+first access. This is possible in Java, for example, through
+bytecode instrumentation. In PHP though this is not possible, so
+there is no way to have "secure" partial objects in an ORM with
+transparent persistence.
+
+Doctrine, by default, does not allow partial objects. That means,
+any query that only selects partial object data and wants to
+retrieve the result as objects (i.e. ``Query#getResult()``) will
+raise an exception telling you that partial objects are dangerous.
+If you want to force a query to return you partial objects,
+possibly as a performance tweak, you can use the ``partial``
+keyword as follows:
+
+.. code-block:: php
+
+    <?php
+    $q = $em->createQuery("select partial u.{id,name} from MyApp\Domain\User u");
+
+You can also get a partial reference instead of a proxy reference by
+calling:
+
+.. code-block:: php
+
+    <?php
+    $reference = $em->getPartialReference('MyApp\Domain\User', 1);
+
+Partial references are objects with only the identifiers set as they
+are passed to the second argument of the ``getPartialReference()`` method.
+All other fields are null.
+
+When should I force partial objects?
+------------------------------------
+
+Mainly for optimization purposes, but be careful of premature
+optimization as partial objects lead to potentially more fragile
+code.
+
+

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -37,6 +37,7 @@
    reference/query-builder
    reference/native-sql
    reference/change-tracking-policies
+   reference/partial-objects
    reference/attributes-reference
    reference/xml-mapping
    reference/php-mapping

--- a/src/Cache/DefaultQueryCache.php
+++ b/src/Cache/DefaultQueryCache.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\UnitOfWork;
 
 use function array_map;
@@ -208,6 +209,10 @@ class DefaultQueryCache implements QueryCache
 
         if (! $rsm->isSelect) {
             throw FeatureNotImplemented::nonSelectStatements();
+        }
+
+        if (($hints[SqlWalker::HINT_PARTIAL] ?? false) === true || ($hints[Query::HINT_FORCE_PARTIAL_LOAD] ?? false) === true) {
+            throw FeatureNotImplemented::partialEntities();
         }
 
         if (! ($key->cacheMode & Cache::MODE_PUT)) {

--- a/src/Cache/Exception/FeatureNotImplemented.php
+++ b/src/Cache/Exception/FeatureNotImplemented.php
@@ -20,4 +20,9 @@ class FeatureNotImplemented extends CacheException
     {
         return new self('Second-level cache query supports only select statements.');
     }
+
+    public static function partialEntities(): self
+    {
+        return new self('Second level cache does not support partial entities.');
+    }
 }

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;

--- a/src/Query.php
+++ b/src/Query.php
@@ -71,6 +71,14 @@ class Query extends AbstractQuery
     public const HINT_REFRESH_ENTITY = 'doctrine.refresh.entity';
 
     /**
+     * The forcePartialLoad query hint forces a particular query to return
+     * partial objects.
+     *
+     * @todo Rename: HINT_OPTIMIZE
+     */
+    public const HINT_FORCE_PARTIAL_LOAD = 'doctrine.forcePartialLoad';
+
+    /**
      * The includeMetaColumns query hint causes meta columns like foreign keys and
      * discriminator columns to be selected and returned as part of the query result.
      *

--- a/src/Query/AST/PartialObjectExpression.php
+++ b/src/Query/AST/PartialObjectExpression.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+class PartialObjectExpression extends Node
+{
+    /** @param mixed[] $partialFieldSet */
+    public function __construct(
+        public string $identificationVariable,
+        public array $partialFieldSet,
+    ) {
+    }
+}

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Lexer\Token;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -13,6 +14,7 @@ use Doctrine\ORM\Query\AST\Functions;
 use LogicException;
 use ReflectionClass;
 
+use function array_intersect;
 use function array_search;
 use function assert;
 use function class_exists;
@@ -101,6 +103,9 @@ final class Parser
 
     /** @psalm-var list<array{token: DqlToken|null, expression: mixed, nestingLevel: int}> */
     private array $deferredIdentificationVariables = [];
+
+    /** @psalm-var list<array{token: DqlToken|null, expression: AST\PartialObjectExpression, nestingLevel: int}> */
+    private array $deferredPartialObjectExpressions = [];
 
     /** @psalm-var list<array{token: DqlToken|null, expression: AST\PathExpression, nestingLevel: int}> */
     private array $deferredPathExpressions = [];
@@ -223,6 +228,10 @@ final class Parser
         // Process any deferred validations of some nodes in the AST.
         // This also allows post-processing of the AST for modification purposes.
         $this->processDeferredIdentificationVariables();
+
+        if ($this->deferredPartialObjectExpressions) {
+            $this->processDeferredPartialObjectExpressions();
+        }
 
         if ($this->deferredPathExpressions) {
             $this->processDeferredPathExpressions();
@@ -595,6 +604,44 @@ final class Parser
 
             if ($class->getConstructor()->getNumberOfRequiredParameters() > count($args)) {
                 $this->semanticalError(sprintf('Number of arguments does not match with "%s" constructor declaration.', $className), $token);
+            }
+        }
+    }
+
+    /**
+     * Validates that the given <tt>PartialObjectExpression</tt> is semantically correct.
+     * It must exist in query components list.
+     */
+    private function processDeferredPartialObjectExpressions(): void
+    {
+        foreach ($this->deferredPartialObjectExpressions as $deferredItem) {
+            $expr  = $deferredItem['expression'];
+            $class = $this->getMetadataForDqlAlias($expr->identificationVariable);
+
+            foreach ($expr->partialFieldSet as $field) {
+                if (isset($class->fieldMappings[$field])) {
+                    continue;
+                }
+
+                if (
+                    isset($class->associationMappings[$field]) &&
+                    $class->associationMappings[$field]->isToOneOwningSide()
+                ) {
+                    continue;
+                }
+
+                $this->semanticalError(sprintf(
+                    "There is no mapped field named '%s' on class %s.",
+                    $field,
+                    $class->name,
+                ), $deferredItem['token']);
+            }
+
+            if (array_intersect($class->identifier, $expr->partialFieldSet) !== $class->identifier) {
+                $this->semanticalError(
+                    'The partial field selection of class ' . $class->name . ' must contain the identifier.',
+                    $deferredItem['token'],
+                );
             }
         }
     }
@@ -1622,6 +1669,69 @@ final class Parser
     }
 
     /**
+     * PartialObjectExpression ::= "PARTIAL" IdentificationVariable "." PartialFieldSet
+     * PartialFieldSet ::= "{" SimpleStateField {"," SimpleStateField}* "}"
+     */
+    public function PartialObjectExpression(): AST\PartialObjectExpression
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/8471',
+            'PARTIAL syntax in DQL is deprecated.',
+        );
+
+        $this->match(TokenType::T_PARTIAL);
+
+        $partialFieldSet = [];
+
+        $identificationVariable = $this->IdentificationVariable();
+
+        $this->match(TokenType::T_DOT);
+        $this->match(TokenType::T_OPEN_CURLY_BRACE);
+        $this->match(TokenType::T_IDENTIFIER);
+
+        assert($this->lexer->token !== null);
+        $field = $this->lexer->token->value;
+
+        // First field in partial expression might be embeddable property
+        while ($this->lexer->isNextToken(TokenType::T_DOT)) {
+            $this->match(TokenType::T_DOT);
+            $this->match(TokenType::T_IDENTIFIER);
+            $field .= '.' . $this->lexer->token->value;
+        }
+
+        $partialFieldSet[] = $field;
+
+        while ($this->lexer->isNextToken(TokenType::T_COMMA)) {
+            $this->match(TokenType::T_COMMA);
+            $this->match(TokenType::T_IDENTIFIER);
+
+            $field = $this->lexer->token->value;
+
+            while ($this->lexer->isNextToken(TokenType::T_DOT)) {
+                $this->match(TokenType::T_DOT);
+                $this->match(TokenType::T_IDENTIFIER);
+                $field .= '.' . $this->lexer->token->value;
+            }
+
+            $partialFieldSet[] = $field;
+        }
+
+        $this->match(TokenType::T_CLOSE_CURLY_BRACE);
+
+        $partialObjectExpression = new AST\PartialObjectExpression($identificationVariable, $partialFieldSet);
+
+        // Defer PartialObjectExpression validation
+        $this->deferredPartialObjectExpressions[] = [
+            'expression'   => $partialObjectExpression,
+            'nestingLevel' => $this->nestingLevel,
+            'token'        => $this->lexer->token,
+        ];
+
+        return $partialObjectExpression;
+    }
+
+    /**
      * NewObjectExpression ::= "NEW" AbstractSchemaName "(" NewObjectArg {"," NewObjectArg}* ")"
      */
     public function NewObjectExpression(): AST\NewObjectExpression
@@ -1920,7 +2030,7 @@ final class Parser
     /**
      * SelectExpression ::= (
      *     IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration |
-     *     "(" Subselect ")" | CaseExpression | NewObjectExpression
+     *     PartialObjectExpression | "(" Subselect ")" | CaseExpression | NewObjectExpression
      * ) [["AS"] ["HIDDEN"] AliasResultVariable]
      */
     public function SelectExpression(): AST\SelectExpression
@@ -1961,6 +2071,12 @@ final class Parser
 
                 break;
 
+            // PartialObjectExpression (PARTIAL u.{id, name})
+            case $lookaheadType === TokenType::T_PARTIAL:
+                $expression    = $this->PartialObjectExpression();
+                $identVariable = $expression->identificationVariable;
+                break;
+
             // Subselect
             case $lookaheadType === TokenType::T_OPEN_PARENTHESIS && $peek->type === TokenType::T_SELECT:
                 $this->match(TokenType::T_OPEN_PARENTHESIS);
@@ -1986,7 +2102,7 @@ final class Parser
 
             default:
                 $this->syntaxError(
-                    'IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | "(" Subselect ")" | CaseExpression',
+                    'IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | PartialObjectExpression | "(" Subselect ")" | CaseExpression',
                     $this->lexer->lookahead,
                 );
         }

--- a/src/Query/QueryException.php
+++ b/src/Query/QueryException.php
@@ -88,6 +88,15 @@ class QueryException extends Exception implements ORMException
         );
     }
 
+    public static function partialObjectsAreDangerous(): self
+    {
+        return new self(
+            'Loading partial objects is dangerous. Fetch full objects or consider ' .
+            'using a different fetch mode. If you really want partial objects, ' .
+            'set the doctrine.forcePartialLoad query hint to TRUE.',
+        );
+    }
+
     /**
      * @param string[] $assoc
      * @psalm-param array<string, string> $assoc

--- a/src/Query/TokenType.php
+++ b/src/Query/TokenType.php
@@ -77,6 +77,7 @@ enum TokenType: int
     case T_OR       = 242;
     case T_ORDER    = 243;
     case T_OUTER    = 244;
+    case T_PARTIAL  = 245;
     case T_SELECT   = 246;
     case T_SET      = 247;
     case T_SOME     = 248;

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -12,6 +12,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Event\OnClearEventArgs;
@@ -2409,6 +2410,18 @@ class UnitOfWork implements PropertyChangedListener
 
         if (isset($this->eagerLoadingEntities[$class->rootEntityName]) && ! $this->eagerLoadingEntities[$class->rootEntityName]) {
             unset($this->eagerLoadingEntities[$class->rootEntityName]);
+        }
+
+        // Properly initialize any unfetched associations, if partial objects are not allowed.
+        if (isset($hints[Query::HINT_FORCE_PARTIAL_LOAD])) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8471',
+                'Partial Objects are deprecated (here entity %s)',
+                $className,
+            );
+
+            return $entity;
         }
 
         foreach ($class->associationMappings as $field => $assoc) {

--- a/tests/Performance/Hydration/MixedQueryFetchJoinPartialObjectHydrationPerformanceBench.php
+++ b/tests/Performance/Hydration/MixedQueryFetchJoinPartialObjectHydrationPerformanceBench.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Performance\Hydration;
+
+use Doctrine\DBAL\Result;
+use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Performance\ArrayResultFactory;
+use Doctrine\Performance\EntityManagerFactory;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+
+/** @BeforeMethods({"init"}) */
+final class MixedQueryFetchJoinPartialObjectHydrationPerformanceBench
+{
+    private ObjectHydrator|null $hydrator = null;
+
+    private ResultSetMapping|null $rsm = null;
+
+    private Result|null $result = null;
+
+    public function init(): void
+    {
+        $resultSet = [
+            [
+                'u__id'          => '1',
+                'u__status'      => 'developer',
+                'u__username'    => 'romanb',
+                'u__name'        => 'Roman',
+                'sclr0'          => 'ROMANB',
+                'p__phonenumber' => '42',
+            ],
+            [
+                'u__id'          => '1',
+                'u__status'      => 'developer',
+                'u__username'    => 'romanb',
+                'u__name'        => 'Roman',
+                'sclr0'          => 'ROMANB',
+                'p__phonenumber' => '43',
+            ],
+            [
+                'u__id'          => '2',
+                'u__status'      => 'developer',
+                'u__username'    => 'romanb',
+                'u__name'        => 'Roman',
+                'sclr0'          => 'JWAGE',
+                'p__phonenumber' => '91',
+            ],
+        ];
+
+        for ($i = 4; $i < 2000; ++$i) {
+            $resultSet[] = [
+                'u__id'          => $i,
+                'u__status'      => 'developer',
+                'u__username'    => 'jwage',
+                'u__name'        => 'Jonathan',
+                'sclr0'          => 'JWAGE' . $i,
+                'p__phonenumber' => '91',
+            ];
+        }
+
+        $this->result   = ArrayResultFactory::createFromArray($resultSet);
+        $this->hydrator = new ObjectHydrator(EntityManagerFactory::getEntityManager([]));
+        $this->rsm      = new ResultSetMapping();
+
+        $this->rsm->addEntityResult(CmsUser::class, 'u');
+        $this->rsm->addJoinedEntityResult(CmsPhonenumber::class, 'p', 'u', 'phonenumbers');
+        $this->rsm->addFieldResult('u', 'u__id', 'id');
+        $this->rsm->addFieldResult('u', 'u__status', 'status');
+        $this->rsm->addFieldResult('u', 'u__username', 'username');
+        $this->rsm->addFieldResult('u', 'u__name', 'name');
+        $this->rsm->addScalarResult('sclr0', 'nameUpper');
+        $this->rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
+    }
+
+    public function benchHydration(): void
+    {
+        $this->hydrator->hydrateAll($this->result, $this->rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+    }
+}

--- a/tests/Performance/Hydration/SimpleQueryPartialObjectHydrationPerformanceBench.php
+++ b/tests/Performance/Hydration/SimpleQueryPartialObjectHydrationPerformanceBench.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Performance\Hydration;
+
+use Doctrine\DBAL\Result;
+use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Performance\ArrayResultFactory;
+use Doctrine\Performance\EntityManagerFactory;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+
+/** @BeforeMethods({"init"}) */
+final class SimpleQueryPartialObjectHydrationPerformanceBench
+{
+    private ObjectHydrator|null $hydrator = null;
+
+    private ResultSetMapping|null $rsm = null;
+
+    private Result|null $result = null;
+
+    public function init(): void
+    {
+        $resultSet = [
+            [
+                'u__id'       => '1',
+                'u__status'   => 'developer',
+                'u__username' => 'romanb',
+                'u__name'     => 'Roman',
+            ],
+            [
+                'u__id'       => '1',
+                'u__status'   => 'developer',
+                'u__username' => 'romanb',
+                'u__name'     => 'Roman',
+            ],
+            [
+                'u__id'       => '2',
+                'u__status'   => 'developer',
+                'u__username' => 'romanb',
+                'u__name'     => 'Roman',
+            ],
+        ];
+
+        for ($i = 4; $i < 10000; ++$i) {
+            $resultSet[] = [
+                'u__id'       => $i,
+                'u__status'   => 'developer',
+                'u__username' => 'jwage',
+                'u__name'     => 'Jonathan',
+            ];
+        }
+
+        $this->result   = ArrayResultFactory::createFromArray($resultSet);
+        $this->hydrator = new ObjectHydrator(EntityManagerFactory::getEntityManager([]));
+        $this->rsm      = new ResultSetMapping();
+
+        $this->rsm->addEntityResult(CmsUser::class, 'u');
+        $this->rsm->addFieldResult('u', 'u__id', 'id');
+        $this->rsm->addFieldResult('u', 'u__status', 'status');
+        $this->rsm->addFieldResult('u', 'u__username', 'username');
+        $this->rsm->addFieldResult('u', 'u__name', 'name');
+    }
+
+    public function benchHydration(): void
+    {
+        $this->hydrator->hydrateAll($this->result, $this->rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+    }
+}

--- a/tests/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceShipping;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -76,6 +77,19 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
 
         self::assertInstanceOf(ECommerceShipping::class, $product->getShipping());
         self::assertEquals(1, $product->getShipping()->getDays());
+    }
+
+    public function testDoesNotLazyLoadObjectsIfConfigurationDoesNotAllowIt(): void
+    {
+        $this->createFixture();
+
+        $query = $this->_em->createQuery('select p from Doctrine\Tests\Models\ECommerce\ECommerceProduct p');
+        $query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
+
+        $result  = $query->getResult();
+        $product = $result[0];
+
+        self::assertNull($product->getShipping());
     }
 
     protected function createFixture(): void

--- a/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1086,6 +1086,31 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
     }
 
+    public function testCacheablePartialQueryException(): void
+    {
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('Second level cache does not support partial entities.');
+        $this->evictRegions();
+        $this->loadFixturesCountries();
+
+        $this->_em->createQuery('SELECT PARTIAL c.{id} FROM Doctrine\Tests\Models\Cache\Country c')
+            ->setCacheable(true)
+            ->getResult();
+    }
+
+    public function testCacheableForcePartialLoadHintQueryException(): void
+    {
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('Second level cache does not support partial entities.');
+        $this->evictRegions();
+        $this->loadFixturesCountries();
+
+        $this->_em->createQuery('SELECT c FROM Doctrine\Tests\Models\Cache\Country c')
+            ->setCacheable(true)
+            ->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true)
+            ->getResult();
+    }
+
     public function testNonCacheableQueryDeleteStatementException(): void
     {
         $this->expectException(CacheException::class);

--- a/tests/Tests/ORM/Functional/Ticket/DDC163Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC163Test.php
@@ -46,7 +46,7 @@ class DDC163Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = 'SELECT person.name as person_name, spouse.name as spouse_name,friend.name as friend_name
+        $dql = 'SELECT PARTIAL person.{id,name}, PARTIAL spouse.{id,name}, PARTIAL friend.{id,name}
             FROM  Doctrine\Tests\Models\Company\CompanyPerson person
             LEFT JOIN person.spouse spouse
             LEFT JOIN person.friends friend

--- a/tests/Tests/ORM/Functional/Ticket/DDC2519Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2519Test.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Legacy\LegacyUser;
+use Doctrine\Tests\Models\Legacy\LegacyUserReference;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('DDC-2519')]
+class DDC2519Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('legacy');
+
+        parent::setUp();
+
+        $this->loadFixture();
+    }
+
+    #[Group('DDC-2519')]
+    public function testIssue(): void
+    {
+        $dql    = 'SELECT PARTIAL l.{_source, _target} FROM Doctrine\Tests\Models\Legacy\LegacyUserReference l';
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        self::assertCount(2, $result);
+        self::assertInstanceOf(LegacyUserReference::class, $result[0]);
+        self::assertInstanceOf(LegacyUserReference::class, $result[1]);
+
+        self::assertInstanceOf(LegacyUser::class, $result[0]->source());
+        self::assertInstanceOf(LegacyUser::class, $result[0]->target());
+        self::assertInstanceOf(LegacyUser::class, $result[1]->source());
+        self::assertInstanceOf(LegacyUser::class, $result[1]->target());
+
+        self::assertTrue($this->isUninitializedObject($result[0]->target()));
+        self::assertTrue($this->isUninitializedObject($result[0]->source()));
+        self::assertTrue($this->isUninitializedObject($result[1]->target()));
+        self::assertTrue($this->isUninitializedObject($result[1]->source()));
+
+        self::assertNotNull($result[0]->source()->getId());
+        self::assertNotNull($result[0]->target()->getId());
+        self::assertNotNull($result[1]->source()->getId());
+        self::assertNotNull($result[1]->target()->getId());
+    }
+
+    public function loadFixture(): void
+    {
+        $user1           = new LegacyUser();
+        $user1->username = 'FabioBatSilva';
+        $user1->name     = 'Fabio B. Silva';
+
+        $user2           = new LegacyUser();
+        $user2->username = 'doctrinebot';
+        $user2->name     = 'Doctrine Bot';
+
+        $user3           = new LegacyUser();
+        $user3->username = 'test';
+        $user3->name     = 'Tester';
+
+        $this->_em->persist($user1);
+        $this->_em->persist($user2);
+        $this->_em->persist($user3);
+
+        $this->_em->flush();
+
+        $this->_em->persist(new LegacyUserReference($user1, $user2, 'foo'));
+        $this->_em->persist(new LegacyUserReference($user1, $user3, 'bar'));
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -527,6 +527,16 @@ class LanguageRecognitionTest extends OrmTestCase
         $this->assertInvalidDQL('SELECT u FROM UnknownClassName u');
     }
 
+    public function testCorrectPartialObjectLoad(): void
+    {
+        $this->assertValidDQL('SELECT PARTIAL u.{id,name} FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    public function testIncorrectPartialObjectLoadBecauseOfMissingIdentifier(): void
+    {
+        $this->assertInvalidDQL('SELECT PARTIAL u.{name} FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testScalarExpressionInSelect(): void
     {
         $this->assertValidDQL('SELECT u, 42 + u.id AS someNumber FROM Doctrine\Tests\Models\CMS\CmsUser u');

--- a/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1330,6 +1330,20 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
+    #[Group('DDC-2519')]
+    public function testPartialWithAssociationIdentifier(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT PARTIAL l.{_source, _target} FROM Doctrine\Tests\Models\Legacy\LegacyUserReference l',
+            'SELECT l0_.iUserIdSource AS iUserIdSource_0, l0_.iUserIdTarget AS iUserIdTarget_1 FROM legacy_users_reference l0_',
+        );
+
+        $this->assertSqlGeneration(
+            'SELECT PARTIAL l.{_description, _source, _target} FROM Doctrine\Tests\Models\Legacy\LegacyUserReference l',
+            'SELECT l0_.description AS description_0, l0_.iUserIdSource AS iUserIdSource_1, l0_.iUserIdTarget AS iUserIdTarget_2 FROM legacy_users_reference l0_',
+        );
+    }
+
     #[Group('DDC-1339')]
     public function testIdentityFunctionInSelectClause(): void
     {
@@ -1364,56 +1378,122 @@ class SelectSqlGenerationTest extends OrmTestCase
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeJoinInRootClass(): void
+    public function testInheritanceTypeJoinInRootClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.title AS title_2, c2_.salary AS salary_3, c2_.department AS department_4, c2_.startDate AS startDate_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c1_.car_id AS car_id_8 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
         );
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeJoinInChildClass(): void
+    public function testInheritanceTypeJoinInRootClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p',
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeJoinInChildClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c2_.car_id AS car_id_8 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ ON c1_.id = c2_.id',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
         );
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeJoinInLeafClass(): void
+    public function testInheritanceTypeJoinInChildClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e',
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeJoinInLeafClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT m FROM Doctrine\Tests\Models\Company\CompanyManager m',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c2_.car_id AS car_id_8 FROM company_managers c2_ INNER JOIN company_employees c1_ ON c2_.id = c1_.id INNER JOIN company_persons c0_ ON c2_.id = c0_.id',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
         );
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeSingleTableInRootClass(): void
+    public function testInheritanceTypeJoinInLeafClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT m FROM Doctrine\Tests\Models\Company\CompanyManager m',
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6 FROM company_managers c2_ INNER JOIN company_employees c1_ ON c2_.id = c1_.id INNER JOIN company_persons c0_ ON c2_.id = c0_.id',
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeSingleTableInRootClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6, c0_.salesPerson_id AS salesPerson_id_7 FROM company_contracts c0_ WHERE c0_.discr IN ('fix', 'flexible', 'flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
         );
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeSingleTableInChildClass(): void
+    public function testInheritanceTypeSingleTableInRootClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c',
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ WHERE c0_.discr IN ('fix', 'flexible', 'flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeSingleTableInChildClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT fc FROM Doctrine\Tests\Models\Company\CompanyFlexContract fc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5, c0_.salesPerson_id AS salesPerson_id_6 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
         );
     }
 
     #[Group('DDC-1389')]
-    public function testInheritanceTypeSingleTableInLeafClass(): void
+    public function testInheritanceTypeSingleTableInChildClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT fc FROM Doctrine\Tests\Models\Company\CompanyFlexContract fc',
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeSingleTableInLeafClassWithDisabledForcePartialLoad(): void
     {
         $this->assertSqlGeneration(
             'SELECT fuc FROM Doctrine\Tests\Models\Company\CompanyFlexUltraContract fuc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5, c0_.salesPerson_id AS salesPerson_id_6 FROM company_contracts c0_ WHERE c0_.discr IN ('flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => false],
+        );
+    }
+
+    #[Group('DDC-1389')]
+    public function testInheritanceTypeSingleTableInLeafClassWithEnabledForcePartialLoad(): void
+    {
+        $this->assertSqlGeneration(
+            'SELECT fuc FROM Doctrine\Tests\Models\Company\CompanyFlexUltraContract fuc',
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5 FROM company_contracts c0_ WHERE c0_.discr IN ('flexultra')",
+            [ORMQuery::HINT_FORCE_PARTIAL_LOAD => true],
         );
     }
 
@@ -1686,6 +1766,20 @@ class SelectSqlGenerationTest extends OrmTestCase
 
         $this->assertSqlGeneration(
             'SELECT p FROM Doctrine\Tests\Models\CustomType\CustomTypeParent p',
+            'SELECT c0_.id AS id_0, -(c0_.customInteger) AS customInteger_1, c0_.child_id AS child_id_2 FROM customtype_parents c0_',
+        );
+    }
+
+    public function testCustomTypeValueSqlForPartialObject(): void
+    {
+        if (DBALType::hasType('negative_to_positive')) {
+            DBALType::overrideType('negative_to_positive', NegativeToPositiveType::class);
+        } else {
+            DBALType::addType('negative_to_positive', NegativeToPositiveType::class);
+        }
+
+        $this->assertSqlGeneration(
+            'SELECT partial p.{id, customInteger} FROM Doctrine\Tests\Models\CustomType\CustomTypeParent p',
             'SELECT c0_.id AS id_0, -(c0_.customInteger) AS customInteger_1, c0_.child_id AS child_id_2 FROM customtype_parents c0_',
         );
     }

--- a/tests/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -137,13 +137,29 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         );
     }
 
-    public function testCountQueryWithComplexScalarOrderByItemJoined(): void
+    public function testCountQueryWithComplexScalarOrderByItemJoinedWithoutPartial(): void
     {
         $this->entityManager = $this->createTestEntityManagerWithPlatform(new MySQLPlatform());
 
         $this->assertQuerySql(
             'SELECT DISTINCT id_0 FROM (SELECT DISTINCT id_0, imageHeight_3 * imageWidth_4 FROM (SELECT u0_.id AS id_0, a1_.id AS id_1, a1_.image AS image_2, a1_.imageHeight AS imageHeight_3, a1_.imageWidth AS imageWidth_4, a1_.imageAltDesc AS imageAltDesc_5, a1_.user_id AS user_id_6 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result_inner ORDER BY imageHeight_3 * imageWidth_4 DESC) dctrn_result',
             'SELECT u FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.avatar a ORDER BY a.imageHeight * a.imageWidth DESC',
+        );
+    }
+
+    public function testCountQueryWithComplexScalarOrderByItemJoinedWithPartial(): void
+    {
+        $entityManager = $this->createTestEntityManagerWithPlatform(new MySQLPlatform());
+
+        $query = $entityManager->createQuery(
+            'SELECT u, partial a.{id, imageAltDesc} FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.avatar a ORDER BY a.imageHeight * a.imageWidth DESC',
+        );
+
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
+
+        self::assertSame(
+            'SELECT DISTINCT id_0 FROM (SELECT DISTINCT id_0, imageHeight_5 * imageWidth_6 FROM (SELECT u0_.id AS id_0, a1_.id AS id_1, a1_.imageAltDesc AS imageAltDesc_2, a1_.id AS id_3, a1_.image AS image_4, a1_.imageHeight AS imageHeight_5, a1_.imageWidth AS imageWidth_6, a1_.imageAltDesc AS imageAltDesc_7, a1_.user_id AS user_id_8 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result_inner ORDER BY imageHeight_5 * imageWidth_6 DESC) dctrn_result',
+            $query->getSQL(),
         );
     }
 


### PR DESCRIPTION
This reverts the decision to deprecate PARTIAL objects syntax and partial objects when created via DQL queries.

This decision was made, because with PHP 8.4 Lazy Objects it will give us the option to make a partial object into a lazy proxy as well that only loads missing columns onto the entity and makes it "full".

This functionality is not available yet in ORM 3.x, we will work on it in the near future and hopefully ship it with 8.4.

Related:
* #8471 
* #11647 