### PR TITLE
Fix fields of transient classes being considered duplicate with `reportFieldsWhereDeclared`

### DIFF
--- a/src/Mapping/Driver/ReflectionBasedDriver.php
+++ b/src/Mapping/Driver/ReflectionBasedDriver.php
@@ -32,7 +32,12 @@ trait ReflectionBasedDriver
                 || $metadata->isInheritedEmbeddedClass($property->name);
         }
 
+        /** @var class-string $declaringClass */
         $declaringClass = $property->class;
+
+        if ($this->isTransient($declaringClass)) {
+            return isset($metadata->fieldMappings[$property->name]);
+        }
 
         if (
             isset($metadata->fieldMappings[$property->name]['declared'])

--- a/tests/Tests/ORM/Functional/Ticket/GH10450Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10450Test.php
@@ -32,6 +32,15 @@ class GH10450Test extends OrmTestCase
         yield 'Entity class that redeclares a protected field inherited from a base entity' => [GH10450EntityChildProtected::class];
         yield 'Entity class that redeclares a protected field inherited from a mapped superclass' => [GH10450MappedSuperclassChildProtected::class];
     }
+
+    public function testFieldsOfTransientClassesAreNotConsideredDuplicate(): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $metadata = $em->getClassMetadata(GH10450Cat::class);
+
+        self::assertArrayHasKey('id', $metadata->fieldMappings);
+    }
 }
 
 /**
@@ -178,4 +187,39 @@ class GH10450MappedSuperclassChildProtected extends GH10450BaseMappedSuperclassP
      * @var string
      */
     protected $field;
+}
+
+abstract class GH10450AbstractEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    protected $id;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({ "cat": "GH10450Cat" })
+ * @ORM\DiscriminatorColumn(name="type")
+ */
+abstract class GH10450Animal extends GH10450AbstractEntity
+{
+    /**
+     * @ORM\Column(type="text", name="base")
+     *
+     * @var string
+     */
+    private $field;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH10450Cat extends GH10450Animal
+{
 }


### PR DESCRIPTION
When I enabled the `reportFieldsWhereDeclared` option introduced in #10455, I encountered a problem when using transient classes. For example, the following code produces an error:

```php
abstract class AbstractEntity
{
    #[ORM\Column]
    #[ORM\Id]
    #[ORM\GeneratedValue]
    protected int $id;
}

#[ORM\Entity]
#[ORM\InheritanceType('SINGLE_TABLE')]
#[ORM\DiscriminatorMap(['cat' => Cat::class])]
#[ORM\DiscriminatorColumn(name: 'type')]
abstract class Animal extends AbstractEntity
{
    #[ORM\Column]
    private string $field;
}

#[ORM\Entity]
class Cat extends Animal
{
}
```

```
Doctrine\ORM\Mapping\MappingException: Duplicate definition of column 'id' on entity 'Cat' 
in a field or discriminator column mapping.
```

To my understanding, this shouldn't happen since `AbstractEntity` is a transient class. Perhaps @mpdude, as the original author, could shed some light on this.