### PR TITLE
Rework tests and benchmarks to work with lazy objects

### DIFF
--- a/tests/Performance/LazyLoading/ProxyInitializationTimeBench.php
+++ b/tests/Performance/LazyLoading/ProxyInitializationTimeBench.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Performance\LazyLoading;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Proxy\InternalProxy as Proxy;
 use Doctrine\Performance\EntityManagerFactory;
 use Doctrine\Performance\Mock\NonProxyLoadingEntityManager;
@@ -25,9 +26,11 @@ final class ProxyInitializationTimeBench
     /** @var Proxy[] */
     private array|null $initializedEmployees = null;
 
+    private EntityManager $em;
+
     public function init(): void
     {
-        $proxyFactory = (new NonProxyLoadingEntityManager(EntityManagerFactory::getEntityManager([])))
+        $proxyFactory = (new NonProxyLoadingEntityManager($this->em = EntityManagerFactory::getEntityManager([])))
             ->getProxyFactory();
 
         for ($i = 0; $i < 10000; ++$i) {
@@ -36,36 +39,36 @@ final class ProxyInitializationTimeBench
             $this->initializedUsers[$i]     = $proxyFactory->getProxy(CmsUser::class, ['id' => $i]);
             $this->initializedEmployees[$i] = $proxyFactory->getProxy(CmsEmployee::class, ['id' => $i]);
 
-            $this->initializedUsers[$i]->__load();
-            $this->initializedEmployees[$i]->__load();
+            $this->em->getUnitOfWork()->initializeObject($this->initializedUsers[$i]);
+            $this->em->getUnitOfWork()->initializeObject($this->initializedEmployees[$i]);
         }
     }
 
     public function benchCmsUserInitialization(): void
     {
         foreach ($this->cmsUsers as $proxy) {
-            $proxy->__load();
+            $this->em->getUnitOfWork()->initializeObject($proxy);
         }
     }
 
     public function benchCmsEmployeeInitialization(): void
     {
         foreach ($this->cmsEmployees as $proxy) {
-            $proxy->__load();
+            $this->em->getUnitOfWork()->initializeObject($proxy);
         }
     }
 
     public function benchInitializationOfAlreadyInitializedCmsUsers(): void
     {
         foreach ($this->initializedUsers as $proxy) {
-            $proxy->__load();
+            $this->em->getUnitOfWork()->initializeObject($proxy);
         }
     }
 
     public function benchInitializationOfAlreadyInitializedCmsEmployees(): void
     {
         foreach ($this->initializedEmployees as $proxy) {
-            $proxy->__load();
+            $this->em->getUnitOfWork()->initializeObject($proxy);
         }
     }
 }

--- a/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -14,8 +14,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser as CmsUserProxy;
 
-use function assert;
-
 /**
  * Test that Doctrine ORM correctly works with proxy instances exactly like with ordinary Entities
  *
@@ -33,10 +31,6 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        if ($this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            self::markTestSkipped('This test is not applicable when lazy proxy is enabled.');
-        }
 
         $this->createSchemaForModels(
             CmsUser::class,
@@ -83,8 +77,7 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
     {
         $userId             = $this->user->getId();
         $uninitializedProxy = $this->_em->getReference(CmsUser::class, $userId);
-        assert($uninitializedProxy instanceof CmsUserProxy);
-        self::assertInstanceOf(CmsUserProxy::class, $uninitializedProxy);
+        $this->assertTrue($this->isUninitializedObject($uninitializedProxy));
 
         $this->_em->persist($uninitializedProxy);
         $this->_em->flush();
@@ -116,6 +109,10 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
      */
     public function testFindWithProxyName(): void
     {
+        if ($this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            self::markTestSkipped('There is no such thing as a proxy class name when native lazy objects are enabled.');
+        }
+
         $result = $this->_em->find(CmsUserProxy::class, $this->user->getId());
         self::assertSame($this->user->getId(), $result->getId());
         $this->_em->clear();

--- a/tests/Tests/ORM/Functional/Ticket/GH10808Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10808Test.php
@@ -14,8 +14,7 @@ use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\Group;
-
-use function get_class;
+use ReflectionClass;
 
 #[Group('GH10808')]
 class GH10808Test extends OrmFunctionalTestCase
@@ -32,10 +31,6 @@ class GH10808Test extends OrmFunctionalTestCase
 
     public function testDQLDeferredEagerLoad(): void
     {
-        if ($this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            self::markTestSkipped('Test requires lazy loading to be disabled');
-        }
-
         $appointment = new GH10808Appointment();
 
         $this->_em->persist($appointment);
@@ -55,14 +50,13 @@ class GH10808Test extends OrmFunctionalTestCase
 
         $eagerLoadResult = $query->setHint(UnitOfWork::HINT_DEFEREAGERLOAD, false)->getSingleResult();
 
-        self::assertNotEquals(
-            GH10808AppointmentChild::class,
-            get_class($deferredLoadResult->child),
-            '$deferredLoadResult->child should be a proxy',
+        $reflector = new ReflectionClass(GH10808AppointmentChild::class);
+        self::assertFalse(
+            $this->isUninitializedObject($deferredLoadResult->child),
+            '$deferredLoadResult->child should be a native lazy object',
         );
-        self::assertEquals(
-            GH10808AppointmentChild::class,
-            get_class($eagerLoadResult->child),
+        self::assertFalse(
+            $this->isUninitializedObject($deferredLoadResult->child),
             '$eagerLoadResult->child should not be a proxy',
         );
     }


### PR DESCRIPTION
This fixes issues spotted by @Ocramius in https://github.com/doctrine/orm/pull/12029

These tests and benchmarks are still relevant with lazy objects. I am not setting up an extra job to test phpbench without native lazy objects. Instead, I'm bumping the PHP version to 8.4 so that native lazy objects are in use.