### PR TITLE
Respect referencedColumnName defaults in custom naming strategies

### DIFF
--- a/src/Mapping/JoinColumnMapping.php
+++ b/src/Mapping/JoinColumnMapping.php
@@ -33,7 +33,7 @@ final class JoinColumnMapping implements ArrayAccess
      * @param array<string, mixed> $mappingArray
      * @phpstan-param array{
      *     name: string,
-     *     referencedColumnName: string,
+     *     referencedColumnName: string|null,
      *     unique?: bool|null,
      *     quoted?: bool|null,
      *     fieldName?: string|null,

--- a/src/Mapping/JoinColumnProperties.php
+++ b/src/Mapping/JoinColumnProperties.php
@@ -9,7 +9,7 @@ trait JoinColumnProperties
     /** @param array<string, mixed> $options */
     public function __construct(
         public readonly string|null $name = null,
-        public readonly string $referencedColumnName = 'id',
+        public readonly string|null $referencedColumnName = null,
         public readonly bool $unique = false,
         public readonly bool $nullable = true,
         public readonly mixed $onDelete = null,

--- a/src/Mapping/ManyToManyOwningSideMapping.php
+++ b/src/Mapping/ManyToManyOwningSideMapping.php
@@ -61,10 +61,13 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
     {
         if (isset($mappingArray['joinTable']['joinColumns'])) {
             foreach ($mappingArray['joinTable']['joinColumns'] as $key => $joinColumn) {
+                if (empty($joinColumn['referencedColumnName'])) {
+                    $mappingArray['joinTable']['joinColumns'][$key]['referencedColumnName'] = $namingStrategy->referenceColumnName();
+                }
                 if (empty($joinColumn['name'])) {
                     $mappingArray['joinTable']['joinColumns'][$key]['name'] = $namingStrategy->joinKeyColumnName(
                         $mappingArray['sourceEntity'],
-                        $joinColumn['referencedColumnName'] ?? null,
+                        $joinColumn['referencedColumnName'] ?? $namingStrategy->referenceColumnName(),
                     );
                 }
             }
@@ -72,10 +75,13 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
 
         if (isset($mappingArray['joinTable']['inverseJoinColumns'])) {
             foreach ($mappingArray['joinTable']['inverseJoinColumns'] as $key => $joinColumn) {
+                if (empty($joinColumn['referencedColumnName'])) {
+                    $mappingArray['joinTable']['inverseJoinColumns'][$key]['referencedColumnName'] = $namingStrategy->referenceColumnName();
+                }
                 if (empty($joinColumn['name'])) {
                     $mappingArray['joinTable']['inverseJoinColumns'][$key]['name'] = $namingStrategy->joinKeyColumnName(
                         $mappingArray['targetEntity'],
-                        $joinColumn['referencedColumnName'] ?? null,
+                        $joinColumn['referencedColumnName'] ?? $namingStrategy->referenceColumnName(),
                     );
                 }
             }

--- a/src/Mapping/ToOneOwningSideMapping.php
+++ b/src/Mapping/ToOneOwningSideMapping.php
@@ -107,6 +107,9 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
                 if (empty($joinColumn['name'])) {
                     $mappingArray['joinColumns'][$index]['name'] = $namingStrategy->joinColumnName($mappingArray['fieldName'], $name);
                 }
+                if (empty($joinColumn['referencedColumnName'])) {
+                    $mappingArray['joinColumns'][$index]['referencedColumnName'] = $namingStrategy->referenceColumnName();
+                }
             }
         }
 

--- a/tests/Tests/ORM/Mapping/NamingStrategy/CustomPascalNamingStrategy.php
+++ b/tests/Tests/ORM/Mapping/NamingStrategy/CustomPascalNamingStrategy.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping\NamingStrategy;
+
+use Doctrine\ORM\Mapping\NamingStrategy;
+
+/**
+ * Fully customized naming strategy changing all namings to a PascalCase model. Included to test some behaviours
+ * regarding fully custom naming strategies.
+ */
+class CustomPascalNamingStrategy implements NamingStrategy
+{
+    /**
+     * Returns a table name for an entity class.
+     *
+     * @param string $className The fully-qualified class name
+     * @return string A table name
+     */
+    public function classToTableName(string $className): string
+    {
+        if (str_contains($className, '\\')) {
+            return substr($className, strrpos($className, '\\') + 1);
+        }
+
+        return $className;
+    }
+
+    /**
+     * Returns a column name for a property.
+     *
+     * @param string $propertyName A property name
+     * @param string|null $className    The fully-qualified class name
+     *
+     * @return string A column name
+     */
+    public function propertyToColumnName(string $propertyName, ?string $className = null): string
+    {
+        if (null !== $className && strtolower($propertyName) == strtolower($this->classToTableName($className)) . 'id') {
+            return 'Id';
+        }
+
+        return ucfirst($propertyName);
+    }
+
+    /**
+     * Returns a column name for an embedded property.
+     */
+    public function embeddedFieldToColumnName(string $propertyName, string $embeddedColumnName, ?string $className = null, $embeddedClassName = null): string
+    {
+        throw new \LogicException(sprintf('Method %s is not implemented', __METHOD__));
+    }
+
+    /**
+     * Returns the default reference column name.
+     *
+     * @return string A column name
+     */
+    public function referenceColumnName(): string
+    {
+        return 'Id';
+    }
+
+    /**
+     * Returns a join column name for a property.
+     *
+     * @return string A join column name
+     */
+    public function joinColumnName(string $propertyName, string $className): string
+    {
+        return ucfirst($propertyName) . $this->referenceColumnName();
+    }
+
+    /**
+     * Returns a join table name.
+     *
+     * @param string $sourceEntity The source entity
+     * @param string $targetEntity The target entity
+     * @param string|null $propertyName A property name
+     *
+     * @return string A join table name
+     */
+    public function joinTableName(string $sourceEntity, string $targetEntity, ?string $propertyName = null): string
+    {
+        return $this->classToTableName($sourceEntity) . $this->classToTableName($targetEntity);
+    }
+
+    /**
+     * Returns the foreign key column name for the given parameters.
+     *
+     * @param string      $entityName           An entity
+     * @param string|null $referencedColumnName A property
+     *
+     * @return string A join column name
+     */
+    public function joinKeyColumnName(string $entityName, ?string $referencedColumnName = null): string
+    {
+        return $this->classToTableName($entityName) . ($referencedColumnName ?: $this->referenceColumnName());
+    }
+}

--- a/tests/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
+use Doctrine\Tests\ORM\Mapping\NamingStrategy\CustomPascalNamingStrategy;
 use Doctrine\Tests\ORM\Mapping\NamingStrategy\JoinColumnClassNamingStrategy;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -33,6 +34,11 @@ class NamingStrategyTest extends OrmTestCase
         return new UnderscoreNamingStrategy(CASE_UPPER);
     }
 
+    private static function customNaming(): CustomPascalNamingStrategy
+    {
+        return new CustomPascalNamingStrategy();
+    }
+
     /**
      * Data Provider for NamingStrategy#classToTableName
      *
@@ -56,6 +62,10 @@ class NamingStrategyTest extends OrmTestCase
             [self::underscoreNamingUpper(), 'NAME', '\Some\Class\Name'],
             [self::underscoreNamingUpper(), 'NAME2_TEST', '\Some\Class\Name2Test'],
             [self::underscoreNamingUpper(), 'NAME2TEST', '\Some\Class\Name2test'],
+
+            // CustomPascalNamingStrategy
+            [self::customNaming(), 'SomeClassName', 'SomeClassName'],
+            [self::customNaming(), 'Name2Test', '\Some\Class\Name2Test'],
         ];
     }
 
@@ -89,6 +99,10 @@ class NamingStrategyTest extends OrmTestCase
             [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY', 'Some\Class'],
             [self::underscoreNamingUpper(), 'BASE64_ENCODED', 'base64Encoded', 'Some\Class'],
             [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded', 'Some\Class'],
+
+            // CustomPascalNamingStrategy
+            [self::customNaming(), 'SomeProperty', 'someProperty', 'Some\Class'],
+            [self::customNaming(), 'Base64Encoded', 'base64Encoded', 'Some\Class'],
         ];
     }
 
@@ -116,6 +130,9 @@ class NamingStrategyTest extends OrmTestCase
             // UnderscoreNamingStrategy
             [self::underscoreNamingLower(), 'id'],
             [self::underscoreNamingUpper(), 'ID'],
+
+            // CustomPascalNamingStrategy
+            [self::customNaming(), 'Id'],
         ];
     }
 

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.BlogPost.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.BlogPost.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\BlogPost">
+
+        <id name="id" type="integer" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.BlogPostComment.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.BlogPostComment.dcm.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\BlogPostComment">
+
+        <id name="id" type="integer">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="blogPost" target-entity="Doctrine\Tests\ORM\Mapping\BlogPost">
+            <join-columns>
+                <join-column nullable="false"/>
+            </join-columns>
+        </many-to-one>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
Previously, when using a custom naming strategy, explicitly declaring a `JoinColumn` required specifying the `referencedColumnName` always as it would default to `id` no matter the naming strategy. This PR fixes this omission.

Refer to https://github.com/doctrine/orm/issues/9558 for full examples.
