### PR TITLE
Use DBAL `Types::*` constants instead of removed `Type::*` in phpdoc and static analysis

### DIFF
--- a/src/Query/ParameterTypeInferer.php
+++ b/src/Query/ParameterTypeInferer.php
@@ -25,9 +25,10 @@ use function is_int;
 final class ParameterTypeInferer
 {
     /**
-     * Infers type of a given value, returning a compatible constant:
-     * - Type (\Doctrine\DBAL\Types\Type::*)
-     * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
+     * Infers type of a given value, returning a compatible constant/enum:
+     * - DBAL Type name (\Doctrine\DBAL\Types\Types::*)
+     * - ParameterType
+     * - ArrayParameterType
      */
     public static function inferType(mixed $value): ParameterType|ArrayParameterType|int|string
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\NoUnknownNamedArguments;
 use Doctrine\ORM\Internal\QueryType;
 use Doctrine\ORM\Query\Expr;
@@ -442,7 +443,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @param string|int                                       $key  The parameter position or name.
-     * @param ParameterType|ArrayParameterType|string|int|null $type ParameterType::*, ArrayParameterType::* or \Doctrine\DBAL\Types\Type::* constant
+     * @param ParameterType|ArrayParameterType|string|int|null $type ParameterType::*, ArrayParameterType::* or \Doctrine\DBAL\Types\Types::* constant
+     * @phpstan-param ParameterType|ArrayParameterType|Types::*|null $type
      *
      * @return $this
      */
@@ -1363,8 +1365,9 @@ class QueryBuilder implements Stringable
      *      ->orWhere('u.username = ' . $qb->createNamedParameter('Bar', Types::STRING))
      *  </code>
      *
-     * @param ParameterType|ArrayParameterType|string|int|null $type        ParameterType::*, ArrayParameterType::* or \Doctrine\DBAL\Types\Type::* constant
+     * @param ParameterType|ArrayParameterType|string|int|null $type        ParameterType::*, ArrayParameterType::* or \Doctrine\DBAL\Types\Types::* constant
      * @param non-empty-string|null                            $placeholder The name to bind with. The string must start with a colon ':'.
+     * @phpstan-param ParameterType|ArrayParameterType|Types::*|null $type
      *
      * @return non-empty-string the placeholder name used.
      */


### PR DESCRIPTION
refer to correct `Types::*` constants, instead of `Type::*` removed in dbal 3.0 (deprecated in dbal 2.10) https://github.com/doctrine/dbal/commit/138eb85234a1faeaa2e6a32cd7bcc66bb51c64e8#diff-f3d4bf18365a2dca0a6e58243f65f84d8337b8999357ed8665cf8662e65e0394

orm 3.3 requres at least dbal 3.8
https://github.com/doctrine/orm/blob/7111cc09f36ef0d872e6f96e2a6184d5573b8401/composer.json#L28