### PR TITLE
test: cover all transactional methods in `EntityManagerTest::testItPreservesTheOriginalExceptionOnRollbackFailure()`

### DIFF
--- a/tests/Tests/ORM/EntityManagerTest.php
+++ b/tests/Tests/ORM/EntityManagerTest.php
@@ -399,7 +399,7 @@ class EntityManagerTest extends OrmTestCase
         });
 
         try {
-            $entityManager->transactional(static function (): void {
+            $entityManager->$methodName(static function (): void {
                 throw new Exception('Original exception');
             });
             self::fail('Exception expected');


### PR DESCRIPTION
Fixes test bug introduced in https://github.com/doctrine/orm/pull/11646