### PR TITLE
 Use enum values from enumType in DiscriminatorColumn and check DiscriminatorMap values against it

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2204,6 +2204,20 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
             }
 
+            if (isset($columnDef['enumType'])) {
+                if (! enum_exists($columnDef['enumType'])) {
+                    throw MappingException::nonEnumTypeMapped($this->name, $columnDef['fieldName'], $columnDef['enumType']);
+                }
+
+                if (
+                    defined('Doctrine\DBAL\Types\Types::ENUM')
+                    && $columnDef['type'] === Types::ENUM
+                    && ! isset($columnDef['options']['values'])
+                ) {
+                    $columnDef['options']['values'] = array_column($columnDef['enumType']::cases(), 'value');
+                }
+            }
+
             $this->discriminatorColumn = DiscriminatorColumnMapping::fromMappingArray($columnDef);
         }
     }
@@ -2222,6 +2236,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * Used for JOINED and SINGLE_TABLE inheritance mapping strategies.
      *
      * @param array<int|string, string> $map
+     *
+     * @throws MappingException
      */
     public function setDiscriminatorMap(array $map): void
     {
@@ -2239,6 +2255,16 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                     return $value > 1;
                 }))),
             );
+        }
+
+        $values = $this->discriminatorColumn->options['values'] ?? null;
+
+        if ($values !== null) {
+            $diff = array_diff(array_keys($map), $values);
+
+            if ($diff !== []) {
+                throw MappingException::invalidEntriesInDiscriminatorMap(array_values($diff), $this->name, $this->discriminatorColumn->enumType);
+            }
         }
 
         foreach ($map as $value => $className) {

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -330,6 +330,24 @@ class MappingException extends PersistenceMappingException implements ORMExcepti
     }
 
     /**
+     * Returns an exception that indicates that discriminator entries used in a discriminator map
+     * does not exist in the backed enum provided by enumType option.
+     *
+     * @param array<int,int|string> $entries     The discriminator entries that could not be found.
+     * @param string                $owningClass The class that declares the discriminator map.
+     * @param string                $enumType    The enum that entries were checked against.
+     */
+    public static function invalidEntriesInDiscriminatorMap(array $entries, string $owningClass, string $enumType): self
+    {
+        return new self(sprintf(
+            "The entries %s in the discriminator map of class '%s' do not correspond to enum cases of '%s'.",
+            implode(', ', array_map(static fn ($entry): string => sprintf("'%s'", $entry), $entries)),
+            $owningClass,
+            $enumType,
+        ));
+    }
+
+    /**
      * Returns an exception that indicates that a class used in a discriminator map does not exist.
      * An example would be an outdated (maybe renamed) classname.
      *

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -13,6 +13,8 @@ use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Table as DbalTable;
+use Doctrine\DBAL\Types\EnumType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
@@ -46,6 +48,7 @@ use Doctrine\Tests\Models\Enums\Card;
 use Doctrine\Tests\Models\Enums\Suit;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
 use Doctrine\Tests\Models\Forum\ForumUser;
+use Doctrine\Tests\Models\GH10288\GH10288People;
 use Doctrine\Tests\Models\NullDefault\NullDefaultColumn;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -270,6 +273,38 @@ class SchemaToolTest extends OrmTestCase
         $column = $table->getColumn('discriminator');
 
         self::assertEquals(255, $column->getLength());
+    }
+
+    public function testSetDiscriminatorColumnWithEnumType(): void
+    {
+        if (! class_exists(EnumType::class)) {
+            self::markTestSkipped('Test valid for doctrine/dbal versions with EnumType only.');
+        }
+
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $metadata   = $em->getClassMetadata(FirstEntity::class);
+
+        $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE);
+        $metadata->setDiscriminatorColumn([
+            'name' => 'discriminator',
+            'type' => Types::ENUM,
+            'enumType' => GH10288People::class,
+        ]);
+
+        $schema = $schemaTool->getSchemaFromMetadata([$metadata]);
+
+        self::assertTrue($schema->hasTable('first_entity'));
+        $table = $schema->getTable('first_entity');
+
+        self::assertTrue($table->hasColumn('discriminator'));
+        $column = $table->getColumn('discriminator');
+        self::assertEquals(GH10288People::class, $column->getPlatformOption('enumType'));
+        self::assertEquals([0 => 'boss', 1 => 'employee'], $column->getValues());
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("The entries 'user' in the discriminator map of class '" . FirstEntity::class . "' do not correspond to enum cases of '" . GH10288People::class . "'.");
+        $metadata->setDiscriminatorMap(['user' => CmsUser::class, 'employee' => CmsEmployee::class]);
     }
 
     public function testDerivedCompositeKey(): void


### PR DESCRIPTION
Fix for issue #11794.

Currently the values of enumType in DiscriminatorColumn are ignored which results in an error when generating a migration:

```
Doctrine\DBAL\Platforms\MySQL80Platform requires the values of a ENUM column to be specified.
```

Fixed by populating values from the enum and also prevent invalid entries in DiscriminatorMap.
