### PR TITLE
Fix documentation for JoinColumn nullable

### DIFF
--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -1368,8 +1368,7 @@ defaults to "id", just as in one-to-one or many-to-one mappings.
 
 Additionally, when using typed properties with Doctrine 2.9 or newer
 you can skip ``targetEntity`` in ``ManyToOne`` and ``OneToOne``
-associations as they will be set based on type. Also ``nullable``
-attribute on ``JoinColumn`` will be inherited from PHP type. So that:
+associations as they will be set based on type. So that:
 
 .. configuration-block::
 
@@ -1409,7 +1408,7 @@ Is essentially the same as following:
         <?php
         /** One Product has One Shipment. */
         #[OneToOne(targetEntity: Shipment::class)]
-        #[JoinColumn(name: 'shipment_id', referencedColumnName: 'id', nullable: false)]
+        #[JoinColumn(name: 'shipment_id', referencedColumnName: 'id')]
         private Shipment $shipment;
 
     .. code-block:: annotation
@@ -1418,7 +1417,7 @@ Is essentially the same as following:
         /**
          * One Product has One Shipment.
          * @OneToOne(targetEntity="Shipment")
-         * @JoinColumn(name="shipment_id", referencedColumnName="id", nullable=false)
+         * @JoinColumn(name="shipment_id", referencedColumnName="id")
          */
         private Shipment $shipment;
 
@@ -1442,7 +1441,6 @@ Is essentially the same as following:
               joinColumn:
                 name: shipment_id
                 referencedColumnName: id
-                nullable: false
 
 If you accept these defaults, you can reduce the mapping code to a
 minimum.


### PR DESCRIPTION
Nullability is not inherited from the PHP type. The change that enabled this feature was reversed in https://github.com/doctrine/orm/pull/8732.

Fixes #11797.