### PR TITLE
Stop using QueryBuilder::getRootAlias()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 3.6
+
+Using `Doctrine\ORM\QueryBuilder::add('join', ...)` with a list of join parts
+is deprecated in favor of using an associative array of join parts with the
+root alias as key.
+
 # Upgrade to 3.5
 
 ## Deprecate not using native lazy objects on PHP 8.4+

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Internal\NoUnknownNamedArguments;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Parameter;
@@ -305,8 +306,13 @@ class QueryBuilder implements Stringable
         } else {
             // Should never happen with correct joining order. Might be
             // thoughtful to throw exception instead.
-            // @phpstan-ignore method.deprecated
-            $rootAlias = $this->getRootAlias();
+            $aliases = $this->getRootAliases();
+
+            if (! isset($aliases[0])) {
+                throw new RuntimeException('No alias was set before invoking getRootAlias().');
+            }
+
+            $rootAlias = $aliases[0];
         }
 
         $this->joinRootAliases[$alias] = $rootAlias;
@@ -582,14 +588,25 @@ class QueryBuilder implements Stringable
             $dqlPart = reset($dqlPart);
         }
 
-        // This is introduced for backwards compatibility reasons.
-        // TODO: Remove for 3.0
         if ($dqlPartName === 'join') {
             $newDqlPart = [];
 
             foreach ($dqlPart as $k => $v) {
-                // @phpstan-ignore method.deprecated
-                $k = is_numeric($k) ? $this->getRootAlias() : $k;
+                if (is_numeric($k)) {
+                    Deprecation::trigger(
+                        'doctrine/orm',
+                        'https://github.com/doctrine/orm/pull/12051',
+                        'Using numeric keys in %s for join parts is deprecated and will not be supported in 4.0. Use an associative array with the root alias as key instead.',
+                        __METHOD__,
+                    );
+                    $aliases = $this->getRootAliases();
+
+                    if (! isset($aliases[0])) {
+                        throw new RuntimeException('No alias was set before invoking add().');
+                    }
+
+                    $k = $aliases[0];
+                }
 
                 $newDqlPart[$k] = $v;
             }

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Order;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
@@ -24,6 +25,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 use function array_filter;
@@ -35,6 +37,8 @@ use function class_exists;
  */
 class QueryBuilderTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     private EntityManagerMock $entityManager;
 
     protected function setUp(): void
@@ -1031,8 +1035,10 @@ class QueryBuilderTest extends OrmTestCase
         self::assertEquals('u', $qb->getRootAlias());
     }
 
+    #[WithoutErrorHandler]
     public function testBCAddJoinWithoutRootAlias(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12051');
         $qb = $this->entityManager->createQueryBuilder()
             ->select('u')
             ->from(CmsUser::class, 'u')


### PR DESCRIPTION
That method has been deprecated for almost 15 years, in 85d40847acc053c0609735d2b9953ada342be189.

On top of that I'm adding a deprecation for something related that was
scheduled for deprecation at in the same commit.