### PR TITLE
Support for DBAL 4.2 EnumType in SchemaTool

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -47,7 +47,7 @@ use function strtolower;
  */
 class SchemaTool
 {
-    private const KNOWN_COLUMN_OPTIONS = ['comment', 'unsigned', 'fixed', 'default'];
+    private const KNOWN_COLUMN_OPTIONS = ['comment', 'unsigned', 'fixed', 'default', 'values'];
 
     private readonly AbstractPlatform $platform;
     private readonly QuoteStrategy $quoteStrategy;


### PR DESCRIPTION
The MySQL/Maria EnumType added in DBAL 4.2 has a new known option "values" that SchemaTool should know about so the following should now work automatically:

```php
#[Column(type: "enum", options: ['values' => ['foo', 'bar', 'baz']])
public $choice;
```