### PR TITLE
Experiment with literalinclude

### DIFF
--- a/docs/en/tutorials/working-with-indexed-associations.rst
+++ b/docs/en/tutorials/working-with-indexed-associations.rst
@@ -31,169 +31,18 @@ You can map indexed associations by adding:
 The code and mappings for the Market entity looks like this:
 
 .. configuration-block::
-    .. code-block:: attribute
+    .. literalinclude:: working-with-indexed-associations/Market.php
+        :language: attribute
 
-        <?php
-        namespace Doctrine\Tests\Models\StockExchange;
+    .. literalinclude:: working-with-indexed-associations/Market-annotations.php
+        :language: annotation
 
-        use Doctrine\Common\Collections\ArrayCollection;
-        use Doctrine\Common\Collections\Collection;
+    .. literalinclude:: working-with-indexed-associations/market.xml
+        :language: xml
 
-        #[Entity]
-        #[Table(name: 'exchange_markets')]
-        class Market
-        {
-            #[Id, Column(type: 'integer'), GeneratedValue]
-            private int|null $id = null;
+    .. literalinclude:: working-with-indexed-associations/market.xml
+        :language: yaml
 
-            #[Column(type: 'string')]
-            private string $name;
-
-            /** @var Collection<string, Stock> */
-            #[OneToMany(targetEntity: Stock::class, mappedBy: 'market', indexBy: 'symbol')]
-            private Collection $stocks;
-
-            public function __construct(string $name)
-            {
-                $this->name = $name;
-                $this->stocks = new ArrayCollection();
-            }
-
-            public function getId(): int|null
-            {
-                return $this->id;
-            }
-
-            public function getName(): string
-            {
-                return $this->name;
-            }
-
-            public function addStock(Stock $stock): void
-            {
-                $this->stocks[$stock->getSymbol()] = $stock;
-            }
-
-            public function getStock(string $symbol): Stock
-            {
-                if (!isset($this->stocks[$symbol])) {
-                    throw new \InvalidArgumentException("Symbol is not traded on this market.");
-                }
-
-                return $this->stocks[$symbol];
-            }
-
-            /** @return array<string, Stock> */
-            public function getStocks(): array
-            {
-                return $this->stocks->toArray();
-            }
-        }
-
-    .. code-block:: annotation
-
-        <?php
-        namespace Doctrine\Tests\Models\StockExchange;
-
-        use Doctrine\Common\Collections\ArrayCollection;
-
-        /**
-         * @Entity
-         * @Table(name="exchange_markets")
-         */
-        class Market
-        {
-            /**
-             * @Id @Column(type="integer") @GeneratedValue
-             * @var int
-             */
-            private int|null $id = null;
-
-            /**
-             * @Column(type="string")
-             * @var string
-             */
-            private string $name;
-
-            /**
-             * @OneToMany(targetEntity="Stock", mappedBy="market", indexBy="symbol")
-             * @var Collection<int, Stock>
-             */
-            private Collection $stocks;
-
-            public function __construct($name)
-            {
-                $this->name = $name;
-                $this->stocks = new ArrayCollection();
-            }
-
-            public function getId(): int|null
-            {
-                return $this->id;
-            }
-
-            public function getName(): string
-            {
-                return $this->name;
-            }
-
-            public function addStock(Stock $stock): void
-            {
-                $this->stocks[$stock->getSymbol()] = $stock;
-            }
-
-            public function getStock($symbol): Stock
-            {
-                if (!isset($this->stocks[$symbol])) {
-                    throw new \InvalidArgumentException("Symbol is not traded on this market.");
-                }
-
-                return $this->stocks[$symbol];
-            }
-
-            /** @return array<string, Stock> */
-            public function getStocks(): array
-            {
-                return $this->stocks->toArray();
-            }
-        }
-
-    .. code-block:: xml
-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-              xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
-                                  https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-
-            <entity name="Doctrine\Tests\Models\StockExchange\Market">
-                <id name="id" type="integer">
-                    <generator strategy="AUTO" />
-                </id>
-
-                <field name="name" type="string"/>
-
-                <one-to-many target-entity="Stock" mapped-by="market" field="stocks" index-by="symbol" />
-            </entity>
-        </doctrine-mapping>
-
-    .. code-block:: yaml
-
-        Doctrine\Tests\Models\StockExchange\Market:
-          type: entity
-          id:
-            id:
-              type: integer
-              generator:
-                strategy: AUTO
-          fields:
-            name:
-              type:string
-          oneToMany:
-            stocks:
-              targetEntity: Stock
-              mappedBy: market
-              indexBy: symbol
 
 Inside the ``addStock()`` method you can see how we directly set the key of the association to the symbol,
 so that we can work with the indexed association directly after invoking ``addStock()``. Inside ``getStock($symbol)``

--- a/docs/en/tutorials/working-with-indexed-associations/Market-annotations.php
+++ b/docs/en/tutorials/working-with-indexed-associations/Market-annotations.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Doctrine\Tests\Models\StockExchange;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
+use InvalidArgumentException;
+
+/**
+ * @Entity
+ * @Table(name="exchange_markets")
+ */
+class Market
+{
+    /**
+     * @Id @Column(type="integer") @GeneratedValue
+     * @var int
+     */
+    private int|null $id = null;
+
+    /**
+     * @Column(type="string")
+     * @var string
+     */
+    private string $name;
+
+    /**
+     * @OneToMany(targetEntity="Stock", mappedBy="market", indexBy="symbol")
+     * @var Collection<int, Stock>
+     */
+    private Collection $stocks;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->stocks = new ArrayCollection();
+    }
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function addStock(Stock $stock): void
+    {
+        $this->stocks[$stock->getSymbol()] = $stock;
+    }
+
+    public function getStock($symbol): Stock
+    {
+        if (!isset($this->stocks[$symbol])) {
+            throw new InvalidArgumentException("Symbol is not traded on this market.");
+        }
+
+        return $this->stocks[$symbol];
+    }
+
+    /** @return array<string, Stock> */
+    public function getStocks(): array
+    {
+        return $this->stocks->toArray();
+    }
+}

--- a/docs/en/tutorials/working-with-indexed-associations/Market.php
+++ b/docs/en/tutorials/working-with-indexed-associations/Market.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\StockExchange;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
+use InvalidArgumentException;
+
+#[Entity]
+#[Table(name: 'exchange_markets')]
+class Market
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    private int|null $id = null;
+
+    #[Column(type: 'string')]
+    private string $name;
+
+    /** @var Collection<string, Stock> */
+    #[OneToMany(targetEntity: Stock::class, mappedBy: 'market', indexBy: 'symbol')]
+    private Collection $stocks;
+
+    public function __construct(string $name)
+    {
+        $this->name   = $name;
+        $this->stocks = new ArrayCollection();
+    }
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function addStock(Stock $stock): void
+    {
+        $this->stocks[$stock->getSymbol()] = $stock;
+    }
+
+    public function getStock(string $symbol): Stock
+    {
+        if (! isset($this->stocks[$symbol])) {
+            throw new InvalidArgumentException('Symbol is not traded on this market.');
+        }
+
+        return $this->stocks[$symbol];
+    }
+
+    /** @return array<string, Stock> */
+    public function getStocks(): array
+    {
+        return $this->stocks->toArray();
+    }
+}

--- a/docs/en/tutorials/working-with-indexed-associations/market.xml
+++ b/docs/en/tutorials/working-with-indexed-associations/market.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+			  https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\StockExchange\Market">
+	<id name="id" type="integer">
+	    <generator strategy="AUTO" />
+	</id>
+
+	<field name="name" type="string"/>
+
+	<one-to-many target-entity="Stock" mapped-by="market" field="stocks" index-by="symbol" />
+    </entity>
+</doctrine-mapping>

--- a/docs/en/tutorials/working-with-indexed-associations/market.yaml
+++ b/docs/en/tutorials/working-with-indexed-associations/market.yaml
@@ -1,0 +1,15 @@
+Doctrine\Tests\Models\StockExchange\Market:
+  type: entity
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    name:
+      type:string
+  oneToMany:
+    stocks:
+      targetEntity: Stock
+      mappedBy: market
+      indexBy: symbol


### PR DESCRIPTION
I think it would be great to use `literalinclude` for big code snippets, because our IDEs could warn us about issues, and it would be easily to showcase our coding standard. Before we do that though, let us validate that it renders as expected. I have picked a complex example where we have a configuration block.