### PR TITLE
[DOC]: Describe custom metadata files regex with AttributeDriver::setFileRegex()

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -415,6 +415,28 @@ state you can pass a closure as the third argument. It will be called with
 the arguments proxydir, namespace and className when the proxy file could not
 be found.
 
+Custom Metadata Files Regex
+---------------------------
+
+When using the ``AttributeDriver`` in combination with domain-oriented folder structures,
+it's common to have domain-related classes like tests, fixtures, commands within the same
+directory as entity classes. These should typically be excluded from metadata mapping.
+
+You can define a regular expression to filter which files the driver will consider as mapping sources:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+
+    $driver = new AttributeDriver([__DIR__ . '/src/Domain/User']);
+    $driver->setFileRegex('/^(?!.*(Test|Fixture|Command)\.php$).*\.php$/');
+
+Provided regular expression is going to be matched against each file name during mapping discovery.
+In this example, files ending with ``Test.php``, ``Fixture.php``, or ``Command.php`` will be excluded.
+This allows to ensure that only actual entity classes are taken into account when loading metadata,
+preventing unrelated files from being included by the driver.
+
 Multiple Metadata Sources
 -------------------------
 

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -418,7 +418,7 @@ be found.
 Custom Metadata Files Regex
 ---------------------------
 
-When using the ``AttributeDriver`` in combination with domain-oriented folder structures,
+When using the ``AttributeDriver`` in combination with domain-oriented directory structures,
 it's common to have domain-related classes like tests, fixtures, commands within the same
 directory as entity classes. These should typically be excluded from metadata mapping.
 
@@ -432,9 +432,9 @@ You can define a regular expression to filter which files the driver will consid
     $driver = new AttributeDriver([__DIR__ . '/src/Domain/User']);
     $driver->setFileRegex('/^(?!.*(Test|Fixture|Command)\.php$).*\.php$/');
 
-Provided regular expression is going to be matched against each file name during mapping discovery.
+The provided regular expression is going to be matched against each file name during mapping discovery.
 In this example, files ending with ``Test.php``, ``Fixture.php``, or ``Command.php`` will be excluded.
-This allows to ensure that only actual entity classes are taken into account when loading metadata,
+This ensures that only actual entity classes are taken into account when loading metadata,
 preventing unrelated files from being included by the driver.
 
 Multiple Metadata Sources

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -422,6 +422,24 @@ When using the ``AttributeDriver`` in combination with domain-oriented directory
 it's common to have domain-related classes like tests, fixtures, commands within the same
 directory as entity classes. These should typically be excluded from metadata mapping.
 
+For example, a typical directory structure for User aggregate might look like this:
+
+.. code-block:: text
+
+	User/
+    ├── User.php
+    ├── UserFixture.php
+	├── Email/
+	│   ├── Email.php
+	│   └── EmailTest.php
+	├── Password/
+	│   ├── Password.php
+	│   └── PasswordTest.php
+    └── Actions/
+        └── Register/
+            ├── RegisterUserCommand.php
+            └── RegisterUserTest.php
+
 You can define a regular expression to filter which files the driver will consider as mapping sources:
 
 .. code-block:: php
@@ -433,7 +451,9 @@ You can define a regular expression to filter which files the driver will consid
     $driver->setFileRegex('/^(?!.*(Test|Fixture|Command)\.php$).*\.php$/');
 
 The provided regular expression is going to be matched against each file name during mapping discovery.
-In this example, files ending with ``Test.php``, ``Fixture.php``, or ``Command.php`` will be excluded.
+In this example, files ending with ``Test.php``, ``Fixture.php``, or ``Command.php`` will be excluded,
+while `User.php`, `Email.php`, and `Password.php` will be included.
+
 This ensures that only actual entity classes are taken into account when loading metadata,
 preventing unrelated files from being included by the driver.
 


### PR DESCRIPTION
This is a PR that follows from https://github.com/doctrine/persistence/pull/417 , and describes usage of `AttributeDriver::setFileRegex()` for custom files exclusion in orm docs.