### PR TITLE
FIX - nested dto's doesn't have arguments in good order and Dto with only objects bug

### DIFF
--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -18,12 +18,14 @@ use Generator;
 use LogicException;
 use ReflectionClass;
 
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
 use function end;
 use function in_array;
 use function is_array;
+use function ksort;
 
 /**
  * Base class for all hydrators. A hydrator is a class that provides some form
@@ -263,6 +265,17 @@ abstract class AbstractHydrator
     {
         $rowData = ['data' => [], 'newObjects' => []];
 
+        foreach ($this->rsm->newObjectMappings as $mapping) {
+            if (! array_key_exists($mapping['objIndex'], $this->rsm->newObject)) {
+                $this->rsm->newObject[$mapping['objIndex']] = $mapping['className'];
+            }
+        }
+
+        foreach ($this->rsm->newObject as $objIndex => $newObject) {
+            $rowData['newObjects'][$objIndex]['class'] = new ReflectionClass($newObject);
+            $rowData['newObjects'][$objIndex]['args']  = [];
+        }
+
         foreach ($data as $key => $value) {
             $cacheKeyInfo = $this->hydrateColumnInfo($key);
             if ($cacheKeyInfo === null) {
@@ -282,7 +295,6 @@ abstract class AbstractHydrator
                         $value = $this->buildEnum($value, $cacheKeyInfo['enumType']);
                     }
 
-                    $rowData['newObjects'][$objIndex]['class']           = $cacheKeyInfo['class'];
                     $rowData['newObjects'][$objIndex]['args'][$argIndex] = $value;
                     break;
 
@@ -336,21 +348,17 @@ abstract class AbstractHydrator
             }
         }
 
-        foreach ($this->resultSetMapping()->nestedNewObjectArguments as $objIndex => ['ownerIndex' => $ownerIndex, 'argIndex' => $argIndex]) {
-            if (! isset($rowData['newObjects'][$ownerIndex . ':' . $argIndex])) {
-                continue;
+        foreach ($this->resultSetMapping()->nestedNewObjectArguments as ['ownerIndex' => $ownerIndex, 'argIndex' => $argIndex, 'argAlias' => $argAlias]) {
+            if (array_key_exists($argAlias, $rowData['newObjects'])) {
+                ksort($rowData['newObjects'][$argAlias]['args']);
+                $rowData['newObjects'][$ownerIndex]['args'][$argIndex] = $rowData['newObjects'][$argAlias]['class']->newInstanceArgs($rowData['newObjects'][$argAlias]['args']);
+                unset($rowData['newObjects'][$argAlias]);
             }
-
-            $newObject = $rowData['newObjects'][$ownerIndex . ':' . $argIndex];
-            unset($rowData['newObjects'][$ownerIndex . ':' . $argIndex]);
-
-            $obj = $newObject['class']->newInstanceArgs($newObject['args']);
-
-            $rowData['newObjects'][$ownerIndex]['args'][$argIndex] = $obj;
         }
 
         foreach ($rowData['newObjects'] as $objIndex => $newObject) {
-            $obj = $newObject['class']->newInstanceArgs($newObject['args']);
+            ksort($rowData['newObjects'][$objIndex]['args']);
+            $obj = $rowData['newObjects'][$objIndex]['class']->newInstanceArgs($rowData['newObjects'][$objIndex]['args']);
 
             $rowData['newObjects'][$objIndex]['obj'] = $obj;
         }
@@ -454,7 +462,6 @@ abstract class AbstractHydrator
                     'type'                 => Type::getType($this->rsm->typeMappings[$key]),
                     'argIndex'             => $mapping['argIndex'],
                     'objIndex'             => $mapping['objIndex'],
-                    'class'                => new ReflectionClass($mapping['className']),
                     'enumType'             => $this->rsm->enumMappings[$key] ?? null,
                 ];
 

--- a/src/Query/AST/NewObjectExpression.php
+++ b/src/Query/AST/NewObjectExpression.php
@@ -6,6 +6,9 @@ namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\SqlWalker;
 
+use function func_get_arg;
+use function func_num_args;
+
 /**
  * NewObjectExpression ::= "NEW" IdentificationVariable "(" NewObjectArg {"," NewObjectArg}* ")"
  *
@@ -13,13 +16,18 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class NewObjectExpression extends Node
 {
-    /** @param mixed[] $args */
+    /**
+     * @param class-string $className
+     * @param mixed[]      $args
+     */
     public function __construct(public string $className, public array $args)
     {
     }
 
-    public function dispatch(SqlWalker $walker): string
+    public function dispatch(SqlWalker $walker /*, string|null $parentAlias = null */): string
     {
-        return $walker->walkNewObject($this);
+        $parentAlias = func_num_args() > 1 ? func_get_arg(1) : null;
+
+        return $walker->walkNewObject($this, $parentAlias);
     }
 }

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1767,6 +1767,7 @@ final class Parser
             $useNamedArguments = true;
         }
 
+        /** @var class-string $className */
         $className = $this->AbstractSchemaName(); // note that this is not yet validated
         $token     = $this->lexer->token;
 
@@ -1854,7 +1855,11 @@ final class Parser
 
         if ($this->lexer->isNextToken(TokenType::T_AS)) {
             $this->match(TokenType::T_AS);
-            $fieldAlias = $this->AliasIdentificationVariable();
+            $this->match(TokenType::T_IDENTIFIER);
+
+            assert($this->lexer->token !== null);
+
+            $fieldAlias = $this->lexer->token->value;
         }
 
         return $expression;

--- a/src/Query/ResultSetMapping.php
+++ b/src/Query/ResultSetMapping.php
@@ -160,6 +160,13 @@ class ResultSetMapping
     public array $newObjectMappings = [];
 
     /**
+     * Maps object Ids in the result set to classnames.
+     *
+     * @phpstan-var array<string|int, class-string>
+     */
+    public array $newObject = [];
+
+    /**
      * Maps last argument for new objects in order to initiate object construction
      *
      * @phpstan-var array<int|string, array{ownerIndex: string|int, argIndex: int|string}>

--- a/tests/Tests/Models/CMS/CmsAddressDTO.php
+++ b/tests/Tests/Models/CMS/CmsAddressDTO.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Models\CMS;
 
 class CmsAddressDTO
 {
-    public function __construct(public string|null $country = null, public string|null $city = null, public string|null $zip = null, public CmsAddressDTO|string|null $address = null)
+    public function __construct(public string|null $country = null, public string|null $city = null, public string|null $zip = null, public string|null $address = null, public CmsDumbDTO|null $other = null)
     {
     }
 }

--- a/tests/Tests/Models/CMS/CmsDumbDTO.php
+++ b/tests/Tests/Models/CMS/CmsDumbDTO.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+class CmsDumbDTO
+{
+    public function __construct(
+        public mixed $val1 = null,
+        public mixed $val2 = null,
+        public mixed $val3 = null,
+        public mixed $val4 = null,
+        public mixed $val5 = null,
+    ) {
+    }
+}


### PR DESCRIPTION
for resolve https://github.com/doctrine/orm/issues/11824

add arguments sort for nested dto's contructors 

Working on another PR, I figure that when a Dto have only objects as arguments `newObjectMappings` was not filled so I move parent declaration in `newObject` (keeping BC)