### PR TITLE
Fix type hint on OrderBy attribute

### DIFF
--- a/src/Mapping/OrderBy.php
+++ b/src/Mapping/OrderBy.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;
+use Doctrine\Common\Collections\Order;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class OrderBy implements MappingAttribute
 {
-    /** @param array<string> $value */
+    /** @param array<string, string|Order> $value */
     public function __construct(
         public readonly array $value,
     ) {


### PR DESCRIPTION
PHPStan 2.0 does not accept a string backed enum as a string.