### PR TITLE
Clone query hints and parameters in `LimitSubqueryOutputWalker` constructor

### DIFF
--- a/src/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/src/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -105,17 +105,24 @@ class LimitSubqueryOutputWalker extends SqlOutputWalker
         $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
         $this->rsm      = $parserResult->getResultSetMapping();
 
-        $query = clone $query;
+        $cloneQuery = clone $query;
+
+        $cloneQuery->setParameters(clone $query->getParameters());
+        $cloneQuery->setCacheable(false);
+
+        foreach ($query->getHints() as $name => $value) {
+            $cloneQuery->setHint($name, $value);
+        }
 
         // Reset limit and offset
-        $this->firstResult = $query->getFirstResult();
-        $this->maxResults  = $query->getMaxResults();
-        $query->setFirstResult(0)->setMaxResults(null);
+        $this->firstResult = $cloneQuery->getFirstResult();
+        $this->maxResults  = $cloneQuery->getMaxResults();
+        $cloneQuery->setFirstResult(0)->setMaxResults(null);
 
-        $this->em            = $query->getEntityManager();
+        $this->em            = $cloneQuery->getEntityManager();
         $this->quoteStrategy = $this->em->getConfiguration()->getQuoteStrategy();
 
-        parent::__construct($query, $parserResult, $queryComponents);
+        parent::__construct($cloneQuery, $parserResult, $queryComponents);
     }
 
     /**

--- a/tests/Tests/ORM/Functional/EagerFetchCollectionTest.php
+++ b/tests/Tests/ORM/Functional/EagerFetchCollectionTest.php
@@ -7,9 +7,11 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function count;
+use function iterator_to_array;
 
 class EagerFetchCollectionTest extends OrmFunctionalTestCase
 {
@@ -94,6 +96,16 @@ class EagerFetchCollectionTest extends OrmFunctionalTestCase
         $query->setFetchMode(EagerFetchChild::class, 'owner', ORM\ClassMetadata::FETCH_LAZY);
 
         $this->assertIsString($query->getSql());
+    }
+
+    public function testSubselectFetchJoinWithAllowedWhenOverriddenNotEagerPaginator(): void
+    {
+        $query = $this->_em->createQuery('SELECT o, c FROM ' . EagerFetchOwner::class . ' o JOIN o.children c WITH c.id = 1');
+        $query->setMaxResults(1);
+        $query->setFetchMode(EagerFetchChild::class, 'owner', ORM\ClassMetadata::FETCH_LAZY);
+
+        $paginator = new Paginator($query, true);
+        $this->assertIsArray(iterator_to_array($paginator));
     }
 
     public function testEagerFetchWithIterable(): void


### PR DESCRIPTION
Fixes #11741

Should be merged up to at least v2.20.0 and v3.3.0.

The problem seems to be that `LimitSubqueryOutputWalker` clones the `Query` object, but not its hints (including the `fetchMode` hint, which causes the issue).
Don't know if cloning the parameters is really needed.
Been inspired on what the class `Paginator` does when cloning a `Query`.
Suggestions are welcome!