### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "doctrine/lexer": "^3",
         "doctrine/persistence": "^3.3.1 || ^4",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/var-exporter": "^6.3.9 || ^7.0"
+        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/var-exporter": "^6.3.9 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^13.0",
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^10.4.0",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.12.0",
-        "symfony/cache": "^5.4 || ^6.2 || ^7.0"
+        "symfony/cache": "^5.4 || ^6.2 || ^7.0 || ^8.0"
     },
     "suggest": {
         "ext-dom": "Provides support for XSD validation for XML mapping files",


### PR DESCRIPTION
Our friends at Symfony need this change so that they can run their test suite against our library. I'm going to open a second PR that reverts this change which we can merge before releasing 3.6.0.