### PR TITLE
Auto-detect values for EnumType columns

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -212,14 +212,14 @@
     </ParamNameMismatch>
   </file>
   <file src="src/Internal/Hydration/AbstractHydrator.php">
-    <ReferenceConstraintViolation>
-      <code><![CDATA[return $rowData;]]></code>
-      <code><![CDATA[return $rowData;]]></code>
-    </ReferenceConstraintViolation>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$newObject['args']]]></code>
       <code><![CDATA[$newObject['args']]]></code>
     </PossiblyUndefinedArrayOffset>
+    <ReferenceConstraintViolation>
+      <code><![CDATA[return $rowData;]]></code>
+      <code><![CDATA[return $rowData;]]></code>
+    </ReferenceConstraintViolation>
   </file>
   <file src="src/Internal/Hydration/ArrayHydrator.php">
     <PossiblyInvalidArgument>
@@ -401,6 +401,7 @@
   </file>
   <file src="src/Mapping/DefaultTypedFieldMapper.php">
     <LessSpecificReturnStatement>
+      <code><![CDATA[$mapping]]></code>
       <code><![CDATA[$mapping]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>

--- a/tests/Tests/Models/Enums/CardNativeEnum.php
+++ b/tests/Tests/Models/Enums/CardNativeEnum.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class CardNativeEnum
+{
+    /** @var int|null */
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: Types::INTEGER)]
+    public $id;
+
+    /** @var Suit */
+    #[Column(type: Types::ENUM, enumType: Suit::class, options: ['values' => ['H', 'D', 'C', 'S', 'Z']])]
+    public $suit;
+}

--- a/tests/Tests/Models/Enums/TypedCardNativeEnum.php
+++ b/tests/Tests/Models/Enums/TypedCardNativeEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class TypedCardNativeEnum
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[Column(type: Types::ENUM)]
+    public Suit $suit;
+}


### PR DESCRIPTION
Follow-up to #11657, leverages doctrine/dbal#6536.

This PR allows us to detect the `enumType` and `options.values` settings for a typed property with `type: Types::ENUM`.

#### Before:

```php
#[Entity]
class Card
{
    #[Id]
    #[GeneratedValue]
    #[Column]
    public int $id;

    #[Column(
        type: Types::ENUM,
        enumType: Suit::class,
        options: ['values' => ['H', 'D', 'C', 'S']],
    )]
    public Suit $suit;
}
```

#### After:

```php
#[Entity]
class Card
{
    #[Id]
    #[GeneratedValue]
    #[Column]
    public int $id;

    #[Column(type: Types::ENUM)]
    public Suit $suit;
}
```

Note that the `type: Types::ENUM` part is still required if we want to have an actual `ENUM` column in MySQL/MariaDB. We still default to `Types::STRING` or `TYPES::INTEGER` for columns types with a PHP enum as this is the more portable solution and the safer default.