### PR TITLE
Fix `IN`/`NOT IN` expression handling and support enums when matching on to-many-collections

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2743,18 +2743,6 @@ parameters:
 			path: src/Persisters/Entity/BasicEntityPersister.php
 
 		-
-			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandCriteriaParameters\(\) should return array\{list\<mixed\>, list\<int\|string\|null\>\} but returns array\{array\<mixed\>, list\<int\|string\|null\>\}\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandParameters\(\) should return array\{list\<mixed\>, list\<int\|string\|null\>\} but returns array\{array\<mixed\>, list\<int\|string\|null\>\}\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
 			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandToManyParameters\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2787,12 +2775,6 @@ parameters:
 		-
 			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getClassMetadata\(\) return type with generic class Doctrine\\ORM\\Mapping\\ClassMetadata does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getIndividualValue\(\) should return list\<mixed\> but returns array\<mixed\>\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Persisters/Entity/BasicEntityPersister.php
 
@@ -2857,12 +2839,6 @@ parameters:
 			path: src/Persisters/Entity/BasicEntityPersister.php
 
 		-
-			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:getTypes\(\) has parameter \$class with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
 			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:load\(\) has parameter \$assoc with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 5
@@ -2920,18 +2896,6 @@ parameters:
 			message: '#^Offset ''joinTable'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 8
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: '#^Offset ''relationToTargetKeyColumns'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: '#^Offset ''sourceToTargetKeyColumns'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
 			path: src/Persisters/Entity/BasicEntityPersister.php
 
 		-
@@ -5590,7 +5554,25 @@ parameters:
 			path: src/Utility/PersisterHelper.php
 
 		-
+			message: '#^Method Doctrine\\ORM\\Utility\\PersisterHelper\:\:inferParameterTypes\(\) has parameter \$class with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/Utility/PersisterHelper.php
+
+		-
 			message: '#^Offset ''joinTable'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Utility/PersisterHelper.php
+
+		-
+			message: '#^Offset ''relationToTargetKeyColumns'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Utility/PersisterHelper.php
+
+		-
+			message: '#^Offset ''sourceToTargetKeyColumns'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: src/Utility/PersisterHelper.php

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\PersisterHelper;
 
 use function array_fill;
+use function array_merge;
 use function array_pop;
 use function count;
 use function get_class;
@@ -257,9 +258,16 @@ class ManyToManyPersister extends AbstractCollectionPersister
             if ($value === null && ($operator === Comparison::EQ || $operator === Comparison::NEQ)) {
                 $whereClauses[] = sprintf('te.%s %s NULL', $field, $operator === Comparison::EQ ? 'IS' : 'IS NOT');
             } else {
-                $whereClauses[] = sprintf('te.%s %s ?', $field, $operator);
-                $params[]       = $value;
-                $paramTypes[]   = PersisterHelper::getTypeOfField($name, $targetClass, $this->em)[0];
+                if ($operator === Comparison::IN) {
+                    $whereClauses[] = sprintf('te.%s IN (?)', $field);
+                } elseif ($operator === Comparison::NIN) {
+                    $whereClauses[] = sprintf('te.%s NOT IN (?)', $field);
+                } else {
+                    $whereClauses[] = sprintf('te.%s %s ?', $field, $operator);
+                }
+
+                $params     = array_merge($params, PersisterHelper::convertToParameterValue($value, $this->em));
+                $paramTypes = array_merge($paramTypes, PersisterHelper::inferParameterTypes($name, $value, $targetClass, $this->em));
             }
         }
 

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Persisters\Entity;
 
-use BackedEnum;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\DBAL\Connection;
@@ -26,9 +25,7 @@ use Doctrine\ORM\Persisters\Exception\InvalidOrientation;
 use Doctrine\ORM\Persisters\Exception\UnrecognizedField;
 use Doctrine\ORM\Persisters\SqlExpressionVisitor;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
-use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Repository\Exception\InvalidFindByCall;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
@@ -47,7 +44,6 @@ use function assert;
 use function count;
 use function implode;
 use function is_array;
-use function is_object;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -392,7 +388,7 @@ class BasicEntityPersister implements EntityPersister
         $types = [];
 
         foreach ($id as $field => $value) {
-            $types = array_merge($types, $this->getTypes($field, $value, $versionedClass));
+            $types = array_merge($types, PersisterHelper::inferParameterTypes($field, $value, $versionedClass, $this->em));
         }
 
         return $types;
@@ -953,8 +949,8 @@ class BasicEntityPersister implements EntityPersister
                 continue;
             }
 
-            $sqlParams = array_merge($sqlParams, $this->getValues($value));
-            $sqlTypes  = array_merge($sqlTypes, $this->getTypes($field, $value, $this->class));
+            $sqlParams = array_merge($sqlParams, PersisterHelper::convertToParameterValue($value, $this->em));
+            $sqlTypes  = array_merge($sqlTypes, PersisterHelper::inferParameterTypes($field, $value, $this->class, $this->em));
         }
 
         return [$sqlParams, $sqlTypes];
@@ -1947,8 +1943,8 @@ class BasicEntityPersister implements EntityPersister
                 continue; // skip null values.
             }
 
-            $types  = array_merge($types, $this->getTypes($field, $value, $this->class));
-            $params = array_merge($params, $this->getValues($value));
+            $types  = array_merge($types, PersisterHelper::inferParameterTypes($field, $value, $this->class, $this->em));
+            $params = array_merge($params, PersisterHelper::convertToParameterValue($value, $this->em));
         }
 
         return [$params, $types];
@@ -1976,125 +1972,11 @@ class BasicEntityPersister implements EntityPersister
                 continue; // skip null values.
             }
 
-            $types  = array_merge($types, $this->getTypes($criterion['field'], $criterion['value'], $criterion['class']));
-            $params = array_merge($params, $this->getValues($criterion['value']));
+            $types  = array_merge($types, PersisterHelper::inferParameterTypes($criterion['field'], $criterion['value'], $criterion['class'], $this->em));
+            $params = array_merge($params, PersisterHelper::convertToParameterValue($criterion['value'], $this->em));
         }
 
         return [$params, $types];
-    }
-
-    /**
-     * Infers field types to be used by parameter type casting.
-     *
-     * @param mixed $value
-     *
-     * @return int[]|null[]|string[]
-     * @phpstan-return list<int|string|null>
-     *
-     * @throws QueryException
-     */
-    private function getTypes(string $field, $value, ClassMetadata $class): array
-    {
-        $types = [];
-
-        switch (true) {
-            case isset($class->fieldMappings[$field]):
-                $types = array_merge($types, [$class->fieldMappings[$field]['type']]);
-                break;
-
-            case isset($class->associationMappings[$field]):
-                $assoc = $class->associationMappings[$field];
-                $class = $this->em->getClassMetadata($assoc['targetEntity']);
-
-                if (! $assoc['isOwningSide']) {
-                    $assoc = $class->associationMappings[$assoc['mappedBy']];
-                    $class = $this->em->getClassMetadata($assoc['targetEntity']);
-                }
-
-                $columns = $assoc['type'] === ClassMetadata::MANY_TO_MANY
-                    ? $assoc['relationToTargetKeyColumns']
-                    : $assoc['sourceToTargetKeyColumns'];
-
-                foreach ($columns as $column) {
-                    $types[] = PersisterHelper::getTypeOfColumn($column, $class, $this->em);
-                }
-
-                break;
-
-            default:
-                $types[] = null;
-                break;
-        }
-
-        if (is_array($value)) {
-            return array_map(static function ($type) {
-                $type = Type::getType($type);
-
-                return $type->getBindingType() + Connection::ARRAY_PARAM_OFFSET;
-            }, $types);
-        }
-
-        return $types;
-    }
-
-    /**
-     * Retrieves the parameters that identifies a value.
-     *
-     * @param mixed $value
-     *
-     * @return mixed[]
-     */
-    private function getValues($value): array
-    {
-        if (is_array($value)) {
-            $newValue = [];
-
-            foreach ($value as $itemValue) {
-                $newValue = array_merge($newValue, $this->getValues($itemValue));
-            }
-
-            return [$newValue];
-        }
-
-        return $this->getIndividualValue($value);
-    }
-
-    /**
-     * Retrieves an individual parameter value.
-     *
-     * @param mixed $value
-     *
-     * @phpstan-return list<mixed>
-     */
-    private function getIndividualValue($value): array
-    {
-        if (! is_object($value)) {
-            return [$value];
-        }
-
-        if ($value instanceof BackedEnum) {
-            return [$value->value];
-        }
-
-        $valueClass = DefaultProxyClassNameResolver::getClass($value);
-
-        if ($this->em->getMetadataFactory()->isTransient($valueClass)) {
-            return [$value];
-        }
-
-        $class = $this->em->getClassMetadata($valueClass);
-
-        if ($class->isIdentifierComposite) {
-            $newValue = [];
-
-            foreach ($class->getIdentifierValues($value) as $innerValue) {
-                $newValue = array_merge($newValue, $this->getValues($innerValue));
-            }
-
-            return $newValue;
-        }
-
-        return [$this->em->getUnitOfWork()->getSingleIdentifierValue($value)];
     }
 
     /**

--- a/src/Utility/PersisterHelper.php
+++ b/src/Utility/PersisterHelper.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Utility;
 
+use BackedEnum;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Query\QueryException;
 use RuntimeException;
 
+use function array_map;
+use function array_merge;
+use function is_array;
+use function is_object;
 use function sprintf;
 
 /**
@@ -112,5 +120,117 @@ class PersisterHelper
             $columnName,
             $class->getName()
         ));
+    }
+
+    /**
+     * Infers field types to be used by parameter type casting.
+     *
+     * @param mixed $value
+     *
+     * @return int[]|null[]|string[]
+     * @phpstan-return list<int|string|null>
+     *
+     * @throws QueryException
+     */
+    public static function inferParameterTypes(string $field, $value, ClassMetadata $class, EntityManagerInterface $em): array
+    {
+        $types = [];
+
+        switch (true) {
+            case isset($class->fieldMappings[$field]):
+                $types = array_merge($types, [$class->fieldMappings[$field]['type']]);
+                break;
+
+            case isset($class->associationMappings[$field]):
+                $assoc = $class->associationMappings[$field];
+                $class = $em->getClassMetadata($assoc['targetEntity']);
+
+                if (! $assoc['isOwningSide']) {
+                    $assoc = $class->associationMappings[$assoc['mappedBy']];
+                    $class = $em->getClassMetadata($assoc['targetEntity']);
+                }
+
+                $columns = $assoc['type'] === ClassMetadata::MANY_TO_MANY
+                    ? $assoc['relationToTargetKeyColumns']
+                    : $assoc['sourceToTargetKeyColumns'];
+
+                foreach ($columns as $column) {
+                    $types[] = self::getTypeOfColumn($column, $class, $em);
+                }
+
+                break;
+
+            default:
+                $types[] = null;
+                break;
+        }
+
+        if (is_array($value)) {
+            return array_map(static function ($type) {
+                $type = Type::getType($type);
+
+                return $type->getBindingType() + Connection::ARRAY_PARAM_OFFSET;
+            }, $types);
+        }
+
+        return $types;
+    }
+
+    /**
+     * Converts a value to the type and value required to bind it as a parameter.
+     *
+     * @param mixed $value
+     *
+     * @return list<mixed>
+     */
+    public static function convertToParameterValue($value, EntityManagerInterface $em): array
+    {
+        if (is_array($value)) {
+            $newValue = [];
+
+            foreach ($value as $itemValue) {
+                $newValue = array_merge($newValue, self::convertToParameterValue($itemValue, $em));
+            }
+
+            return [$newValue];
+        }
+
+        return self::convertIndividualValue($value, $em);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @phpstan-return list<mixed>
+     */
+    private static function convertIndividualValue($value, EntityManagerInterface $em): array
+    {
+        if (! is_object($value)) {
+            return [$value];
+        }
+
+        if ($value instanceof BackedEnum) {
+            return [$value->value];
+        }
+
+        $valueClass = DefaultProxyClassNameResolver::getClass($value);
+
+        if ($em->getMetadataFactory()->isTransient($valueClass)) {
+            return [$value];
+        }
+
+        $class = $em->getClassMetadata($valueClass);
+
+        if ($class->isIdentifierComposite) {
+            $newValue = [];
+
+            foreach ($class->getIdentifierValues($value) as $innerValue) {
+                $newValue = array_merge($newValue, self::convertToParameterValue($innerValue, $em));
+            }
+
+            return $newValue;
+        }
+
+        return [$em->getUnitOfWork()->getSingleIdentifierValue($value)];
     }
 }

--- a/tests/Tests/Models/Enums/BookCategory.php
+++ b/tests/Tests/Models/Enums/BookCategory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+#[Entity]
+class BookCategory
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int $id;
+
+    #[ManyToMany(targetEntity: BookWithGenre::class, mappedBy: 'categories')]
+    public Collection $books;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+}

--- a/tests/Tests/Models/Enums/BookGenre.php
+++ b/tests/Tests/Models/Enums/BookGenre.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+enum BookGenre: string
+{
+    case FICTION     = 'fiction';
+    case NON_FICTION = 'non fiction';
+}

--- a/tests/Tests/Models/Enums/BookWithGenre.php
+++ b/tests/Tests/Models/Enums/BookWithGenre.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+#[Entity]
+class BookWithGenre
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[ManyToOne(targetEntity: Library::class, inversedBy: 'books')]
+    public Library $library;
+
+    #[Column(enumType: BookGenre::class)]
+    public BookGenre $genre;
+
+    #[ManyToMany(targetEntity: BookCategory::class, inversedBy: 'books')]
+    public Collection $categories;
+
+    public function __construct(BookGenre $genre)
+    {
+        $this->genre      = $genre;
+        $this->categories = new ArrayCollection();
+    }
+}

--- a/tests/Tests/Models/Enums/Library.php
+++ b/tests/Tests/Models/Enums/Library.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Enums;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class Library
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[OneToMany(targetEntity: BookWithGenre::class, mappedBy: 'library')]
+    public Collection $books;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+}

--- a/tests/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Tests/ORM/Functional/EnumTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -12,9 +14,13 @@ use Doctrine\ORM\Query\Expr\Func;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\DataTransferObjects\DtoWithArrayOfEnums;
 use Doctrine\Tests\Models\DataTransferObjects\DtoWithEnum;
+use Doctrine\Tests\Models\Enums\BookCategory;
+use Doctrine\Tests\Models\Enums\BookGenre;
+use Doctrine\Tests\Models\Enums\BookWithGenre;
 use Doctrine\Tests\Models\Enums\Card;
 use Doctrine\Tests\Models\Enums\CardWithDefault;
 use Doctrine\Tests\Models\Enums\CardWithNullable;
+use Doctrine\Tests\Models\Enums\Library;
 use Doctrine\Tests\Models\Enums\Product;
 use Doctrine\Tests\Models\Enums\Quantity;
 use Doctrine\Tests\Models\Enums\Scale;
@@ -22,6 +28,7 @@ use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\Enums\TypedCard;
 use Doctrine\Tests\Models\Enums\Unit;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
 
 use function dirname;
 use function sprintf;
@@ -523,5 +530,73 @@ EXCEPTION
         $card = $this->_em->find(CardWithDefault::class, $cardId);
 
         self::assertSame(Suit::Hearts, $card->suit);
+    }
+
+    /**
+     * @dataProvider provideGenreMatchingExpressions
+     */
+    public function testEnumCollectionMatchingOnOneToMany(Comparison $comparison): void
+    {
+        $this->setUpEntitySchema([BookWithGenre::class, Library::class, BookCategory::class]);
+
+        $library = new Library();
+
+        $fictionBook          = new BookWithGenre(BookGenre::FICTION);
+        $fictionBook->library = $library;
+
+        $nonfictionBook          = new BookWithGenre(BookGenre::NON_FICTION);
+        $nonfictionBook->library = $library;
+
+        $this->_em->persist($library);
+        $this->_em->persist($nonfictionBook);
+        $this->_em->persist($fictionBook);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $library = $this->_em->find(Library::class, $library->id);
+        self::assertFalse($library->books->isInitialized(), 'Pre-condition: lazy collection');
+
+        $result = $library->books->matching(Criteria::create()->where($comparison));
+
+        self::assertCount(1, $result);
+        self::assertSame($nonfictionBook->id, $result[0]->id);
+    }
+
+    /**
+     * @dataProvider provideGenreMatchingExpressions
+     */
+    public function testEnumCollectionMatchingOnManyToMany(Comparison $comparison): void
+    {
+        $this->setUpEntitySchema([Library::class, BookWithGenre::class, BookCategory::class]);
+
+        $category = new BookCategory();
+
+        $fictionBook = new BookWithGenre(BookGenre::FICTION);
+        $fictionBook->categories->add($category);
+
+        $nonfictionBook = new BookWithGenre(BookGenre::NON_FICTION);
+        $nonfictionBook->categories->add($category);
+
+        $this->_em->persist($category);
+        $this->_em->persist($nonfictionBook);
+        $this->_em->persist($fictionBook);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $category = $this->_em->find(BookCategory::class, $category->id);
+        self::assertFalse($category->books->isInitialized(), 'Pre-condition: lazy collection');
+
+        $result = $category->books->matching(Criteria::create()->where($comparison));
+
+        self::assertCount(1, $result);
+        self::assertSame($nonfictionBook->id, $result[0]->id);
+    }
+
+    public function provideGenreMatchingExpressions(): Generator
+    {
+        yield [Criteria::expr()->eq('genre', BookGenre::NON_FICTION)];
+        yield [Criteria::expr()->in('genre', [BookGenre::NON_FICTION])];
     }
 }

--- a/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -578,6 +578,44 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         self::assertFalse($user->groups->isInitialized(), 'Post-condition: matching does not initialize collection');
     }
 
+    public function testMatchingWithInCondition(): void
+    {
+        $user = $this->addCmsUserGblancoWithGroups(2);
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $groups = $user->groups;
+        self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
+
+        $criteria = Criteria::create()->where(Criteria::expr()->in('name', ['Developers_1']));
+        $result   = $groups->matching($criteria);
+
+        self::assertCount(1, $result);
+        self::assertEquals('Developers_1', $result[0]->name);
+
+        self::assertFalse($user->groups->isInitialized(), 'Post-condition: matching does not initialize collection');
+    }
+
+    public function testMatchingWithNotInCondition(): void
+    {
+        $user = $this->addCmsUserGblancoWithGroups(2);
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $groups = $user->groups;
+        self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
+
+        $criteria = Criteria::create()->where(Criteria::expr()->notIn('name', ['Developers_0']));
+        $result   = $groups->matching($criteria);
+
+        self::assertCount(1, $result);
+        self::assertEquals('Developers_1', $result[0]->name);
+
+        self::assertFalse($user->groups->isInitialized(), 'Post-condition: matching does not initialize collection');
+    }
+
     private function removeTransactionCommandsFromQueryLog(): void
     {
         $log = $this->getQueryLog();


### PR DESCRIPTION
This fixes that using a `Criteria` with an `IN` or `NIN` expression on a many-to-many collection currently leads to an SQL error (#6173). The `ManyToMany` persister needs to know about the slightly different SQL syntax for `[NOT] IN ()`.

In the case of `[NOT] IN` expressions, the value will be an array, which also required me to change (fix?) the parameter type handling. I have pulled the necessary code from the `BasicEntityPersister` and placed it as static helper methods in `PersisterHelper`.

This is somewhat inspired by #11516, which aims at fixing #11481: By re-using the parameter type handling code, it also fixes using backed enums in `EQ`, `IN` and `NIN` expressions within `Criteria` when `matching()` on one-to-many and many-to-many collections.

Fixes #6173, fixes #11031, fixes #11481, closes #11516.