### PR TITLE
Make proxyDir and proxyNs nullable and optional

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -132,6 +132,9 @@ EOPHP;
     /** @var array<class-string, Closure> */
     private array $proxyFactories = [];
 
+    private readonly string $proxyDir;
+    private readonly string $proxyNs;
+
     /**
      * Initializes a new instance of the <tt>ProxyFactory</tt> class that is
      * connected to the given <tt>EntityManager</tt>.
@@ -143,8 +146,8 @@ EOPHP;
      */
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly string $proxyDir,
-        private readonly string $proxyNs,
+        string|null $proxyDir = null,
+        string|null $proxyNs = null,
         bool|int $autoGenerate = self::AUTOGENERATE_NEVER,
     ) {
         if (! $proxyDir && ! $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
@@ -158,6 +161,17 @@ EOPHP;
         if (is_int($autoGenerate) ? $autoGenerate < 0 || $autoGenerate > 4 : ! is_bool($autoGenerate)) {
             throw ORMInvalidArgumentException::invalidAutoGenerateMode($autoGenerate);
         }
+
+        if ($proxyDir === null && $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $proxyDir = '';
+        }
+
+        if ($proxyNs === null && $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $proxyNs = '';
+        }
+
+        $this->proxyDir = $proxyDir;
+        $this->proxyNs  = $proxyNs;
 
         $this->uow                 = $em->getUnitOfWork();
         $this->autoGenerate        = (int) $autoGenerate;

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -20,6 +20,8 @@ use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
 
@@ -208,6 +210,24 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertSame(42, $cloned->getId(), 'Expected the Id to be cloned');
         self::assertSame(1000, $cloned->getSalary(), 'Expect properties on the CompanyEmployee class to be cloned');
         self::assertSame('Bob', $cloned->getName(), 'Expect properties on the CompanyPerson class to be cloned');
+    }
+
+    #[RequiresPhp('8.4')]
+    public function testProxyFactoryAcceptsNullProxyArgsWhenNativeLazyObjectsAreEnabled(): void
+    {
+        $this->emMock->getConfiguration()->enableNativeLazyObjects(true);
+        $this->proxyFactory = new ProxyFactory(
+            $this->emMock,
+            null,
+            null,
+        );
+        $proxy              = $this->proxyFactory->getProxy(
+            ECommerceFeature::class,
+            ['id' => 42],
+        );
+        $reflection         = new ReflectionClass($proxy);
+
+        self::assertTrue($reflection->isUninitializedLazyObject($proxy));
     }
 }
 


### PR DESCRIPTION
When using native lazy objects, it should be possible to omit these arguments, hence the default value.
Also, when using native lazy objects, one should not have to configure the corresponding Configuration attributes, which means EntityManager__construct() should be able to pass null to this class, hence the nullability.

Fixes #11997