### PR TITLE
Fix calls to Application::add()

### DIFF
--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -11,7 +11,7 @@ parameters:
 
         # Fallback logic for DBAL 2
         -
-            message: '/Application::add\(\) expects Symfony\\Component\\Console\\Command\\Command/'
+            message: '/Parameter #2 \$command of static method Doctrine\\ORM\\Tools\\Console\\ConsoleRunner\:\:addCommandToApplication\(\) expects Symfony\\Component\\Console\\Command\\Command/'
             path: src/Tools/Console/ConsoleRunner.php
 
         - '/^Class Doctrine\\DBAL\\Platforms\\SQLAnywherePlatform not found\.$/'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,7 @@ parameters:
 
         # Fallback logic for DBAL 2
         -
-            message: '/Application::add\(\) expects Symfony\\Component\\Console\\Command\\Command/'
+            message: '/Parameter #2 \$command of static method Doctrine\\ORM\\Tools\\Console\\ConsoleRunner\:\:addCommandToApplication\(\) expects Symfony\\Component\\Console\\Command\\Command/'
             path: src/Tools/Console/ConsoleRunner.php
 
         - '/^Class Doctrine\\DBAL\\Platforms\\SQLAnywherePlatform not found\.$/'

--- a/src/Tools/Console/ApplicationCompatibility.php
+++ b/src/Tools/Console/ApplicationCompatibility.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+use function method_exists;
+
+/**
+ * Forward compatibility with Symfony Console 7.4
+ *
+ * @internal
+ */
+trait ApplicationCompatibility
+{
+    private static function addCommandToApplication(Application $application, Command $command): ?Command
+    {
+        if (method_exists(Application::class, 'addCommand')) {
+            // @phpstan-ignore method.notFound (This method will be added in Symfony 7.4)
+            return $application->addCommand($command);
+        }
+
+        return $application->add($command);
+    }
+}

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -23,6 +23,8 @@ use function class_exists;
  */
 final class ConsoleRunner
 {
+    use ApplicationCompatibility;
+
     /**
      * Create a Symfony Console HelperSet
      *
@@ -91,7 +93,7 @@ final class ConsoleRunner
         $connectionProvider = new ConnectionFromManagerProvider($entityManagerProvider);
 
         if (class_exists(DBALConsole\Command\ImportCommand::class)) {
-            $cli->add(new DBALConsole\Command\ImportCommand());
+            self::addCommandToApplication($cli, new DBALConsole\Command\ImportCommand());
         }
 
         $cli->addCommands(

--- a/tests/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\Models\Cache\State;
@@ -14,6 +15,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 /** @group DDC-2183 */
 class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -29,7 +32,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
         $this->command = new CollectionRegionCommand(new SingleManagerProvider($this->_em));
 
         $this->application = new Application();
-        $this->application->add($this->command);
+        self::addCommandToApplication($this->application, $this->command);
     }
 
     public function testClearAllRegion(): void

--- a/tests/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\EntityRegionCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\Models\Cache\Country;
@@ -17,6 +18,8 @@ use function trim;
 /** @group DDC-2183 */
 class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -32,7 +35,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
         $this->command = new EntityRegionCommand(new SingleManagerProvider($this->_em));
 
         $this->application = new Application();
-        $this->application->add($this->command);
+        self::addCommandToApplication($this->application, $this->command);
     }
 
     public function testClearAllRegion(): void

--- a/tests/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -13,6 +14,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 /** @group DDC-2183 */
 class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -28,7 +31,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
         $this->command = new QueryRegionCommand(new SingleManagerProvider($this->_em));
 
         $this->application = new Application();
-        $this->application->add($this->command);
+        self::addCommandToApplication($this->application, $this->command);
     }
 
     public function testClearAllRegion(): void

--- a/tests/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\DoctrineTestCase;
@@ -18,6 +19,8 @@ use function array_merge;
 
 class EnsureProductionSettingsCommandTest extends DoctrineTestCase
 {
+    use ApplicationCompatibility;
+
     public function testExecute(): void
     {
         $em = $this->createMock(EntityManagerInterface::class);
@@ -103,7 +106,7 @@ class EnsureProductionSettingsCommandTest extends DoctrineTestCase
         array $input = []
     ): int {
         $application = new Application();
-        $application->add(new EnsureProductionSettingsCommand(new SingleManagerProvider($em)));
+        self::addCommandToApplication($application, new EnsureProductionSettingsCommand(new SingleManagerProvider($em)));
 
         $command = $application->find('orm:ensure-production-settings');
         $tester  = new CommandTester($command);

--- a/tests/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -35,6 +36,8 @@ use const DIRECTORY_SEPARATOR;
 
 class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -53,7 +56,7 @@ class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
         $metadataDriver->addPaths([__DIR__ . '/../../../../Models/DDC3231/']);
 
         $this->application = new Application();
-        $this->application->add(new GenerateRepositoriesCommand(new SingleManagerProvider($this->_em)));
+        self::addCommandToApplication($this->application, new GenerateRepositoriesCommand(new SingleManagerProvider($this->_em)));
     }
 
     public function tearDown(): void
@@ -163,7 +166,7 @@ class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
 
         $application = new Application();
         $application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($em)]));
-        $application->add(new GenerateRepositoriesCommand());
+        self::addCommandToApplication($application, new GenerateRepositoriesCommand());
 
         $command = $application->find('orm:generate-repositories');
         $tester  = new CommandTester($command);

--- a/tests/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\InfoCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -20,6 +21,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class InfoCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -35,7 +38,7 @@ class InfoCommandTest extends OrmFunctionalTestCase
 
         $this->application = new Application();
 
-        $this->application->add(new InfoCommand(new SingleManagerProvider($this->_em)));
+        self::addCommandToApplication($this->application, new InfoCommand(new SingleManagerProvider($this->_em)));
 
         $this->command = $this->application->find('orm:info');
         $this->tester  = new CommandTester($this->command);
@@ -66,7 +69,7 @@ class InfoCommandTest extends OrmFunctionalTestCase
 
         $application = new Application();
         $application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($em)]));
-        $application->add(new InfoCommand());
+        self::addCommandToApplication($application, new InfoCommand());
 
         $command = $application->find('orm:info');
         $tester  = new CommandTester($command);
@@ -105,7 +108,7 @@ class InfoCommandTest extends OrmFunctionalTestCase
 
         $application = new Application();
         $application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($em)]));
-        $application->add(new InfoCommand());
+        self::addCommandToApplication($application, new InfoCommand());
 
         $command = $application->find('orm:info');
         $tester  = new CommandTester($command);

--- a/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\Models\Cache\AttractionInfo;
@@ -18,6 +19,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class MappingDescribeCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -32,7 +35,7 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->application = new Application();
-        $this->application->add(new MappingDescribeCommand(new SingleManagerProvider($this->_em)));
+        self::addCommandToApplication($this->application, new MappingDescribeCommand(new SingleManagerProvider($this->_em)));
 
         $this->command = $this->application->find('orm:mapping:describe');
         $this->tester  = new CommandTester($this->command);

--- a/tests/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\RunDqlCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
@@ -20,6 +21,8 @@ use function trim;
  */
 class RunDqlCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var Application */
     private $application;
 
@@ -38,7 +41,7 @@ class RunDqlCommandTest extends OrmFunctionalTestCase
         $this->command = new RunDqlCommand(new SingleManagerProvider($this->_em));
 
         $this->application = new Application();
-        $this->application->add($this->command);
+        self::addCommandToApplication($this->application, $this->command);
 
         $this->tester = new CommandTester($this->command);
     }

--- a/tests/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/ValidateSchemaCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -19,6 +20,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ValidateSchemaCommandTest extends OrmFunctionalTestCase
 {
+    use ApplicationCompatibility;
+
     /** @var ValidateSchemaCommand */
     private $command;
 
@@ -34,7 +37,7 @@ class ValidateSchemaCommandTest extends OrmFunctionalTestCase
         }
 
         $application = new Application();
-        $application->add(new ValidateSchemaCommand(new SingleManagerProvider($this->_em)));
+        self::addCommandToApplication($application, new ValidateSchemaCommand(new SingleManagerProvider($this->_em)));
 
         $this->command = $application->find('orm:validate-schema');
         $this->tester  = new CommandTester($this->command);


### PR DESCRIPTION
The `Application::add()` method has been deprecated in favor of `Application::addCommand()`. This PR prepares support for Symfony 8.