### PR TITLE
Move LazyGhost deprecation to ProxyFactory

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -652,17 +652,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     public function isNativeLazyObjectsEnabled(): bool
     {
-        $nativeLazyObjects = $this->attributes['nativeLazyObjects'] ?? false;
-
-        if (! $nativeLazyObjects && PHP_VERSION_ID >= 80400) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/pull/12005',
-                'Not enabling native lazy objects is deprecated and will be impossible in Doctrine ORM 4.0.',
-            );
-        }
-
-        return $nativeLazyObjects;
+        return $this->attributes['nativeLazyObjects'] ?? false;
     }
 
     public function enableNativeLazyObjects(bool $nativeLazyObjects): void

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -152,21 +152,29 @@ EOPHP;
         string|null $proxyNs = null,
         bool|int $autoGenerate = self::AUTOGENERATE_NEVER,
     ) {
-        if (PHP_VERSION_ID >= 80400 && func_num_args() > 1) {
+        if (! $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            if (PHP_VERSION_ID >= 80400) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/pull/12005',
+                    'Not enabling native lazy objects is deprecated and will be impossible in Doctrine ORM 4.0.',
+                );
+            }
+
+            if (! $proxyDir) {
+                throw ORMInvalidArgumentException::proxyDirectoryRequired();
+            }
+
+            if (! $proxyNs) {
+                throw ORMInvalidArgumentException::proxyNamespaceRequired();
+            }
+        } elseif (PHP_VERSION_ID >= 80400 && func_num_args() > 1) {
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/pull/12005',
                 'Passing more than just the EntityManager to the %s is deprecated and will not be possible in Doctrine ORM 4.0.',
                 __METHOD__,
             );
-        }
-
-        if (! $proxyDir && ! $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            throw ORMInvalidArgumentException::proxyDirectoryRequired();
-        }
-
-        if (! $proxyNs && ! $em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            throw ORMInvalidArgumentException::proxyNamespaceRequired();
         }
 
         if (is_int($autoGenerate) ? $autoGenerate < 0 || $autoGenerate > 4 : ! is_bool($autoGenerate)) {

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -229,19 +229,4 @@ class ConfigurationTest extends TestCase
 
         $this->configuration->enableNativeLazyObjects(false);
     }
-
-    #[RequiresPhp('<8.4')]
-    public function testNotEnablingNativeLazyObjectIsFineOnPhpLowerThan84(): void
-    {
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
-        self::assertFalse($this->configuration->isNativeLazyObjectsEnabled());
-    }
-
-    #[RequiresPhp('8.4')]
-    #[WithoutErrorHandler]
-    public function testNotEnablingNativeLazyObjectIsDeprecatedOnPhp84(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
-        self::assertFalse($this->configuration->isNativeLazyObjectsEnabled());
-    }
 }

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Proxy;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
@@ -21,6 +22,7 @@ use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
@@ -34,10 +36,10 @@ use function sys_get_temp_dir;
  */
 class ProxyFactoryTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     private UnitOfWorkMock $uowMock;
-
     private EntityManagerMock $emMock;
-
     private ProxyFactory $proxyFactory;
 
     protected function setUp(): void
@@ -242,6 +244,37 @@ class ProxyFactoryTest extends OrmTestCase
         $reflection         = new ReflectionClass($proxy);
 
         self::assertTrue($reflection->isUninitializedLazyObject($proxy));
+    }
+
+    #[RequiresPhp('8.4')]
+    #[WithoutErrorHandler]
+    public function testProxyFactoryTriggersDeprecationWhenNativeLazyObjectsAreDisabled(): void
+    {
+        $this->emMock->getConfiguration()->enableNativeLazyObjects(false);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
+
+        $this->proxyFactory = new ProxyFactory(
+            $this->emMock,
+            sys_get_temp_dir(),
+            'Proxies',
+            ProxyFactory::AUTOGENERATE_ALWAYS,
+        );
+    }
+
+    #[RequiresPhp('< 8.4')]
+    public function testProxyFactoryDoesNotTriggerDeprecationWhenNativeLazyObjectsAreDisabled(): void
+    {
+        $this->emMock->getConfiguration()->enableNativeLazyObjects(false);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');
+
+        $this->proxyFactory = new ProxyFactory(
+            $this->emMock,
+            sys_get_temp_dir(),
+            'Proxies',
+            ProxyFactory::AUTOGENERATE_ALWAYS,
+        );
     }
 }
 


### PR DESCRIPTION
The `Configuration::isNativeLazyObjectsEnabled()` method is called quite often in our codebase. It shouldn't be necessary to check for an trigger a deprecation whenever we call that method. As a performance improvement, I therefore propose to trigger the deprecation only once when we create the proxy factory.