### PR TITLE
Treat empty strings for enums as null

### DIFF
--- a/src/Internal/Hydration/SimpleObjectHydrator.php
+++ b/src/Internal/Hydration/SimpleObjectHydrator.php
@@ -138,7 +138,7 @@ class SimpleObjectHydrator extends AbstractHydrator
                 $value = $type->convertToPHPValue($value, $this->platform);
             }
 
-            if ($value !== null && isset($cacheKeyInfo['enumType'])) {
+            if ($value !== null && $value !== '' && isset($cacheKeyInfo['enumType'])) {
                 $originalValue = $currentValue = $value;
                 try {
                     if (! is_array($originalValue)) {


### PR DESCRIPTION
There might be cases when (for legacy reasons) your database contains empty strings instead of `null`. In these cases the `SimpleObjectHydrator` tries to instantiate an enum with an empty string which always will fail.
This PR therefore widens the condition to treat those empty strings same as `null`.