### PR TITLE
Clean the handling of proxy initialization in the UnitOfWork

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2383,9 +2383,9 @@ class UnitOfWork implements PropertyChangedListener
                     $class->reflClass->markLazyObjectAsInitialized($entity);
                 } else {
                     $entity->__setInitialized(true);
-                }
 
-                Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                    Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                }
             } else {
                 if (
                     ! isset($hints[Query::HINT_REFRESH])


### PR DESCRIPTION
Using the VarExporter Hydrator to assign default values of properties when marking an entity as initialized is needed only when using var-exporter proxies. For lazy objects, this behavior is already provided by `ReflectionClass::markLazyObjectAsInitialized`.

See the discussion in https://github.com/doctrine/orm/pull/12029#discussion_r2170999009