### PR TITLE
Create the default namespace in the schema

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools;
 
 use BackedEnum;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Index;
@@ -176,6 +177,15 @@ class SchemaTool
         $metadataSchemaConfig = $this->schemaManager->createSchemaConfig();
 
         $schema = new Schema([], [], $metadataSchemaConfig);
+
+        // the platform check should be removed once the support for DBAL 3.x is dropped
+        // see https://github.com/doctrine/dbal/pull/4821, https://github.com/doctrine/dbal/pull/4831
+        if ($this->em->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $defaultNamespace = $metadataSchemaConfig->getName();
+            if ($defaultNamespace !== null) {
+                $schema->createNamespace($defaultNamespace);
+            }
+        }
 
         $addedFks       = [];
         $blacklistedFks = [];

--- a/tests/Tests/ORM/Functional/SchemaToolTest.php
+++ b/tests/Tests/ORM/Functional/SchemaToolTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class SchemaToolTest extends OrmFunctionalTestCase
+{
+    public function testValidateModelSets(): void
+    {
+        $schemaTool = new SchemaTool($this->_em);
+        $schema     = $schemaTool->getSchemaFromMetadata([]);
+        $namespaces = $schema->getNamespaces();
+
+        if ($this->_em->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::assertContains('public', $namespaces);
+        } else {
+            self::assertEmpty($namespaces);
+        }
+    }
+}


### PR DESCRIPTION
This patch should address https://github.com/doctrine/migrations/issues/1415.

## Problem details

1. When the Postgres schema manager introspects a deployed schema, it creates the namespace with the name corresponding to the value of `current_schema()` in the `Schema`.
2. When `SchemaTool` generates the schema to be deployed, it doesn't create the default namespace.

As a result, we have a mismatch in the list of schemas between the "from" and "to" schemas.

## Solution

Instead of the approach proposed in https://github.com/doctrine/dbal/issues/5609, here, we add the default namespace obtain from the schema configuration, to the schema. This replicates the behavior of the schema manager.

## Alternatives
As an option, the DBAL `Schema` could automatically create the namespace with the name from configuration in its constructor. There are certain difficulties with that:
1. Prior to DBAL 4, the schema configuration name is not only set to the value of the current schema for Postgres, but is also set to the name of the current database for all other databases. Implementing the fix in DBAL prior to 4.0 will likely introduce a regression for all other platforms except for Postgres.
2. Prior to DBAL 4, the schema configuration name is equal not to the current schema name but to the first value from the search path, (which by default is `postgres`).
3. The operation of adding a namespace to the schema is not idempotent. So if we register the namespace in the constructor, then the subsequent call to `createNamespace` with the same name (as the DBAL's schema manager does) will fail.

## Limitations
This fix cannot be implemented in ORM 2.x which still supports DBAL 3.x, which has the issue #​2 from the above list.