### PR TITLE
Fix php doc for getPropertyAccessors method

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -546,7 +546,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      */
     public LegacyReflectionFields|array $reflFields = [];
 
-    /** @var array<string, PropertyAccessors\PropertyAccessor> */
+    /** @var array<string, PropertyAccessor> */
     public array $propertyAccessors = [];
 
     private InstantiatorInterface|null $instantiator = null;
@@ -584,7 +584,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Gets the ReflectionProperties of the mapped class.
      *
-     * @return PropertyAccessor[] An array of PropertyAccessor instances.
+     * @return array<string, PropertyAccessor> An array of PropertyAccessor instances by name.
      */
     public function getPropertyAccessors(): array
     {


### PR DESCRIPTION
Rebased to 3.6.x instead closed https://github.com/doctrine/orm/pull/12158

Fixes:

getPropertyAccessors returns PropertyAccessor instead ReflectionProperties
getPropertyAccessors returns associative array mapped by accessor name, not a simple array