### PR TITLE
Test quoted qualified name

### DIFF
--- a/tests/Tests/ORM/Functional/Mapping/PostgreSqlDefaultQuoteStrategyTest.php
+++ b/tests/Tests/ORM/Functional/Mapping/PostgreSqlDefaultQuoteStrategyTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Mapping;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function method_exists;
+
+class PostgreSqlDefaultQuoteStrategyTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+        if (! $platform instanceof PostgreSQLPlatform) {
+            self::markTestSkipped(self::class . ' requires the use of postgresql.');
+        }
+
+        $this->_em         = $this->getEntityManager(
+            null,
+            new AttributeDriver([__DIR__], true)
+        );
+        $this->_schemaTool = new SchemaTool($this->_em);
+    }
+
+    public function testQuotingStillAllowsInterpretingDotAsSchemaSeparator(): void
+    {
+        $this->createSchemaForModels(Product::class);
+        $schemaManager = $this->createSchemaManager();
+        if (! method_exists($schemaManager, 'listSchemaNames')) {
+            self::markTestSkipped('This test requires DBAL 3.1 or newer.');
+        }
+
+        self::assertContains(
+            'inventory',
+            $schemaManager->listSchemaNames(),
+            '"inventory" should be interpreted as a schema name, even when quoted.'
+        );
+        self::assertContains(
+            'inventory."Products"',
+            $schemaManager->listTableNames(),
+            '"Products" should be interpreted as a table name, even when quoted.'
+        );
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: '`inventory`.`Products`')] // Using backticks to make sure capitalization is preserved
+class Product
+{
+    /** @var int|null */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    public $id = null;
+}


### PR DESCRIPTION
The current behavior is that a quote in the table name should result in the name being considered "quoted" and be passed to DBAL's `quoteIdentifier()` method, which should quote each identifier individually (so the dot is still interpreted as a schema separator).

This is prompted by https://github.com/doctrine/dbal/pull/6590: let's make sure we don't break the current behavior when addressing the deprecation.