### PR TITLE
Only throw PHP 8.4 requirement exception when enabling native lazy objects.

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -602,7 +602,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     public function enableNativeLazyObjects(bool $nativeLazyObjects): void
     {
-        if (PHP_VERSION_ID < 80400) {
+        if (PHP_VERSION_ID < 80400 && $nativeLazyObjects) {
             throw new LogicException('Lazy loading proxies require PHP 8.4 or higher.');
         }
 


### PR DESCRIPTION
Fixes #12040 