### PR TITLE
[RFC] Expose QueryBuilder::getType

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\Internal\NoUnknownNamedArguments;
-use Doctrine\ORM\Internal\QueryType;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryExpressionVisitor;
@@ -126,6 +125,11 @@ class QueryBuilder implements Stringable
         private readonly EntityManagerInterface $em,
     ) {
         $this->parameters = new ArrayCollection();
+    }
+
+    final protected function getType(): QueryType
+    {
+        return $this->type;
     }
 
     /**

--- a/src/QueryType.php
+++ b/src/QueryType.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\ORM\Internal;
+namespace Doctrine\ORM;
 
-/** @internal To be used inside the QueryBuilder only. */
 enum QueryType
 {
     case Select;

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\QueryType;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\Models\CMS\CmsArticle;
@@ -23,6 +24,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
 
 use function array_filter;
 use function class_exists;
@@ -1325,5 +1327,26 @@ class QueryBuilderTest extends OrmTestCase
         self::assertEquals(Types::STRING, $qb->getParameter('test')->getType());
         self::assertEquals(100, $qb->getParameter('dcValue1')->getValue());
         self::assertEquals(Types::INTEGER, $qb->getParameter('dcValue1')->getType());
+    }
+
+    public function testType(): void
+    {
+        $qb = new class ($this->entityManager) extends QueryBuilder {
+            public function test(): void
+            {
+                TestCase::assertSame(QueryType::Select, $this->getType());
+
+                $this->delete();
+                TestCase::assertSame(QueryType::Delete, $this->getType());
+
+                $this->update();
+                TestCase::assertSame(QueryType::Update, $this->getType());
+
+                $this->select();
+                TestCase::assertSame(QueryType::Select, $this->getType());
+            }
+        };
+
+        $qb->test();
     }
 }


### PR DESCRIPTION
I have an implementation where I extends the QueryBuilder in order to provide extra methods.
In one of them, I'd like an easy way to know if the queryBuilder is creating a select, an update or a delete query.

I could extends `select`, `addSelect`, `update` and `delete` to keep a state with the type of the current query, but it seems like the QueryBuilder already does this. So I'd like to expose this information.

Are you okay with this ?