### PR TITLE
Make generated QueryComponents publicly available in ParserResult

### DIFF
--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -377,6 +377,8 @@ final class Parser
             $this->parserResult->setSqlExecutor($executor);
         }
 
+        $this->parserResult->setQueryComponents($this->queryComponents);
+
         return $this->parserResult;
     }
 

--- a/src/Query/ParserResult.php
+++ b/src/Query/ParserResult.php
@@ -155,7 +155,6 @@ class ParserResult
      * Sets the queryComponents of the parsed query.
      *
      * @param array<string, QueryComponent> $queryComponents
-     * @return void
      */
     public function setQueryComponents(array $queryComponents): void
     {

--- a/src/Query/ParserResult.php
+++ b/src/Query/ParserResult.php
@@ -16,6 +16,8 @@ use function sprintf;
  * can be serialized.
  *
  * @link        http://www.doctrine-project.org
+ *
+ * @phpstan-import-type QueryComponent from Parser
  */
 class ParserResult
 {
@@ -40,6 +42,13 @@ class ParserResult
      * @phpstan-var array<string|int, list<int>>
      */
     private array $parameterMappings = [];
+
+    /**
+     * Map of declared query components in the parsed query.
+     *
+     * @phpstan-var array<string, QueryComponent>
+     */
+    private array $queryComponents = [];
 
     /**
      * Initializes a new instance of the <tt>ParserResult</tt> class.
@@ -130,6 +139,27 @@ class ParserResult
     public function getParameterMappings(): array
     {
         return $this->parameterMappings;
+    }
+
+    /**
+     * Returns the generated queryComponents array.
+     *
+     * @return array<string, QueryComponent>
+     */
+    public function getQueryComponents(): array
+    {
+        return $this->queryComponents;
+    }
+
+    /**
+     * Sets the queryComponents of the parsed query.
+     *
+     * @param array<string, QueryComponent> $queryComponents
+     * @return void
+     */
+    public function setQueryComponents(array $queryComponents): void
+    {
+        $this->queryComponents = $queryComponents;
     }
 
     /**


### PR DESCRIPTION
The Parser turns A DQL query in a ParserResult. This parser generates all the **QueryComponents**, which hold all the mappings calculated from the DQL query. But in the end these calculated components are never consultable. This is actually very useful information but you can't access it anywhere. So that really is a pity!

A scenario where access to this generated data becomes very useful is when you have a QueryBuilder with subQueries which are injected with DQL.
Let's say you have a dynamic query builder that goes through a lot of code and might add subqueries along the way.
````
// $subqueryBuilder holds potential ToMany joins

if ($forSomeReason) {
    $queryBuilder->andWhere($qb->expr()->in('n.user', $subqueryBuilder->getDQL()))
}
````

In the end just before executing the query I want to check my QueryBuilder if it has at least one ...toMany relation before I add
* **->distinct()** (if no aggregate selects found)
* OR **->addGroupBy('rootalias.id')** (depending if the select has aggregates or not)

I only want to add distinct or groupBy if it is really necessary because it is a **performance hit**. There is no need to add it if we don't have toMany relations in the final query.

Because we have DQL injected in our query we lose the original "$subqueryBuilder" join mapping information in the final $queryBuilder

So By adding the generated QueryComponents to the ParserResult all the oh-so-valuable mapping information with all the join types becomes available.

To solve this problem in my current project I made this solution with a ReflectionClass to access the private generated "queryComponents"
````
$parser = new Parser($qb->getQuery());
$parser->parse();
$reflectionParser = new \ReflectionClass($parser);
$queryComponentsProp = $reflectionParser->getProperty('queryComponents');
$queryComponentsProp->setAccessible(true);
$queryComponents = $queryComponentsProp->getValue($parser);
````


But it would be nice that we all could just do $parserResult->getQueryComponents(), and then we can check if there is at least one ...toMany relation with

````
$parser = new Parser($qb->getQuery());
$parserResult = $parser->parse();

$hasToManyJoins = false;
foreach ($parserResult->getQueryComponents() as $queryComponent) {
    $relationType = $queryComponent['relation']['type'] ?? null;
            
    if (in_array($relationType, [
        ClassMetadataInfo::ONE_TO_MANY,
        ClassMetadataInfo::MANY_TO_MANY,
    ])) {
        $hasToManyJoins = true;
        break;
    }
}
````
