### PR TITLE
fix: DefaultQuoteStrategy not Oracle db compatible

### DIFF
--- a/src/Mapping/DefaultQuoteStrategy.php
+++ b/src/Mapping/DefaultQuoteStrategy.php
@@ -145,11 +145,12 @@ class DefaultQuoteStrategy implements QuoteStrategy
         // 2 ) Trim the column alias to the maximum identifier length of the platform.
         //     If the alias is to long, characters are cut off from the beginning.
         // 3 ) Strip non alphanumeric characters
-        // 4 ) Prefix with "_" if the result its numeric
+        // 4 ) Replace first character with "C" if it is not an alphabetic character
         $columnName .= '_' . $counter;
         $columnName  = substr($columnName, -$platform->getMaxIdentifierLength());
         $columnName  = preg_replace('/[^A-Za-z0-9_]/', '', $columnName);
-        $columnName  = is_numeric($columnName) ? '_' . $columnName : $columnName;
+        if (!ctype_alpha($columnName[0]))
+            $columnName[0] = 'C';
 
         return $this->getSQLResultCasing($platform, $columnName);
     }


### PR DESCRIPTION
 1. Oracle enforces non-quoted column aliases to start with an alphabetic character
 2. by prefixing the length limit is exceeded again

see list of Database Object Naming Rules, Point 6 at https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Database-Object-Names-and-Qualifiers.html

I guess this is a valid approach for all databases?

This was also addressed in ~#1600~, #4610, #5607

FIXES DDC-2733/#3476
