### PR TITLE
Failing test: Criteria matching on fields with custom column types

### DIFF
--- a/tests/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
+++ b/tests/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
@@ -26,6 +26,12 @@ class InversedManyToManyEntity
     public $id1;
 
     /**
+     * @var string
+     * @Column(type="rot13", length=255, nullable=true)
+     */
+    public $field = null;
+
+    /**
      * @phpstan-var Collection<int, OwningManyToManyEntity>
      * @ManyToMany(targetEntity="OwningManyToManyEntity", mappedBy="associatedEntities")
      */

--- a/tests/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
+++ b/tests/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
@@ -33,7 +33,7 @@ class InversedOneToManyEntity
 
     /**
      * @var string
-     * @Column(type="string", name="some_property", length=255)
+     * @Column(type="string", name="some_property", length=255, nullable=true)
      */
     public $someProperty;
 

--- a/tests/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
+++ b/tests/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
@@ -28,6 +28,12 @@ class OwningManyToManyEntity
     public $id2;
 
     /**
+     * @var string
+     * @Column(type="rot13", length=255, nullable=true)
+     */
+    public $field = null;
+
+    /**
      * @var Collection<int, InversedManyToManyEntity>
      * @ManyToMany(targetEntity="InversedManyToManyEntity", inversedBy="associatedEntities")
      * @JoinTable(

--- a/tests/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
+++ b/tests/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
@@ -25,6 +25,12 @@ class OwningManyToOneEntity
     public $id2;
 
     /**
+     * @var string
+     * @Column(type="rot13", length=255, nullable=true)
+     */
+    public $field = null;
+
+    /**
      * @var InversedOneToManyEntity
      * @ManyToOne(targetEntity="InversedOneToManyEntity", inversedBy="associatedEntities")
      * @JoinColumn(name="associated_id", referencedColumnName="id1")

--- a/tests/Tests/ORM/Functional/ValueConversionType/ManyToManyCriteriaMatchingTest.php
+++ b/tests/Tests/ORM/Functional/ValueConversionType/ManyToManyCriteriaMatchingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity;
+use Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
+
+class ManyToManyCriteriaMatchingTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('vct_manytomany');
+
+        parent::setUp();
+    }
+
+    /**
+     * @dataProvider provideMatchingExpressions
+     */
+    public function testCriteriaMatchingOnFieldInManyToManyTarget(Comparison $comparison): void
+    {
+        $associated      = new InversedManyToManyEntity();
+        $associated->id1 = 'associated';
+
+        $matching        = new OwningManyToManyEntity();
+        $matching->id2   = 'first';
+        $matching->field = 'match this';
+        $matching->associatedEntities->add($associated);
+
+        $nonMatching        = new OwningManyToManyEntity();
+        $nonMatching->id2   = 'second';
+        $nonMatching->field = 'this is no match';
+        $nonMatching->associatedEntities->add($associated);
+
+        $this->_em->persist($associated);
+        $this->_em->persist($matching);
+        $this->_em->persist($nonMatching);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $associated = $this->_em->find(InversedManyToManyEntity::class, 'associated');
+        self::assertFalse($associated->associatedEntities->isInitialized(), 'Pre-condition: lazy collection');
+
+        $result = $associated->associatedEntities->matching(Criteria::create()->where($comparison));
+
+        $l = $this->getQueryLog();
+
+        self::assertCount(1, $result);
+        self::assertSame('first', $result[0]->id2);
+    }
+
+    public function provideMatchingExpressions(): Generator
+    {
+        yield [Criteria::expr()->eq('field', 'match this')];
+        yield [Criteria::expr()->in('field', ['match this'])];
+    }
+}

--- a/tests/Tests/ORM/Functional/ValueConversionType/OneToManyCriteriaMatchingTest.php
+++ b/tests/Tests/ORM/Functional/ValueConversionType/OneToManyCriteriaMatchingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity;
+use Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Generator;
+
+class OneToManyCriteriaMatchingTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('vct_onetomany');
+
+        parent::setUp();
+    }
+
+    /**
+     * @dataProvider provideMatchingExpressions
+     */
+    public function testCriteriaMatchingOnFieldInOneToManyTarget(Comparison $comparison): void
+    {
+        $entityWithCollection      = new InversedOneToManyEntity();
+        $entityWithCollection->id1 = 'associated';
+
+        $matching                   = new OwningManyToOneEntity();
+        $matching->id2              = 'first';
+        $matching->field            = 'match this';
+        $matching->associatedEntity = $entityWithCollection;
+
+        $notMatching                   = new OwningManyToOneEntity();
+        $notMatching->id2              = 'second';
+        $notMatching->field            = 'this is no match';
+        $notMatching->associatedEntity = $entityWithCollection;
+
+        $this->_em->persist($entityWithCollection);
+        $this->_em->persist($matching);
+        $this->_em->persist($notMatching);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $entityWithCollection = $this->_em->find(InversedOneToManyEntity::class, 'associated');
+        self::assertFalse($entityWithCollection->associatedEntities->isInitialized(), 'Pre-condition: lazy collection');
+
+        $result = $entityWithCollection->associatedEntities->matching(Criteria::create()->where($comparison));
+
+        $l = $this->getQueryLog();
+
+        self::assertCount(1, $result);
+        self::assertSame('first', $result[0]->id2);
+    }
+
+    public function provideMatchingExpressions(): Generator
+    {
+        yield [Criteria::expr()->eq('field', 'match this')];
+        yield [Criteria::expr()->in('field', ['match this'])];
+    }
+}


### PR DESCRIPTION
This adds failing tests that show that `Criteria` matching with at least `in` and `eq` expressions does not work for the case of SQL-based lookups (uninitialized `PersistentCollections`) when the targeted field uses custom types.

In that case, we need to convert the value used within the expression to what it looks like in the database.

The challenging part is that I do not know how to combine the handling of custom types with the fact that the `in` and `notIn` expressions need to deal with query parameters that are arrays.

https://www.doctrine-project.org/projects/doctrine-dbal/en/4.2/reference/data-retrieval-and-manipulation.html#list-of-parameters-conversion seems to be part of the puzzle, but I guess we somehow have to apply the type conversion (derive the value that would be found at the DBMS level) before constructing such a list?

Maybe @morozov or @derrabus could advise, you guys are much more knowledgeable with the DBAL type system.