### PR TITLE
[DDC-551] fix, add filter support in oneToOne relation 3.3.x

### DIFF
--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1332,6 +1332,12 @@ class BasicEntityPersister implements EntityPersister
                     $joinCondition[] = $this->getSQLTableAlias($association->sourceEntity, $assocAlias) . '.' . $sourceCol . ' = '
                         . $this->getSQLTableAlias($association->targetEntity) . '.' . $targetCol;
                 }
+
+                // Add filter SQL
+                $filterSql = $this->generateFilterConditionSQL($eagerEntity, $joinTableAlias);
+                if ($filterSql) {
+                    $joinCondition[] = $filterSql;
+                }
             }
 
             $this->currentPersisterContext->selectJoinSql .= ' ' . $joinTableName . ' ' . $joinTableAlias . ' ON ';

--- a/tests/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Tests/ORM/Functional/SQLFilterTest.php
@@ -503,6 +503,21 @@ class SQLFilterTest extends OrmFunctionalTestCase
         self::assertEquals(2, count($query->getResult()));
     }
 
+    public function testOneToOneInverseSideWithFilter(): void
+    {
+        $this->loadFixtureData();
+
+        $conf = $this->_em->getConfiguration();
+        $conf->addFilter('country', '\Doctrine\Tests\ORM\Functional\CMSCountryFilter');
+        $this->_em->getFilters()->enable('country')->setParameterList('country', ['Germany'], Types::STRING);
+
+        $user = $this->_em->find(CmsUser::class, $this->userId);
+        self::assertNotEmpty($user->address);
+
+        $user2 = $this->_em->find(CmsUser::class, $this->userId2);
+        self::assertEmpty($user2->address);
+    }
+
     public function testManyToManyFilter(): void
     {
         $this->loadFixtureData();


### PR DESCRIPTION
Filters weren't applied for oneToOne relations
2.20.x PR -> https://github.com/doctrine/orm/pull/11707

https://github.com/doctrine/orm/pull/5664 can also be closed when this is merged
Maybe fixes https://github.com/doctrine/orm/issues/6343 (did not test)