### PR TITLE
Address quoteIdentifier() deprecation

### DIFF
--- a/src/Mapping/DefaultQuoteStrategy.php
+++ b/src/Mapping/DefaultQuoteStrategy.php
@@ -24,7 +24,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
     public function getColumnName(string $fieldName, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return isset($class->fieldMappings[$fieldName]->quoted)
-            ? $platform->quoteIdentifier($class->fieldMappings[$fieldName]->columnName)
+            ? $platform->quoteSingleIdentifier($class->fieldMappings[$fieldName]->columnName)
             : $class->fieldMappings[$fieldName]->columnName;
     }
 
@@ -42,7 +42,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
         }
 
         return isset($class->table['quoted'])
-            ? $platform->quoteIdentifier($tableName)
+            ? $platform->quoteSingleIdentifier($tableName)
             : $tableName;
     }
 
@@ -52,14 +52,14 @@ class DefaultQuoteStrategy implements QuoteStrategy
     public function getSequenceName(array $definition, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return isset($definition['quoted'])
-            ? $platform->quoteIdentifier($definition['sequenceName'])
+            ? $platform->quoteSingleIdentifier($definition['sequenceName'])
             : $definition['sequenceName'];
     }
 
     public function getJoinColumnName(JoinColumnMapping $joinColumn, ClassMetadata $class, AbstractPlatform $platform): string
     {
         return isset($joinColumn->quoted)
-            ? $platform->quoteIdentifier($joinColumn->name)
+            ? $platform->quoteSingleIdentifier($joinColumn->name)
             : $joinColumn->name;
     }
 
@@ -69,7 +69,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
         AbstractPlatform $platform,
     ): string {
         return isset($joinColumn->quoted)
-            ? $platform->quoteIdentifier($joinColumn->referencedColumnName)
+            ? $platform->quoteSingleIdentifier($joinColumn->referencedColumnName)
             : $joinColumn->referencedColumnName;
     }
 
@@ -87,7 +87,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
         $tableName = $association->joinTable->name;
 
         if (isset($association->joinTable->quoted)) {
-            $tableName = $platform->quoteIdentifier($tableName);
+            $tableName = $platform->quoteSingleIdentifier($tableName);
         }
 
         return $schema . $tableName;
@@ -113,7 +113,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
             $joinColumns            = $assoc->joinColumns;
             $assocQuotedColumnNames = array_map(
                 static fn (JoinColumnMapping $joinColumn) => isset($joinColumn->quoted)
-                    ? $platform->quoteIdentifier($joinColumn->name)
+                    ? $platform->quoteSingleIdentifier($joinColumn->name)
                     : $joinColumn->name,
                 $joinColumns,
             );

--- a/tests/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -42,14 +42,14 @@ class DDC832Test extends OrmFunctionalTestCase
         $platform = $this->_em->getConnection()->getDatabasePlatform();
 
         $sm = $this->createSchemaManager();
-        $sm->dropTable($platform->quoteIdentifier('TREE_INDEX'));
-        $sm->dropTable($platform->quoteIdentifier('INDEX'));
-        $sm->dropTable($platform->quoteIdentifier('LIKE'));
+        $sm->dropTable($platform->quoteSingleIdentifier('TREE_INDEX'));
+        $sm->dropTable($platform->quoteSingleIdentifier('INDEX'));
+        $sm->dropTable($platform->quoteSingleIdentifier('LIKE'));
 
         // DBAL 3
         if ($platform instanceof PostgreSQLPlatform && method_exists($platform, 'getIdentitySequenceName')) {
-            $sm->dropSequence($platform->quoteIdentifier('INDEX_id_seq'));
-            $sm->dropSequence($platform->quoteIdentifier('LIKE_id_seq'));
+            $sm->dropSequence($platform->quoteSingleIdentifier('INDEX_id_seq'));
+            $sm->dropSequence($platform->quoteSingleIdentifier('LIKE_id_seq'));
         }
     }
 

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -614,7 +614,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($this->_usedModelSets['directorytree'])) {
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('file'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('file'));
             // MySQL doesn't know deferred deletions therefore only executing the second query gives errors.
             $conn->executeStatement('DELETE FROM Directory WHERE parentDirectory_id IS NOT NULL');
             $conn->executeStatement('DELETE FROM Directory');
@@ -707,17 +707,17 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement(
                 sprintf(
                     'UPDATE %s SET %s = NULL',
-                    $platform->quoteIdentifier('quote-address'),
-                    $platform->quoteIdentifier('user-id'),
+                    $platform->quoteSingleIdentifier('quote-address'),
+                    $platform->quoteSingleIdentifier('user-id'),
                 ),
             );
 
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-users-groups'));
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-group'));
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-phone'));
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-user'));
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-address'));
-            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-city'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-users-groups'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-group'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-phone'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-user'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-address'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteSingleIdentifier('quote-city'));
         }
 
         if (isset($this->_usedModelSets['vct_onetoone'])) {


### PR DESCRIPTION
We should be using `quoteSingleIdentifier()`, assuming we only ever pass single identifiers here.

See https://github.com/doctrine/dbal/pull/6590