### PR TITLE
[DOC]: fix setFileExtension() xml mapping documentation

### DIFF
--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -46,7 +46,8 @@ In order to work, this requires certain conventions:
 .. code-block:: php
 
     <?php
-    $driver->setFileExtension('.xml');
+    $locator = $driver->getLocator();
+    $locator->setFileExtension('.xml');
 
 It is recommended to put all XML mapping documents in a single
 folder but you can spread the documents over several folders if you

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -46,8 +46,7 @@ In order to work, this requires certain conventions:
 .. code-block:: php
 
     <?php
-    $locator = $driver->getLocator();
-    $locator->setFileExtension('.xml');
+    $driver->getLocator()->setFileExtension('.xml');
 
 It is recommended to put all XML mapping documents in a single
 folder but you can spread the documents over several folders if you


### PR DESCRIPTION
Since `XmlDriver`  doesn't have `setFileExtension()` method any longer, the current documentation is outdated.

This PR aims to fix this, moving `setFileExtension()` method call to the actual file locator rather than a driver.
