### PR TITLE
Forbid nullable on columns that are part of a primary key

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 4.0
 
+## BC BREAK: throw on `nullable` on columns that end up being used in a primary key
+
+Specifying `nullable` on join columns that are part of a primary key is
+an error and will cause an exception to be thrown.
+
 ## BC BREAK: `Doctrine\ORM\Mapping\LegacyReflectionFields` is removed
 
 The `Doctrine\ORM\Mapping\LegacyReflectionFields` class has been removed.

--- a/src/Mapping/ManyToManyOwningSideMapping.php
+++ b/src/Mapping/ManyToManyOwningSideMapping.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\Deprecations\Deprecation;
-
 use function strtolower;
 use function trim;
 
@@ -130,14 +128,7 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
 
         foreach ($mapping->joinTable->joinColumns as $joinColumn) {
             if ($joinColumn->nullable !== null) {
-                Deprecation::trigger(
-                    'doctrine/orm',
-                    'https://github/doctrine/orm/pull/12125',
-                    <<<'DEPRECATION'
-                    Specifying the "nullable" attribute for join columns in many-to-many associations (here, %s::$%s) is a no-op.
-                    The ORM will always set it to false.
-                    Doing so is deprecated and will be an error in 4.0.
-                    DEPRECATION,
+                throw MappingException::cannotSetNullableOnManyToManyJoinColumns(
                     $mapping->sourceEntity,
                     $mapping->fieldName,
                 );
@@ -169,14 +160,7 @@ final class ManyToManyOwningSideMapping extends ToManyOwningSideMapping implemen
 
         foreach ($mapping->joinTable->inverseJoinColumns as $inverseJoinColumn) {
             if ($inverseJoinColumn->nullable !== null) {
-                Deprecation::trigger(
-                    'doctrine/orm',
-                    'https://github/doctrine/orm/pull/12125',
-                    <<<'DEPRECATION'
-                    Specifying the "nullable" attribute for join columns in many-to-many associations (here, %s::$%s) is a no-op.
-                    The ORM will always set it to false.
-                    Doing so is deprecated and will be an error in 4.0.
-                    DEPRECATION,
+                throw MappingException::cannotSetNullableOnManyToManyJoinColumns(
                     $mapping->targetEntity,
                     $mapping->fieldName,
                 );

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -406,6 +406,28 @@ class MappingException extends PersistenceMappingException implements ORMExcepti
         return new self(sprintf("Discriminator column name on entity class '%s' is not defined.", $className));
     }
 
+    public static function cannotSetNullableOnToOneIdentifierJoinColumns(
+        string $className,
+        string $fieldName,
+    ): self {
+        return new self(sprintf(
+            'Cannot specify the "nullable" attribute for join columns in to-one associations (%s::$%s) that are part of the identifier',
+            $className,
+            $fieldName,
+        ));
+    }
+
+    public static function cannotSetNullableOnManyToManyJoinColumns(
+        string $className,
+        string $fieldName,
+    ): self {
+        return new self(sprintf(
+            'Cannot specify the "nullable" attribute for join columns in many-to-many associations (%s::$%s)',
+            $className,
+            $fieldName,
+        ));
+    }
+
     public static function cannotVersionIdField(string $className, string $fieldName): self
     {
         return new self(sprintf(

--- a/src/Mapping/ToOneOwningSideMapping.php
+++ b/src/Mapping/ToOneOwningSideMapping.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\Deprecations\Deprecation;
 use RuntimeException;
 
 use function array_flip;
@@ -133,14 +132,7 @@ abstract class ToOneOwningSideMapping extends OwningSideMapping implements ToOne
         foreach ($mapping->joinColumns as $joinColumn) {
             if ($mapping->id) {
                 if ($joinColumn->nullable !== null) {
-                    Deprecation::trigger(
-                        'doctrine/orm',
-                        'https://github/doctrine/orm/pull/12125',
-                        <<<'DEPRECATION'
-                        Specifying the "nullable" attribute for join columns in to-one associations (here, %s::$%s) that are part of the identifier is a no-op.
-                        The ORM will always set it to false.
-                        Doing so is deprecated and will be an error in 4.0.
-                        DEPRECATION,
+                    throw MappingException::cannotSetNullableOnToOneIdentifierJoinColumns(
                         $mapping->sourceEntity,
                         $mapping->fieldName,
                     );

--- a/tests/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
+++ b/tests/Tests/ORM/Mapping/ManyToManyOwningSideMappingTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\JoinTableMapping;
 use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
+use Doctrine\ORM\Mapping\MappingException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -18,8 +17,6 @@ use function unserialize;
 
 final class ManyToManyOwningSideMappingTest extends TestCase
 {
-    use VerifyDeprecations;
-
     public function testItSurvivesSerialization(): void
     {
         $mapping = new ManyToManyOwningSideMapping(
@@ -44,20 +41,15 @@ final class ManyToManyOwningSideMappingTest extends TestCase
 
     /** @param array<string,mixed> $mappingArray */
     #[DataProvider('mappingsProvider')]
-    #[WithoutErrorHandler]
     public function testNullableDefaults(
-        bool $expectDeprecation,
+        bool $expectException,
         bool $expectedValue,
         array $mappingArray,
     ): void {
         $namingStrategy = new DefaultNamingStrategy();
-        if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
-            );
-        } else {
-            $this->expectNoDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
+        if ($expectException) {
+            $this->expectException(
+                MappingException::class,
             );
         }
 

--- a/tests/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
+++ b/tests/Tests/ORM/Mapping/ManyToOneAssociationMappingTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\MappingException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -18,8 +17,6 @@ use function unserialize;
 
 final class ManyToOneAssociationMappingTest extends TestCase
 {
-    use VerifyDeprecations;
-
     public function testItSurvivesSerialization(): void
     {
         $mapping = new ManyToOneAssociationMapping(
@@ -44,21 +41,14 @@ final class ManyToOneAssociationMappingTest extends TestCase
 
     /** @param array<string, mixed> $mappingArray */
     #[DataProvider('mappingsProvider')]
-    #[WithoutErrorHandler]
     public function testNullableDefaults(
-        bool $expectDeprecation,
+        bool $expectException,
         bool $expectedValue,
         array $mappingArray,
     ): void {
         $namingStrategy = new DefaultNamingStrategy();
-        if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
-            );
-        } else {
-            $this->expectNoDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
-            );
+        if ($expectException) {
+            $this->expectException(MappingException::class);
         }
 
         $mapping = ManyToOneAssociationMapping::fromMappingArrayAndName(

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -1132,7 +1132,6 @@ class User
                             'name' => 'user_id',
                             'referencedColumnName' => 'id',
                             'unique' => false,
-                            'nullable' => false,
                         ],
                     ],
                     'inverseJoinColumns' =>

--- a/tests/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
+++ b/tests/Tests/ORM/Mapping/OneToOneOwningSideMappingTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -18,8 +17,6 @@ use function unserialize;
 
 final class OneToOneOwningSideMappingTest extends TestCase
 {
-    use VerifyDeprecations;
-
     public function testItSurvivesSerialization(): void
     {
         $mapping = new OneToOneOwningSideMapping(
@@ -44,21 +41,15 @@ final class OneToOneOwningSideMappingTest extends TestCase
 
     /** @param array<string, mixed> $mappingArray */
     #[DataProvider('mappingsProvider')]
-    #[WithoutErrorHandler]
     public function testNullableDefaults(
-        bool $expectDeprecation,
+        bool $expectException,
         bool $expectedValue,
         array $mappingArray,
     ): void {
         $namingStrategy = new DefaultNamingStrategy();
-        if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
-            );
-        } else {
-            $this->expectNoDeprecationWithIdentifier(
-                'https://github/doctrine/orm/pull/12125',
-            );
+
+        if ($expectException) {
+            $this->expectException(MappingException::class);
         }
 
         $mapping = OneToOneOwningSideMapping::fromMappingArrayAndName(

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -324,7 +324,7 @@ class DDC1587ValidEntity2
 {
     #[Id]
     #[OneToOne(targetEntity: 'DDC1587ValidEntity1', inversedBy: 'identifier')]
-    #[JoinColumn(name: 'pk_agent', referencedColumnName: 'pk', nullable: false)]
+    #[JoinColumn(name: 'pk_agent', referencedColumnName: 'pk')]
     private DDC1587ValidEntity1 $agent;
 
     #[Column(name: 'num', type: 'string', length: 16, nullable: true)]


### PR DESCRIPTION
This behavior has been deprecated.