### PR TITLE
Check hint value before considering instance read-only

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2968,7 +2968,7 @@ EXCEPTION
             $oid    = spl_object_id($entity);
             $this->registerManaged($entity, $id, $data);
 
-            if (isset($hints[Query::HINT_READ_ONLY])) {
+            if (isset($hints[Query::HINT_READ_ONLY]) && $hints[Query::HINT_READ_ONLY] === true) {
                 $this->readOnlyObjects[$oid] = true;
             }
         }

--- a/tests/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Tests/ORM/Functional/ReadOnlyTest.php
@@ -90,6 +90,24 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         self::assertTrue($this->_em->getUnitOfWork()->isReadOnly($user));
     }
 
+    public function testNotReadOnlyQueryHint(): void
+    {
+        $user = new ReadOnlyEntity('beberlei', 1234);
+
+        $this->_em->persist($user);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('SELECT u FROM ' . ReadOnlyEntity::class . ' u WHERE u.id = ?1');
+        $query->setParameter(1, $user->id);
+        $query->setHint(Query::HINT_READ_ONLY, false);
+
+        $user = $query->getSingleResult();
+
+        self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
+    }
+
     public function testNotReadOnlyIfObjectWasProxyBefore(): void
     {
         $user = new ReadOnlyEntity('beberlei', 1234);


### PR DESCRIPTION
Documentation suggests that HINT_READ_ONLY accept a boolean value.
https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/improving-performance.html#read-only-entities

But UnitOfWork only check if hint is set to register new Entity instance as read-only.

Using the value parameter will code more consistent to documentation.