### PR TITLE
do not register the legacy proxy class name resolver with enabled native lazy ghost

### DIFF
--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -66,7 +66,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     public function setEntityManager(EntityManagerInterface $em): void
     {
-        parent::setProxyClassNameResolver(new DefaultProxyClassNameResolver());
+        if (! $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            parent::setProxyClassNameResolver(new DefaultProxyClassNameResolver());
+        }
 
         $this->em = $em;
     }


### PR DESCRIPTION
With the class resolver still being registered there is no way to resolve the deprecation triggered in `DefaultProxyClassNameResolver::resolveClassName()` (which is called in `AbstractClassMetadataFactory::getRealClass()` which in turn is located in the `doctrine/persistence` package).