### PR TITLE
Use PHP attributes syntax in schema validator message

### DIFF
--- a/src/Tools/SchemaValidator.php
+++ b/src/Tools/SchemaValidator.php
@@ -153,7 +153,7 @@ class SchemaValidator
                     $ce[] = 'The field ' . $class->name . '#' . $fieldName . ' is on the inverse side of a ' .
                             'bi-directional relationship, but the specified mappedBy association on the target-entity ' .
                             $assoc->targetEntity . '#' . $assoc->mappedBy . ' does not contain the required ' .
-                            "'inversedBy=\"" . $fieldName . "\"' attribute.";
+                            "'inversedBy: \"" . $fieldName . "\"' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc->mappedBy]->inversedBy !== $fieldName) {
                     $ce[] = 'The mappings ' . $class->name . '#' . $fieldName . ' and ' .
                             $assoc->targetEntity . '#' . $assoc->mappedBy . ' are ' .
@@ -174,7 +174,7 @@ class SchemaValidator
                     $ce[] = 'The field ' . $class->name . '#' . $fieldName . ' is on the owning side of a ' .
                             'bi-directional relationship, but the specified inversedBy association on the target-entity ' .
                             $assoc->targetEntity . '#' . $assoc->inversedBy . ' does not contain the required ' .
-                            "'mappedBy=\"" . $fieldName . "\"' attribute.";
+                            "'mappedBy: \"" . $fieldName . "\"' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc->inversedBy]->mappedBy !== $fieldName) {
                     $ce[] = 'The mappings ' . $class->name . '#' . $fieldName . ' and ' .
                             $assoc->targetEntity . '#' . $assoc->inversedBy . ' are ' .

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -135,7 +135,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 'The field Doctrine\Tests\ORM\Tools\DDC3274One#two is on the inverse side of a bi-directional ' .
                 'relationship, but the specified mappedBy association on the target-entity ' .
-                "Doctrine\Tests\ORM\Tools\DDC3274Two#one does not contain the required 'inversedBy=\"two\"' attribute.",
+                "Doctrine\Tests\ORM\Tools\DDC3274Two#one does not contain the required 'inversedBy: \"two\"' attribute.",
             ],
             $ce,
         );
@@ -151,7 +151,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 'The field Doctrine\Tests\ORM\Tools\Issue9536Owner#one is on the owning side of a bi-directional ' .
                 'relationship, but the specified inversedBy association on the target-entity ' .
-                "Doctrine\Tests\ORM\Tools\Issue9536Target#two does not contain the required 'mappedBy=\"one\"' " .
+                "Doctrine\Tests\ORM\Tools\Issue9536Target#two does not contain the required 'mappedBy: \"one\"' " .
                 'attribute.',
             ],
             $ce,


### PR DESCRIPTION
Updates the suggested syntax for PHP attributes instead of annotations:

```diff
-... does not contain the required 'inversedBy="images"' attribute.
+... does not contain the required 'inversedBy: "images"' attribute.
```