### PR TITLE
Close stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: 'Close stale pull requests'
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: >
+            There hasn't been any activity on this pull request in the past 90 days, so
+            it has been marked as stale and it will be closed automatically if no
+            further activity occurs in the next 7 days.
+
+            If you want to continue working on it, please leave a comment.
+
+          close-pr-message: >
+            This pull request was closed due to inactivity.
+
+          days-before-stale:    -1
+          days-before-pr-stale: 90
+          days-before-pr-close: 7


### PR DESCRIPTION
On the DBAL repository, we let a bot close stale pull requests. This has worked very well for us because it reminds authors and reviewers that a PR might need attention. Closed stale PRs can be taken over by another contributor who might want to finish the work. Contributors can browse the list of open PRs to see what's actually being worked on.

Merging this PR will make the bot bump _A LOT_ of PRs that can already be considered stale. This will cause some noise for everyone, but after that, we will end up with a way smaller list of open PRs.