### PR TITLE
Revert "Allow Symfony 8"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "doctrine/lexer": "^3",
         "doctrine/persistence": "^3.3.1 || ^4",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/var-exporter": "^6.3.9 || ^7.0 || ^8.0"
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/var-exporter": "^6.3.9 || ^7.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^13.0",
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^10.4.0",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.13.2",
-        "symfony/cache": "^5.4 || ^6.2 || ^7.0 || ^8.0"
+        "symfony/cache": "^5.4 || ^6.2 || ^7.0"
     },
     "suggest": {
         "ext-dom": "Provides support for XSD validation for XML mapping files",


### PR DESCRIPTION
This reverts commit 6b8207bb11f7a38569831d3a5a775e3742f59034 of #12110.

As long as Symfony 8 is not final yet, we should not indicate compatibility. I'm adding this to the 3.6.0 milestone, so we don't forget to merge it before we release a stable 3.6.0.