### PR TITLE
Provide upgrade path to new ORMSetup::create* signature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,7 +22,7 @@ objects have been deprecated on PHP 8.4+:
 - `Doctrine\ORM\Configuration::setProxyDir()`
 - `Doctrine\ORM\Configuration::setProxyNamespace()`
 - Passing anything but `null` as $proxyDir argument to `Doctrine\ORM\ORMSetup` methods
-- Passing more than one Argument to `Doctrine\ORM\Proxy\ProxyFactory::__construct()`
+- Passing more than one argument to `Doctrine\ORM\Proxy\ProxyFactory::__construct()`
 
 ## Deprecate methods for configuring no longer configurable features
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,8 +21,17 @@ objects have been deprecated on PHP 8.4+:
 - `Doctrine\ORM\Configuration::setAutoGenerateProxyClasses()`
 - `Doctrine\ORM\Configuration::setProxyDir()`
 - `Doctrine\ORM\Configuration::setProxyNamespace()`
-- Passing anything but `null` as $proxyDir argument to `Doctrine\ORM\ORMSetup` methods
 - Passing more than one argument to `Doctrine\ORM\Proxy\ProxyFactory::__construct()`
+
+Additionally, some methods of ORMSetup have been deprecated in favor of a new
+counterpart.
+
+- `Doctrine\ORM\ORMSetup::createAttributeMetadataConfiguration()` is deprecated in favor of
+  `Doctrine\ORM\ORMSetup::createAttributeMetadataConfig()`
+- `Doctrine\ORM\ORMSetup::createXMLMetadataConfiguration()` is deprecated in favor of
+  `Doctrine\ORM\ORMSetup::createXMLMetadataConfig()`
+- `Doctrine\ORM\ORMSetup::createConfiguration()` is deprecated in favor of
+  `Doctrine\ORM\ORMSetup::createConfig()`
 
 ## Deprecate methods for configuring no longer configurable features
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -56,7 +56,8 @@ access point to ORM functionality provided by Doctrine.
         'dbname'   => 'foo',
     ];
 
-    $config = ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
+    $config = ORMSetup::createAttributeMetadataConfig($paths, $isDevMode);
+    // on PHP < 8.4, use ORMSetup::createAttributeMetadataConfiguration() instead
     $connection = DriverManager::getConnection($dbParams, $config);
     $entityManager = new EntityManager($connection, $config);
 
@@ -66,7 +67,8 @@ Or if you prefer XML:
 
     <?php
     $paths = ['/path/to/xml-mappings'];
-    $config = ORMSetup::createXMLMetadataConfiguration($paths, $isDevMode);
+    $config = ORMSetup::createXMLMetadataConfig($paths, $isDevMode);
+    // on PHP < 8.4, use ORMSetup::createXMLMetadataConfiguration() instead
     $connection = DriverManager::getConnection($dbParams, $config);
     $entityManager = new EntityManager($connection, $config);
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -138,12 +138,12 @@ step:
     require_once "vendor/autoload.php";
 
     // Create a simple "default" Doctrine ORM configuration for Attributes
-    $config = ORMSetup::createAttributeMetadataConfiguration(
+    $config = ORMSetup::createAttributeMetadataConfig( // on PHP < 8.4, use ORMSetup::createAttributeMetadataConfiguration()
         paths: [__DIR__ . '/src'],
         isDevMode: true,
     );
     // or if you prefer XML
-    // $config = ORMSetup::createXMLMetadataConfiguration(
+    // $config = ORMSetup::createXMLMetadataConfig( // on PHP < 8.4, use ORMSetup::createXMLMetadataConfiguration()
     //    paths: [__DIR__ . '/config/xml'],
     //    isDevMode: true,
     //);

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -43,7 +43,7 @@ use function method_exists;
  *
  *     $paths = ['/path/to/entity/mapping/files'];
  *
- *     $config = ORMSetup::createAttributeMetadataConfiguration($paths);
+ *     $config = ORMSetup::createAttributeMetadataConfig($paths);
  *     $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
  *     $entityManager = new EntityManager($connection, $config);
  *

--- a/src/ORMSetup.php
+++ b/src/ORMSetup.php
@@ -36,16 +36,34 @@ final class ORMSetup
         string|null $proxyDir = null,
         CacheItemPoolInterface|null $cache = null,
     ): Configuration {
-        if (PHP_VERSION_ID >= 80400 && $proxyDir !== null) {
+        if (PHP_VERSION_ID >= 80400) {
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/pull/12005',
-                'Passing anything but null as $proxyDir to %s is deprecated and will not be possible in Doctrine ORM 3.0.',
+                '%s is deprecated in favor of %s, and will be removed in 4.0.',
                 __METHOD__,
+                self::class . '::createAttributeMetadataConfig()',
             );
         }
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config->setMetadataDriverImpl(new AttributeDriver($paths));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration with an attribute metadata driver.
+     *
+     * @param string[] $paths
+     */
+    public static function createAttributeMetadataConfig(
+        array $paths,
+        bool $isDevMode = false,
+        string|null $cacheNamespaceSeed = null,
+        CacheItemPoolInterface|null $cache = null,
+    ): Configuration {
+        $config = self::createConfig($isDevMode, $cacheNamespaceSeed, $cache);
         $config->setMetadataDriverImpl(new AttributeDriver($paths));
 
         return $config;
@@ -63,17 +81,40 @@ final class ORMSetup
         CacheItemPoolInterface|null $cache = null,
         bool $isXsdValidationEnabled = true,
     ): Configuration {
-        if (PHP_VERSION_ID >= 80400 && $proxyDir !== null) {
+        if (PHP_VERSION_ID >= 80400) {
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/pull/12005',
-                'Passing anything but null as $proxyDir to %s is deprecated and will not be possible in Doctrine ORM 3.0.',
+                '%s is deprecated in favor of %s, and will be removed in 4.0.',
                 __METHOD__,
+                self::class . '::createXMLMetadataConfig()',
             );
         }
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new XmlDriver($paths, XmlDriver::DEFAULT_FILE_EXTENSION, $isXsdValidationEnabled));
+
+        return $config;
+    }
+
+    /**
+     * Creates a configuration with an XML metadata driver.
+     *
+     * @param string[] $paths
+     */
+    public static function createXMLMetadataConfig(
+        array $paths,
+        bool $isDevMode = false,
+        string|null $cacheNamespaceSeed = null,
+        CacheItemPoolInterface|null $cache = null,
+        bool $isXsdValidationEnabled = true,
+    ): Configuration {
+        $config = self::createConfig($isDevMode, $cacheNamespaceSeed, $cache);
+        $config->setMetadataDriverImpl(new XmlDriver(
+            $paths,
+            XmlDriver::DEFAULT_FILE_EXTENSION,
+            $isXsdValidationEnabled,
+        ));
 
         return $config;
     }
@@ -90,8 +131,9 @@ final class ORMSetup
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/pull/12005',
-                'Passing anything but null as $proxyDir to %s is deprecated and will not be possible in Doctrine ORM 3.0.',
+                '%s is deprecated in favor of %s, and will be removed in 4.0.',
                 __METHOD__,
+                self::class . '::createConfig()',
             );
         }
 
@@ -111,9 +153,23 @@ final class ORMSetup
         return $config;
     }
 
+    public static function createConfig(
+        bool $isDevMode = false,
+        string|null $cacheNamespaceSeed = null,
+        CacheItemPoolInterface|null $cache = null,
+    ): Configuration {
+        $cache  = self::createCacheInstance($isDevMode, $cacheNamespaceSeed, $cache);
+        $config = new Configuration();
+        $config->setMetadataCache($cache);
+        $config->setQueryCache($cache);
+        $config->setResultCache($cache);
+
+        return $config;
+    }
+
     private static function createCacheInstance(
         bool $isDevMode,
-        string $proxyDir,
+        string|null $cacheNamespaceSeed,
         CacheItemPoolInterface|null $cache,
     ): CacheItemPoolInterface {
         if ($cache !== null) {
@@ -131,7 +187,7 @@ final class ORMSetup
             return new ArrayAdapter();
         }
 
-        $namespace = 'dc2_' . md5($proxyDir);
+        $namespace = 'dc2_' . md5($cacheNamespaceSeed ?? 'default');
 
         if (extension_loaded('apcu') && apcu_enabled()) {
             return new ApcuAdapter($namespace);

--- a/tests/Tests/ORM/ORMSetupTest.php
+++ b/tests/Tests/ORM/ORMSetupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping as MappingNamespace;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -12,6 +13,7 @@ use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RequiresSetting;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -20,10 +22,19 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function sys_get_temp_dir;
 
+use const PHP_VERSION_ID;
+
 class ORMSetupTest extends TestCase
 {
+    use VerifyDeprecations;
+
+    #[WithoutErrorHandler]
     public function testAttributeConfiguration(): void
     {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
+        }
+
         $config = ORMSetup::createAttributeMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
@@ -32,8 +43,21 @@ class ORMSetupTest extends TestCase
         self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
     }
 
+    public function testAttributeConfig(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfig([], true);
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
+    }
+
+    #[WithoutErrorHandler]
     public function testXMLConfiguration(): void
     {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
+        }
+
         $config = ORMSetup::createXMLMetadataConfiguration([], true);
 
         self::assertInstanceOf(Configuration::class, $config);
@@ -44,14 +68,18 @@ class ORMSetupTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        ORMSetup::createXMLMetadataConfiguration(paths: [], isXsdValidationEnabled: false);
+        ORMSetup::createXMLMetadataConfig(paths: [], isXsdValidationEnabled: false);
     }
 
     #[RequiresPhpExtension('apcu')]
     #[RequiresSetting('apc.enable_cli', '1')]
     #[RequiresSetting('apc.enabled', '1')]
-    public function testCacheNamespaceShouldBeGeneratedForApcu(): void
+    public function testCacheNamespaceShouldBeGeneratedForApcuWhenUsingLegacyConstructor(): void
     {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
+        }
+
         $config = ORMSetup::createConfiguration(false, '/foo');
         $cache  = $config->getMetadataCache();
 
@@ -61,7 +89,22 @@ class ORMSetupTest extends TestCase
         self::assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf:', $namespaceProperty->getValue($cache));
     }
 
+    #[RequiresPhpExtension('apcu')]
+    #[RequiresSetting('apc.enable_cli', '1')]
+    #[RequiresSetting('apc.enabled', '1')]
+    public function testCacheNamespaceShouldBeGeneratedForApcu(): void
+    {
+        $config = ORMSetup::createConfig(false, '/foo');
+        $cache  = $config->getMetadataCache();
+
+        $namespaceProperty = new ReflectionProperty(AbstractAdapter::class, 'namespace');
+
+        self::assertInstanceOf(ApcuAdapter::class, $cache);
+        self::assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf:', $namespaceProperty->getValue($cache));
+    }
+
     #[Group('DDC-1350')]
+    #[WithoutErrorHandler]
     public function testConfigureProxyDir(): void
     {
         $config = ORMSetup::createAttributeMetadataConfiguration([], true, '/foo');
@@ -72,7 +115,7 @@ class ORMSetupTest extends TestCase
     public function testConfigureCache(): void
     {
         $cache  = new ArrayAdapter();
-        $config = ORMSetup::createAttributeMetadataConfiguration([], true, null, $cache);
+        $config = ORMSetup::createAttributeMetadataConfig([], true, null, $cache);
 
         self::assertSame($cache, $config->getResultCache());
         self::assertSame($cache, $config->getQueryCache());
@@ -83,7 +126,7 @@ class ORMSetupTest extends TestCase
     public function testConfigureCacheCustomInstance(): void
     {
         $cache  = new ArrayAdapter();
-        $config = ORMSetup::createConfiguration(true, null, $cache);
+        $config = ORMSetup::createConfig(true, null, $cache);
 
         self::assertSame($cache, $config->getResultCache());
         self::assertSame($cache, $config->getQueryCache());


### PR DESCRIPTION
Currently we have `ORMSetup::create*Configuration` methods with a
`$proxyDir` argument that is used to configure the proxy directory, but
also as a seed for generating a namespace for cache systems.

Since these methods could be used with named arguments, renaming the
argument is not really an option and we need separate methods.