### PR TITLE
#11977 implemented batching of `INSERT` operations in `UnitOfWork#executeInserts()` so that `EntityPersister#executeInserts()` calls are reduced

### DIFF
--- a/src/Internal/UnitOfWork/InsertBatch.php
+++ b/src/Internal/UnitOfWork/InsertBatch.php
@@ -37,6 +37,12 @@ final class InsertBatch
     /**
      * Note: Code in here is procedural/ugly due to it being in a hot path of the {@see UnitOfWork}
      *
+     * This method will batch the given entity set by type, preserving their order. For example,
+     * given an input [A1, A2, A3, B1, B2, A4, A5], it will create an [[A1, A2, A3], [B1, B2], [A4, A5]] batch.
+     *
+     * Entities for which the identifier needs to be generated or fetched by a sequence are put as single
+     * items in a batch of their own, since it is unsafe to batch-insert them.
+     *
      * @param list<TEntities> $entities
      *
      * @return list<self<TEntities>>

--- a/src/Internal/UnitOfWork/InsertBatch.php
+++ b/src/Internal/UnitOfWork/InsertBatch.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\UnitOfWork;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * An {@see InsertBatch} represents a set of entities that are safe to be batched
+ * together in a single query.
+ *
+ * These entities are only those that have all fields already assigned, including the
+ * identifier field(s).
+ *
+ * This data structure only exists for internal {@see UnitOfWork} optimisations, and
+ * should not be relied upon outside the ORM.
+ *
+ * @internal
+ *
+ * @template TEntity of object
+ */
+final class InsertBatch
+{
+    /**
+     * @param ClassMetadata<TEntity>  $class
+     * @param non-empty-list<TEntity> $entities
+     */
+    public function __construct(
+        public readonly ClassMetadata $class,
+        public array $entities,
+    ) {
+    }
+
+    /**
+     * Note: Code in here is procedural/ugly due to it being in a hot path of the {@see UnitOfWork}
+     *
+     * @param list<TEntities> $entities
+     *
+     * @return list<self<TEntities>>
+     *
+     * @template TEntities of object
+     */
+    public static function batchByEntityType(
+        EntityManagerInterface $entityManager,
+        array $entities,
+    ): array {
+        $currentClass = null;
+        $batches      = [];
+        $batchIndex   = -1;
+
+        foreach ($entities as $entity) {
+            $entityClass = $entityManager->getClassMetadata($entity::class);
+
+            if (
+                $currentClass?->name !== $entityClass->name
+                || $entityClass->idGenerator->isPostInsertGenerator()
+            ) {
+                $currentClass = $entityClass;
+                $batches[]    = new InsertBatch($entityClass, [$entity]);
+                $batchIndex  += 1;
+
+                continue;
+            }
+
+            $batches[$batchIndex]->entities[] = $entity;
+        }
+
+        return $batches;
+    }
+}

--- a/src/Internal/UnitOfWork/InsertBatch.php
+++ b/src/Internal/UnitOfWork/InsertBatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Internal\UnitOfWork;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
@@ -55,7 +56,7 @@ final class InsertBatch
 
             if (
                 $currentClass?->name !== $entityClass->name
-                || $entityClass->idGenerator->isPostInsertGenerator()
+                || ! $entityClass->idGenerator instanceof AssignedGenerator
             ) {
                 $currentClass = $entityClass;
                 $batches[]    = new InsertBatch($entityClass, [$entity]);

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -61,6 +61,7 @@ use function array_map;
 use function array_sum;
 use function array_values;
 use function assert;
+use function count;
 use function current;
 use function get_debug_type;
 use function implode;
@@ -1039,28 +1040,60 @@ class UnitOfWork implements PropertyChangedListener
     {
         $entities         = $this->computeInsertExecutionOrder();
         $eventsToDispatch = [];
+        // @TODO #11977 this is ugly and to be tested: making it work, then refactoring later.
+        //       We assemble micro-batches to process together: this should probably occur in a `private` function?
+        // @TODO #11977 test this by verifying the number of executed SQL queries in a flush operation?
+        // @TODO #11977 could this be applied also to batch updates? If so, let's raise a new issue.
+        /** @var list<array{class: Mapping\ClassMetadata, entities: non-empty-list<object>}> $batchedByType */
+        $batchedByType = [];
 
         foreach ($entities as $entity) {
-            $oid       = spl_object_id($entity);
-            $class     = $this->em->getClassMetadata($entity::class);
+            $currentClass = ($batchedByType[count($batchedByType) - 1]['class'] ?? null)?->getName();
+            $entityClass  = $this->em->getClassMetadata($entity::class);
+
+            if (
+                $currentClass !== $entityClass->name
+                // don't batch things together, if an ID generator is needed
+                || $entityClass->idGenerator->isPostInsertGenerator()
+            ) {
+                $batchedByType[] = [
+                    'class'    => $entityClass,
+                    'entities' => [$entity],
+                ];
+
+                continue;
+            }
+
+            $batchedByType[count($batchedByType) - 1]['entities'][] = $entity;
+        }
+
+        foreach ($batchedByType as $batch) {
+            $class     = $batch['class'];
+            $invoke    = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
             $persister = $this->getEntityPersister($class->name);
 
-            $persister->addInsert($entity);
+            foreach ($batch['entities'] as $entity) {
+                $oid = spl_object_id($entity);
 
-            unset($this->entityInsertions[$oid]);
+                $persister->addInsert($entity);
+
+                unset($this->entityInsertions[$oid]);
+            }
 
             $persister->executeInserts();
 
-            if (! isset($this->entityIdentifiers[$oid])) {
-                //entity was not added to identity map because some identifiers are foreign keys to new entities.
-                //add it now
-                $this->addToEntityIdentifiersAndEntityMap($class, $oid, $entity);
-            }
+            foreach ($batch['entities'] as $entity) {
+                $oid = spl_object_id($entity);
 
-            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
+                if (! isset($this->entityIdentifiers[$oid])) {
+                    //entity was not added to identity map because some identifiers are foreign keys to new entities.
+                    //add it now
+                    $this->addToEntityIdentifiersAndEntityMap($class, $oid, $entity);
+                }
 
-            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $eventsToDispatch[] = ['class' => $class, 'entity' => $entity, 'invoke' => $invoke];
+                if ($invoke !== ListenersInvoker::INVOKE_NONE) {
+                    $eventsToDispatch[] = ['class' => $class, 'entity' => $entity, 'invoke' => $invoke];
+                }
             }
         }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Internal\StronglyConnectedComponents;
 use Doctrine\ORM\Internal\TopologicalSort;
+use Doctrine\ORM\Internal\UnitOfWork\InsertBatch;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
@@ -61,7 +62,6 @@ use function array_map;
 use function array_sum;
 use function array_values;
 use function assert;
-use function count;
 use function current;
 use function get_debug_type;
 use function implode;
@@ -1038,41 +1038,18 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeInserts(): void
     {
-        $entities         = $this->computeInsertExecutionOrder();
         $eventsToDispatch = [];
-        // @TODO #11977 this is ugly and to be tested: making it work, then refactoring later.
-        //       We assemble micro-batches to process together: this should probably occur in a `private` function?
         // @TODO #11977 test this by verifying the number of executed SQL queries in a flush operation?
         // @TODO #11977 could this be applied also to batch updates? If so, let's raise a new issue.
-        /** @var list<array{class: Mapping\ClassMetadata, entities: non-empty-list<object>}> $batchedByType */
-        $batchedByType = [];
-
-        foreach ($entities as $entity) {
-            $currentClass = ($batchedByType[count($batchedByType) - 1]['class'] ?? null)?->getName();
-            $entityClass  = $this->em->getClassMetadata($entity::class);
-
-            if (
-                $currentClass !== $entityClass->name
-                // don't batch things together, if an ID generator is needed
-                || $entityClass->idGenerator->isPostInsertGenerator()
-            ) {
-                $batchedByType[] = [
-                    'class'    => $entityClass,
-                    'entities' => [$entity],
-                ];
-
-                continue;
-            }
-
-            $batchedByType[count($batchedByType) - 1]['entities'][] = $entity;
-        }
+        /** @var list<InsertBatch<object>> $batchedByType */
+        $batchedByType = InsertBatch::batchByEntityType($this->em, $this->computeInsertExecutionOrder());
 
         foreach ($batchedByType as $batch) {
-            $class     = $batch['class'];
+            $class     = $batch->class;
             $invoke    = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
             $persister = $this->getEntityPersister($class->name);
 
-            foreach ($batch['entities'] as $entity) {
+            foreach ($batch->entities as $entity) {
                 $oid = spl_object_id($entity);
 
                 $persister->addInsert($entity);
@@ -1082,7 +1059,7 @@ class UnitOfWork implements PropertyChangedListener
 
             $persister->executeInserts();
 
-            foreach ($batch['entities'] as $entity) {
+            foreach ($batch->entities as $entity) {
                 $oid = spl_object_id($entity);
 
                 if (! isset($this->entityIdentifiers[$oid])) {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1038,7 +1038,6 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeInserts(): void
     {
-        /** @var list<InsertBatch<object>> $batchedByType */
         $batchedByType    = InsertBatch::batchByEntityType($this->em, $this->computeInsertExecutionOrder());
         $eventsToDispatch = [];
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1038,11 +1038,9 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeInserts(): void
     {
-        $eventsToDispatch = [];
-        // @TODO #11977 test this by verifying the number of executed SQL queries in a flush operation?
-        // @TODO #11977 could this be applied also to batch updates? If so, let's raise a new issue.
         /** @var list<InsertBatch<object>> $batchedByType */
-        $batchedByType = InsertBatch::batchByEntityType($this->em, $this->computeInsertExecutionOrder());
+        $batchedByType    = InsertBatch::batchByEntityType($this->em, $this->computeInsertExecutionOrder());
+        $eventsToDispatch = [];
 
         foreach ($batchedByType as $batch) {
             $class     = $batch->class;

--- a/tests/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Tests/Mocks/EntityPersisterMock.php
@@ -13,6 +13,8 @@ use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
  */
 class EntityPersisterMock extends BasicEntityPersister
 {
+    /** @var int<0, max> */
+    private int $countOfExecuteInsertCalls  = 0;
     private array $inserts                  = [];
     private array $updates                  = [];
     private array $deletes                  = [];
@@ -40,6 +42,8 @@ class EntityPersisterMock extends BasicEntityPersister
 
     public function executeInserts(): void
     {
+        $this->countOfExecuteInsertCalls += 1;
+
         foreach ($this->postInsertIds as $item) {
             $this->em->getUnitOfWork()->assignPostInsertId($item['entity'], $item['generatedId']);
         }
@@ -86,6 +90,7 @@ class EntityPersisterMock extends BasicEntityPersister
 
     public function reset(): void
     {
+        $this->countOfExecuteInsertCalls  = 0;
         $this->existsCalled               = false;
         $this->identityColumnValueCounter = 0;
         $this->inserts                    = [];
@@ -96,5 +101,11 @@ class EntityPersisterMock extends BasicEntityPersister
     public function isExistsCalled(): bool
     {
         return $this->existsCalled;
+    }
+
+    /** @return int<0, max> */
+    public function countOfExecuteInsertCalls(): int
+    {
+        return $this->countOfExecuteInsertCalls;
     }
 }

--- a/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
+++ b/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
@@ -10,10 +10,12 @@ use Doctrine\ORM\Id\IdentityGenerator;
 use Doctrine\ORM\Internal\UnitOfWork\InsertBatch;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(InsertBatch::class)]
+#[Group('#11977')]
 final class InsertBatchTest extends TestCase
 {
     private EntityManagerInterface&Stub $entityManager;

--- a/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
+++ b/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
@@ -57,6 +57,7 @@ final class InsertBatchTest extends TestCase
         );
 
         self::assertCount(1, $batches);
+        self::assertSame(EntityA::class, $batches[0]->class->name);
         self::assertCount(3, $batches[0]->entities);
     }
 
@@ -75,8 +76,11 @@ final class InsertBatchTest extends TestCase
         );
 
         self::assertCount(3, $batches);
+        self::assertSame(EntityA::class, $batches[0]->class->name);
         self::assertCount(2, $batches[0]->entities);
+        self::assertSame(EntityB::class, $batches[1]->class->name);
         self::assertCount(2, $batches[1]->entities);
+        self::assertSame(EntityA::class, $batches[2]->class->name);
         self::assertCount(2, $batches[2]->entities);
     }
 
@@ -92,8 +96,11 @@ final class InsertBatchTest extends TestCase
         );
 
         self::assertCount(3, $batches);
+        self::assertSame(EntityC::class, $batches[0]->class->name);
         self::assertCount(1, $batches[0]->entities);
+        self::assertSame(EntityC::class, $batches[1]->class->name);
         self::assertCount(1, $batches[1]->entities);
+        self::assertSame(EntityC::class, $batches[2]->class->name);
         self::assertCount(1, $batches[2]->entities);
     }
 }

--- a/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
+++ b/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
@@ -103,6 +103,31 @@ final class InsertBatchTest extends TestCase
         self::assertSame(EntityC::class, $batches[2]->class->name);
         self::assertCount(1, $batches[2]->entities);
     }
+
+    public function testWillIsolateBatchesForEntitiesWithGeneratedIdentifiers(): void
+    {
+        $batches = InsertBatch::batchByEntityType(
+            $this->entityManager,
+            [
+                new EntityA(),
+                new EntityA(),
+                new EntityC(),
+                new EntityC(),
+                new EntityA(),
+                new EntityA(),
+            ],
+        );
+
+        self::assertCount(4, $batches);
+        self::assertSame(EntityA::class, $batches[0]->class->name);
+        self::assertCount(2, $batches[0]->entities);
+        self::assertSame(EntityC::class, $batches[1]->class->name);
+        self::assertCount(1, $batches[1]->entities);
+        self::assertSame(EntityC::class, $batches[2]->class->name);
+        self::assertCount(1, $batches[2]->entities);
+        self::assertSame(EntityA::class, $batches[3]->class->name);
+        self::assertCount(2, $batches[3]->entities);
+    }
 }
 
 class EntityA

--- a/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
+++ b/tests/Tests/ORM/Internal/UnitOfWork/InsertBatchTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Internal\UnitOfWork;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Id\AssignedGenerator;
+use Doctrine\ORM\Id\IdentityGenerator;
+use Doctrine\ORM\Internal\UnitOfWork\InsertBatch;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InsertBatch::class)]
+final class InsertBatchTest extends TestCase
+{
+    private EntityManagerInterface&Stub $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $entityAMetadata = new ClassMetadata(EntityA::class);
+        $entityBMetadata = new ClassMetadata(EntityB::class);
+        $entityCMetadata = new ClassMetadata(EntityC::class);
+
+        $entityAMetadata->idGenerator = new AssignedGenerator();
+        $entityBMetadata->idGenerator = new AssignedGenerator();
+        $entityCMetadata->idGenerator = new IdentityGenerator();
+
+        $this->entityManager->method('getClassMetadata')
+            ->willReturnMap([
+                [EntityA::class, $entityAMetadata],
+                [EntityB::class, $entityBMetadata],
+                [EntityC::class, $entityCMetadata],
+            ]);
+    }
+
+    public function testWillProduceEmptyBatchOnNoGivenEntities(): void
+    {
+        self::assertEmpty(InsertBatch::batchByEntityType($this->entityManager, []));
+    }
+
+    public function testWillBatchSameEntityOperationsInSingleBatch(): void
+    {
+        $batches = InsertBatch::batchByEntityType(
+            $this->entityManager,
+            [
+                new EntityA(),
+                new EntityA(),
+                new EntityA(),
+            ],
+        );
+
+        self::assertCount(1, $batches);
+        self::assertCount(3, $batches[0]->entities);
+    }
+
+    public function testWillBatchInterleavedEntityOperationsInGroups(): void
+    {
+        $batches = InsertBatch::batchByEntityType(
+            $this->entityManager,
+            [
+                new EntityA(),
+                new EntityA(),
+                new EntityB(),
+                new EntityB(),
+                new EntityA(),
+                new EntityA(),
+            ],
+        );
+
+        self::assertCount(3, $batches);
+        self::assertCount(2, $batches[0]->entities);
+        self::assertCount(2, $batches[1]->entities);
+        self::assertCount(2, $batches[2]->entities);
+    }
+
+    public function testWillNotBatchOperationsForAGeneratedIdentifierEntity(): void
+    {
+        $batches = InsertBatch::batchByEntityType(
+            $this->entityManager,
+            [
+                new EntityC(),
+                new EntityC(),
+                new EntityC(),
+            ],
+        );
+
+        self::assertCount(3, $batches);
+        self::assertCount(1, $batches[0]->entities);
+        self::assertCount(1, $batches[1]->entities);
+        self::assertCount(1, $batches[2]->entities);
+    }
+}
+
+class EntityA
+{
+}
+
+class EntityB
+{
+}
+
+class EntityC
+{
+}

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -32,6 +32,7 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
 use Doctrine\Tests\Models\Forum\ForumUser;
+use Doctrine\Tests\Models\MixedToOneIdentity\Country;
 use Doctrine\Tests\OrmTestCase;
 use Exception as BaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -139,6 +140,25 @@ class UnitOfWorkTest extends OrmTestCase
 
         // should have an id
         self::assertIsNumeric($user->id);
+    }
+
+    #[Group('#11977')]
+    public function testMultipleInsertsAreBatchedInThePersister(): void
+    {
+        $userPersister = new EntityPersisterMock($this->_emMock, $this->_emMock->getClassMetadata(Country::class));
+        $this->_unitOfWork->setEntityPersister(Country::class, $userPersister);
+
+        $country1          = new Country();
+        $country1->country = 'Italy';
+        $country2          = new Country();
+        $country2->country = 'Germany';
+
+        $this->_unitOfWork->persist($country1);
+        $this->_unitOfWork->persist($country2);
+        $this->_unitOfWork->commit();
+
+        self::assertCount(2, $userPersister->getInserts());
+        self::assertSame(1, $userPersister->countOfExecuteInsertCalls());
     }
 
     /**


### PR DESCRIPTION
This logic also brings a minor benefit in reducing the number of times `ListenersInvoker#getSubscribedSystems` is queried.

Implements #11977

TODOs:

* [x] integration test this - it is expected to reduce the number of `EntityPersister#executeInserts()` calls
* [x] refactor this by creating a new `@internal` class for the batch, and perhaps batch via a generator
* [x] reduce amount of repeated `getClassMetadata()` calls
* [x] reduce overall size of `UnitOfWork` code, instead of increasing it

The final effect of this patch is that `EntityPersister#executeInserts()` will be performed on a **batch** of entities being persisted, which improves efficiency, since a single prepared statement is re-used to perform all `INSERT` operations.