### PR TITLE
Update branch metadata for 3.5.0

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -12,16 +12,22 @@
             "upcoming": true
         },
         {
+            "name": "3.6",
+            "branchName": "3.6.x",
+            "slug": "3.6",
+            "upcoming": true
+        },
+        {
             "name": "3.5",
             "branchName": "3.5.x",
             "slug": "3.5",
-            "upcoming": true
+            "current": true
         },
         {
             "name": "3.4",
             "branchName": "3.4.x",
             "slug": "3.4",
-            "current": true
+            "maintained": false
         },
         {
             "name": "3.3",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-|                      [4.0.x][4.0]                      |                      [3.5.x][3.5]                      |                      [3.4.x][3.4]                      |                      [2.21.x][2.21]                      |                      [2.20.x][2.20]                      |
+|                      [4.0.x][4.0]                      |                      [3.6.x][3.6]                      |                      [3.5.x][3.5]                      |                      [2.21.x][2.21]                      |                      [2.20.x][2.20]                      |
 |:------------------------------------------------------:|:------------------------------------------------------:|:------------------------------------------------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
-|           [![Build status][4.0 image]][4.0]            |           [![Build status][3.5 image]][3.5]            |           [![Build status][3.4 image]][3.4]            |           [![Build status][2.21 image]][2.21]            |           [![Build status][2.20 image]][2.20]            |
-| [![Coverage Status][4.0 coverage image]][4.0 coverage] | [![Coverage Status][3.5 coverage image]][3.5 coverage] | [![Coverage Status][3.4 coverage image]][3.4 coverage] | [![Coverage Status][2.21 coverage image]][2.21 coverage] | [![Coverage Status][2.20 coverage image]][2.20 coverage] |
+|           [![Build status][4.0 image]][4.0]            |           [![Build status][3.6 image]][3.6]            |           [![Build status][3.5 image]][3.5]            |           [![Build status][2.21 image]][2.21]            |           [![Build status][2.20 image]][2.20]            |
+| [![Coverage Status][4.0 coverage image]][4.0 coverage] | [![Coverage Status][3.6 coverage image]][3.6 coverage] | [![Coverage Status][3.5 coverage image]][3.5 coverage] | [![Coverage Status][2.21 coverage image]][2.21 coverage] | [![Coverage Status][2.20 coverage image]][2.20 coverage] |
 
 Doctrine ORM is an object-relational mapper for PHP 8.1+ that provides transparent persistence
 for PHP objects. It sits on top of a powerful database abstraction layer (DBAL). One of its key features
@@ -20,14 +20,14 @@ without requiring unnecessary code duplication.
   [4.0]: https://github.com/doctrine/orm/tree/4.0.x
   [4.0 coverage image]: https://codecov.io/gh/doctrine/orm/branch/4.0.x/graph/badge.svg
   [4.0 coverage]: https://codecov.io/gh/doctrine/orm/branch/4.0.x
+  [3.6 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.6.x
+  [3.6]: https://github.com/doctrine/orm/tree/3.6.x
+  [3.6 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.6.x/graph/badge.svg
+  [3.6 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.6.x
   [3.5 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.5.x
   [3.5]: https://github.com/doctrine/orm/tree/3.5.x
   [3.5 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.5.x/graph/badge.svg
   [3.5 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.5.x
-  [3.4 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.4.x
-  [3.4]: https://github.com/doctrine/orm/tree/3.4.x
-  [3.4 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.4.x/graph/badge.svg
-  [3.4 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.4.x
   [2.21 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=2.21.x
   [2.21]: https://github.com/doctrine/orm/tree/2.21.x
   [2.21 coverage image]: https://codecov.io/gh/doctrine/orm/branch/2.21.x/graph/badge.svg


### PR DESCRIPTION
3.5.0 has been released.

- 3.6.x is the new upcoming branch;
- 3.5.x is now the current branch;
- 3.4.x is no longer maintained.