### PR TITLE
Use properties over array keys

### DIFF
--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -509,7 +509,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function first()
     {
-        if (! $this->initialized && ! $this->isDirty && $this->getMapping()['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
+        if (! $this->initialized && ! $this->isDirty && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY) {
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return array_values($persister->slice($this, 0, 1))[0] ?? false;


### PR DESCRIPTION
Using array access is deprecated.