### PR TITLE
Performance optimization in `ScalarColumnHydrator::hydrateAllData()`

### DIFF
--- a/src/Internal/Hydration/ScalarColumnHydrator.php
+++ b/src/Internal/Hydration/ScalarColumnHydrator.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Internal\Hydration;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\ORM\Exception\MultipleSelectorsFoundException;
 
-use function array_column;
 use function count;
 
 /**
@@ -27,8 +26,6 @@ final class ScalarColumnHydrator extends AbstractHydrator
             throw MultipleSelectorsFoundException::create($this->resultSetMapping()->fieldMappings);
         }
 
-        $result = $this->statement()->fetchAllNumeric();
-
-        return array_column($result, 0);
+        return $this->statement()->fetchFirstColumn();
     }
 }


### PR DESCRIPTION
This optimization removes the intermediate array allocation during scalar column hydration. Instead of fetching all numeric rows and extracting the first column via array_column, it now calls fetchFirstColumn() directly. In the context of PDO, this aligns with the driver's native behavior (e.g. [Doctrine\DBAL\Driver\PDO\Result::fetchFirstColumn()](https://github.com/doctrine/dbal/blob/ca0c02766abedaec642f02c308d010b098029b34/src/Driver/PDO/Result.php#L57)), allowing the hydration layer to skip redundant copying and memory usage.