### PR TITLE
Remove if statement

### DIFF
--- a/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -41,11 +41,7 @@ class DDC2825Test extends OrmFunctionalTestCase
         self::assertEquals($expectedTableName, $classMetadata->table['name']);
         self::assertEquals($expectedSchemaName, $classMetadata->table['schema']);
 
-        if ($this->_em->getConnection()->getDatabasePlatform()->supportsSchemas()) {
-            $fullTableName = sprintf('%s.%s', $expectedSchemaName, $expectedTableName);
-        } else {
-            $fullTableName = sprintf('%s__%s', $expectedSchemaName, $expectedTableName);
-        }
+        $fullTableName = sprintf('%s.%s', $expectedSchemaName, $expectedTableName);
 
         self::assertEquals($fullTableName, $quotedTableName);
 


### PR DESCRIPTION
Tests should not have conditional logic, and since #9259, the else branch of this conditional statement is dead.

#9259 targeted 3.x, which is why I'm not targeting 2.x