### PR TITLE
Add `isEmpty()` method to the Extra Lazy Associations tutorial

### DIFF
--- a/docs/en/tutorials/extra-lazy-associations.rst
+++ b/docs/en/tutorials/extra-lazy-associations.rst
@@ -18,6 +18,7 @@ can be called without triggering a full load of the collection:
 -  ``Collection#containsKey($key)``
 -  ``Collection#count()``
 -  ``Collection#get($key)``
+-  ``Collection#isEmpty()``
 -  ``Collection#slice($offset, $length = null)``
 
 For each of the above methods the following semantics apply:


### PR DESCRIPTION
Extra lazy support for it was added a long time ago (see https://github.com/doctrine/orm/pull/912) but was never properly documented.