### PR TITLE
fix: calling scheduleForInsert twice

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1059,7 +1059,9 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->entityStates[$oid] = self::STATE_MANAGED;
 
-        $this->scheduleForInsert($entity);
+        if (!isset($this->entityInsertions[$oid])) {
+            $this->scheduleForInsert($entity);;
+        }
     }
 
     /** @param mixed[] $idValue */

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1060,7 +1060,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->entityStates[$oid] = self::STATE_MANAGED;
 
         if (!isset($this->entityInsertions[$oid])) {
-            $this->scheduleForInsert($entity);;
+            $this->scheduleForInsert($entity);
         }
     }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1059,7 +1059,7 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->entityStates[$oid] = self::STATE_MANAGED;
 
-        if (!isset($this->entityInsertions[$oid])) {
+        if (! isset($this->entityInsertions[$oid])) {
             $this->scheduleForInsert($entity);
         }
     }

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -13,6 +13,8 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function uniqid;
+
 /**
  * PrePersistEventTest
  */
@@ -24,19 +26,19 @@ class PrePersistEventTest extends OrmFunctionalTestCase
 
         $this->createSchemaForModels(
             EntityWithUnmapEntity::class,
-            EntityWithCascadeAssociation::class,
+            EntityWithCascadeAssociation::class
         );
     }
 
     public function testCallingPersistInPrePersistHook(): void
     {
         $entityWithUnmapped = new EntityWithUnmapEntity();
-        $entityWithCascade = new EntityWithCascadeAssociation();
+        $entityWithCascade  = new EntityWithCascadeAssociation();
 
         $entityWithUnmapped->unmapped = $entityWithCascade;
-        $entityWithCascade->cascaded = $entityWithUnmapped;
+        $entityWithCascade->cascaded  = $entityWithUnmapped;
 
-        $this->_em->getEventManager()->addEventListener(Events::prePersist, new PrePersistUnmappedPersistListener);
+        $this->_em->getEventManager()->addEventListener(Events::prePersist, new PrePersistUnmappedPersistListener());
         $this->_em->persist($entityWithUnmapped);
 
         $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForInsert($entityWithCascade));
@@ -53,22 +55,30 @@ class PrePersistUnmappedPersistListener
         if ($object instanceof EntityWithUnmapEntity) {
             $uow = $args->getObjectManager()->getUnitOfWork();
 
-            if (!$uow->isInIdentityMap($object->unmapped) && !$uow->isScheduledForInsert($object->unmapped) && $object->unmapped) {
+            if (! $uow->isInIdentityMap($object->unmapped) && ! $uow->isScheduledForInsert($object->unmapped) && $object->unmapped) {
                 $args->getObjectManager()->persist($object->unmapped);
             }
         }
     }
 }
 
+/** @Entity */
 #[Entity]
 class EntityWithUnmapEntity
 {
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string", length=255)
+     * @GeneratedValue(strategy="NONE")
+     */
     #[Id]
     #[Column(type: 'string', length: 255)]
     #[GeneratedValue(strategy: 'NONE')]
-    public string $id;
+    public $id;
 
-    public EntityWithCascadeAssociation|null $unmapped = null;
+    /** @var ?EntityWithCascadeAssociation  */
+    public $unmapped = null;
 
     public function __construct()
     {
@@ -76,16 +86,27 @@ class EntityWithUnmapEntity
     }
 }
 
+/** @Entity */
 #[Entity]
 class EntityWithCascadeAssociation
 {
+    /**
+     * @var string
+     * @Id
+     * @Column(type="string", length=255)
+     * @GeneratedValue(strategy="NONE")
+     */
     #[Id]
     #[Column(type: 'string', length: 255)]
     #[GeneratedValue(strategy: 'NONE')]
-    public string $id;
+    public $id;
 
+    /**
+     * @var ?EntityWithUnmapEntity
+     * @ManyToOne(targetEntity=EntityWithUnmapEntity::class, cascade={"persist"})
+     */
     #[ManyToOne(targetEntity: EntityWithUnmapEntity::class, cascade: ['persist'])]
-    public EntityWithUnmapEntity|null $cascaded = null;
+    public $cascaded = null;
 
     public function __construct()
     {

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -15,9 +15,6 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function uniqid;
 
-/**
- * PrePersistEventTest
- */
 class PrePersistEventTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
@@ -25,14 +22,14 @@ class PrePersistEventTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->createSchemaForModels(
-            EntityWithUnmapEntity::class,
+            EntityWithUnmappedEntity::class,
             EntityWithCascadeAssociation::class
         );
     }
 
     public function testCallingPersistInPrePersistHook(): void
     {
-        $entityWithUnmapped = new EntityWithUnmapEntity();
+        $entityWithUnmapped = new EntityWithUnmappedEntity();
         $entityWithCascade  = new EntityWithCascadeAssociation();
 
         $entityWithUnmapped->unmapped = $entityWithCascade;
@@ -52,7 +49,7 @@ class PrePersistUnmappedPersistListener
     {
         $object = $args->getObject();
 
-        if ($object instanceof EntityWithUnmapEntity) {
+        if ($object instanceof EntityWithUnmappedEntity) {
             $uow = $args->getObjectManager()->getUnitOfWork();
 
             if ($object->unmapped && ! $uow->isInIdentityMap($object->unmapped) && ! $uow->isScheduledForInsert($object->unmapped)) {
@@ -64,7 +61,7 @@ class PrePersistUnmappedPersistListener
 
 /** @Entity */
 #[Entity]
-class EntityWithUnmapEntity
+class EntityWithUnmappedEntity
 {
     /**
      * @var string
@@ -102,10 +99,10 @@ class EntityWithCascadeAssociation
     public $id;
 
     /**
-     * @var ?EntityWithUnmapEntity
-     * @ManyToOne(targetEntity=EntityWithUnmapEntity::class, cascade={"persist"})
+     * @var ?EntityWithUnmappedEntity
+     * @ManyToOne(targetEntity=EntityWithUnmappedEntity::class, cascade={"persist"})
      */
-    #[ManyToOne(targetEntity: EntityWithUnmapEntity::class, cascade: ['persist'])]
+    #[ManyToOne(targetEntity: EntityWithUnmappedEntity::class, cascade: ['persist'])]
     public $cascaded = null;
 
     public function __construct()

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -55,7 +55,7 @@ class PrePersistUnmappedPersistListener
         if ($object instanceof EntityWithUnmapEntity) {
             $uow = $args->getObjectManager()->getUnitOfWork();
 
-            if (! $uow->isInIdentityMap($object->unmapped) && ! $uow->isScheduledForInsert($object->unmapped) && $object->unmapped) {
+            if ($object->unmapped && ! $uow->isInIdentityMap($object->unmapped) && ! $uow->isScheduledForInsert($object->unmapped)) {
                 $args->getObjectManager()->persist($object->unmapped);
             }
         }

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * PrePersistEventTest
+ */
+class PrePersistEventTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            EntityWithUnmapEntity::class,
+            EntityWithCascadeAssociation::class,
+        );
+    }
+
+    public function testCallingPersistInPrePersistHook(): void
+    {
+        $entityWithUnmapped = new EntityWithUnmapEntity();
+        $entityWithCascade = new EntityWithCascadeAssociation();
+
+        $entityWithUnmapped->unmapped = $entityWithCascade;
+        $entityWithCascade->cascaded = $entityWithUnmapped;
+
+        $this->_em->getEventManager()->addEventListener(Events::prePersist, new PrePersistUnmappedPersistListener);
+        $this->_em->persist($entityWithUnmapped);
+
+        $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForInsert($entityWithCascade));
+        $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForInsert($entityWithUnmapped));
+    }
+}
+
+class PrePersistUnmappedPersistListener
+{
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $object = $args->getObject();
+
+        if ($object instanceof EntityWithUnmapEntity) {
+            $uow = $args->getObjectManager()->getUnitOfWork();
+
+            if (!$uow->isInIdentityMap($object->unmapped) && !$uow->isScheduledForInsert($object->unmapped) && $object->unmapped) {
+                $args->getObjectManager()->persist($object->unmapped);
+            }
+        }
+    }
+}
+
+#[Entity]
+class EntityWithUnmapEntity
+{
+    #[Id]
+    #[Column(type: 'string', length: 255)]
+    #[GeneratedValue(strategy: 'NONE')]
+    public string $id;
+
+    public EntityWithCascadeAssociation|null $unmapped = null;
+
+    public function __construct()
+    {
+        $this->id = uniqid(self::class, true);
+    }
+}
+
+#[Entity]
+class EntityWithCascadeAssociation
+{
+    #[Id]
+    #[Column(type: 'string', length: 255)]
+    #[GeneratedValue(strategy: 'NONE')]
+    public string $id;
+
+    #[ManyToOne(targetEntity: EntityWithUnmapEntity::class, cascade: ['persist'])]
+    public EntityWithUnmapEntity|null $cascaded = null;
+
+    public function __construct()
+    {
+        $this->id = uniqid(self::class, true);
+    }
+}


### PR DESCRIPTION
If `scheduleForInsert` was called in `prePersist` hook already, then `persistNew` need to check this case first, otherwise a `ORMInvalidArgumentException` will be thrown.

Describing my use case:

Trying to implement some "two column polymorphism", see discusson https://github.com/doctrine/orm/discussions/9928.
So I want to call a persist on an unmapped property. This works fine for most cases. But if the entity inside the unmapped property has some cascade persist to the entity carrying the unmapped property, then the `scheduleForInsert` will be called twice. Once for the cascading inside the hook and later on the `persistNew` which called the hook at first. You may see the use case on the provided functional test.
