### PR TITLE
Use the correct environment variable name for lazy objects and enable them by default

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,27 +43,27 @@ jobs:
           - "pdo_sqlite"
         deps:
           - "highest"
-        lazy_proxy:
+        native_lazy:
           - "0"
         include:
           - php-version: "8.2"
             dbal-version: "4@dev"
             extension: "pdo_sqlite"
-            lazy_proxy: "0"
+            native_lazy: "0"
           - php-version: "8.2"
             dbal-version: "4@dev"
             extension: "sqlite3"
-            lazy_proxy: "0"
+            native_lazy: "0"
           - php-version: "8.1"
             dbal-version: "default"
             deps: "lowest"
             extension: "pdo_sqlite"
-            lazy_proxy: "0"
+            native_lazy: "0"
           - php-version: "8.4"
             dbal-version: "default"
             deps: "highest"
             extension: "pdo_sqlite"
-            lazy_proxy: "1"
+            native_lazy: "1"
 
     steps:
       - name: "Checkout"
@@ -93,18 +93,18 @@ jobs:
         run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage-no-cache.xml"
         env:
             ENABLE_SECOND_LEVEL_CACHE: 0
-            ENABLE_LAZY_PROXY: ${{ matrix.lazy_proxy }}
+            ENABLE_NATIVE_LAZY_OBJECTS: ${{ matrix.native_lazy }}
 
       - name: "Run PHPUnit with Second Level Cache"
         run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --exclude-group performance,non-cacheable,locking_functional --coverage-clover=coverage-cache.xml"
         env:
             ENABLE_SECOND_LEVEL_CACHE: 1
-            ENABLE_LAZY_PROXY: ${{ matrix.lazy_proxy }}
+            ENABLE_NATIVE_LAZY_OBJECTS: ${{ matrix.native_lazy }}
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "phpunit-${{ matrix.extension }}-${{ matrix.php-version }}-${{ matrix.dbal-version }}-${{ matrix.deps }}-${{ matrix.lazy_proxy }}-coverage"
+          name: "phpunit-${{ matrix.extension }}-${{ matrix.php-version }}-${{ matrix.dbal-version }}-${{ matrix.deps }}-${{ matrix.native_lazy }}-coverage"
           path: "coverage*.xml"
 
 


### PR DESCRIPTION
The test suite checks for `ENABLE_NATIVE_LAZY_OBJECTS`.
I have also renamed the matrix variable for the sake of consistency.