### PR TITLE
Add `isEmpty()` method to the Extra Lazy associations tutorial

### DIFF
--- a/docs/en/tutorials/extra-lazy-associations.rst
+++ b/docs/en/tutorials/extra-lazy-associations.rst
@@ -19,6 +19,7 @@ can be called without triggering a full load of the collection:
 -  ``Collection#count()``
 -  ``Collection#get($key)``
 -  ``Collection#slice($offset, $length = null)``
+-  ``Collection#isEmpty()``
 
 For each of the above methods the following semantics apply:
 

--- a/docs/en/tutorials/extra-lazy-associations.rst
+++ b/docs/en/tutorials/extra-lazy-associations.rst
@@ -18,8 +18,8 @@ can be called without triggering a full load of the collection:
 -  ``Collection#containsKey($key)``
 -  ``Collection#count()``
 -  ``Collection#get($key)``
--  ``Collection#slice($offset, $length = null)``
 -  ``Collection#isEmpty()``
+-  ``Collection#slice($offset, $length = null)``
 
 For each of the above methods the following semantics apply:
 


### PR DESCRIPTION
It was added a long time ago (see https://github.com/doctrine/orm/pull/912) but the `isEmpty()` function also does not trigger a full collection load.