### PR TITLE
doc: add links to GitHub Actions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 |                      [4.0.x][4.0]                      |                      [3.4.x][3.4]                      |                      [3.3.x][3.3]                      |                      [2.21.x][2.21]                      |                      [2.20.x][2.20]                      |
 |:------------------------------------------------------:|:------------------------------------------------------:|:------------------------------------------------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
-|           [![Build status][4.0 image]][4.0]            |           [![Build status][3.4 image]][3.4]            |           [![Build status][3.3 image]][3.3]            |           [![Build status][2.21 image]][2.21]            |           [![Build status][2.20 image]][2.20]            |
+|       [![Build status][4.0 image]][4.0 workflow]       |       [![Build status][3.4 image]][3.4 workflow]       |       [![Build status][3.3 image]][3.3 workflow]       |       [![Build status][2.21 image]][2.21 workflow]       |       [![Build status][2.20 image]][2.20 workflow]       |
 | [![Coverage Status][4.0 coverage image]][4.0 coverage] | [![Coverage Status][3.4 coverage image]][3.4 coverage] | [![Coverage Status][3.3 coverage image]][3.3 coverage] | [![Coverage Status][2.21 coverage image]][2.21 coverage] | [![Coverage Status][2.20 coverage image]][2.20 coverage] |
 
 [<h1 align="center">🇺🇦 UKRAINE NEEDS YOUR HELP NOW!</h1>](https://www.doctrine-project.org/stop-war.html)
@@ -20,21 +20,26 @@ without requiring unnecessary code duplication.
 
   [4.0 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=4.0.x
   [4.0]: https://github.com/doctrine/orm/tree/4.0.x
+  [4.0 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A4.0.x
   [4.0 coverage image]: https://codecov.io/gh/doctrine/orm/branch/4.0.x/graph/badge.svg
   [4.0 coverage]: https://codecov.io/gh/doctrine/orm/branch/4.0.x
   [3.4 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.4.x
   [3.4]: https://github.com/doctrine/orm/tree/3.4.x
+  [3.4 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A3.4.x
   [3.4 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.4.x/graph/badge.svg
   [3.4 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.4.x
   [3.3 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.3.x
   [3.3]: https://github.com/doctrine/orm/tree/3.3.x
+  [3.3 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A3.3.x
   [3.3 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.3.x/graph/badge.svg
   [3.3 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.3.x
   [2.21 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=2.21.x
   [2.21]: https://github.com/doctrine/orm/tree/2.21.x
+  [2.21 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A2.21.x
   [2.21 coverage image]: https://codecov.io/gh/doctrine/orm/branch/2.21.x/graph/badge.svg
   [2.21 coverage]: https://codecov.io/gh/doctrine/orm/branch/2.21.x
   [2.20 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=2.20.x
   [2.20]: https://github.com/doctrine/orm/tree/2.20.x
+  [2.20 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A2.20.x
   [2.20 coverage image]: https://codecov.io/gh/doctrine/orm/branch/2.20.x/graph/badge.svg
   [2.20 coverage]: https://codecov.io/gh/doctrine/orm/branch/2.20.x


### PR DESCRIPTION
The headers of the table already contain links to the branches.

Proposal: The link on each CI badge can show the result of the CI instead of the branch.