### PR TITLE
fix: compute changes on lately added entities for insertions

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -551,9 +551,11 @@ class UnitOfWork implements PropertyChangedListener
     private function computeScheduleInsertsChangeSets(): void
     {
         foreach ($this->entityInsertions as $entity) {
-            $class = $this->em->getClassMetadata(get_class($entity));
-
-            $this->computeChangeSet($class, $entity);
+            $oid = spl_object_id($entity);
+            if (!isset($this->entityChangeSets[$oid])) {
+                $class = $this->em->getClassMetadata(get_class($entity));
+                $this->computeChangeSet($class, $entity);
+            }
         }
     }
 
@@ -929,6 +931,8 @@ class UnitOfWork implements PropertyChangedListener
                 }
             }
         }
+
+        $this->computeScheduleInsertsChangeSets();
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -552,7 +552,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         foreach ($this->entityInsertions as $entity) {
             $oid = spl_object_id($entity);
-            if (!isset($this->entityChangeSets[$oid])) {
+            if (! isset($this->entityChangeSets[$oid])) {
                 $class = $this->em->getClassMetadata(get_class($entity));
                 $this->computeChangeSet($class, $entity);
             }
@@ -932,6 +932,7 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
+        // Check again for uncomputed changes that might be added by hooks
         $this->computeScheduleInsertsChangeSets();
     }
 

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -40,6 +40,25 @@ class PrePersistEventTest extends OrmFunctionalTestCase
 
         $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForInsert($entityWithCascade));
         $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForInsert($entityWithUnmapped));
+
+        $this->_em->flush();
+    }
+
+    public function testPersistEntityOnFlushWithPrePersistHook(): void
+    {
+        $this->_em->getEventManager()->addEventListener(Events::prePersist, new PrePersistUnmappedPersistListener());
+
+        $alreadyPersistedEntity  = new EntityWithCascadeAssociation();
+        $this->_em->persist($alreadyPersistedEntity);
+        $this->_em->flush();
+
+        $entityWithUnmapped = new EntityWithUnmappedEntity();
+        $entityWithCascade  = new EntityWithCascadeAssociation();
+
+        $entityWithUnmapped->unmapped = $entityWithCascade;
+        $alreadyPersistedEntity->cascaded = $entityWithUnmapped;
+
+        $this->_em->flush();
     }
 }
 

--- a/tests/Tests/ORM/Functional/PrePersistEventTest.php
+++ b/tests/Tests/ORM/Functional/PrePersistEventTest.php
@@ -48,17 +48,19 @@ class PrePersistEventTest extends OrmFunctionalTestCase
     {
         $this->_em->getEventManager()->addEventListener(Events::prePersist, new PrePersistUnmappedPersistListener());
 
-        $alreadyPersistedEntity  = new EntityWithCascadeAssociation();
+        $alreadyPersistedEntity = new EntityWithCascadeAssociation();
         $this->_em->persist($alreadyPersistedEntity);
         $this->_em->flush();
 
         $entityWithUnmapped = new EntityWithUnmappedEntity();
         $entityWithCascade  = new EntityWithCascadeAssociation();
 
-        $entityWithUnmapped->unmapped = $entityWithCascade;
+        $entityWithUnmapped->unmapped     = $entityWithCascade;
         $alreadyPersistedEntity->cascaded = $entityWithUnmapped;
 
         $this->_em->flush();
+
+        $this->assertTrue($this->_em->getUnitOfWork()->isInIdentityMap($entityWithCascade));
     }
 }
 


### PR DESCRIPTION
In the uow the function `computeChangeSets` will `computeScheduleInsertsChangeSets` first to get all changes for new insert entities. For freshly added entities during a compute over a cascade persist, a single computeSet will be called, see:

https://github.com/doctrine/orm/blob/fe48a6d5584667fd38984d9ea27b09c3a6797866/src/UnitOfWork.php#L997-L998

But a persist hook may call a persist on further entities. This entities are dangling in the `entityInsertions` but never computed. This lead to sql errors later on.

This PR will check `entityInsertions` that aren't computed yet at the end of `computeChangeSets` to avoid sql errors.

