### PR TITLE
Quote parts of the table name

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -400,13 +400,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public DiscriminatorColumnMapping|null $discriminatorColumn = null;
 
     /**
-     * READ-ONLY: The primary table definition. The definition is an array with the
-     * following entries:
+     * READ-ONLY: The primary table definition.
      *
-     * name => <tableName>
-     * schema => <schemaName>
-     * indexes => array
-     * uniqueConstraints => array
+     * "quoted" indicates whether the table name is quoted (with backticks) or not
      *
      * @var mixed[]
      * @phpstan-var array{

--- a/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -11,8 +11,6 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
-use function sprintf;
-
 /**
  * This class makes tests on the correct use of a database schema when entities are stored
  */
@@ -30,41 +28,7 @@ class DDC2825Test extends OrmFunctionalTestCase
         }
     }
 
-    #[DataProvider('getTestedClasses')]
-    public function testClassSchemaMappingsValidity(
-        string $className,
-        string $expectedSchemaName,
-        string $expectedTableName,
-        bool $isQuoted,
-    ): void {
-        $classMetadata   = $this->_em->getClassMetadata($className);
-        $platform        = $this->_em->getConnection()->getDatabasePlatform();
-        $quotedTableName = $this->_em->getConfiguration()->getQuoteStrategy()->getTableName($classMetadata, $platform);
-
-        // Check if table name and schema properties are defined in the class metadata
-        self::assertEquals($expectedTableName, $classMetadata->table['name']);
-        self::assertEquals($expectedSchemaName, $classMetadata->table['schema']);
-
-        $fullTableName = sprintf(
-            $isQuoted ? '"%s"."%s"' : '%s.%s',
-            $expectedSchemaName,
-            $expectedTableName,
-        );
-
-        self::assertEquals($fullTableName, $quotedTableName);
-
-        // Checks sequence name validity
-        self::assertEquals(
-            sprintf(
-                '%s.%s_%s_seq',
-                $expectedSchemaName,
-                $expectedTableName,
-                $classMetadata->getSingleIdentifierColumnName(),
-            ),
-            $classMetadata->getSequenceName($platform),
-        );
-    }
-
+    /** @param class-string $className */
     #[DataProvider('getTestedClasses')]
     public function testPersistenceOfEntityWithSchemaMapping(string $className): void
     {
@@ -77,18 +41,14 @@ class DDC2825Test extends OrmFunctionalTestCase
         self::assertCount(1, $this->_em->getRepository($className)->findAll());
     }
 
-    /**
-     * Data provider
-     *
-     * @return string[][]
-     */
+    /** @return list<array{class-string}> */
     public static function getTestedClasses(): array
     {
         return [
-            [ExplicitSchemaAndTable::class, 'explicit_schema', 'explicit_table', false],
-            [SchemaAndTableInTableName::class, 'implicit_schema', 'implicit_table', false],
-            [DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::class, 'myschema', 'order', false],
-            [File::class, 'yourschema', 'file', true],
+            [ExplicitSchemaAndTable::class],
+            [SchemaAndTableInTableName::class],
+            [DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::class],
+            [File::class],
         ];
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -31,8 +31,12 @@ class DDC2825Test extends OrmFunctionalTestCase
     }
 
     #[DataProvider('getTestedClasses')]
-    public function testClassSchemaMappingsValidity(string $className, string $expectedSchemaName, string $expectedTableName): void
-    {
+    public function testClassSchemaMappingsValidity(
+        string $className,
+        string $expectedSchemaName,
+        string $expectedTableName,
+        bool $isQuoted,
+    ): void {
         $classMetadata   = $this->_em->getClassMetadata($className);
         $platform        = $this->_em->getConnection()->getDatabasePlatform();
         $quotedTableName = $this->_em->getConfiguration()->getQuoteStrategy()->getTableName($classMetadata, $platform);
@@ -41,13 +45,22 @@ class DDC2825Test extends OrmFunctionalTestCase
         self::assertEquals($expectedTableName, $classMetadata->table['name']);
         self::assertEquals($expectedSchemaName, $classMetadata->table['schema']);
 
-        $fullTableName = sprintf('%s.%s', $expectedSchemaName, $expectedTableName);
+        $fullTableName = sprintf(
+            $isQuoted ? '"%s"."%s"' : '%s.%s',
+            $expectedSchemaName,
+            $expectedTableName,
+        );
 
         self::assertEquals($fullTableName, $quotedTableName);
 
         // Checks sequence name validity
         self::assertEquals(
-            $fullTableName . '_' . $classMetadata->getSingleIdentifierColumnName() . '_seq',
+            sprintf(
+                '%s.%s_%s_seq',
+                $expectedSchemaName,
+                $expectedTableName,
+                $classMetadata->getSingleIdentifierColumnName(),
+            ),
             $classMetadata->getSequenceName($platform),
         );
     }
@@ -72,9 +85,10 @@ class DDC2825Test extends OrmFunctionalTestCase
     public static function getTestedClasses(): array
     {
         return [
-            [ExplicitSchemaAndTable::class, 'explicit_schema', 'explicit_table'],
-            [SchemaAndTableInTableName::class, 'implicit_schema', 'implicit_table'],
-            [DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::class, 'myschema', 'order'],
+            [ExplicitSchemaAndTable::class, 'explicit_schema', 'explicit_table', false],
+            [SchemaAndTableInTableName::class, 'implicit_schema', 'implicit_table', false],
+            [DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::class, 'myschema', 'order', false],
+            [File::class, 'yourschema', 'file', true],
         ];
     }
 }
@@ -88,4 +102,14 @@ class DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     public $id;
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: '`file`', schema: 'yourschema')]
+class File
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int $id;
 }

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use ArrayObject;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Events;
@@ -51,6 +52,7 @@ use Doctrine\Tests\ORM\Mapping\TypedFieldMapper\CustomIntAsStringTypedFieldMappe
 use Doctrine\Tests\OrmTestCase;
 use DoctrineGlobalArticle;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group as TestGroup;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionClass;
@@ -968,6 +970,47 @@ class ClassMetadataTest extends OrmTestCase
             ['sequenceName' => 'foo', 'quoted' => true, 'allocationSize' => '1', 'initialValue' => '1'],
             $cm->sequenceGeneratorDefinition,
         );
+    }
+
+    #[DataProvider('fullTableNameProvider')]
+    public function testGetSequenceName(
+        string $expectedSequenceName,
+        string $fullTableName,
+    ): void {
+        $cm = new ClassMetadata(self::class);
+        $cm->setIdentifier(['id']);
+        $cm->setPrimaryTable(['name' => $fullTableName]);
+
+        $platform = $this->createStub(AbstractPlatform::class);
+
+        self::assertSame(
+            $expectedSequenceName,
+            $cm->getSequenceName($platform),
+        );
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function fullTableNameProvider(): iterable
+    {
+        yield 'quoted table name with schema' => [
+            'custom.reserved_id_seq',
+            'custom.`reserved`',
+        ];
+
+        yield 'unquoted table name with schema' => [
+            'custom.non_reserved_id_seq',
+            'custom.non_reserved',
+        ];
+
+        yield 'quoted table name without schema' => [
+            'reserved_id_seq',
+            '`reserved`',
+        ];
+
+        yield 'unquoted table name without schema' => [
+            'non_reserved_id_seq',
+            'non_reserved',
+        ];
     }
 
     #[TestGroup('DDC-2700')]

--- a/tests/Tests/ORM/Mapping/DefaultQuoteStrategyTest.php
+++ b/tests/Tests/ORM/Mapping/DefaultQuoteStrategyTest.php
@@ -6,13 +6,16 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\Tests\Models\NonPublicSchemaJoins\User as NonPublicSchemaUser;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 use function assert;
 use function enum_exists;
+use function sprintf;
 
 /**
  * Doctrine\Tests\ORM\Mapping\DefaultQuoteStrategyTest
@@ -33,5 +36,49 @@ class DefaultQuoteStrategyTest extends OrmTestCase
             'readers.author_reader',
             $strategy->getJoinTableName($metadata->associationMappings['readers'], $metadata, $platform),
         );
+    }
+
+    #[DataProvider('fullTableNameProvider')]
+    public function testGetTableName(string $expectedFullTableName, string $tableName): void
+    {
+        $classMetadata = new ClassMetadata(self::class);
+        $classMetadata->setPrimaryTable(['name' => $tableName]);
+
+        $platform = $this->createStub(AbstractPlatform::class);
+        $platform->method('quoteSingleIdentifier')
+            ->willReturnCallback(
+                static fn (string $identifier): string => sprintf('✌️%s✌️', $identifier),
+            );
+
+        $quotedTableName = (new DefaultQuoteStrategy())->getTableName(
+            $classMetadata,
+            $platform,
+        );
+
+        self::assertSame($expectedFullTableName, $quotedTableName);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function fullTableNameProvider(): iterable
+    {
+        yield 'quoted table name with schema' => [
+            '✌️custom✌️.✌️reserved✌️',
+            'custom.`reserved`',
+        ];
+
+        yield 'unquoted table name with schema' => [
+            'custom.non_reserved',
+            'custom.non_reserved',
+        ];
+
+        yield 'quoted table name without schema' => [
+            '✌️reserved✌️',
+            '`reserved`',
+        ];
+
+        yield 'unquoted table name without schema' => [
+            'non_reserved',
+            'non_reserved',
+        ];
     }
 }


### PR DESCRIPTION
In #11811, I wrongly assumed that
`$tableName` would never contain a dot as I was not able to write a test
that caused that to happen.

The secret recipe appears to be to define a schema and to quote the
table name.

Fixes https://github.com/doctrine/orm/issues/12041