### PR TITLE
Final tests and adjustments to allow mapping properties with hooks

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -214,6 +214,8 @@ These are the "automatic" mapping rules:
 | Any other type        | ``Types::STRING``             |
 +-----------------------+-------------------------------+
 
+.. versionadded:: 2.11
+
 As of version 2.11 Doctrine can also automatically map typed properties using a
 PHP 8.1 enum to set the right ``type`` and ``enumType``.
 
@@ -223,6 +225,70 @@ Since version 2.14 you can specify custom typed field mapping between PHP type a
 and a custom ``Doctrine\ORM\Mapping\TypedFieldMapper`` implementation.
 
 :doc:`Read more about TypedFieldMapper <typedfieldmapper>`.
+
+Property Hooks
+--------------
+
+.. versionadded:: 3.4
+
+Doctrine supports mapping hooked properties as long as they have a backed property
+and are not virtual.
+
+
+.. configuration-block::
+
+    .. code-block:: attribute
+
+        <?php
+        use Doctrine\ORM\Mapping\Column;
+        use Doctrine\DBAL\Types\Types;
+
+        #[Entity]
+        class Message
+        {
+            #[Column(type: Types::INTEGER)]
+            private $id;
+            #[Column(type: Types::STRING)]
+            public string $language = 'de' {
+                // Override the "read" action with arbitrary logic.
+                get => strtoupper($this->language);
+
+                // Override the "write" action with arbitrary logic.
+                set {
+                    $this->language = strtolower($value);
+                }
+            }
+        }
+
+    .. code-block:: xml
+
+        <doctrine-mapping>
+          <entity name="Message">
+            <field name="id" type="integer" />
+            <field name="language" />
+          </entity>
+        </doctrine-mapping>
+
+If you attempt to map a virtual property with `#[Column]` an exception will be thrown.
+
+Some caveats apply to the use of property hooks, as they behave differently when accessing the property through
+the entity or directly through DQL/EntityRepository. Because the property hook can modify the value of the property in a way
+that value and raw value are different, you have to use the raw value representation when querying for the property.
+
+.. code-block:: php
+
+    <?php
+    $queryBuilder = $entityManager->createQueryBuilder();
+    $queryBuilder->select('m')
+        ->from(Message::class, 'm')
+        ->where('m.language = :language')
+        ->setParameter('language', 'de'); // Use lower case here for raw value representation
+
+    $query = $queryBuilder->getQuery();
+    $result = $query->getResult();
+
+    $messageRepository = $entityManager->getRepository(Message::class);
+    $deMessages = $messageRepository->findBy(['language' => 'de']); // Use lower case here for raw value representation
 
 .. _reference-mapping-types:
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -269,7 +269,7 @@ and are not virtual.
           </entity>
         </doctrine-mapping>
 
-If you attempt to map a virtual property with `#[Column]` an exception will be thrown.
+If you attempt to map a virtual property with ``#[Column]`` an exception will be thrown.
 
 Some caveats apply to the use of property hooks, as they behave differently when accessing the property through
 the entity or directly through DQL/EntityRepository. Because the property hook can modify the value of the property in a way

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -24,7 +24,6 @@ use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\ReflectionService;
-use LogicException;
 use ReflectionClass;
 use ReflectionException;
 
@@ -298,14 +297,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         } elseif ($class->isMappedSuperclass && $class->name === $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
             throw MappingException::noInheritanceOnMappedSuperClass($class->name);
-        }
-
-        foreach ($class->propertyAccessors as $propertyAccessor) {
-            $property = $propertyAccessor->getUnderlyingReflector();
-
-            if (PHP_VERSION_ID >= 80400 && count($property->getHooks()) > 0) {
-                throw new LogicException('Doctrine ORM does not support property hooks without also enabling Configuration::enableNativeLazyObjects(true). Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.');
-            }
         }
     }
 
@@ -710,6 +701,18 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     protected function wakeupReflection(ClassMetadataInterface $class, ReflectionService $reflService): void
     {
         $class->wakeupReflection($reflService);
+
+        if (PHP_VERSION_ID < 80400) {
+            return;
+        }
+
+        foreach ($class->propertyAccessors as $propertyAccessor) {
+            $property = $propertyAccessor->getUnderlyingReflector();
+
+            if ($property->isVirtual()) {
+                throw MappingException::mappingVirtualPropertyNotAllowed($class->name, $property->getName());
+            }
+        }
     }
 
     protected function initializeReflection(ClassMetadataInterface $class, ReflectionService $reflService): void

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -688,4 +688,13 @@ EXCEPTION
             $entityName,
         ));
     }
+
+    public static function mappingVirtualPropertyNotAllowed(string $entityName, string $propertyName): self
+    {
+        return new self(sprintf(
+            'Mapping virtual property "%s" on entity "%s" is not allowed.',
+            $propertyName,
+            $entityName,
+        ));
+    }
 }

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Proxy;
+use LogicException;
 use ReflectionClass;
 use ReflectionProperty;
 use Symfony\Component\VarExporter\ProxyHelper;

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -24,6 +24,7 @@ use function assert;
 use function bin2hex;
 use function chmod;
 use function class_exists;
+use function count;
 use function dirname;
 use function file_exists;
 use function file_put_contents;
@@ -38,6 +39,7 @@ use function preg_match_all;
 use function random_bytes;
 use function rename;
 use function rtrim;
+use function sprintf;
 use function str_replace;
 use function strpos;
 use function strrpos;
@@ -46,6 +48,7 @@ use function substr;
 use function ucfirst;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_VERSION_ID;
 
 /**
  * This factory is used to create proxy objects for entities at runtime.
@@ -281,6 +284,14 @@ EOPHP;
         while ($reflector) {
             foreach ($reflector->getProperties($filter) as $property) {
                 $name = $property->name;
+
+                if (PHP_VERSION_ID >= 80400 && count($property->getHooks()) > 0) {
+                    throw new LogicException(sprintf(
+                        'Doctrine ORM does not support property hook on %s::%s without using native lazy objects. Check https://github.com/doctrine/orm/issues/11624 for details of versions that support property hooks.',
+                        $property->getDeclaringClass()->getName(),
+                        $property->getName(),
+                    ));
+                }
 
                 if ($property->isStatic() || (($class->hasField($name) || $class->hasAssociation($name)) && ! isset($identifiers[$name]))) {
                     continue;

--- a/tests/Tests/Models/PropertyHooks/MappingVirtualProperty.php
+++ b/tests/Tests/Models/PropertyHooks/MappingVirtualProperty.php
@@ -1,0 +1,32 @@
+<?php
+// phpcs:ignoreFile
+namespace Doctrine\Tests\Models\PropertyHooks;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'property_hooks_user')]
+class MappingVirtualProperty
+{
+    #[Id, GeneratedValue, Column(type: Types::INTEGER)]
+    public ?int $id;
+
+    #[Column(type: Types::STRING)]
+    public string $first;
+
+    #[Column(type: Types::STRING)]
+    public string $last;
+
+    #[Column(type: Types::STRING)]
+    public string $fullName {
+        get => $this->first . " " . $this->last;
+        set {
+            [$this->first, $this->last] = explode(' ', $value, 2);
+        }
+    }
+}

--- a/tests/Tests/Models/PropertyHooks/User.php
+++ b/tests/Tests/Models/PropertyHooks/User.php
@@ -2,10 +2,21 @@
 // phpcs:ignoreFile
 namespace Doctrine\Tests\Models\PropertyHooks;
 
-use DateTime;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
 
+#[Entity]
+#[Table(name: 'property_hooks_user')]
 class User
 {
+    #[Id, GeneratedValue, Column(type: Types::INTEGER)]
+    public ?int $id;
+
+    #[Column(type: Types::STRING)]
     public string $first {
         set {
             if (strlen($value) === 0) {
@@ -15,6 +26,7 @@ class User
         }
     }
 
+    #[Column(type: Types::STRING)]
     public string $last {
         set {
             if (strlen($value) === 0) {
@@ -34,6 +46,7 @@ class User
         }
     }
 
+    #[Column(type: Types::STRING)]
     public string $language = 'de' {
         // Override the "read" action with arbitrary logic.
         get => strtoupper($this->language);

--- a/tests/Tests/Models/PropertyHooks/User.php
+++ b/tests/Tests/Models/PropertyHooks/User.php
@@ -37,10 +37,7 @@ class User
     }
 
     public string $fullName {
-        // Override the "read" action with arbitrary logic.
         get => $this->first . " " . $this->last;
-
-        // Override the "write" action with arbitrary logic.
         set {
             [$this->first, $this->last] = explode(' ', $value, 2);
         }

--- a/tests/Tests/ORM/Functional/PropertyHooksTest.php
+++ b/tests/Tests/ORM/Functional/PropertyHooksTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Tests\Models\PropertyHooks\MappingVirtualProperty;
 use Doctrine\Tests\Models\PropertyHooks\User;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -60,9 +62,27 @@ class PropertyHooksTest extends OrmFunctionalTestCase
 
         $user = $this->_em->getReference(User::class, $user->id);
 
+        $this->assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($user));
+
         self::assertEquals('Ludwig', $user->first);
         self::assertEquals('von Beethoven', $user->last);
         self::assertEquals('Ludwig von Beethoven', $user->fullName);
         self::assertEquals('DE', $user->language, 'The property hook uppercases the language.');
+
+        $this->assertFalse($this->_em->getUnitOfWork()->isUninitializedObject($user));
+
+        $this->_em->clear();
+
+        $user = $this->_em->getReference(User::class, $user->id);
+
+        self::assertEquals('Ludwig von Beethoven', $user->fullName);
+    }
+
+    public function testMappingVirtualPropertyIsNotSupported(): void
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Mapping virtual property "fullName" on entity "Doctrine\Tests\Models\PropertyHooks\MappingVirtualProperty" is not allowed.');
+
+        $this->_em->getClassMetadata(MappingVirtualProperty::class);
     }
 }

--- a/tests/Tests/ORM/Functional/PropertyHooksTest.php
+++ b/tests/Tests/ORM/Functional/PropertyHooksTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\PropertyHooks\User;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+#[RequiresPhp('>= 8.4.0')]
+class PropertyHooksTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            User::class,
+        );
+    }
+
+    public function testMapPropertyHooks(): void
+    {
+        $user = new User();
+        $user->fullName = 'John Doe';
+        $user->language = 'EN';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find(User::class, $user->id);
+
+        self::assertEquals('John', $user->first);
+        self::assertEquals('Doe', $user->last);
+        self::assertEquals('John Doe', $user->fullName);
+        self::assertEquals('EN', $user->language, 'The property hook uppercases the language.');
+
+        $language = $this->_em->createQuery('SELECT u.language FROM ' . User::class . ' u WHERE u.id = :id')
+            ->setParameter('id', $user->id)
+            ->getSingleScalarResult();
+
+        $this->assertEquals('en', $language, 'Selecting a field from DQL does not go through the property hook, accessing raw data.');
+    }
+
+    public function testTriggerLazyLoadingWhenAccessingPropertyHooks(): void
+    {
+        $user = new User();
+        $user->fullName = 'Ludwig von Beethoven';
+        $user->language = 'DE';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->getReference(User::class, $user->id);
+
+        self::assertEquals('John', $user->first);
+        self::assertEquals('Doe', $user->last);
+        self::assertEquals('John Doe', $user->fullName);
+        self::assertEquals('EN', $user->language, 'The property hook uppercases the language.');
+    }
+}

--- a/tests/Tests/ORM/Functional/PropertyHooksTest.php
+++ b/tests/Tests/ORM/Functional/PropertyHooksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\PropertyHooks\User;
@@ -13,6 +15,10 @@ class PropertyHooksTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
+        if (! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $this->markTestSkipped('Property hooks require native lazy objects to be enabled.');
+        }
+
         $this->createSchemaForModels(
             User::class,
         );
@@ -20,7 +26,7 @@ class PropertyHooksTest extends OrmFunctionalTestCase
 
     public function testMapPropertyHooks(): void
     {
-        $user = new User();
+        $user           = new User();
         $user->fullName = 'John Doe';
         $user->language = 'EN';
 
@@ -44,7 +50,7 @@ class PropertyHooksTest extends OrmFunctionalTestCase
 
     public function testTriggerLazyLoadingWhenAccessingPropertyHooks(): void
     {
-        $user = new User();
+        $user           = new User();
         $user->fullName = 'Ludwig von Beethoven';
         $user->language = 'DE';
 
@@ -54,9 +60,9 @@ class PropertyHooksTest extends OrmFunctionalTestCase
 
         $user = $this->_em->getReference(User::class, $user->id);
 
-        self::assertEquals('John', $user->first);
-        self::assertEquals('Doe', $user->last);
-        self::assertEquals('John Doe', $user->fullName);
-        self::assertEquals('EN', $user->language, 'The property hook uppercases the language.');
+        self::assertEquals('Ludwig', $user->first);
+        self::assertEquals('von Beethoven', $user->last);
+        self::assertEquals('Ludwig von Beethoven', $user->fullName);
+        self::assertEquals('DE', $user->language, 'The property hook uppercases the language.');
     }
 }

--- a/tests/Tests/ORM/Functional/PropertyHooksTest.php
+++ b/tests/Tests/ORM/Functional/PropertyHooksTest.php
@@ -48,6 +48,16 @@ class PropertyHooksTest extends OrmFunctionalTestCase
             ->getSingleScalarResult();
 
         $this->assertEquals('en', $language, 'Selecting a field from DQL does not go through the property hook, accessing raw data.');
+
+        $this->_em->clear();
+
+        $user = $this->_em->getRepository(User::class)->findOneBy(['language' => 'EN']);
+
+        self::assertNull($user);
+
+        $user = $this->_em->getRepository(User::class)->findOneBy(['language' => 'en']);
+
+        self::assertNotNull($user);
     }
 
     public function testTriggerLazyLoadingWhenAccessingPropertyHooks(): void


### PR DESCRIPTION
Adding support for non-virtual property hooks now that native lazy objects are supported.

Property hooks are not supported when using symfony/var-exporter.
