### PR TITLE
Support for overriding system hydrators with custom ones

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -541,15 +541,20 @@ class EntityManager implements EntityManagerInterface
 
     public function newHydrator(string|int $hydrationMode): AbstractHydrator
     {
-        return match ($hydrationMode) {
-            Query::HYDRATE_OBJECT => new Internal\Hydration\ObjectHydrator($this),
-            Query::HYDRATE_ARRAY => new Internal\Hydration\ArrayHydrator($this),
-            Query::HYDRATE_SCALAR => new Internal\Hydration\ScalarHydrator($this),
-            Query::HYDRATE_SINGLE_SCALAR => new Internal\Hydration\SingleScalarHydrator($this),
-            Query::HYDRATE_SIMPLEOBJECT => new Internal\Hydration\SimpleObjectHydrator($this),
-            Query::HYDRATE_SCALAR_COLUMN => new Internal\Hydration\ScalarColumnHydrator($this),
-            default => $this->createCustomHydrator((string) $hydrationMode),
-        };
+        $hydrationClass = $this->config->getCustomHydrationMode((string) $hydrationMode);
+        if ($hydrationClass === null) {
+            $hydrationClass = match ($hydrationMode) {
+                Query::HYDRATE_OBJECT => Internal\Hydration\ObjectHydrator::class,
+                Query::HYDRATE_ARRAY => Internal\Hydration\ArrayHydrator::class,
+                Query::HYDRATE_SCALAR => Internal\Hydration\ScalarHydrator::class,
+                Query::HYDRATE_SINGLE_SCALAR => Internal\Hydration\SingleScalarHydrator::class,
+                Query::HYDRATE_SIMPLEOBJECT => Internal\Hydration\SimpleObjectHydrator::class,
+                Query::HYDRATE_SCALAR_COLUMN => Internal\Hydration\ScalarColumnHydrator::class,
+                default => throw InvalidHydrationMode::fromMode((string) $hydrationMode)
+            };
+        }
+
+        return new $hydrationClass($this);
     }
 
     public function getProxyFactory(): ProxyFactory
@@ -616,16 +621,5 @@ class EntityManager implements EntityManagerInterface
         }
 
         $this->metadataFactory->setCache($metadataCache);
-    }
-
-    private function createCustomHydrator(string $hydrationMode): AbstractHydrator
-    {
-        $class = $this->config->getCustomHydrationMode($hydrationMode);
-
-        if ($class !== null) {
-            return new $class($this);
-        }
-
-        throw InvalidHydrationMode::fromMode($hydrationMode);
     }
 }

--- a/tests/Tests/ORM/Hydration/CustomHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/CustomHydratorTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Internal\Hydration\ScalarHydrator;
+use Doctrine\ORM\Query;
 
 class CustomHydratorTest extends HydrationTestCase
 {
@@ -12,11 +15,21 @@ class CustomHydratorTest extends HydrationTestCase
     {
         $em     = $this->getTestEntityManager();
         $config = $em->getConfiguration();
-        $config->addCustomHydrationMode('CustomHydrator', CustomHydrator::class);
 
+        $config->addCustomHydrationMode('CustomHydrator', CustomHydrator::class);
         $hydrator = $em->newHydrator('CustomHydrator');
         self::assertInstanceOf(CustomHydrator::class, $hydrator);
         self::assertNull($config->getCustomHydrationMode('does not exist'));
+
+        $hydrator = $em->newHydrator(Query::HYDRATE_SCALAR);
+        self::assertInstanceOf(ScalarHydrator::class, $hydrator);
+
+        $config->addCustomHydrationMode((string) Query::HYDRATE_SCALAR, CustomHydrator::class);
+        $hydrator = $em->newHydrator(Query::HYDRATE_SCALAR);
+        self::assertInstanceOf(CustomHydrator::class, $hydrator);
+
+        $this->expectException(InvalidHydrationMode::class);
+        $em->newHydrator('does not exist');
     }
 }
 


### PR DESCRIPTION
Previously, system hydrators were hardcoded, limiting flexibility for specific use cases. This update introduces functionality to allow developers to override system hydrators with their own custom implementations, providing greater adaptability for unique project requirements.