### PR TITLE
Enhance setParameters behavior to preserve existing parameters and add new ones

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -313,7 +313,13 @@ abstract class AbstractQuery
             $parameters = $parameterCollection;
         }
 
-        $this->parameters = $parameters;
+        foreach ($parameters as $parameter) {
+            $this->setParameter(
+                $parameter->getName(),
+                $parameter->getValue(),
+                $parameter->typeWasSpecified() ? $parameter->getType() : null,
+            );
+        }
 
         return $this;
     }

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -987,4 +987,24 @@ class QueryTest extends OrmFunctionalTestCase
         self::assertInstanceOf(CmsUser::class, $users[2]);
         self::assertNull($users[3]);
     }
+
+    public function testSetParametersWontRemoveExistingParameters(): void
+    {
+        $parameters = new ArrayCollection();
+        $parameters->add(new Parameter(1, 'jwage'));
+        $parameters->add(new Parameter(2, 'active'));
+
+        $query = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1 AND u.status = ?2 AND u.username = ?3')
+            ->setParameters($parameters);
+
+        $query->setParameters(new ArrayCollection([
+            new Parameter(1, 'new-jwage'),
+            new Parameter(3, 'test-jwage'),
+        ]))->getResult();
+
+        self::assertSame(
+            [1 => 'new-jwage', 2 => 'active', 3 => 'test-jwage'],
+            $this->getLastLoggedQuery()['params'],
+        );
+    }
 }


### PR DESCRIPTION
This unifies the behavior for setParameters function to avoid confusion. Now when using setParameters after setParameter while building complex queries, all other parameters are removed and only new parameters are loaded.