### PR TITLE
Run SA checks with PHP 8.4

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: "8.3"
+          php-version: "8.4"
           tools: cs2pr
 
       - name: Require specific DBAL version


### PR DESCRIPTION
This change was accidentally dropped during a merge up.