### PR TITLE
Partially revert to stdout

### DIFF
--- a/src/Tools/Console/Command/InfoCommand.php
+++ b/src/Tools/Console/Command/InfoCommand.php
@@ -39,7 +39,7 @@ EOT
 
     private function doExecute(InputInterface $input, OutputInterface $output): int
     {
-        $ui = (new SymfonyStyle($input, $output))->getErrorStyle();
+        $ui = new SymfonyStyle($input, $output);
 
         $entityManager = $this->getEntityManager($input);
 
@@ -48,7 +48,7 @@ EOT
                                           ->getAllClassNames();
 
         if (! $entityClassNames) {
-            $ui->caution(
+            $ui->getErrorStyle()->caution(
                 [
                     'You do not have any mapped Doctrine ORM entities according to the current configuration.',
                     'If you have entities or mapping files you should check your mapping configuration for errors.',


### PR DESCRIPTION
This command's purpose is to provide structured data, except for a call to caution() that warns the user in case they do not have any mapped entities or they have errors.