### PR TITLE
Support entities with association column names that conflict with a field name

### DIFF
--- a/src/Cache/DefaultEntityHydrator.php
+++ b/src/Cache/DefaultEntityHydrator.php
@@ -78,7 +78,7 @@ class DefaultEntityHydrator implements EntityHydrator
                         assert($owningAssociation->isToOneOwningSide());
                         $fieldMapping = $targetClassMetadata->fieldMappings[$fieldName];
 
-                        $data[$owningAssociation->targetToSourceKeyColumns[$fieldMapping->columnName]] = $fieldValue;
+                        $data['.column:' . $owningAssociation->targetToSourceKeyColumns[$fieldMapping->columnName]] = $fieldValue;
 
                         continue;
                     }
@@ -88,7 +88,7 @@ class DefaultEntityHydrator implements EntityHydrator
                     assert($assoc->isToOneOwningSide());
                     foreach ($assoc->targetToSourceKeyColumns as $referencedColumn => $localColumn) {
                         if (isset($targetAssoc->sourceToTargetKeyColumns[$referencedColumn])) {
-                            $data[$localColumn] = $fieldValue;
+                            $data['.column:' . $localColumn] = $fieldValue;
                         }
                     }
                 }

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -259,7 +259,7 @@ abstract class AbstractHydrator
      *                   scalars?: array
      *               }
      */
-    protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents): array
+    protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents, bool $prefixColumns = true): array
     {
         $rowData = ['data' => [], 'newObjects' => []];
 
@@ -300,6 +300,12 @@ abstract class AbstractHydrator
 
                 //case (isset($cacheKeyInfo['isMetaColumn'])):
                 default:
+                    // Meta column field name is actually a column name.  This
+                    // prevents possible clashes with actual field names
+                    if (isset($cacheKeyInfo['isMetaColumn']) && $cacheKeyInfo['isMetaColumn'] && $prefixColumns) {
+                        $fieldName = '.column:' . $fieldName;
+                    }
+
                     $dqlAlias = $cacheKeyInfo['dqlAlias'];
                     $type     = $cacheKeyInfo['type'];
 

--- a/src/Internal/Hydration/ArrayHydrator.php
+++ b/src/Internal/Hydration/ArrayHydrator.php
@@ -65,7 +65,7 @@ class ArrayHydrator extends AbstractHydrator
         // 1) Initialize
         $id                 = $this->idTemplate; // initialize the id-memory
         $nonemptyComponents = [];
-        $rowData            = $this->gatherRowData($row, $id, $nonemptyComponents);
+        $rowData            = $this->gatherRowData($row, $id, $nonemptyComponents, false);
 
         // 2) Now hydrate the data found in the current row.
         foreach ($rowData['data'] as $dqlAlias => $data) {

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -228,10 +228,11 @@ class ObjectHydrator extends AbstractHydrator
                 throw HydrationException::missingDiscriminatorMetaMappingColumn($className, $fieldName, $dqlAlias);
             }
 
-            $discrColumn = $this->resultSetMapping()->metaMappings[$fieldName];
+            $originalDiscrColumn = $this->resultSetMapping()->metaMappings[$fieldName];
+            $discrColumn         = '.column:' . $originalDiscrColumn;
 
             if (! isset($data[$discrColumn])) {
-                throw HydrationException::missingDiscriminatorColumn($className, $discrColumn, $dqlAlias);
+                throw HydrationException::missingDiscriminatorColumn($className, $originalDiscrColumn, $dqlAlias);
             }
 
             if ($data[$discrColumn] === '') {
@@ -278,7 +279,7 @@ class ObjectHydrator extends AbstractHydrator
                 array_map(
                     /** @return mixed */
                     static fn (string $fieldName) => isset($class->associationMappings[$fieldName]) && assert($class->associationMappings[$fieldName]->isToOneOwningSide())
-                        ? $data[$class->associationMappings[$fieldName]->joinColumns[0]->name]
+                        ? $data['.column:' . $class->associationMappings[$fieldName]->joinColumns[0]->name]
                         : $data[$fieldName],
                     $class->identifier,
                 ),

--- a/src/Internal/Hydration/SimpleObjectHydrator.php
+++ b/src/Internal/Hydration/SimpleObjectHydrator.php
@@ -160,7 +160,10 @@ class SimpleObjectHydrator extends AbstractHydrator
                 }
             }
 
-            $fieldName = $cacheKeyInfo['fieldName'];
+            // Meta column field name is actually a column name.  This
+            // prevents possible clashes with actual field names
+            $isMetaColumn = isset($cacheKeyInfo['isMetaColumn']) && $cacheKeyInfo['isMetaColumn'];
+            $fieldName    = $isMetaColumn ? '.column:' . $cacheKeyInfo['fieldName'] : $cacheKeyInfo['fieldName'];
 
             // Prevent overwrite in case of inherit classes using same property name (See AbstractHydrator)
             if (! isset($data[$fieldName]) || ! $valueIsNull) {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2456,7 +2456,7 @@ class UnitOfWork implements PropertyChangedListener
                     assert($assoc->isToOneOwningSide());
                     // TODO: Is this even computed right in all cases of composite keys?
                     foreach ($assoc->targetToSourceKeyColumns as $targetColumn => $srcColumn) {
-                        $joinColumnValue = $data[$srcColumn] ?? null;
+                        $joinColumnValue = $data['.column:' . $srcColumn] ?? null;
 
                         if ($joinColumnValue !== null) {
                             if ($joinColumnValue instanceof BackedEnum) {
@@ -2667,7 +2667,7 @@ class UnitOfWork implements PropertyChangedListener
                     $data = $this->getOriginalEntityData($targetValue);
                     $id   = [];
                     foreach ($targetClass->associationMappings[$mappedBy]->joinColumns as $joinColumn) {
-                        $id[] = $data[$joinColumn->name];
+                        $id[] = $data['.column:' . $joinColumn->name];
                     }
                 } else {
                     $id = $this->identifierFlattener->flattenIdentifier($class, $class->getIdentifierValues($sourceEntity));

--- a/src/Utility/IdentifierFlattener.php
+++ b/src/Utility/IdentifierFlattener.php
@@ -65,7 +65,7 @@ final class IdentifierFlattener
                 $associatedId = [];
 
                 foreach ($class->associationMappings[$field]->joinColumns as $joinColumn) {
-                    $associatedId[] = $id[$joinColumn->name];
+                    $associatedId[] = $id['.column:' . $joinColumn->name];
                 }
 
                 $flatId[$field] = implode(' ', $associatedId);

--- a/tests/Tests/Models/FieldColumnConflict/User.php
+++ b/tests/Tests/Models/FieldColumnConflict/User.php
@@ -12,16 +12,16 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: "user")]
+#[Table(name: 'user')]
 #[Entity]
 class User
 {
     #[Id]
-    #[Column(type: "integer", name: "user_id")]
+    #[Column(type: 'integer', name: 'user_id')]
     #[GeneratedValue]
     public int $id;
 
     #[OneToOne(targetEntity: UserContent::class)]
-    #[JoinColumn(name: "id", referencedColumnName: "id")]
-    public ?UserContent $userContent;
+    #[JoinColumn(name: 'id', referencedColumnName: 'id')]
+    public UserContent|null $userContent;
 }

--- a/tests/Tests/Models/FieldColumnConflict/User.php
+++ b/tests/Tests/Models/FieldColumnConflict/User.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\FieldColumnConflict;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: "user")]
+#[Entity]
+class User
+{
+    #[Id]
+    #[Column(type: "integer", name: "user_id")]
+    #[GeneratedValue]
+    public int $id;
+
+    #[OneToOne(targetEntity: UserContent::class)]
+    #[JoinColumn(name: "id", referencedColumnName: "id")]
+    public ?UserContent $userContent;
+}

--- a/tests/Tests/Models/FieldColumnConflict/UserContent.php
+++ b/tests/Tests/Models/FieldColumnConflict/UserContent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\FieldColumnConflict;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: "user_content")]
+#[Entity]
+class UserContent
+{
+    #[Id]
+    #[Column(type: "string")]
+    public $id;
+
+    #[Column(type: "string")]
+    public $data;
+}

--- a/tests/Tests/Models/FieldColumnConflict/UserContent.php
+++ b/tests/Tests/Models/FieldColumnConflict/UserContent.php
@@ -9,14 +9,14 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
 
-#[Table(name: "user_content")]
+#[Table(name: 'user_content')]
 #[Entity]
 class UserContent
 {
     #[Id]
-    #[Column(type: "string")]
-    public $id;
+    #[Column(type: 'string')]
+    public string $id;
 
-    #[Column(type: "string")]
-    public $data;
+    #[Column(type: 'string')]
+    public string $data;
 }

--- a/tests/Tests/ORM/Functional/Ticket/FieldColumnConflictTest.php
+++ b/tests/Tests/ORM/Functional/Ticket/FieldColumnConflictTest.php
@@ -10,22 +10,22 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 class FieldColumnConflictTest extends OrmFunctionalTestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->createSchemaForModels(User::class, UserContent::class);
     }
 
-    public function testIssue() : void
+    public function testIssue(): void
     {
-        $user = new User();
+        $user     = new User();
         $user->id = 1;
-        
+
         $this->_em->persist($user);
-        
-        $userContent = new UserContent();
-        $userContent->id = 'uuid';
+
+        $userContent       = new UserContent();
+        $userContent->id   = 'uuid';
         $userContent->data = 'data';
 
         $this->_em->persist($userContent);

--- a/tests/Tests/ORM/Functional/Ticket/FieldColumnConflictTest.php
+++ b/tests/Tests/ORM/Functional/Ticket/FieldColumnConflictTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\FieldColumnConflict\User;
+use Doctrine\Tests\Models\FieldColumnConflict\UserContent;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class FieldColumnConflictTest extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(User::class, UserContent::class);
+    }
+
+    public function testIssue() : void
+    {
+        $user = new User();
+        $user->id = 1;
+        
+        $this->_em->persist($user);
+        
+        $userContent = new UserContent();
+        $userContent->id = 'uuid';
+        $userContent->data = 'data';
+
+        $this->_em->persist($userContent);
+
+        $user->userContent = $userContent;
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find(User::class, 1);
+        self::assertSame(1, $user->id);
+        self::assertNotNull($user->userContent);
+        self::assertSame('uuid', $user->userContent->id);
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH7869Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7869Test.php
@@ -57,7 +57,7 @@ class GH7869Test extends OrmTestCase
         ];
 
         $uow = new UnitOfWork($em);
-        $uow->createEntity(GH7869Appointment::class, ['id' => 1, 'patient_id' => 1], $hints);
+        $uow->createEntity(GH7869Appointment::class, ['id' => 1, '.column:patient_id' => 1], $hints);
         $uow->clear();
         $uow->triggerEagerLoads();
 


### PR DESCRIPTION
If an entity is defined such that it has a field `$a` based on a column `c`, and an association field `$b` based on a column `a`, hydration will fail.  This is because the data array that is created during hydration uses field names for keys except for associations.  For associations it uses the column names, leading to a conflict.

This PR adds a prefix to the column-valued array keys to avoid clashes.  The prefix uses characters that could not occur in a field name so it should be safe for all possible field and column names.
