### PR TITLE
Make SchemaTool use the new DBAL API

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3150,7 +3150,7 @@ parameters:
 				Use \{@see getPrimaryKeyConstraint\(\)\} instead\.$#
 			'''
 			identifier: method.deprecated
-			count: 1
+			count: 2
 			path: src/Tools/SchemaTool.php
 
 		-
@@ -3256,12 +3256,6 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:getIndexColumns\(\) has parameter \$class with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
 			message: '#^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:getSchemaFromMetadata\(\) has parameter \$classes with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -3292,37 +3286,13 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addIndex\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addUniqueIndex\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
 			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:setPrimaryKey\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#1 \$value of static method Doctrine\\DBAL\\Schema\\Name\\Identifier\:\:unquoted\(\) expects non\-empty\-string, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#2 \$columnNames of class Doctrine\\DBAL\\Schema\\PrimaryKeyConstraint constructor expects non\-empty\-list\<Doctrine\\DBAL\\Schema\\Name\\UnqualifiedName\>, list\<Doctrine\\DBAL\\Schema\\Name\\UnqualifiedName\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#2 \$columns of class Doctrine\\DBAL\\Schema\\Index constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			message: '#^Parameter \#1 \$firstColumnName of method Doctrine\\DBAL\\Schema\\PrimaryKeyConstraintEditor\:\:setUnquotedColumnNames\(\) expects non\-empty\-string, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Tools/SchemaTool.php
@@ -3336,12 +3306,6 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$foreignColumnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addForeignKeyConstraint\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Property Doctrine\\ORM\\Tools\\SchemaTool\:\:\$schemaManager with generic class Doctrine\\DBAL\\Schema\\AbstractSchemaManager does not specify its types\: T$#'
-			identifier: missingType.generics
 			count: 1
 			path: src/Tools/SchemaTool.php
 

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -86,6 +86,9 @@ parameters:
             identifier: argument.unresolvableType
             path: src/Mapping/Driver/DatabaseDriver.php
 
+        - '~undefined static method Doctrine\\DBAL\\Schema\\Index\:\:editor\(\)~'
+        - '~^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:getIndexedColumns\(\) should return non-empty-list<string>~'
+
         # To be removed in 4.0
         -
             message: '#Negated boolean expression is always false\.#'

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
-use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\IndexEditor;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
@@ -38,6 +38,7 @@ use function array_filter;
 use function array_flip;
 use function array_intersect_key;
 use function array_map;
+use function array_values;
 use function assert;
 use function class_exists;
 use function count;
@@ -60,6 +61,7 @@ class SchemaTool
 
     private readonly AbstractPlatform $platform;
     private readonly QuoteStrategy $quoteStrategy;
+    /** @var AbstractSchemaManager<AbstractPlatform> */
     private readonly AbstractSchemaManager $schemaManager;
 
     /**
@@ -128,9 +130,10 @@ class SchemaTool
     /**
      * Resolves fields in index mapping to column names
      *
-     * @param mixed[] $indexData index or unique constraint data
+     * @param ClassMetadata<object> $class
+     * @param mixed[]               $indexData index or unique constraint data
      *
-     * @return list<string> Column names from combined fields and columns mappings
+     * @return non-empty-list<non-empty-string> Column names from combined fields and columns mappings
      */
     private function getIndexColumns(ClassMetadata $class, array $indexData): array
     {
@@ -165,6 +168,13 @@ class SchemaTool
                     }
                 }
             }
+        }
+
+        if ($columns === []) {
+            throw MappingException::invalidIndexConfiguration(
+                (string) $class,
+                $indexData['name'] ?? 'unnamed',
+            );
         }
 
         return $columns;
@@ -314,17 +324,13 @@ class SchemaTool
                 }
             }
 
-            if (! $table->hasIndex('primary')) {
-                self::addPrimaryKeyConstraint($table, $pkColumns);
-            }
+            $primaryKey = $this->getPrimaryKeyConstraint($table) ?? $this->addPrimaryKeyConstraint($table, $pkColumns);
 
             // there can be unique indexes automatically created for join column
             // if join column is also primary key we should keep only primary key on this column
             // so, remove indexes overruled by primary key
-            $primaryKey = $table->getIndex('primary');
-
             foreach ($table->getIndexes() as $idxKey => $existingIndex) {
-                if ($existingIndex !== $primaryKey && $primaryKey->spansColumns(self::getIndexedColumns($existingIndex))) {
+                if ($idxKey !== 'primary' && $this->doesIndexOverlapWithPrimaryKey($existingIndex, $primaryKey)) {
                     $table->dropIndex($idxKey);
                 }
             }
@@ -346,7 +352,7 @@ class SchemaTool
 
             if (isset($class->table['uniqueConstraints'])) {
                 foreach ($class->table['uniqueConstraints'] as $indexName => $indexData) {
-                    $uniqIndex = new Index('tmp__' . $indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
+                    $uniqIndex = $this->createIndexForComparison('tmp__' . $indexName, $this->getIndexColumns($class, $indexData), $indexData['options'] ?? []);
 
                     foreach ($table->getIndexes() as $tableIndexName => $tableIndex) {
                         if ($tableIndex->isFulfilledBy($uniqIndex)) {
@@ -872,11 +878,7 @@ class SchemaTool
             }
 
             foreach ($schema->getTables() as $table) {
-                if (method_exists($table, 'getPrimaryKeyConstraint')) {
-                    $primaryKey = $table->getPrimaryKeyConstraint();
-                } else {
-                    $primaryKey = $table->getPrimaryKey();
-                }
+                $primaryKey = $this->getPrimaryKeyConstraint($table);
 
                 if ($primaryKey === null) {
                     continue;
@@ -969,29 +971,84 @@ class SchemaTool
         }
     }
 
-    /** @param string[] $primaryKeyColumns */
-    private function addPrimaryKeyConstraint(Table $table, array $primaryKeyColumns): void
+    private function getPrimaryKeyConstraint(Table $table): PrimaryKeyConstraint|Index|null
     {
-        if (class_exists(PrimaryKeyConstraint::class)) {
-            $primaryKeyColumnNames = [];
-
-            foreach ($primaryKeyColumns as $primaryKeyColumn) {
-                $primaryKeyColumnNames[] = new UnqualifiedName(Identifier::unquoted($primaryKeyColumn));
-            }
-
-            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, $primaryKeyColumnNames, true));
-        } else {
-            $table->setPrimaryKey($primaryKeyColumns);
+        // DBAL < 4.3
+        if (! method_exists($table, 'getPrimaryKeyConstraint')) {
+            return $table->getPrimaryKey();
         }
+
+        return $table->getPrimaryKeyConstraint();
     }
 
-    /** @return string[] */
-    private static function getIndexedColumns(Index $index): array
+    /** @param string[] $primaryKeyColumns */
+    private function addPrimaryKeyConstraint(Table $table, array $primaryKeyColumns): PrimaryKeyConstraint|Index
     {
-        if (method_exists(Index::class, 'getIndexedColumns')) {
-            return array_map(static fn (IndexedColumn $indexedColumn) => $indexedColumn->getColumnName()->toString(), $index->getIndexedColumns());
+        // DBAL < 4.3
+        if (! class_exists(PrimaryKeyConstraint::class)) {
+            $table->setPrimaryKey($primaryKeyColumns);
+
+            return $table->getPrimaryKey();
         }
 
-        return $index->getColumns();
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setUnquotedColumnNames(...array_values($primaryKeyColumns))
+            ->setIsClustered(true)
+            ->create();
+
+        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
+
+        return $table->getPrimaryKeyConstraint();
+    }
+
+    /** @return non-empty-list<string> */
+    private static function getIndexedColumns(Index $index): array
+    {
+        // DBAL < 4.3
+        if (! method_exists(Index::class, 'getIndexedColumns')) {
+            return $index->getColumns();
+        }
+
+        return array_map(static fn (IndexedColumn $indexedColumn) => $indexedColumn->getColumnName()->getIdentifier()->getValue(), $index->getIndexedColumns());
+    }
+
+    private function doesIndexOverlapWithPrimaryKey(Index $index, PrimaryKeyConstraint|Index $primaryKey): bool
+    {
+        // DBAL < 4.3
+        if ($primaryKey instanceof Index) {
+            return $index !== $primaryKey && $primaryKey->spansColumns(self::getIndexedColumns($index));
+        }
+
+        $indexedColumns = $index->getIndexedColumns();
+        foreach ($primaryKey->getColumnNames() as $i => $column) {
+            if (
+                ! isset($indexedColumns[$i])
+                || strtolower($column->getIdentifier()->getValue())
+                    !== strtolower($indexedColumns[$i]->getColumnName()->getIdentifier()->getValue())
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param non-empty-string                 $indexName
+     * @param non-empty-list<non-empty-string> $indexColumns
+     * @param array<string, mixed>             $indexOptions
+     */
+    private function createIndexForComparison(string $indexName, array $indexColumns, mixed $indexOptions): Index
+    {
+        // DBAL < 4.3
+        if (! class_exists(IndexEditor::class)) {
+            return new Index($indexName, $indexColumns, true, false, [], $indexOptions);
+        }
+
+        return Index::editor()
+            ->setUnquotedName($indexName)
+            ->setUnquotedColumnNames(...$indexColumns)
+            ->setType(Index\IndexType::UNIQUE)
+            ->create();
     }
 }

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Index as DbalIndex;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Table as DbalTable;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -52,8 +53,8 @@ use PHPUnit\Framework\Attributes\Group;
 use function array_map;
 use function class_exists;
 use function count;
-use function current;
 use function enum_exists;
+use function in_array;
 use function method_exists;
 
 class SchemaToolTest extends OrmTestCase
@@ -76,7 +77,7 @@ class SchemaToolTest extends OrmTestCase
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
         self::assertTrue($schema->hasTable('cms_users'), 'Table cms_users should exist.');
-        self::assertTrue(self::columnIsIndexed($schema->getTable('cms_users'), 'username'), 'username column should be indexed.');
+        self::assertTrue($this->columnIsIndexed($schema->getTable('cms_users'), 'username'), 'username column should be indexed.');
     }
 
     public function testAttributeOptionsArgument(): void
@@ -209,8 +210,12 @@ class SchemaToolTest extends OrmTestCase
     }
 
     #[Group('DDC-3671')]
-    public function testSchemaHasProperIndexesFromUniqueConstraintAttribute(): void
+    public function testSchemaHasProperIndexesFromUniqueConstraintAttributeLegacy(): void
     {
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            self::markTestSkipped('This test is valid for DBAL < 4.3 only');
+        }
+
         $em         = $this->getTestEntityManager();
         $schemaTool = new SchemaTool($em);
         $classes    = [
@@ -222,13 +227,40 @@ class SchemaToolTest extends OrmTestCase
         self::assertTrue($schema->hasTable('unique_constraint_attribute_table'));
         $table = $schema->getTable('unique_constraint_attribute_table');
 
-        self::assertCount(2, $table->getIndexes());
+        self::assertCount(1, $this->getIndexesWithoutPrimaryKey($table));
         self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('uniq_hash'));
     }
 
-    public function testRemoveUniqueIndexOverruledByPrimaryKey(): void
+    #[Group('DDC-3671')]
+    public function testSchemaHasProperIndexesFromUniqueConstraintAttribute(): void
     {
+        if (! class_exists(PrimaryKeyConstraint::class)) {
+            self::markTestSkipped('This test is valid for DBAL >= 4.3 only');
+        }
+
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $classes    = [
+            $em->getClassMetadata(UniqueConstraintAttributeModel::class),
+        ];
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('unique_constraint_attribute_table'));
+        $table = $schema->getTable('unique_constraint_attribute_table');
+
+        self::assertCount(1, $this->getIndexesWithoutPrimaryKey($table));
+        self::assertNotNull($table->getPrimaryKeyConstraint());
+        self::assertTrue($table->hasIndex('uniq_hash'));
+    }
+
+    public function testRemoveUniqueIndexOverruledByPrimaryKeyLegacy(): void
+    {
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            self::markTestSkipped('This test is valid for DBAL < 4.3 only');
+        }
+
         $em         = $this->getTestEntityManager();
         $schemaTool = new SchemaTool($em);
         $classes    = [
@@ -244,11 +276,30 @@ class SchemaToolTest extends OrmTestCase
 
         self::assertTrue($table->hasIndex('primary'), 'Table should have a primary key.');
 
-        $primaryKey = $table->getIndex('primary');
-        $indexes    = $table->getIndexes();
+        self::assertCount(0, $this->getIndexesWithoutPrimaryKey($table), 'there should be no indexes besides the primary key');
+    }
 
-        self::assertCount(1, $indexes, 'there should be only one index');
-        self::assertSame($primaryKey, current($indexes), 'index should be primary');
+    public function testRemoveUniqueIndexOverruledByPrimaryKey(): void
+    {
+        if (! class_exists(PrimaryKeyConstraint::class)) {
+            self::markTestSkipped('This test is valid for DBAL >= 4.3 only');
+        }
+
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $classes    = [
+            $em->getClassMetadata(FirstEntity::class),
+            $em->getClassMetadata(SecondEntity::class),
+        ];
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('first_entity'), 'Table first_entity should exist.');
+
+        $table = $schema->getTable('first_entity');
+
+        self::assertNotNull($table->getPrimaryKeyConstraint(), 'Table should have a primary key.');
+        self::assertCount(0, $this->getIndexesWithoutPrimaryKey($table), 'there should be no indexes besides the primary key');
     }
 
     public function testSetDiscriminatorColumnWithoutLength(): void
@@ -435,22 +486,32 @@ class SchemaToolTest extends OrmTestCase
     /** @return string[] */
     private static function getIndexedColumns(DbalIndex $index): array
     {
-        if (method_exists(DbalIndex::class, 'getIndexedColumns')) {
-            return array_map(static fn (IndexedColumn $indexedColumn) => $indexedColumn->getColumnName()->toString(), $index->getIndexedColumns());
+        // DBAL < 4.3
+        if (! method_exists(DbalIndex::class, 'getIndexedColumns')) {
+            return $index->getColumns();
         }
 
-        return $index->getColumns();
+        return array_map(static fn (IndexedColumn $indexedColumn) => $indexedColumn->getColumnName()->getIdentifier()->getValue(), $index->getIndexedColumns());
     }
 
     private static function columnIsIndexed(DbalTable $table, string $column): bool
     {
-        foreach ($table->getIndexes() as $index) {
-            if ($index->spansColumns([$column])) {
+        foreach (self::getIndexesWithoutPrimaryKey($table) as $index) {
+            if (in_array($column, self::getIndexedColumns($index), true)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /** @return array<string, DbalIndex> */
+    private static function getIndexesWithoutPrimaryKey(DbalTable $table): array
+    {
+        $indexes = $table->getIndexes();
+        unset($indexes['primary']);
+
+        return $indexes;
     }
 }
 


### PR DESCRIPTION
This is my attempt at getting our `SchemaTool` ready for DBAL 5. Not all tests are green with DBAL 5 yet, but we're getting there.