### PR TITLE
Remove calls to `getMockForAbstractClass()`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -234,6 +234,7 @@
         <!-- extending a class from another package -->
         <exclude-pattern>tests/Tests/Mocks/DatabasePlatformMock.php</exclude-pattern>
         <exclude-pattern>tests/Tests/Mocks/SchemaManagerMock.php</exclude-pattern>
+        <exclude-pattern>tests/Tests/ORM/AbstractQueryTest.php</exclude-pattern>
         <exclude-pattern>tests/Tests/ORM/Functional/Ticket/DDC3634Test.php</exclude-pattern>
     </rule>
 

--- a/tests/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Tests/ORM/AbstractQueryTest.php
@@ -27,9 +27,7 @@ final class AbstractQueryTest extends TestCase
 
         $configuration = new Configuration();
         $configuration->setHydrationCache($cache);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn($configuration);
-        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $query        = $this->createAbstractQuery($configuration);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setHydrationCacheProfile($cacheProfile);
@@ -45,9 +43,7 @@ final class AbstractQueryTest extends TestCase
 
         $configuration = new Configuration();
         $configuration->setHydrationCache($cache);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn($configuration);
-        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $query        = $this->createAbstractQuery($configuration);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setHydrationCacheProfile($cacheProfile);
@@ -61,9 +57,7 @@ final class AbstractQueryTest extends TestCase
 
         $configuration = new Configuration();
         $configuration->setResultCache($cache);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn($configuration);
-        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $query        = $this->createAbstractQuery($configuration);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setResultCacheProfile($cacheProfile);
@@ -74,9 +68,7 @@ final class AbstractQueryTest extends TestCase
     /** @dataProvider provideSettersWithDeprecatedDefault */
     public function testCallingSettersWithoutArgumentsIsDeprecated(string $setter): void
     {
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn(new Configuration());
-        $query = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $query = $this->createAbstractQuery(new Configuration());
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9791');
         $query->$setter();
@@ -95,10 +87,7 @@ final class AbstractQueryTest extends TestCase
     public function testSettingTheResultCacheIsPossibleWithoutCallingDeprecatedMethods(): void
     {
         $cache = $this->createMock(CacheItemPoolInterface::class);
-
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn(new Configuration());
-        $query = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $query = $this->createAbstractQuery(new Configuration());
 
         $query->setResultCache($cache);
         self::assertSame($cache, CacheAdapter::wrap($query->getResultCacheDriver()));
@@ -107,13 +96,27 @@ final class AbstractQueryTest extends TestCase
 
     public function testSettingTheFetchModeToRandomIntegersIsDeprecated(): void
     {
-        $query = $this->getMockForAbstractClass(
-            AbstractQuery::class,
-            [],
-            '',
-            false // no need to call the constructor
-        );
+        $query = $this->createAbstractQuery(new Configuration());
+
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/9777');
         $query->setFetchMode(stdClass::class, 'foo', 42);
+    }
+
+    private function createAbstractQuery(Configuration $configuration): AbstractQuery
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
+
+        return new class ($entityManager) extends AbstractQuery {
+            public function getSQL(): string
+            {
+                return '';
+            }
+
+            protected function _doExecute(): int
+            {
+                return 0;
+            }
+        };
     }
 }

--- a/tests/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/QueryCacheTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
@@ -121,15 +122,15 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $sqlExecMock = $this->getMockBuilder(AbstractSqlExecutor::class)
-                            ->getMockForAbstractClass();
-
-        $sqlExecMock->expects(self::once())
-                    ->method('execute')
-                    ->willReturn(10);
+        $sqlExecutorStub = new class extends AbstractSqlExecutor {
+            public function execute(Connection $conn, array $params, array $types): int
+            {
+                return 10;
+            }
+        };
 
         $parserResultMock = new ParserResult();
-        $parserResultMock->setSqlExecutor($sqlExecMock);
+        $parserResultMock->setSqlExecutor($sqlExecutorStub);
 
         $cache = $this->createMock(CacheItemPoolInterface::class);
 

--- a/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -30,7 +31,7 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
     /** @var ResultSetMapping&MockObject */
     private $mockResultMapping;
 
-    /** @var AbstractHydrator&MockObject */
+    /** @var DummyHydrator */
     private $hydrator;
 
     protected function setUp(): void
@@ -56,10 +57,7 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
             ->method('fetchAssociative')
             ->willReturn(false);
 
-        $this->hydrator = $this
-            ->getMockBuilder(AbstractHydrator::class)
-            ->setConstructorArgs([$mockEntityManagerInterface])
-            ->getMockForAbstractClass();
+        $this->hydrator = new DummyHydrator($mockEntityManagerInterface);
     }
 
     /**
@@ -146,11 +144,7 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
                 $this->assertTrue($eventListenerHasBeenRegistered);
             });
 
-        $this
-            ->hydrator
-            ->expects(self::once())
-            ->method('hydrateAllData')
-            ->willThrowException(new ORMException());
+        $this->hydrator->throwException = true;
 
         $this->expectException(ORMException::class);
         $this->hydrator->hydrateAll($this->mockResult, $this->mockResultMapping);
@@ -183,5 +177,21 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
         }
 
         self::assertCount(0, $evm->getListeners(Events::onClear));
+    }
+}
+
+class DummyHydrator extends AbstractHydrator
+{
+    /** @var bool */
+    public $throwException = false;
+
+    /** {@inheritDoc} */
+    protected function hydrateAllData()
+    {
+        if ($this->throwException) {
+            throw NotSupported::create();
+        }
+
+        return [];
     }
 }

--- a/tests/Tests/ORM/Mapping/DefaultQuoteStrategyTest.php
+++ b/tests/Tests/ORM/Mapping/DefaultQuoteStrategyTest.php
@@ -9,8 +9,6 @@ use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\Tests\Models\NonPublicSchemaJoins\User as NonPublicSchemaUser;
 use Doctrine\Tests\OrmTestCase;
 
-use function assert;
-
 /**
  * Doctrine\Tests\ORM\Mapping\DefaultQuoteStrategyTest
  */
@@ -25,8 +23,7 @@ class DefaultQuoteStrategyTest extends OrmTestCase
         $em       = $this->getTestEntityManager();
         $metadata = $em->getClassMetadata(NonPublicSchemaUser::class);
         $strategy = new DefaultQuoteStrategy();
-        $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
-        assert($platform instanceof AbstractPlatform);
+        $platform = $this->createStub(AbstractPlatform::class);
 
         self::assertSame(
             'readers.author_reader',

--- a/tests/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Tests/ORM/Query/ParserResultTest.php
@@ -28,7 +28,7 @@ class ParserResultTest extends TestCase
     {
         self::assertNull($this->parserResult->getSqlExecutor());
 
-        $executor = $this->getMockForAbstractClass(AbstractSqlExecutor::class);
+        $executor = $this->createMock(AbstractSqlExecutor::class);
         $this->parserResult->setSqlExecutor($executor);
         self::assertSame($executor, $this->parserResult->getSqlExecutor());
     }


### PR DESCRIPTION
PHPUnit has deprecated partial mocking, so we should avoud calling `getMockForAbstractClass()` in our tests.