### PR TITLE
Ensure proxies implementations behave the same on entity not found

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -185,11 +185,23 @@ EOPHP;
     public function getProxy(string $className, array $identifier): object
     {
         if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            $classMetadata   = $this->em->getClassMetadata($className);
-            $entityPersister = $this->uow->getEntityPersister($className);
+            $classMetadata       = $this->em->getClassMetadata($className);
+            $entityPersister     = $this->uow->getEntityPersister($className);
+            $identifierFlattener = $this->identifierFlattener;
 
-            $proxy = $classMetadata->reflClass->newLazyGhost(static function (object $object) use ($identifier, $entityPersister): void {
-                $entityPersister->loadById($identifier, $object);
+            $proxy = $classMetadata->reflClass->newLazyGhost(static function (object $object) use (
+                $identifier,
+                $entityPersister,
+                $identifierFlattener,
+                $classMetadata,
+            ): void {
+                $original = $entityPersister->loadById($identifier, $object);
+                if ($original === null) {
+                    throw EntityNotFoundException::fromClassNameAndIdentifier(
+                        $classMetadata->getName(),
+                        $identifierFlattener->flattenIdentifier($classMetadata, $identifier),
+                    );
+                }
             }, ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE);
 
             foreach ($identifier as $idField => $value) {

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -122,10 +122,6 @@ class ProxyFactoryTest extends OrmTestCase
     #[Group('DDC-2432')]
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized(): void
     {
-        if ($this->emMock->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            self::markTestSkipped('This test is not relevant when native lazy objects are enabled');
-        }
-
         $persister = $this->getMockBuilder(BasicEntityPersister::class)
             ->onlyMethods(['load'])
             ->disableOriginalConstructor()
@@ -133,7 +129,6 @@ class ProxyFactoryTest extends OrmTestCase
         $this->uowMock->setEntityPersister(ECommerceFeature::class, $persister);
 
         $proxy = $this->proxyFactory->getProxy(ECommerceFeature::class, ['id' => 42]);
-        assert($proxy instanceof Proxy);
 
         $persister
             ->expects(self::atLeastOnce())
@@ -146,16 +141,24 @@ class ProxyFactoryTest extends OrmTestCase
         } catch (EntityNotFoundException) {
         }
 
-        self::assertFalse($proxy->__isInitialized());
+        self::assertUninitializedLazyObject($proxy);
+    }
+
+    private static function assertUninitializedLazyObject(object $proxy): void
+    {
+        if ($proxy instanceof Proxy) {
+            self::assertFalse($proxy->__isInitialized());
+
+            return;
+        }
+
+        $reflectionClass = new ReflectionClass($proxy);
+        self::assertTrue($reflectionClass->isUninitializedLazyObject($proxy));
     }
 
     #[Group('DDC-2432')]
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized(): void
     {
-        if ($this->emMock->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            self::markTestSkipped('This test is not relevant when native lazy objects are enabled');
-        }
-
         $persister = $this->getMockBuilder(BasicEntityPersister::class)
             ->onlyMethods(['load', 'getClassMetadata'])
             ->disableOriginalConstructor()
@@ -163,7 +166,6 @@ class ProxyFactoryTest extends OrmTestCase
         $this->uowMock->setEntityPersister(ECommerceFeature::class, $persister);
 
         $proxy = $this->proxyFactory->getProxy(ECommerceFeature::class, ['id' => 42]);
-        assert($proxy instanceof Proxy);
 
         $persister
             ->expects(self::atLeastOnce())
@@ -177,7 +179,7 @@ class ProxyFactoryTest extends OrmTestCase
         } catch (EntityNotFoundException) {
         }
 
-        self::assertFalse($proxy->__isInitialized());
+        self::assertUninitializedLazyObject($proxy);
     }
 
     public function testProxyClonesParentFields(): void


### PR DESCRIPTION
Both implementations are supposed to throw `EntityNotFoundException`.