### PR TITLE
Add JSON format option for orm:mapping:describe command output

### DIFF
--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -76,6 +76,9 @@ Or:
 To output the metadata in JSON format, use the <info>--format</info> option:
   <info>%command.full_name% My\Namespace\Entity\MyEntity --format=json</info>
 
+To use a specific entity manager (e.g., for multi-DB projects), use the <info>--em</info> option:
+  <info>%command.full_name% My\Namespace\Entity\MyEntity --em=my_custom_entity_manager</info>
+
 EOT);
     }
 

--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
+use JsonException;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
@@ -52,9 +53,17 @@ final class MappingDescribeCommand extends AbstractEntityManagerCommand
     protected function configure(): void
     {
         $this->setName('orm:mapping:describe')
-             ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
-             ->setDescription('Display information about mapped objects')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
+            ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
+            ->setDescription('Display information about mapped objects')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Output format (text, json)',
+                MappingDescribeCommandFormat::TEXT->value,
+                array_map(static fn (MappingDescribeCommandFormat $format) => $format->value, MappingDescribeCommandFormat::cases()),
+            )
              ->setHelp(<<<'EOT'
 The %command.full_name% command describes the metadata for the given full or partial entity class name.
 
@@ -63,6 +72,10 @@ The %command.full_name% command describes the metadata for the given full or par
 Or:
 
     <info>%command.full_name%</info> MyEntity
+    
+To output the metadata in JSON format, use the <info>--format</info> option:
+  <info>%command.full_name% My\Namespace\Entity\MyEntity --format=json</info>
+
 EOT);
     }
 
@@ -70,9 +83,11 @@ EOT);
     {
         $ui = new SymfonyStyle($input, $output);
 
+        $format = MappingDescribeCommandFormat::from($input->getOption('format'));
+
         $entityManager = $this->getEntityManager($input);
 
-        $this->displayEntity($input->getArgument('entityName'), $entityManager, $ui);
+        $this->displayEntity($input->getArgument('entityName'), $entityManager, $ui, $format);
 
         return 0;
     }
@@ -89,6 +104,10 @@ EOT);
 
             $suggestions->suggestValues(array_values($entities));
         }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(array_map(static fn (MappingDescribeCommandFormat $format) => $format->value, MappingDescribeCommandFormat::cases()));
+        }
     }
 
     /**
@@ -100,8 +119,46 @@ EOT);
         string $entityName,
         EntityManagerInterface $entityManager,
         SymfonyStyle $ui,
+        MappingDescribeCommandFormat $format,
     ): void {
         $metadata = $this->getClassMetadata($entityName, $entityManager);
+
+        if ($format === MappingDescribeCommandFormat::JSON) {
+            $ui->text(json_encode(
+                [
+                    'name' => $metadata->name,
+                    'rootEntityName' => $metadata->rootEntityName,
+                    'customGeneratorDefinition' => $this->formatValueAsJson($metadata->customGeneratorDefinition),
+                    'customRepositoryClassName' => $metadata->customRepositoryClassName,
+                    'isMappedSuperclass' => $metadata->isMappedSuperclass,
+                    'isEmbeddedClass' => $metadata->isEmbeddedClass,
+                    'parentClasses' => $metadata->parentClasses,
+                    'subClasses' => $metadata->subClasses,
+                    'embeddedClasses' => $metadata->embeddedClasses,
+                    'identifier' => $metadata->identifier,
+                    'inheritanceType' => $metadata->inheritanceType,
+                    'discriminatorColumn' => $this->formatValueAsJson($metadata->discriminatorColumn),
+                    'discriminatorValue' => $metadata->discriminatorValue,
+                    'discriminatorMap' => $metadata->discriminatorMap,
+                    'generatorType' => $metadata->generatorType,
+                    'table' => $this->formatValueAsJson($metadata->table),
+                    'isIdentifierComposite' => $metadata->isIdentifierComposite,
+                    'containsForeignIdentifier' => $metadata->containsForeignIdentifier,
+                    'containsEnumIdentifier' => $metadata->containsEnumIdentifier,
+                    'sequenceGeneratorDefinition' => $this->formatValueAsJson($metadata->sequenceGeneratorDefinition),
+                    'changeTrackingPolicy' => $metadata->changeTrackingPolicy,
+                    'isVersioned' => $metadata->isVersioned,
+                    'versionField' => $metadata->versionField,
+                    'isReadOnly' => $metadata->isReadOnly,
+                    'entityListeners' => $metadata->entityListeners,
+                    'associationMappings' => $this->formatMappingsAsJson($metadata->associationMappings),
+                    'fieldMappings' => $this->formatMappingsAsJson($metadata->fieldMappings),
+                ],
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            ));
+
+            return;
+        }
 
         $ui->table(
             ['Field', 'Value'],
@@ -240,6 +297,22 @@ EOT);
         throw new InvalidArgumentException(sprintf('Do not know how to format value "%s"', print_r($value, true)));
     }
 
+    /** @throws JsonException */
+    private function formatValueAsJson(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $value[$k] = $this->formatValueAsJson($v);
+            }
+        }
+
+        return $value;
+    }
+
     /**
      * Add the given label and value to the two column table output
      *
@@ -276,6 +349,22 @@ EOT);
             foreach ((array) $mapping as $field => $value) {
                 $output[] = $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
             }
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param array<string, FieldMapping|AssociationMapping> $propertyMappings
+     *
+     * @return array<string, mixed>
+     */
+    private function formatMappingsAsJson(array $propertyMappings): array
+    {
+        $output = [];
+
+        foreach ($propertyMappings as $propertyName => $mapping) {
+            $output[$propertyName] = $this->formatValueAsJson((array) $mapping);
         }
 
         return $output;

--- a/src/Tools/Console/Command/MappingDescribeCommandFormat.php
+++ b/src/Tools/Console/Command/MappingDescribeCommandFormat.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console\Command;
+
+enum MappingDescribeCommandFormat: string
+{
+    case TEXT = 'text';
+    case JSON = 'json';
+}

--- a/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function json_decode;
+
 /**
  * Tests for {@see \Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand}
  */
@@ -54,6 +56,25 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
 
         self::assertStringContainsString(AttractionInfo::class, $display);
         self::assertStringContainsString('Root entity name', $display);
+    }
+
+    public function testShowSpecificFuzzySingleJson(): void
+    {
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'entityName' => 'AttractionInfo',
+            '--format' => 'json',
+        ]);
+
+        $display     = $this->tester->getDisplay();
+        $decodedJson = json_decode($display, true);
+
+        self::assertJson($display);
+        self::assertSame(AttractionInfo::class, $decodedJson['name']);
+        self::assertArrayHasKey('rootEntityName', $decodedJson);
+        self::assertArrayHasKey('fieldMappings', $decodedJson);
+        self::assertArrayHasKey('associationMappings', $decodedJson);
+        self::assertArrayHasKey('id', $decodedJson['fieldMappings']);
     }
 
     public function testShowSpecificFuzzyAmbiguous(): void
@@ -110,6 +131,11 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
                 'Doctrine\\\\Tests\\\\Models\\\\Cache\\\\Beach',
                 'Doctrine\\\\Tests\\\\Models\\\\Cache\\\\Bar',
             ],
+        ];
+
+        yield 'format option value' => [
+            ['--format='],
+            ['text', 'json'],
         ];
     }
 }


### PR DESCRIPTION
Following suggestion from https://github.com/doctrine/DoctrineBundle/issues/1883, this PR adds the `--format=json `option to the `orm:mapping:describe` command to enable JSON output (hence allowing [jq](https://jqlang.org/) filtering of said-output).

For example, when running `symfony console doctrine:mapping:describe App\\Entity\\Book --format=json`, we get the following output :

```json

{
    "name": "App\\Entity\\Book",
    "rootEntityName": "App\\Entity\\Book",
    "customGeneratorDefinition": null,
    "customRepositoryClassName": "App\\Repository\\BookRepository",
    "isMappedSuperclass": false,
    "isEmbeddedClass": false,
    "parentClasses": [],
    "subClasses": [],
    "embeddedClasses": [],
    "identifier": [
        "id"
    ],
    "inheritanceType": 1,
    "discriminatorColumn": null,
    "discriminatorValue": null,
    "discriminatorMap": [],
    "generatorType": 4,
    "table": {
        "name": "book"
    },
    "isIdentifierComposite": false,
    "containsForeignIdentifier": false,
    "containsEnumIdentifier": false,
    "sequenceGeneratorDefinition": null,
    "changeTrackingPolicy": 1,
    "isVersioned": false,
    "versionField": null,
    "isReadOnly": false,
    "entityListeners": [],
    "associationMappings": {
        "author": {
            "cascade": [],
            "fetch": 2,
            "inherited": null,
            "declared": null,
            "cache": null,
            "id": null,
            "isOnDeleteCascade": true,
            "originalClass": null,
            "originalField": null,
            "orphanRemoval": false,
            "unique": null,
            "fieldName": "author",
            "sourceEntity": "App\\Entity\\Book",
            "targetEntity": "App\\Entity\\Author",
            "inversedBy": "books",
            "indexBy": null,
            "orderBy": [],
            "joinTable": {
                "quoted": null,
                "joinColumns": [
                    {
                        "deferrable": null,
                        "unique": null,
                        "quoted": null,
                        "fieldName": null,
                        "onDelete": "CASCADE",
                        "columnDefinition": null,
                        "nullable": null,
                        "options": null,
                        "name": "book_id",
                        "referencedColumnName": "id"
                    }
                ],
                "inverseJoinColumns": [
                    {
                        "deferrable": null,
                        "unique": null,
                        "quoted": null,
                        "fieldName": null,
                        "onDelete": "CASCADE",
                        "columnDefinition": null,
                        "nullable": null,
                        "options": null,
                        "name": "author_id",
                        "referencedColumnName": "id"
                    }
                ],
                "options": [],
                "schema": null,
                "name": "book_author"
            },
            "joinTableColumns": [
                "book_id",
                "author_id"
            ],
            "relationToSourceKeyColumns": {
                "book_id": "id"
            },
            "relationToTargetKeyColumns": {
                "author_id": "id"
            }
        }
    },
    "fieldMappings": {
        "id": {
            "length": null,
            "id": true,
            "nullable": false,
            "notInsertable": null,
            "notUpdatable": null,
            "columnDefinition": null,
            "generated": null,
            "enumType": null,
            "precision": null,
            "scale": null,
            "unique": false,
            "index": false,
            "inherited": null,
            "originalClass": null,
            "originalField": null,
            "quoted": null,
            "declared": null,
            "declaredField": null,
            "options": null,
            "version": null,
            "default": null,
            "type": "integer",
            "fieldName": "id",
            "columnName": "id"
        },
        "title": {
            "length": 255,
            "id": null,
            "nullable": false,
            "notInsertable": null,
            "notUpdatable": null,
            "columnDefinition": null,
            "generated": null,
            "enumType": null,
            "precision": null,
            "scale": null,
            "unique": false,
            "index": false,
            "inherited": null,
            "originalClass": null,
            "originalField": null,
            "quoted": null,
            "declared": null,
            "declaredField": null,
            "options": null,
            "version": null,
            "default": null,
            "type": "string",
            "fieldName": "title",
            "columnName": "title"
        },
        "price": {
            "length": null,
            "id": null,
            "nullable": false,
            "notInsertable": null,
            "notUpdatable": null,
            "columnDefinition": null,
            "generated": null,
            "enumType": null,
            "precision": null,
            "scale": null,
            "unique": false,
            "index": false,
            "inherited": null,
            "originalClass": null,
            "originalField": null,
            "quoted": null,
            "declared": null,
            "declaredField": null,
            "options": null,
            "version": null,
            "default": null,
            "type": "integer",
            "fieldName": "price",
            "columnName": "price"
        },
        "topics": {
            "length": null,
            "id": null,
            "nullable": true,
            "notInsertable": null,
            "notUpdatable": null,
            "columnDefinition": null,
            "generated": null,
            "enumType": null,
            "precision": null,
            "scale": null,
            "unique": false,
            "index": false,
            "inherited": null,
            "originalClass": null,
            "originalField": null,
            "quoted": null,
            "declared": null,
            "declaredField": null,
            "options": null,
            "version": null,
            "default": null,
            "type": "json",
            "fieldName": "topics",
            "columnName": "topics"
        }
    }
}
```



which we can then filter using jq - for example : 

```bash

symfony console doctrine:mapping:describe App\\Entity\\Book --format=json | jq '.fieldMappings | to_entries | map({(.key): .value.type}) | add'
```

will output a simple fieldMapping + typehint list 
<img width="1688" height="157" alt="image" src="https://github.com/user-attachments/assets/a18c1d73-1aff-428c-bf85-16112e48e3a7" />



Bonus small fix of embeddedClasses output which falsely returned subClasses