### PR TITLE
Display Doctrine deprecations when running PHPUnit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          failOnNotice="true"
@@ -67,5 +68,12 @@
         <var name="privileged_db_port" value="3306"/>
         -->
         <env name="COLUMNS" value="120"/>
+        <env name="DOCTRINE_DEPRECATIONS" value="trigger"/>
     </php>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Tests/ORM/Functional/PaginationTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\AST\WhereClause;
+use Doctrine\ORM\Query\SqlOutputWalker;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -643,7 +644,7 @@ class PaginationTest extends OrmFunctionalTestCase
         self::assertCount(2, $getCountQuery->invoke($paginator)->getParameters());
         self::assertCount(9, $paginator);
 
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SqlWalker::class);
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SqlOutputWalker::class);
 
         $paginator = new Paginator($query);
 

--- a/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionMethod;
 use Symfony\Component\VarExporter\Instantiator;
 use Symfony\Component\VarExporter\VarExporter;
@@ -34,6 +35,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
 
     /** @param Closure(ParserResult): ParserResult $toSerializedAndBack */
     #[DataProvider('provideToSerializedAndBack')]
+    #[WithoutErrorHandler]
     public function testSerializeParserResultForQueryWithSqlWalker(Closure $toSerializedAndBack): void
     {
         $query = $this->_em

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -52,6 +52,7 @@ use Doctrine\Tests\OrmTestCase;
 use DoctrineGlobalArticle;
 use LogicException;
 use PHPUnit\Framework\Attributes\Group as TestGroup;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionClass;
 use stdClass;
 
@@ -1074,6 +1075,7 @@ class ClassMetadataTest extends OrmTestCase
         $metadata->addLifecycleCallback('foo', 'bar');
     }
 
+    #[WithoutErrorHandler]
     public function testGettingAnFQCNForNullIsDeprecated(): void
     {
         $metadata = new ClassMetadata(self::class);
@@ -1112,6 +1114,7 @@ class ClassMetadataTest extends OrmTestCase
         );
     }
 
+    #[WithoutErrorHandler]
     public function testDiscriminatorMapWithSameClassMultipleTimesDeprecated(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/3519');

--- a/tests/Tests/ORM/Mapping/TableMappingTest.php
+++ b/tests/Tests/ORM/Mapping/TableMappingTest.php
@@ -6,12 +6,14 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\Table;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 final class TableMappingTest extends TestCase
 {
     use VerifyDeprecations;
 
+    #[WithoutErrorHandler]
     public function testDeprecationOnIndexesPropertyIsTriggered(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');
@@ -19,6 +21,7 @@ final class TableMappingTest extends TestCase
         new Table(indexes: []);
     }
 
+    #[WithoutErrorHandler]
     public function testDeprecationOnUniqueConstraintsPropertyIsTriggered(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');


### PR DESCRIPTION
This will give a signal that there is work to be done without blocking other contributions by failing the build.