### PR TITLE
Ignore values assigned to initialized readonly properties

### DIFF
--- a/src/Mapping/ReflectionReadonlyProperty.php
+++ b/src/Mapping/ReflectionReadonlyProperty.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use InvalidArgumentException;
-use LogicException;
 use ReflectionProperty;
 
-use function assert;
 use function func_get_args;
 use function func_num_args;
-use function is_object;
-use function sprintf;
 
 /** @internal */
 final class ReflectionReadonlyProperty extends ReflectionProperty
@@ -36,14 +32,6 @@ final class ReflectionReadonlyProperty extends ReflectionProperty
     {
         if (func_num_args() < 2 || $objectOrValue === null || ! $this->isInitialized($objectOrValue)) {
             $this->wrappedProperty->setValue(...func_get_args());
-
-            return;
-        }
-
-        assert(is_object($objectOrValue));
-
-        if (parent::getValue($objectOrValue) !== $value) {
-            throw new LogicException(sprintf('Attempting to change readonly property %s::$%s.', $this->class, $this->name));
         }
     }
 }

--- a/tests/Tests/ORM/Mapping/ReflectionReadonlyPropertyTest.php
+++ b/tests/Tests/ORM/Mapping/ReflectionReadonlyPropertyTest.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping\ReflectionReadonlyProperty;
 use Doctrine\Tests\Models\CMS\CmsTag;
 use Doctrine\Tests\Models\ReadonlyProperties\Author;
 use InvalidArgumentException;
-use LogicException;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -44,9 +43,10 @@ class ReflectionReadonlyPropertyTest extends TestCase
 
         $reflection->setValue($author, 'John Doe');
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Attempting to change readonly property Doctrine\Tests\Models\ReadonlyProperties\Author::$name.');
         $reflection->setValue($author, 'Jane Doe');
+
+        self::assertSame('John Doe', $wrappedReflection->getValue($author));
+        self::assertSame('John Doe', $reflection->getValue($author));
     }
 
     public function testNonReadonlyPropertiesAreForbidden(): void


### PR DESCRIPTION
Attempt to fix #9505 the simplest way: since value objects equality cannot be computed in a generic way, we no longer attempt it in order to avoid false positives.