### PR TITLE
chore: use a shorter name for CI on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: "Continuous Integration"
+name: "CI"
 
 on:
   pull_request:


### PR DESCRIPTION
With the current text, the badges have very tiny text:

> ![image](https://github.com/user-attachments/assets/b04ae3b0-647f-4d45-ae71-d65c45324246)

With this PR, it will display "CI" and "passing" with a bigger font, it will be easier to read.