### PR TITLE
Changed confusing negative wording on 'Mapped Superclasses' doc

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -16,7 +16,7 @@ is common to multiple entity classes.
 Mapped superclasses, just as regular, non-mapped classes, can
 appear in the middle of an otherwise mapped inheritance hierarchy
 (through Single Table Inheritance or Class Table Inheritance). They
-are not query-able, and need not have an ``#[Id]`` property.
+are not query-able, and do not require an ``#[Id]`` property.
 
 No database table will be created for a mapped superclass itself,
 only for entity classes inheriting from it. That  implies that a


### PR DESCRIPTION
As I was reading more about [Inheritance Mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/inheritance-mapping.html), I've come across this turn of phrase that's a bit confusing, especially if english is not your first language. Or maybe it's just me, in which case I'd understand if you refused this PR.
Otherwise, I've simply used a slightly clearer negation that makes it explicit (perhaps only in my opinion) that Mapped Superclasses don't need an ID column.