### PR TITLE
Fix ClassMetadata::fullyQualifiedClassName

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,10 @@ Instead, use `Doctrine\Persistence\Reflection\EnumReflectionProperty` from
 Passing `null` to `Doctrine\ORM\ClassMetadata::fullyQualifiedClassName()` is
 no longer possible.
 
+## Fix result for classes in global namespace in `ClassMetadata::fullyQualifiedClassName()`
+
+If entity class in namespace and given `$className` in global namespace, then method not append namespace to `$className` because class not exists in this namespace.
+
 ## Remove array access
 
 Using array access on instances of the following classes is no longer possible:

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2518,7 +2518,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      */
     public function fullyQualifiedClassName(string $className): string
     {
-        if (! str_contains($className, '\\') && $this->namespace) {
+        if ($this->namespace && ! str_contains($className, '\\') && class_exists($this->namespace . '\\' . $className)) {
             return $this->namespace . '\\' . $className;
         }
 

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -815,6 +815,16 @@ class ClassMetadataTest extends OrmTestCase
         ]);
     }
 
+    public function testFullyQualifiedClassNameNotAppendNamespaceToClassInGlobalNamespace(): void
+    {
+        $metadata            = new ClassMetadata(CmsAddress::class);
+        $metadata->namespace = 'Doctrine\Tests\Models\CMS';
+
+        $this->assertEquals('ArrayObject', $metadata->fullyQualifiedClassName(ArrayObject::class));
+        $this->assertEquals('\ArrayObject', $metadata->fullyQualifiedClassName('\ArrayObject'));
+        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $metadata->fullyQualifiedClassName('CmsUser'));
+    }
+
     #[TestGroup('DDC-1746')]
     public function testInvalidCascade(): void
     {

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -748,7 +748,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm->mapManyToOne(['fieldName' => 'address', 'targetEntity' => 'UnknownClass']);
 
         $this->expectException(MappingException::class);
-        $this->expectExceptionMessage("The target-entity Doctrine\\Tests\\Models\\CMS\\UnknownClass cannot be found in '" . CmsUser::class . "#address'.");
+        $this->expectExceptionMessage("The target-entity UnknownClass cannot be found in '" . CmsUser::class . "#address'.");
 
         $cm->validateAssociations();
     }

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -109,9 +109,11 @@ class ClassMetadataTest extends OrmTestCase
         self::assertInstanceOf(ReflectionClass::class, $cm->reflClass);
         self::assertEquals(CmsUser::class, $cm->name);
         self::assertEquals('UserParent', $cm->rootEntityName);
-        self::assertEquals([One::class, Two::class, Three::class], $cm->subClasses);
+        self::assertNotEquals([One::class, Two::class, Three::class], $cm->subClasses);
+        self::assertEquals(['One', 'Two', 'Three'], $cm->subClasses);
         self::assertEquals(['UserParent'], $cm->parentClasses);
-        self::assertEquals(UserRepository::class, $cm->customRepositoryClassName);
+        self::assertNotEquals(UserRepository::class, $cm->customRepositoryClassName);
+        self::assertEquals('UserRepository', $cm->customRepositoryClassName);
         self::assertEquals(DiscriminatorColumnMapping::fromMappingArray([
             'name' => 'disc',
             'type' => 'integer',


### PR DESCRIPTION
Fix for cases like as: 
entity class in namespace X, listener class in global namespace and passed as ::class constant (`#[\Doctrine\ORM\Mapping\EntityListeners([\ProductImageFile::class])]`). In this case PHP convert class name to `ProductImageFile` when pass to `EntityListeners::__construct()`.