### PR TITLE
Proxy class with BackedEnum as primary key does not convert the enum

### DIFF
--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -693,11 +693,11 @@ class BasicEntityPersister implements EntityPersister
                 $targetColumn = $joinColumn->referencedColumnName;
                 $quotedColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
 
-                $this->quotedColumns[$sourceColumn]  = $quotedColumn;
-                $this->columnTypes[$sourceColumn]    = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
-                $result[$owningTable][$sourceColumn] = $newValId
-                    ? $newValId[$targetClass->getFieldForColumn($targetColumn)]
-                    : null;
+                $this->quotedColumns[$sourceColumn] = $quotedColumn;
+                $this->columnTypes[$sourceColumn]   = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
+
+                $newValue                            = $newValId ? $newValId[$targetClass->getFieldForColumn($targetColumn)] : null;
+                $result[$owningTable][$sourceColumn] = $newValue instanceof BackedEnum ? $newValue->value : $newValue;
             }
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH12063.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH12063.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12063 extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH12063Association::class, GH12063Entity::class);
+    }
+
+    public function testLoadedAssociationWithBackedEnum(): void
+    {
+        $association       = new GH12063Association();
+        $association->code = GH12063Code::One;
+
+        $this->_em->persist($association);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity              = new GH12063Entity();
+        $entity->association = $this->_em->find(GH12063Association::class, GH12063Code::One);
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->assertNotNull($entity->id);
+    }
+
+    public function testProxyAssociationWithBackedEnum(): void
+    {
+        $association       = new GH12063Association();
+        $association->code = GH12063Code::Two;
+
+        $this->_em->persist($association);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity              = new GH12063Entity();
+        $entity->association = $this->_em->getReference(GH12063Association::class, GH12063Code::Two);
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->assertNotNull($entity->id);
+    }
+}
+
+enum GH12063Code: string
+{
+    case One = 'one';
+    case Two = 'two';
+}
+
+#[Entity]
+class GH12063Association
+{
+    #[Id]
+    #[Column]
+    public GH12063Code $code;
+}
+
+#[Entity]
+class GH12063Entity
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(referencedColumnName: 'code')]
+    public GH12063Association $association;
+}


### PR DESCRIPTION
```
There was 1 error:

1) Doctrine\Tests\ORM\Functional\Ticket\GH12063::testProxyAssociationWithBackedEnum
Error: Object of class Doctrine\Tests\ORM\Functional\Ticket\GH12063Code could not be converted to string

vendor/doctrine/dbal/src/Driver/PDO/Statement.php:26
vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php:19
vendor/doctrine/dbal/src/Logging/Statement.php:35
vendor/doctrine/dbal/src/Statement.php:93
src/Persisters/Entity/BasicEntityPersister.php:257
src/UnitOfWork.php:1057
src/UnitOfWork.php:402
src/EntityManager.php:268
tests/Doctrine/Tests/ORM/Functional/Ticket/GH12063.php:54
```

Affected versions: 3.0.0 through 4.0.x