### PR TITLE
Revert to stdout for MappingDescribeCommand

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1109,6 +1109,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     public function setLazyGhostObjectEnabled(bool $flag): void
     {
+        // @phpstan-ignore classConstant.deprecatedTrait (Because we support Symfony < 7.3)
         if ($flag && ! trait_exists(LazyGhostTrait::class)) {
             throw new LogicException(
                 'Lazy ghost objects cannot be enabled because the "symfony/var-exporter" library'

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -568,6 +568,7 @@ EOPHP;
 
     private function generateUseLazyGhostTrait(ClassMetadata $class): string
     {
+        // @phpstan-ignore staticMethod.deprecated (Because we support Symfony < 7.3)
         $code = ProxyHelper::generateLazyGhost($class->getReflectionClass());
         $code = substr($code, 7 + (int) strpos($code, "\n{"));
         $code = substr($code, 0, (int) strpos($code, "\n}"));

--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -65,7 +65,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
+        $ui = new SymfonyStyle($input, $output);
 
         $entityManager = $this->getEntityManager($input);
 


### PR DESCRIPTION
In f256d996cc0dc1ce59b4f147a664eaacdcf929ec, I did a global move to stderr for notifications, and went a bit overboard for MappingDescribeCommand, which purpose is to output a description.

Spotted by @stof in https://github.com/doctrine/DoctrineBundle/issues/1883#issuecomment-2945130400