### PR TITLE
Don't partially mock the AbstractPlatform class

### DIFF
--- a/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -452,6 +452,8 @@ class SelectSqlGenerationTest extends OrmTestCase
 
     public function testSupportsTrimFunction(): void
     {
+        $this->entityManager = $this->createTestEntityManagerWithPlatform(new MySQLPlatform());
+
         $this->assertSqlGeneration(
             "SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE TRIM(TRAILING ' ' FROM u.name) = 'someone'",
             "SELECT c0_.name AS name_0 FROM cms_users c0_ WHERE TRIM(TRAILING ' ' FROM c0_.name) = 'someone'",
@@ -461,6 +463,8 @@ class SelectSqlGenerationTest extends OrmTestCase
     #[Group('DDC-2668')]
     public function testSupportsTrimLeadingZeroString(): void
     {
+        $this->entityManager = $this->createTestEntityManagerWithPlatform(new MySQLPlatform());
+
         $this->assertSqlGeneration(
             "SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE TRIM(TRAILING '0' FROM u.name) != ''",
             "SELECT c0_.name AS name_0 FROM cms_users c0_ WHERE TRIM(TRAILING '0' FROM c0_.name) <> ''",
@@ -584,6 +588,8 @@ class SelectSqlGenerationTest extends OrmTestCase
     #[Group('DDC-1802')]
     public function testSupportsNotInExpressionForModFunction(): void
     {
+        $this->entityManager = $this->createTestEntityManagerWithPlatform(new MySQLPlatform());
+
         $this->assertSqlGeneration(
             'SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE MOD(u.id, 5) NOT IN(1,3,4)',
             'SELECT c0_.name AS name_0 FROM cms_users c0_ WHERE MOD(c0_.id, 5) NOT IN (1, 3, 4)',
@@ -1925,6 +1931,8 @@ SQL,
     #[Group('DDC-2268')]
     public function testCaseThenFunction(): void
     {
+        $this->entityManager = $this->createTestEntityManagerWithPlatform(new PostgreSQLPlatform());
+
         $this->assertSqlGeneration(
             'SELECT CASE WHEN LENGTH(u.name) <> 0 THEN CONCAT(u.id, u.name) ELSE u.id END AS name  FROM Doctrine\Tests\Models\CMS\CmsUser u',
             'SELECT CASE WHEN LENGTH(c0_.name) <> 0 THEN c0_.id || c0_.name ELSE c0_.id END AS sclr_0 FROM cms_users c0_',

--- a/tests/Tests/OrmTestCase.php
+++ b/tests/Tests/OrmTestCase.php
@@ -8,9 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
-use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\CacheFactory;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -22,10 +20,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-use function enum_exists;
+use function class_exists;
 use function method_exists;
 use function realpath;
 use function sprintf;
+
+// DBAL 3 compatibility
+class_exists('Doctrine\\DBAL\\Platforms\\SqlitePlatform');
 
 /**
  * Base testcase class for all ORM testcases.
@@ -71,9 +72,7 @@ abstract class OrmTestCase extends TestCase
      */
     protected function getTestEntityManager(): EntityManagerMock
     {
-        return $this->buildTestEntityManagerWithPlatform(
-            $this->createConnectionMock($this->createPlatformMock()),
-        );
+        return $this->createTestEntityManagerWithPlatform(new SQLitePlatform());
     }
 
     protected function createTestEntityManagerWithConnection(Connection $connection): EntityManagerMock
@@ -151,24 +150,6 @@ abstract class OrmTestCase extends TestCase
         $connection->method('quote')->willReturnCallback(static fn (string $input) => sprintf("'%s'", $input));
 
         return $connection;
-    }
-
-    private function createPlatformMock(): AbstractPlatform
-    {
-        $schemaManager = $this->createMock(AbstractSchemaManager::class);
-        $schemaManager->method('createSchemaConfig')
-            ->willReturn(new SchemaConfig());
-
-        $platform = $this->getMockBuilder(AbstractPlatform::class)
-            ->setConstructorArgs(enum_exists(UnquotedIdentifierFolding::class) ? [UnquotedIdentifierFolding::UPPER] : [])
-            ->onlyMethods(['supportsIdentityColumns', 'createSchemaManager'])
-            ->getMockForAbstractClass();
-        $platform->method('supportsIdentityColumns')
-            ->willReturn(true);
-        $platform->method('createSchemaManager')
-            ->willReturn($schemaManager);
-
-        return $platform;
     }
 
     private function createDriverMock(AbstractPlatform $platform): Driver


### PR DESCRIPTION
In DBAL 5 is has become harder to mock the `AbstractPlatform` class because of its protected constructor. In addition to this, PHPUnit has deprecated the `getMockForAbstractClass()` that we've used for that purpose (sebastianbergmann/phpunit#5241).

I think, I'll be easier for us if used actual platform classes instead. In this PR, I'm defaulting to `SQLitePlatform`. For some tests that tested SQL code generation, I've switched to different platforms if the test did not expect the SQLite flavor of the generated SQL.