### PR TITLE
Introduce testNotListedValueInEnumArray

### DIFF
--- a/tests/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -7,11 +7,13 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\DbalTypes\GH8565EmployeePayloadType;
 use Doctrine\Tests\DbalTypes\GH8565ManagerPayloadType;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\Company\CompanyPerson;
+use Doctrine\Tests\Models\Enums\Scale;
 use Doctrine\Tests\Models\GH8565\GH8565Employee;
 use Doctrine\Tests\Models\GH8565\GH8565Manager;
 use Doctrine\Tests\Models\GH8565\GH8565Person;
@@ -154,5 +156,24 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $hydrator = new SimpleObjectHydrator($this->entityManager);
         $result   = $hydrator->hydrateAll($stmt, $rsm);
         self::assertEquals($result[0], $expectedEntity);
+    }
+
+    public function testNotListedValueInEnumArray(): void
+    {
+        $this->expectException(MappingException::class);
+        $rsm = new ResultSetMapping();
+        $rsm->addEntityResult(Scale::class, 's');
+        $rsm->addFieldResult('s', 's__id', 'id');
+        $rsm->addFieldResult('s', 's__supported_units', 'supportedUnits');
+        $resultSet = [
+            [
+                's__id' => 1,
+                's__supported_units' => 'g,m,unknown_case',
+            ],
+        ];
+
+        $stmt     = $this->createResultMock($resultSet);
+        $hydrator = new SimpleObjectHydrator($this->entityManager);
+        $hydrator->hydrateAll($stmt, $rsm);
     }
 }


### PR DESCRIPTION
Add a test that failed to highlight the error described in #11796

> Using a json column with enumType, if the database contains a value that is not in enum, so an exception is thrown `AbstractHydrator::buildEnum` then converted to another exception in SimpleObjectHydrator. During this conversion, [the original value is casted into string](https://github.com/doctrine/orm/blob/3.3.x/src/Internal/Hydration/SimpleObjectHydrator.php#L148). In case of array of enum (json or simple array), `$originalValue` contains an array of string that can not be casted to string. So we got the "Array to string conversion" error instead of a proper error about a case not listed in the enum.