### PR TITLE
Enable native lazy objects by default

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3057,7 +3057,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function isUninitializedObject(mixed $obj): bool
     {
-        if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled() && ! ($obj instanceof Collection)) {
+        if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled() && ! ($obj instanceof Collection) && is_object($obj)) {
             return $this->em->getClassMetadata($obj::class)->reflClass->isUninitializedLazyObject($obj);
         }
 

--- a/tests/Tests/ORM/EntityManagerTest.php
+++ b/tests/Tests/ORM/EntityManagerTest.php
@@ -25,9 +25,10 @@ use Generator;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
-use Symfony\Component\VarExporter\LazyGhostTrait;
 use TypeError;
 
 class EntityManagerTest extends OrmTestCase
@@ -180,17 +181,12 @@ class EntityManagerTest extends OrmTestCase
     }
 
     /** Resetting the EntityManager relies on lazy objects until https://github.com/doctrine/orm/issues/5933 is resolved */
+    #[RequiresPhp('8.4')]
     public function testLazyGhostEntityManager(): void
     {
-        $em = new class () extends EntityManager {
-            use LazyGhostTrait;
+        $reflector = new ReflectionClass(EntityManager::class);
 
-            public function __construct()
-            {
-            }
-        };
-
-        $em = $em::createLazyGhost(static function ($em): void {
+        $em = $reflector->newLazyGhost($initializer = static function (EntityManager $em): void {
             $r = new ReflectionProperty(EntityManager::class, 'unitOfWork');
             $r->setValue($em, new class () extends UnitOfWork {
                 public function __construct()
@@ -207,7 +203,7 @@ class EntityManagerTest extends OrmTestCase
         $em->close();
         $this->assertFalse($em->isOpen());
 
-        $em->resetLazyObject();
+        $reflector->resetAsLazyGhost($em, $initializer);
         $this->assertTrue($em->isOpen());
     }
 

--- a/tests/Tests/ORM/Functional/PropertyHooksTest.php
+++ b/tests/Tests/ORM/Functional/PropertyHooksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Tests\Models\PropertyHooks\MappingVirtualProperty;
 use Doctrine\Tests\Models\PropertyHooks\User;
@@ -16,6 +17,10 @@ class PropertyHooksTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        if ($this->_em->getConnection()->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            self::markTestSkipped('MySQL/MariaDB is case-insensitive by default, and the logic of this test relies on case sensitivity.');
+        }
 
         if (! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
             $this->markTestSkipped('Property hooks require native lazy objects to be enabled.');

--- a/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\Proxy\InternalProxy;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Mocks\ArrayResultFactory;
@@ -1030,7 +1029,7 @@ class ObjectHydratorTest extends HydrationTestCase
             'Proxies',
             ProxyFactory::AUTOGENERATE_ALWAYS,
         ) extends ProxyFactory {
-            public function getProxy(string $className, array $identifier): InternalProxy
+            public function getProxy(string $className, array $identifier): object
             {
                 TestCase::assertSame(ECommerceShipping::class, $className);
                 TestCase::assertSame(['id' => 42], $identifier);
@@ -1084,7 +1083,7 @@ class ObjectHydratorTest extends HydrationTestCase
             'Proxies',
             ProxyFactory::AUTOGENERATE_ALWAYS,
         ) extends ProxyFactory {
-            public function getProxy(string $className, array $identifier): InternalProxy
+            public function getProxy(string $className, array $identifier): object
             {
                 TestCase::assertSame(ECommerceShipping::class, $className);
                 TestCase::assertSame(['id' => 42], $identifier);

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -120,6 +120,10 @@ class ProxyFactoryTest extends OrmTestCase
     #[Group('DDC-2432')]
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized(): void
     {
+        if ($this->emMock->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            self::markTestSkipped('This test is not relevant when native lazy objects are enabled');
+        }
+
         $persister = $this->getMockBuilder(BasicEntityPersister::class)
             ->onlyMethods(['load'])
             ->disableOriginalConstructor()
@@ -146,6 +150,10 @@ class ProxyFactoryTest extends OrmTestCase
     #[Group('DDC-2432')]
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized(): void
     {
+        if ($this->emMock->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            self::markTestSkipped('This test is not relevant when native lazy objects are enabled');
+        }
+
         $persister = $this->getMockBuilder(BasicEntityPersister::class)
             ->onlyMethods(['load', 'getClassMetadata'])
             ->disableOriginalConstructor()
@@ -172,6 +180,10 @@ class ProxyFactoryTest extends OrmTestCase
 
     public function testProxyClonesParentFields(): void
     {
+        if ($this->emMock->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            self::markTestSkipped('This test is not relevant when native lazy objects are enabled');
+        }
+
         $companyEmployee = new CompanyEmployee();
         $companyEmployee->setSalary(1000); // A property on the CompanyEmployee
         $companyEmployee->setName('Bob'); // A property on the parent class, CompanyPerson

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\Version;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMInvalidArgumentException;
@@ -40,6 +41,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 use function enum_exists;
+use function is_object;
 use function random_int;
 use function uniqid;
 
@@ -278,7 +280,19 @@ class UnitOfWorkTest extends OrmTestCase
         $user->username = 'John';
         $user->avatar   = $invalidValue;
 
-        $this->expectException(ORMInvalidArgumentException::class);
+        if (
+            is_object($invalidValue) &&
+            ! $invalidValue instanceof ArrayCollection &&
+            $this->_emMock->getConfiguration()->isNativeLazyObjectsEnabled()
+        ) {
+            // in the case of stdClass, the changeset is rejected because
+            // stdClass is not a valid entity
+            // when using native lazy objects, this happens because UnitOfWork::isUninitializedObject()
+            // needs to load the class metadata to do its job
+            $this->expectException(MappingException::class);
+        } else {
+            $this->expectException(ORMInvalidArgumentException::class);
+        }
 
         $this->_unitOfWork->computeChangeSet($metadata, $user);
     }

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -941,6 +941,13 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
 
         $enableNativeLazyObjects = getenv('ENABLE_NATIVE_LAZY_OBJECTS');
 
+        if ($enableNativeLazyObjects === false) {
+            // If the environment variable is not set, we default to true.
+            // This is OK because environment variables are always strings, and
+            // we are comparing it to a boolean.
+            $enableNativeLazyObjects = true;
+        }
+
         if (PHP_VERSION_ID >= 80400 && $enableNativeLazyObjects) {
             $config->enableNativeLazyObjects(true);
         }

--- a/tests/Tests/TestUtil.php
+++ b/tests/Tests/TestUtil.php
@@ -19,12 +19,14 @@ use function class_exists;
 use function explode;
 use function fwrite;
 use function get_debug_type;
+use function getenv;
 use function in_array;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
 
+use const PHP_VERSION_ID;
 use const STDERR;
 
 /**
@@ -89,8 +91,23 @@ class TestUtil
 
     public static function configureProxies(Configuration $configuration): void
     {
+        $enableNativeLazyObjects = getenv('ENABLE_NATIVE_LAZY_OBJECTS');
+
+        if ($enableNativeLazyObjects === false) {
+            // If the environment variable is not set, we default to true.
+            // This is OK because environment variables are always strings, and
+            // we are comparing it to a boolean.
+            $enableNativeLazyObjects = true;
+        }
+
         $configuration->setProxyDir(__DIR__ . '/Proxies');
         $configuration->setProxyNamespace('Doctrine\Tests\Proxies');
+
+        if (PHP_VERSION_ID >= 80400 && $enableNativeLazyObjects) {
+            $configuration->enableNativeLazyObjects(true);
+
+            return;
+        }
     }
 
     private static function initializeDatabase(): void


### PR DESCRIPTION
This should make the test suite look less like a christmas tree.