### PR TITLE
QueryBuilder: prevent misuse of DELETE with LIMIT

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -547,6 +547,10 @@ class QueryBuilder implements Stringable
      */
     public function setMaxResults(int|null $maxResults): static
     {
+        if ($this->type === QueryType::Delete || $this->type === QueryType::Update) {
+            throw new RuntimeException('Setting a limit is not supported for delete or update queries.');
+        }
+
         $this->maxResults = $maxResults;
 
         return $this;

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -27,6 +27,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 use function array_filter;
 use function class_exists;
@@ -70,6 +71,26 @@ class QueryBuilderTest extends OrmTestCase
             ->delete();
 
         $this->assertValidQueryBuilder($qb, 'DELETE Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    public function testDeleteWithLimitNotSupported(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Setting a limit is not supported for delete or update queries.');
+
+        $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'c')
+            ->setMaxResults(1);
+    }
+
+    public function testUpdateWithLimitNotSupported(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Setting a limit is not supported for delete or update queries.');
+
+        $this->entityManager->createQueryBuilder()
+            ->update(CmsUser::class, 'c')
+            ->setMaxResults(1);
     }
 
     public function testUpdateSetsType(): void


### PR DESCRIPTION
Imagine you want to **delete just last entry, but all your rows disappear**:

```php
$this->entityManager->createQueryBuilder()
            ->delete(MyEntity::class, 'e')
            ->orderBy('e.createdAt', 'ASC')
            ->setMaxResults(1); // limit ignored silently
```

I believe Doctrine should protect developers from doing destructive operations by not silently omitting crucial part of query builder (`LIMIT`, although named `setMaxResults`).