### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/tests/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -77,7 +77,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($metadata->cache))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
@@ -97,7 +97,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($metadata->cache))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
@@ -117,7 +117,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($metadata->cache))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
@@ -138,7 +138,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($mapping['cache']))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 
@@ -159,7 +159,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($mapping['cache']))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 
@@ -180,7 +180,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->factory->expects(self::once())
             ->method('getRegion')
             ->with(self::equalTo($mapping['cache']))
-            ->will(self::returnValue($region));
+            ->willReturn($region);
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 

--- a/tests/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -253,7 +253,7 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $this->collectionPersister->expects(self::once())
             ->method('delete')
@@ -278,7 +278,7 @@ class ReadWriteCachedCollectionPersisterTest extends CollectionPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $this->collectionPersister->expects(self::once())
             ->method('update')

--- a/tests/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -63,7 +63,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends EntityPersisterTestCas
 
         $this->entityPersister->expects(self::once())
             ->method('getInserts')
-            ->will(self::returnValue([$entity]));
+            ->willReturn([$entity]);
 
         $this->entityPersister->expects(self::once())
             ->method('executeInserts');

--- a/tests/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -39,7 +39,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->em->getUnitOfWork()->registerManaged($entity, ['id' => 1], ['id' => 1, 'name' => 'Foo']);
 
@@ -56,7 +56,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->em->getUnitOfWork()->registerManaged($entity, ['id' => 1], ['id' => 1, 'name' => 'Foo']);
 
@@ -73,12 +73,12 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->region->expects(self::once())
             ->method('evict')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->em->getUnitOfWork()->registerManaged($entity, ['id' => 1], ['id' => 1, 'name' => 'Foo']);
 
@@ -96,7 +96,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->region->expects(self::once())
             ->method('evict')
@@ -121,7 +121,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::exactly(2))
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->region->expects(self::exactly(2))
             ->method('evict')
@@ -152,7 +152,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::exactly(2))
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue($lock));
+            ->willReturn($lock);
 
         $this->region->expects(self::exactly(2))
             ->method('evict')
@@ -182,7 +182,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $this->entityPersister->expects(self::once())
             ->method('delete')
@@ -206,7 +206,7 @@ class ReadWriteCachedEntityPersisterTest extends EntityPersisterTestCase
         $this->region->expects(self::once())
             ->method('lock')
             ->with(self::equalTo($key))
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $this->entityPersister->expects(self::once())
             ->method('update')

--- a/tests/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Tests/ORM/Functional/PostLoadEventTest.php
@@ -35,8 +35,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsUser and CmsAddres, because it's a ToOne inverse side on CmsUser
         $mockListener
             ->expects(self::exactly(2))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 
@@ -52,8 +51,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsUser and CmsAddres, because it's a ToOne inverse side on CmsUser
         $mockListener
             ->expects(self::exactly(2))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 
@@ -72,8 +70,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsUser (root), CmsAddress (ToOne inverse side), CmsEmail (joined association)
         $mockListener
             ->expects(self::exactly(3))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 
@@ -92,8 +89,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsUser (root), CmsAddress (ToOne inverse side), 2 CmsPhonenumber (joined association)
         $mockListener
             ->expects(self::exactly(4))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 
@@ -114,8 +110,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
         $mockListener
             ->expects(self::never())
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager->addEventListener([Events::postLoad], $mockListener);
 
@@ -128,8 +123,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
         $mockListener2
             ->expects(self::exactly(2))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager->addEventListener([Events::postLoad], $mockListener2);
 
@@ -146,8 +140,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsUser (partially loaded), CmsAddress (inverse ToOne), 2 CmsPhonenumber
         $mockListener
             ->expects(self::exactly(4))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager->addEventListener([Events::postLoad], $mockListener);
 
@@ -166,8 +159,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // CmsEmail (proxy)
         $mockListener
             ->expects(self::exactly(1))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 
@@ -187,8 +179,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // 2 CmsPhonenumber (proxy)
         $mockListener
             ->expects(self::exactly(2))
-            ->method('postLoad')
-            ->will(self::returnValue(true));
+            ->method('postLoad');
 
         $eventManager = $this->_em->getEventManager();
 

--- a/tests/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Tests/ORM/Functional/SQLFilterTest.php
@@ -255,7 +255,7 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
         $em->expects(self::any())
             ->method('getFilters')
-            ->will(self::returnValue($filterCollection));
+            ->willReturn($filterCollection);
 
         return $filterCollection;
     }
@@ -267,12 +267,12 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $conn->expects(self::once())
             ->method('quote')
             ->with(self::equalTo('en'))
-            ->will(self::returnValue("'en'"));
+            ->willReturn("'en'");
 
         $em = $this->getMockEntityManager();
         $em->expects(self::once())
             ->method('getConnection')
-            ->will(self::returnValue($conn));
+            ->willReturn($conn);
 
         $filterCollection = $this->addMockFilterCollection($em);
         $filterCollection
@@ -298,7 +298,7 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $em = $this->getMockEntityManager();
         $em->expects(self::once())
             ->method('getConnection')
-            ->will(self::returnValue($conn));
+            ->willReturn($conn);
 
         $filter = new MyLocaleFilter($em);
 
@@ -315,12 +315,12 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $conn->expects(self::once())
             ->method('quote')
             ->with(self::equalTo('en'))
-            ->will(self::returnValue("'en'"));
+            ->willReturn("'en'");
 
         $em = $this->getMockEntityManager();
         $em->expects(self::once())
             ->method('getConnection')
-            ->will(self::returnValue($conn));
+            ->willReturn($conn);
 
         $filterCollection = $this->addMockFilterCollection($em);
         $filterCollection
@@ -339,13 +339,13 @@ class SQLFilterTest extends OrmFunctionalTestCase
         // Setup mock connection
         $conn = $this->getMockConnection();
         $conn->method('quote')
-             ->will(self::returnCallback(static function ($value) {
+             ->willReturnCallback(static function ($value) {
                  return "'" . $value . "'";
-             }));
+             });
 
         $em = $this->getMockEntityManager();
         $em->method('getConnection')
-           ->will(self::returnValue($conn));
+           ->willReturn($conn);
 
         $filterCollection = $this->addMockFilterCollection($em);
         $filterCollection

--- a/tests/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -45,15 +45,15 @@ class DDC2359Test extends TestCase
 
         $configuration
             ->method('getMetadataDriverImpl')
-            ->will(self::returnValue($mockDriver));
+            ->willReturn($mockDriver);
 
-        $entityManager->expects(self::any())->method('getConfiguration')->will(self::returnValue($configuration));
-        $entityManager->expects(self::any())->method('getConnection')->will(self::returnValue($connection));
+        $entityManager->expects(self::any())->method('getConfiguration')->willReturn($configuration);
+        $entityManager->expects(self::any())->method('getConnection')->willReturn($connection);
         $entityManager
             ->method('getEventManager')
-            ->will(self::returnValue($this->createMock(EventManager::class)));
+            ->willReturn($this->createMock(EventManager::class));
 
-        $metadataFactory->method('newClassMetadataInstance')->will(self::returnValue($mockMetadata));
+        $metadataFactory->method('newClassMetadataInstance')->willReturn($mockMetadata);
         $metadataFactory->expects(self::once())->method('wakeupReflection');
 
         $metadataFactory->setEntityManager($entityManager);

--- a/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1036,7 +1036,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyFactory->expects(self::once())
                      ->method('getProxy')
                      ->with(self::equalTo(ECommerceShipping::class), ['id' => 42])
-                     ->will(self::returnValue($proxyInstance));
+                     ->willReturn($proxyInstance);
 
         $this->entityManager->setProxyFactory($proxyFactory);
 
@@ -1084,7 +1084,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyFactory->expects(self::once())
                      ->method('getProxy')
                      ->with(self::equalTo(ECommerceShipping::class), ['id' => 42])
-                     ->will(self::returnValue($proxyInstance));
+                     ->willReturn($proxyInstance);
 
         $this->entityManager->setProxyFactory($proxyFactory);
 

--- a/tests/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -53,7 +53,7 @@ class HydrationCompleteHandlerTest extends TestCase
             ->expects(self::any())
             ->method('getSubscribedSystems')
             ->with($metadata)
-            ->will(self::returnValue($listenersFlag));
+            ->willReturn($listenersFlag);
 
         $this->handler->deferPostLoadInvoking($metadata, $entity);
 
@@ -86,7 +86,7 @@ class HydrationCompleteHandlerTest extends TestCase
             ->expects(self::any())
             ->method('getSubscribedSystems')
             ->with($metadata)
-            ->will(self::returnValue($listenersFlag));
+            ->willReturn($listenersFlag);
 
         $this->handler->deferPostLoadInvoking($metadata, $entity);
 
@@ -110,7 +110,7 @@ class HydrationCompleteHandlerTest extends TestCase
             ->expects(self::any())
             ->method('getSubscribedSystems')
             ->with(self::logicalOr($metadata1, $metadata2))
-            ->will(self::returnValue($listenersFlag));
+            ->willReturn($listenersFlag);
 
         $this->handler->deferPostLoadInvoking($metadata1, $entity1);
         $this->handler->deferPostLoadInvoking($metadata2, $entity2);
@@ -144,7 +144,7 @@ class HydrationCompleteHandlerTest extends TestCase
             ->expects(self::any())
             ->method('getSubscribedSystems')
             ->with($metadata)
-            ->will(self::returnValue(ListenersInvoker::INVOKE_NONE));
+            ->willReturn(ListenersInvoker::INVOKE_NONE);
 
         $this->handler->deferPostLoadInvoking($metadata, $entity);
 

--- a/tests/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -33,7 +33,7 @@ class LazyCriteriaCollectionTest extends TestCase
 
     public function testCountIsCached(): void
     {
-        $this->persister->expects(self::once())->method('count')->with($this->criteria)->will(self::returnValue(10));
+        $this->persister->expects(self::once())->method('count')->with($this->criteria)->willReturn(10);
 
         self::assertSame(10, $this->lazyCriteriaCollection->count());
         self::assertSame(10, $this->lazyCriteriaCollection->count());
@@ -42,7 +42,7 @@ class LazyCriteriaCollectionTest extends TestCase
 
     public function testCountIsCachedEvenWithZeroResult(): void
     {
-        $this->persister->expects(self::once())->method('count')->with($this->criteria)->will(self::returnValue(0));
+        $this->persister->expects(self::once())->method('count')->with($this->criteria)->willReturn(0);
 
         self::assertSame(0, $this->lazyCriteriaCollection->count());
         self::assertSame(0, $this->lazyCriteriaCollection->count());
@@ -56,7 +56,7 @@ class LazyCriteriaCollectionTest extends TestCase
             ->expects(self::once())
             ->method('loadCriteria')
             ->with($this->criteria)
-            ->will(self::returnValue(['foo', 'bar', 'baz']));
+            ->willReturn(['foo', 'bar', 'baz']);
 
         // should never call the persister's count
         $this->persister->expects(self::never())->method('count');
@@ -81,7 +81,7 @@ class LazyCriteriaCollectionTest extends TestCase
             ->expects(self::once())
             ->method('loadCriteria')
             ->with($this->criteria)
-            ->will(self::returnValue([$foo, $bar, $baz]));
+            ->willReturn([$foo, $bar, $baz]);
 
         $criteria = new Criteria();
 
@@ -97,14 +97,14 @@ class LazyCriteriaCollectionTest extends TestCase
 
     public function testIsEmptyUsesCountWhenNotInitialized(): void
     {
-        $this->persister->expects(self::once())->method('count')->with($this->criteria)->will(self::returnValue(0));
+        $this->persister->expects(self::once())->method('count')->with($this->criteria)->willReturn(0);
 
         self::assertTrue($this->lazyCriteriaCollection->isEmpty());
     }
 
     public function testIsEmptyIsFalseIfCountIsNotZero(): void
     {
-        $this->persister->expects(self::once())->method('count')->with($this->criteria)->will(self::returnValue(1));
+        $this->persister->expects(self::once())->method('count')->with($this->criteria)->willReturn(1);
 
         self::assertFalse($this->lazyCriteriaCollection->isEmpty());
     }
@@ -116,7 +116,7 @@ class LazyCriteriaCollectionTest extends TestCase
             ->expects(self::once())
             ->method('loadCriteria')
             ->with($this->criteria)
-            ->will(self::returnValue(['foo', 'bar', 'baz']));
+            ->willReturn(['foo', 'bar', 'baz']);
 
         // should never call the persister's count
         $this->persister->expects(self::never())->method('count');

--- a/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -320,7 +320,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $conn->expects(self::any())
             ->method('getDatabasePlatform')
-            ->will(self::throwException(new Exception('Exception thrown in test when calling getDatabasePlatform')));
+            ->willThrowException(new Exception('Exception thrown in test when calling getDatabasePlatform'));
 
         $cmf = new ClassMetadataFactory();
         $cmf->setEntityManager($em);

--- a/tests/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
+++ b/tests/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
@@ -101,10 +101,10 @@ class ReflectionPropertiesGetterTest extends TestCase
             ->expects(self::exactly(2))
             ->method('getClass')
             ->with(self::logicalOr(ClassWithMixedProperties::class, ParentClass::class))
-            ->will(self::returnValueMap([
+            ->willReturnMap([
                 [ClassWithMixedProperties::class, new ReflectionClass(ClassWithMixedProperties::class)],
                 [ParentClass::class, new ReflectionClass(ParentClass::class)],
-            ]));
+            ]);
 
         $reflectionService
             ->expects(self::atLeastOnce())

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -76,7 +76,7 @@ class ProxyFactoryTest extends OrmTestCase
             ->expects(self::atLeastOnce())
             ->method('loadById')
             ->with(self::equalTo($identifier))
-            ->will(self::returnValue($proxy));
+            ->willReturn($proxy);
 
         $proxy->getDescription();
     }
@@ -133,7 +133,7 @@ class ProxyFactoryTest extends OrmTestCase
         $persister
             ->expects(self::atLeastOnce())
             ->method('load')
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         try {
             $proxy->getDescription();
@@ -160,7 +160,7 @@ class ProxyFactoryTest extends OrmTestCase
         $persister
             ->expects(self::atLeastOnce())
             ->method('load')
-            ->will(self::throwException($exception));
+            ->willThrowException($exception);
 
         try {
             $proxy->getDescription();
@@ -186,7 +186,7 @@ class ProxyFactoryTest extends OrmTestCase
         $persister
             ->expects(self::atLeastOnce())
             ->method('load')
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         try {
             $cloned = clone $proxy;

--- a/tests/Tests/ORM/Query/SqlExpressionVisitorTest.php
+++ b/tests/Tests/ORM/Query/SqlExpressionVisitorTest.php
@@ -41,7 +41,7 @@ class SqlExpressionVisitorTest extends TestCase
         $this->persister
             ->expects(self::once())
             ->method('getSelectConditionStatementSQL')
-            ->will(self::returnValue('dummy expression'));
+            ->willReturn('dummy expression');
 
         $expr = $this->visitor->walkCompositeExpression(
             $cb->not(

--- a/tests/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -40,7 +40,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->configuration
             ->expects(self::any())
             ->method('getDefaultRepositoryClassName')
-            ->will(self::returnValue(DDC869PaymentRepository::class));
+            ->willReturn(DDC869PaymentRepository::class);
     }
 
     public function testCreatesRepositoryFromDefaultRepositoryClass(): void
@@ -48,7 +48,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->entityManager
             ->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
+            ->willReturnCallback(Closure::fromCallable([$this, 'buildClassMetadata']));
 
         self::assertInstanceOf(
             DDC869PaymentRepository::class,
@@ -61,7 +61,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->entityManager
             ->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
+            ->willReturnCallback(Closure::fromCallable([$this, 'buildClassMetadata']));
 
         self::assertSame(
             $this->repositoryFactory->getRepository($this->entityManager, self::class),
@@ -77,7 +77,7 @@ class DefaultRepositoryFactoryTest extends TestCase
         $this->entityManager
             ->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnValue($customMetadata));
+            ->willReturn($customMetadata);
 
         self::assertInstanceOf(
             DDC753DefaultRepository::class,
@@ -92,11 +92,11 @@ class DefaultRepositoryFactoryTest extends TestCase
 
         $em1->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
+            ->willReturnCallback(Closure::fromCallable([$this, 'buildClassMetadata']));
 
         $em2->expects(self::any())
             ->method('getClassMetadata')
-            ->will(self::returnCallback(Closure::fromCallable([$this, 'buildClassMetadata'])));
+            ->willReturnCallback(Closure::fromCallable([$this, 'buildClassMetadata']));
 
         $repo1 = $this->repositoryFactory->getRepository($em1, self::class);
         $repo2 = $this->repositoryFactory->getRepository($em2, self::class);


### PR DESCRIPTION
This PR migrates some method calls that have become deprecated in PHPUnit 10. This will allow us to upgrade to more recent PHPUnit versions on higher branches.