### PR TITLE
Fix the initialization of lazy-ghost proxies with postLoad listeners

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -378,7 +378,7 @@ EOPHP;
             $class = $entityPersister->getClassMetadata();
 
             foreach ($class->getReflectionProperties() as $property) {
-                if (isset($identifier[$property->name]) || ! $class->hasField($property->name) && ! $class->hasAssociation($property->name)) {
+                if (isset($identifier[$property->name])) {
                     continue;
                 }
 
@@ -448,7 +448,7 @@ EOPHP;
             foreach ($reflector->getProperties($filter) as $property) {
                 $name = $property->name;
 
-                if ($property->isStatic() || (($class->hasField($name) || $class->hasAssociation($name)) && ! isset($identifiers[$name]))) {
+                if ($property->isStatic() || ! isset($identifiers[$name])) {
                     continue;
                 }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -49,6 +49,7 @@ use Doctrine\Persistence\PropertyChangedListener;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
+use Symfony\Component\VarExporter\Hydrator;
 use UnexpectedValueException;
 
 use function array_chunk;
@@ -2944,6 +2945,11 @@ EXCEPTION
 
             if ($this->isUninitializedObject($entity)) {
                 $entity->__setInitialized(true);
+
+                if ($this->em->getConfiguration()->isLazyGhostObjectEnabled()) {
+                    // Initialize properties that have default values to their default value (similar to what
+                    Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                }
             } else {
                 if (
                     ! isset($hints[Query::HINT_REFRESH])

--- a/tests/Tests/Models/GH11524/GH11524Entity.php
+++ b/tests/Tests/Models/GH11524/GH11524Entity.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh11524_entities")
+ */
+class GH11524Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int|null
+     */
+    public $id = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH11524Relation")
+     * @ORM\JoinColumn(name="relation_id", referencedColumnName="id", nullable=true)
+     *
+     * @var GH11524Relation|null
+     */
+    public $relation = null;
+}

--- a/tests/Tests/Models/GH11524/GH11524Listener.php
+++ b/tests/Tests/Models/GH11524/GH11524Listener.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Event\PostLoadEventArgs;
+
+class GH11524Listener
+{
+    public function postLoad(PostloadEventArgs $eventArgs): void
+    {
+        $object = $eventArgs->getObject();
+
+        if (! $object instanceof GH11524Relation) {
+            return;
+        }
+
+        $object->setCurrentLocale('en');
+    }
+}

--- a/tests/Tests/Models/GH11524/GH11524Relation.php
+++ b/tests/Tests/Models/GH11524/GH11524Relation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH11524;
+
+use Doctrine\ORM\Mapping as ORM;
+use LogicException;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="gh11524_relations")
+ */
+class GH11524Relation
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int|null
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string|null
+     */
+    private $currentLocale;
+
+    public function setCurrentLocale(string $locale): void
+    {
+        $this->currentLocale = $locale;
+    }
+
+    public function getTranslation(): string
+    {
+        if ($this->currentLocale === null) {
+            throw new LogicException('The current locale must be set to retrieve translation.');
+        }
+
+        return 'fake';
+    }
+}

--- a/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -66,10 +66,11 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
         self::assertTrue($entity->postPersistCallbackInvoked);
 
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
 
         $query  = $this->_em->createQuery('select e from Doctrine\Tests\ORM\Functional\LifecycleCallbackTestEntity e');
         $result = $query->getResult();
-        self::assertTrue($result[0]->postLoadCallbackInvoked);
+        self::assertTrue($result[0]::$postLoadCallbackInvoked);
 
         $result[0]->value = 'hello again';
 
@@ -130,12 +131,14 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
         $id = $entity->getId();
 
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
 
         $reference = $this->_em->getReference(LifecycleCallbackTestEntity::class, $id);
-        self::assertFalse($reference->postLoadCallbackInvoked);
+        self::assertFalse($reference::$postLoadCallbackInvoked);
+        $this->assertTrue($this->isUninitializedObject($reference));
 
         $reference->getValue(); // trigger proxy load
-        self::assertTrue($reference->postLoadCallbackInvoked);
+        self::assertTrue($reference::$postLoadCallbackInvoked);
     }
 
     /** @group DDC-958 */
@@ -148,13 +151,14 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
         $id = $entity->getId();
 
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
 
         $reference = $this->_em->find(LifecycleCallbackTestEntity::class, $id);
-        self::assertTrue($reference->postLoadCallbackInvoked);
-        $reference->postLoadCallbackInvoked = false;
+        self::assertTrue($reference::$postLoadCallbackInvoked);
+        $reference::$postLoadCallbackInvoked = false;
 
         $this->_em->refresh($reference);
-        self::assertTrue($reference->postLoadCallbackInvoked, 'postLoad should be invoked when refresh() is called.');
+        self::assertTrue($reference::$postLoadCallbackInvoked, 'postLoad should be invoked when refresh() is called.');
     }
 
     /** @group DDC-113 */
@@ -197,6 +201,7 @@ class LifecycleCallbackTest extends OrmFunctionalTestCase
 
         $this->_em->flush();
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
 
         $dql = <<<'DQL'
 SELECT
@@ -214,9 +219,9 @@ DQL;
             ->createQuery(sprintf($dql, $e1->getId(), $e2->getId()))
             ->getResult();
 
-        self::assertTrue(current($entities)->postLoadCallbackInvoked);
+        self::assertTrue(current($entities)::$postLoadCallbackInvoked);
         self::assertTrue(current($entities)->postLoadCascaderNotNull);
-        self::assertTrue(current($entities)->cascader->postLoadCallbackInvoked);
+        self::assertTrue(current($entities)->cascader::$postLoadCallbackInvoked);
         self::assertEquals(current($entities)->cascader->postLoadEntitiesCount, 2);
     }
 
@@ -239,6 +244,8 @@ DQL;
 
         $this->_em->flush();
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
+        LifecycleCallbackCascader::$postLoadCallbackInvoked   = false;
 
         $dql = <<<'DQL'
 SELECT
@@ -256,7 +263,7 @@ DQL;
         $result = iterator_to_array($query->iterate());
 
         foreach ($result as $entity) {
-            self::assertTrue($entity[0]->postLoadCallbackInvoked);
+            self::assertTrue($entity[0]::$postLoadCallbackInvoked);
             self::assertFalse($entity[0]->postLoadCascaderNotNull);
 
             break;
@@ -265,7 +272,7 @@ DQL;
         $iterableResult = iterator_to_array($query->toIterable());
 
         foreach ($iterableResult as $entity) {
-            self::assertTrue($entity->postLoadCallbackInvoked);
+            self::assertTrue($entity::$postLoadCallbackInvoked);
             self::assertFalse($entity->postLoadCascaderNotNull);
 
             break;
@@ -283,6 +290,7 @@ DQL;
 
         $this->_em->flush();
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
 
         $query = $this->_em->createQuery(
             'SELECT e FROM Doctrine\Tests\ORM\Functional\LifecycleCallbackTestEntity AS e'
@@ -291,7 +299,7 @@ DQL;
         $result = iterator_to_array($query->iterate(null, Query::HYDRATE_SIMPLEOBJECT));
 
         foreach ($result as $entity) {
-            self::assertTrue($entity[0]->postLoadCallbackInvoked);
+            self::assertTrue($entity[0]::$postLoadCallbackInvoked);
             self::assertFalse($entity[0]->postLoadCascaderNotNull);
 
             break;
@@ -300,7 +308,7 @@ DQL;
         $result = iterator_to_array($query->toIterable([], Query::HYDRATE_SIMPLEOBJECT));
 
         foreach ($result as $entity) {
-            self::assertTrue($entity->postLoadCallbackInvoked);
+            self::assertTrue($entity::$postLoadCallbackInvoked);
             self::assertFalse($entity->postLoadCascaderNotNull);
 
             break;
@@ -325,6 +333,8 @@ DQL;
 
         $this->_em->flush();
         $this->_em->clear();
+        LifecycleCallbackTestEntity::$postLoadCallbackInvoked = false; // Reset the tracking of the postLoad invocation
+        LifecycleCallbackCascader::$postLoadCallbackInvoked   = false;
 
         $dql = <<<'DQL'
 SELECT
@@ -342,9 +352,9 @@ DQL;
             ->createQuery($dql)->setParameter('entA_id', $entA->getId())
             ->getOneOrNullResult();
 
-        self::assertTrue($fetchedA->postLoadCallbackInvoked);
+        self::assertTrue($fetchedA::$postLoadCallbackInvoked);
         foreach ($fetchedA->entities as $fetchJoinedEntB) {
-            self::assertTrue($fetchJoinedEntB->postLoadCallbackInvoked);
+            self::assertTrue($fetchJoinedEntB::$postLoadCallbackInvoked);
         }
     }
 
@@ -492,7 +502,7 @@ class LifecycleCallbackTestEntity
     public $postPersistCallbackInvoked = false;
 
     /** @var bool */
-    public $postLoadCallbackInvoked = false;
+    public static $postLoadCallbackInvoked = false;
 
     /** @var bool */
     public $postLoadCascaderNotNull = false;
@@ -546,7 +556,7 @@ class LifecycleCallbackTestEntity
     /** @PostLoad */
     public function doStuffOnPostLoad(): void
     {
-        $this->postLoadCallbackInvoked = true;
+        self::$postLoadCallbackInvoked = true;
         $this->postLoadCascaderNotNull = isset($this->cascader);
     }
 
@@ -572,7 +582,7 @@ class LifecycleCallbackCascader
 {
     /* test stuff */
     /** @var bool */
-    public $postLoadCallbackInvoked = false;
+    public static $postLoadCallbackInvoked = false;
 
     /** @var int */
     public $postLoadEntitiesCount = 0;
@@ -599,7 +609,7 @@ class LifecycleCallbackCascader
     /** @PostLoad */
     public function doStuffOnPostLoad(): void
     {
-        $this->postLoadCallbackInvoked = true;
+        self::$postLoadCallbackInvoked = true;
         $this->postLoadEntitiesCount   = count($this->entities);
     }
 

--- a/tests/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -57,16 +57,17 @@ class DDC2230Test extends OrmFunctionalTestCase
         $this->_em->persist($insertedAddress);
         $this->_em->flush();
         $this->_em->clear();
+        DDC2230Address::$listener = null; // Reset the tracking state
 
         $addressProxy = $this->_em->getReference(DDC2230Address::class, $insertedAddress->id);
         assert($addressProxy instanceof DDC2230Address);
 
         self::assertTrue($this->isUninitializedObject($addressProxy));
-        self::assertNull($addressProxy->listener);
+        self::assertNull($addressProxy::$listener);
 
         $this->_em->getUnitOfWork()->initializeObject($addressProxy);
 
-        self::assertSame($this->_em->getUnitOfWork(), $addressProxy->listener);
+        self::assertSame($this->_em->getUnitOfWork(), $addressProxy::$listener);
     }
 }
 
@@ -102,12 +103,12 @@ class DDC2230Address implements NotifyPropertyChanged
      */
     public $id;
 
-    /** @var \Doctrine\Common\PropertyChangedListener */
-    public $listener;
+    /** @var \Doctrine\Common\PropertyChangedListener|null */
+    public static $listener;
 
     /** {@inheritDoc} */
     public function addPropertyChangedListener(PropertyChangedListener $listener)
     {
-        $this->listener = $listener;
+        self::$listener = $listener;
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/GH11524Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11524Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Events;
+use Doctrine\Tests\Models\GH11524\GH11524Entity;
+use Doctrine\Tests\Models\GH11524\GH11524Listener;
+use Doctrine\Tests\Models\GH11524\GH11524Relation;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH11524Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH11524Entity::class,
+            GH11524Relation::class
+        );
+
+        $this->_em->getEventManager()->addEventListener(Events::postLoad, new GH11524Listener());
+    }
+
+    public function testPostLoadCalledOnProxy(): void
+    {
+        $relation       = new GH11524Relation();
+        $relation->name = 'test';
+        $this->_em->persist($relation);
+
+        $entity           = new GH11524Entity();
+        $entity->relation = $relation;
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $reloadedEntity = $this->_em->find(GH11524Entity::class, $entity->id);
+
+        $reloadedRelation = $reloadedEntity->relation;
+
+        $this->assertTrue($this->isUninitializedObject($reloadedRelation));
+
+        $this->assertSame('fake', $reloadedRelation->getTranslation(), 'The property set by the postLoad listener must get initialized on usage.');
+    }
+}


### PR DESCRIPTION
This is reopening https://github.com/doctrine/orm/pull/11544 (against the newer branch as some release has been done in the meantime), with the fixes for the testsuite that were missing in it.

PostLoad listeners might initialize values for transient properties, so the proxy should not skip initialization when using transient properties.

Closes https://github.com/doctrine/orm/issues/11524