### PR TITLE
Deprecate ClassMetadata::$reflFields

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -69,6 +69,8 @@ that implements `ArrayAccess`.
 Use the new `Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessor` API and access
 through `Doctrine\ORM\Mapping\ClassMetadata::$propertyAccessors` instead.
 
+Companion accessor methods are deprecated as well.
+
 # Upgrade to 3.3
 
 ## Deprecate `DatabaseDriver`

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -544,6 +544,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * The ReflectionProperty instances of the mapped class.
      *
+     * @deprecated Use $propertyAccessors instead.
+     *
      * @var LegacyReflectionFields|array<string, ReflectionProperty>
      */
     public LegacyReflectionFields|array $reflFields = [];
@@ -573,6 +575,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Gets the ReflectionProperties of the mapped class.
      *
+     * @deprecated Use getPropertyAccessors() instead.
+     *
      * @return LegacyReflectionFields|ReflectionProperty[] An array of ReflectionProperty instances.
      * @phpstan-return LegacyReflectionFields|array<string, ReflectionProperty>
      */
@@ -593,6 +597,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
     /**
      * Gets a ReflectionProperty for a specific field of the mapped class.
+     *
+     * @deprecated Use getPropertyAccessor() instead.
      */
     public function getReflectionProperty(string $name): ReflectionProperty|null
     {
@@ -604,7 +610,11 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         return $this->propertyAccessors[$name] ?? null;
     }
 
-    /** @throws BadMethodCallException If the class has a composite identifier. */
+    /**
+     * @deprecated Use getPropertyAccessor() instead.
+     *
+     * @throws BadMethodCallException If the class has a composite identifier.
+     */
     public function getSingleIdReflectionProperty(): ReflectionProperty|null
     {
         if ($this->isIdentifierComposite) {
@@ -818,7 +828,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public function wakeupReflection(ReflectionService $reflService): void
     {
         // Restore ReflectionClass and properties
-        $this->reflClass    = $reflService->getClass($this->name);
+        $this->reflClass = $reflService->getClass($this->name);
+        /** @phpstan-ignore property.deprecated */
         $this->reflFields   = new LegacyReflectionFields($this, $reflService);
         $this->instantiator = $this->instantiator ?: new Instantiator();
 


### PR DESCRIPTION
It is replaced with property accessors since
https://github.com/doctrine/orm/pull/11659

Fixes #12082 