### PR TITLE
Deprecate proxy autoloader and class name resolver

### DIFF
--- a/src/Proxy/Autoloader.php
+++ b/src/Proxy/Autoloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Proxy;
 
 use Closure;
+use Doctrine\Deprecations\Deprecation;
 
 use function file_exists;
 use function ltrim;
@@ -15,6 +16,7 @@ use function strlen;
 use function substr;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_VERSION_ID;
 
 /**
  * Special Autoloader for Proxy classes, which are not PSR-0 compliant.
@@ -34,6 +36,15 @@ final class Autoloader
      */
     public static function resolveFile(string $proxyDir, string $proxyNamespace, string $className): string
     {
+        if (PHP_VERSION_ID >= 80400) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12005',
+                'Class "%s" is deprecated. Use native lazy objects instead.',
+                self::class,
+            );
+        }
+
         if (! str_starts_with($className, $proxyNamespace)) {
             throw new NotAProxyClass($className, $proxyNamespace);
         }
@@ -59,6 +70,15 @@ final class Autoloader
         string $proxyNamespace,
         Closure|null $notFoundCallback = null,
     ): Closure {
+        if (PHP_VERSION_ID >= 80400) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12005',
+                'Class "%s" is deprecated. Use native lazy objects instead.',
+                self::class,
+            );
+        }
+
         $proxyNamespace = ltrim($proxyNamespace, '\\');
 
         $autoloader = /** @param class-string $className */ static function (string $className) use ($proxyDir, $proxyNamespace, $notFoundCallback): void {

--- a/src/Proxy/DefaultProxyClassNameResolver.php
+++ b/src/Proxy/DefaultProxyClassNameResolver.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Proxy;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
 use Doctrine\Persistence\Proxy;
 
 use function strrpos;
 use function substr;
+
+use const PHP_VERSION_ID;
 
 /**
  * Class-related functionality for objects that might or not be proxy objects
@@ -18,6 +21,15 @@ final class DefaultProxyClassNameResolver implements ProxyClassNameResolver
 {
     public function resolveClassName(string $className): string
     {
+        if (PHP_VERSION_ID >= 80400) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12005',
+                'Class "%s" is deprecated. Use native lazy objects instead.',
+                self::class,
+            );
+        }
+
         $pos = strrpos($className, '\\' . Proxy::MARKER . '\\');
 
         if ($pos === false) {
@@ -30,6 +42,15 @@ final class DefaultProxyClassNameResolver implements ProxyClassNameResolver
     /** @return class-string */
     public static function getClass(object $object): string
     {
+        if (PHP_VERSION_ID >= 80400) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12005',
+                'Class "%s" is deprecated. Use native lazy objects instead.',
+                self::class,
+            );
+        }
+
         return (new self())->resolveClassName($object::class);
     }
 }

--- a/tests/Tests/Proxy/AutoloaderTest.php
+++ b/tests/Tests/Proxy/AutoloaderTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Proxy;
 
 use Doctrine\ORM\Proxy\Autoloader;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 use function class_exists;
@@ -31,6 +32,7 @@ class AutoloaderTest extends TestCase
 
     /** @param class-string $className */
     #[DataProvider('dataResolveFile')]
+    #[WithoutErrorHandler]
     public function testResolveFile(
         string $proxyDir,
         string $proxyNamespace,
@@ -41,6 +43,7 @@ class AutoloaderTest extends TestCase
         self::assertEquals($expectedProxyFile, $actualProxyFile);
     }
 
+    #[WithoutErrorHandler]
     public function testAutoload(): void
     {
         if (file_exists(sys_get_temp_dir() . '/AutoloaderTestClass.php')) {


### PR DESCRIPTION
These are only needed when not using native lazy objects.