### PR TITLE
Add support for ReflectionClass::newLazyGhost of PHP 8.4

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -171,6 +171,16 @@ parameters:
 			path: src/Proxy/ProxyFactory.php
 
 		-
+			message: "#^Call to an undefined method ReflectionClass\\<object\\>\\:\\:newLazyGhost\\(\\)\\.$#"
+			count: 1
+			path: src/Proxy/ProxyFactory.php
+
+		-
+			message: "#^Call to an undefined method ReflectionProperty\\:\\:setRawValueWithoutLazyInitialization\\(\\)\\.$#"
+			count: 1
+			path: src/Proxy/ProxyFactory.php
+
+		-
 			message: "#^Call to an undefined static method Doctrine\\\\ORM\\\\Proxy\\\\ProxyFactory\\:\\:createLazyGhost\\(\\)\\.$#"
 			count: 1
 			path: src/Proxy/ProxyFactory.php

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -30,6 +30,8 @@ use function class_exists;
 use function is_a;
 use function strtolower;
 
+use const PHP_VERSION_ID;
+
 /**
  * Configuration container for all configuration options of Doctrine.
  * It combines all configuration options from DBAL & ORM.
@@ -593,6 +595,20 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setSchemaIgnoreClasses(array $schemaIgnoreClasses): void
     {
         $this->attributes['schemaIgnoreClasses'] = $schemaIgnoreClasses;
+    }
+
+    public function isLazyProxyEnabled(): bool
+    {
+        return $this->attributes['lazyProxy'] ?? false;
+    }
+
+    public function setLazyProxyEnabled(bool $lazyProxy): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            throw new LogicException('Lazy loading proxies require PHP 8.4 or higher.');
+        }
+
+        $this->attributes['lazyProxy'] = $lazyProxy;
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -49,6 +49,7 @@ use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
 use InvalidArgumentException;
+use ReflectionObject;
 use RuntimeException;
 use Stringable;
 use Throwable;
@@ -64,6 +65,7 @@ use function array_sum;
 use function array_values;
 use function assert;
 use function current;
+use function get_class;
 use function get_debug_type;
 use function implode;
 use function in_array;
@@ -2383,7 +2385,11 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             if ($this->isUninitializedObject($entity)) {
-                $entity->__setInitialized(true);
+                if ($this->em->getConfiguration()->isLazyProxyEnabled()) {
+                    $class->reflClass->markLazyObjectAsInitialized($entity);
+                } else {
+                    $entity->__setInitialized(true);
+                }
             } else {
                 if (
                     ! isset($hints[Query::HINT_REFRESH])
@@ -3040,6 +3046,11 @@ class UnitOfWork implements PropertyChangedListener
         if ($obj instanceof PersistentCollection) {
             $obj->initialize();
         }
+
+        if ($this->em->getConfiguration()->isLazyProxyEnabled()) {
+            $reflection = new ReflectionObject($obj);
+            $reflection->initializeLazyObject($obj);
+        }
     }
 
     /**
@@ -3049,6 +3060,10 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function isUninitializedObject(mixed $obj): bool
     {
+        if ($this->em->getConfiguration()->isLazyProxyEnabled() && ! ($obj instanceof Collection)) {
+            return $this->em->getClassMetadata(get_class($obj))->reflClass->isUninitializedLazyObject($obj);
+        }
+
         return $obj instanceof InternalProxy && ! $obj->__isInitialized();
     }
 

--- a/tests/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -557,7 +557,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        self::assertFalse($userRef->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($userRef));
 
         $this->_em->clear();
 
@@ -592,7 +592,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        self::assertFalse($groupRef->__isInitialized());
+        self::assertTrue($this->isUninitializedObject($groupRef));
 
         $this->_em->clear();
 
@@ -940,8 +940,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
                              ->setParameter(1, $article->id)
                              ->setFetchMode(CmsArticle::class, 'user', ClassMetadata::FETCH_EAGER)
                              ->getSingleResult();
-        self::assertInstanceOf(InternalProxy::class, $article->user, 'It IS a proxy, ...');
-        self::assertFalse($this->isUninitializedObject($article->user), '...but its initialized!');
+        self::assertFalse($this->isUninitializedObject($article->user));
         $this->assertQueryCount(2);
     }
 

--- a/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -34,6 +34,10 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
+        if ($this->_em->getConfiguration()->isLazyProxyEnabled()) {
+            self::markTestSkipped('This test is not applicable when lazy proxy is enabled.');
+        }
+
         $this->createSchemaForModels(
             CmsUser::class,
             CmsTag::class,

--- a/tests/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -248,7 +248,6 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         assert($entity instanceof ECommerceProduct);
         $className = DefaultProxyClassNameResolver::getClass($entity);
 
-        self::assertInstanceOf(InternalProxy::class, $entity);
         self::assertTrue($this->isUninitializedObject($entity));
         self::assertEquals(ECommerceProduct::class, $className);
 
@@ -257,7 +256,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace('\\', '', $restName) . '.php';
         self::assertTrue(file_exists($proxyFileName), 'Proxy file name cannot be found generically.');
 
-        $entity->__load();
+        $this->initializeObject($entity);
         self::assertFalse($this->isUninitializedObject($entity));
     }
 }

--- a/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Cache\QueryCacheEntry;
 use Doctrine\ORM\Cache\QueryCacheKey;
-use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\Cache\Attraction;
@@ -939,7 +938,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state1->getCountry());
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertEquals($countryName, $state1->getCountry()->getName());
         self::assertEquals($stateId, $state1->getId());
 
@@ -957,7 +955,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
         self::assertNotNull($state2->getCountry());
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertEquals($countryName, $state2->getCountry()->getName());
         self::assertEquals($stateId, $state2->getId());
     }
@@ -1031,7 +1028,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(1);
         self::assertInstanceOf(State::class, $state1);
-        self::assertInstanceOf(InternalProxy::class, $state1->getCountry());
         self::assertInstanceOf(City::class, $state1->getCities()->get(0));
         self::assertInstanceOf(State::class, $state1->getCities()->get(0)->getState());
         self::assertSame($state1, $state1->getCities()->get(0)->getState());
@@ -1048,7 +1044,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheFunctionalTestCase
 
         $this->assertQueryCount(0);
         self::assertInstanceOf(State::class, $state2);
-        self::assertInstanceOf(InternalProxy::class, $state2->getCountry());
         self::assertInstanceOf(City::class, $state2->getCities()->get(0));
         self::assertInstanceOf(State::class, $state2->getCities()->get(0)->getState());
         self::assertSame($state2, $state2->getCities()->get(0)->getState());

--- a/tests/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -198,8 +198,6 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // load from cache
         $this->getQueryLog()->reset()->enable();
@@ -212,8 +210,6 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // invalidate cache
         $this->_em->persist(new State('foo', $this->_em->find(Country::class, $this->countries[0]->getId())));
@@ -231,8 +227,6 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
 
         // load from cache
         $this->getQueryLog()->reset()->enable();
@@ -245,7 +239,5 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheFunctionalTestCase
         self::assertInstanceOf(State::class, $entities[1]);
         self::assertInstanceOf(Country::class, $entities[0]->getCountry());
         self::assertInstanceOf(Country::class, $entities[1]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[0]->getCountry());
-        self::assertInstanceOf(InternalProxy::class, $entities[1]->getCountry());
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -57,11 +57,11 @@ class DDC1238Test extends OrmFunctionalTestCase
 
         $user2 = $this->_em->getReference(DDC1238User::class, $userId);
 
-        //$user->__load();
+        //$this->initializeObject($user);
 
         self::assertIsInt($user->getId(), 'Even if a proxy is detached, it should still have an identifier');
 
-        $user2->__load();
+        $this->initializeObject($user2);
 
         self::assertIsInt($user2->getId(), 'The managed instance still has an identifier');
     }

--- a/tests/Tests/ORM/Functional/Ticket/GH10808Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10808Test.php
@@ -49,18 +49,11 @@ class GH10808Test extends OrmFunctionalTestCase
         // Clear the EM to prevent the recovery of the loaded instance, which would otherwise result in a proxy.
         $this->_em->clear();
 
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($deferredLoadResult->child));
+
         $eagerLoadResult = $query->setHint(UnitOfWork::HINT_DEFEREAGERLOAD, false)->getSingleResult();
 
-        self::assertNotEquals(
-            GH10808AppointmentChild::class,
-            get_class($deferredLoadResult->child),
-            '$deferredLoadResult->child should be a proxy',
-        );
-        self::assertEquals(
-            GH10808AppointmentChild::class,
-            get_class($eagerLoadResult->child),
-            '$eagerLoadResult->child should not be a proxy',
-        );
+        self::assertFalse($this->_em->getUnitOfWork()->isUninitializedObject($eagerLoadResult->child));
     }
 }
 

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\ToolsException;

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -193,6 +193,7 @@ use function strtolower;
 use function var_export;
 
 use const PHP_EOL;
+use const PHP_VERSION_ID;
 
 /**
  * Base testcase class for all functional ORM testcases.
@@ -941,6 +942,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $this->isSecondLevelCacheEnabled = true;
         }
 
+        $enableLazyProxy = getenv('ENABLE_LAZY_PROXY');
+
+        if (PHP_VERSION_ID >= 80400 && $enableLazyProxy) {
+            $config->setLazyProxyEnabled(true);
+        }
+
         $config->setMetadataDriverImpl(
             $mappingDriver ?? new AttributeDriver([
                 realpath(__DIR__ . '/Models/Cache'),
@@ -1117,5 +1124,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     final protected function isUninitializedObject(object $entity): bool
     {
         return $this->_em->getUnitOfWork()->isUninitializedObject($entity);
+    }
+
+    final protected function initializeObject(object $entity): void
+    {
+        $this->_em->getUnitOfWork()->initializeObject($entity);
     }
 }


### PR DESCRIPTION
Our goal is that we can completely replace all kinds of code for proxy generation and proxy usage with the new lazy objects feature of PHP 8.4: https://wiki.php.net/rfc/lazy-objects

In 3.x we can add support for optionally using lazy objects, and in 4.x we increase the requirement for PHP to 8.4 and automatically always use lazy objects.

The benefit of lazy objects is that we don't need code-generation anymore, and that it also allows us to treat partial objects as lazy objects that can load their missing properites only when accessed.

## Todos

* Due to property hooks and lazy initialization interactions, this PR also needs to make sure we replace all ReflectionProperty::getValue calls with ReflectionProperty::getRawValue and ReflectionProperty::setValue with ReflectionProperty::setValueWithoutLazyInitialization.
* Move from `ClassMetadata::$reflFields` to a new abstraction `PropertyAccessor` that avoids us having to extend ReflectionProperty for our edge cases (enums, typed no default, embedded, ....).

See #11659 for those prerequisites.

## Future

As a next step this also allows us to implement a feature to mark properties as lazy, meaning that they are never fully fetched on the first query unless specify in the query (query hint? dql keyword?).