### PR TITLE
Add console completion for entityName param of orm:mapping:describe c…

### DIFF
--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +21,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use function array_filter;
 use function array_map;
 use function array_merge;
+use function array_values;
 use function count;
 use function current;
 use function get_debug_type;
@@ -32,6 +35,7 @@ use function preg_match;
 use function preg_quote;
 use function print_r;
 use function sprintf;
+use function str_replace;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
@@ -71,6 +75,20 @@ EOT);
         $this->displayEntity($input->getArgument('entityName'), $entityManager, $ui);
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('entityName')) {
+            $entityManager = $this->getEntityManager($input);
+
+            $entities = array_map(
+                static fn (string $fqcn) => str_replace('\\', '\\\\', $fqcn),
+                $this->getMappedEntities($entityManager),
+            );
+
+            $suggestions->suggestValues(array_values($entities));
+        }
     }
 
     /**

--- a/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -11,7 +11,9 @@ use Doctrine\Tests\Models\Cache\AttractionInfo;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -76,5 +78,38 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
                 'entityName' => 'AttractionFooBar',
             ],
         );
+    }
+
+    /**
+     * @param string[] $input
+     * @param string[] $expectedSuggestions
+     */
+    #[DataProvider('provideCompletionSuggestions')]
+    public function testComplete(array $input, array $expectedSuggestions): void
+    {
+        $this->useModelSet('cache');
+
+        parent::setUp();
+
+        $completionTester = new CommandCompletionTester(new MappingDescribeCommand(new SingleManagerProvider($this->_em)));
+
+        $suggestions = $completionTester->complete($input);
+
+        foreach ($expectedSuggestions as $expected) {
+            self::assertContains($expected, $suggestions);
+        }
+    }
+
+    /** @return iterable<string, array{string[], string[]}> */
+    public static function provideCompletionSuggestions(): iterable
+    {
+        yield 'entityName' => [
+            [''],
+            [
+                'Doctrine\\\\Tests\\\\Models\\\\Cache\\\\Restaurant',
+                'Doctrine\\\\Tests\\\\Models\\\\Cache\\\\Beach',
+                'Doctrine\\\\Tests\\\\Models\\\\Cache\\\\Bar',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
…ommand

As suggested in https://github.com/doctrine/DoctrineBundle/issues/1883 

This PR adds autocompletion for the entityName argument of the orm:mapping:describe command 

https://github.com/user-attachments/assets/789790bb-fda2-4eb7-bb89-247d569134e6

