### PR TITLE
Switch to IgnoreDeprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "2.1.22",
         "phpstan/phpstan-deprecation-rules": "^2",
-        "phpunit/phpunit": "^10.4.0 || ^11.5",
+        "phpunit/phpunit": "^10.5.0 || ^11.5",
         "psr/log": "^1 || ^2 || ^3",
         "squizlabs/php_codesniffer": "3.13.2",
         "symfony/cache": "^5.4 || ^6.2 || ^7.0"

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -18,8 +18,8 @@ use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhp;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -39,7 +39,7 @@ class ConfigurationTest extends TestCase
         $this->configuration = new Configuration();
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testSetGetProxyDir(): void
     {
         self::assertNull($this->configuration->getProxyDir()); // defaults
@@ -48,7 +48,7 @@ class ConfigurationTest extends TestCase
         self::assertSame(__DIR__, $this->configuration->getProxyDir());
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testSetGetAutoGenerateProxyClasses(): void
     {
         self::assertSame(ProxyFactory::AUTOGENERATE_ALWAYS, $this->configuration->getAutoGenerateProxyClasses()); // defaults
@@ -63,7 +63,7 @@ class ConfigurationTest extends TestCase
         self::assertSame(ProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS, $this->configuration->getAutoGenerateProxyClasses());
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testSetGetProxyNamespace(): void
     {
         self::assertNull($this->configuration->getProxyNamespace()); // defaults
@@ -222,7 +222,7 @@ class ConfigurationTest extends TestCase
     }
 
     #[RequiresPhp('8.4')]
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testDisablingNativeLazyObjectsIsDeprecated(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12005');

--- a/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionMethod;
 use Symfony\Component\VarExporter\Instantiator;
 use Symfony\Component\VarExporter\VarExporter;
@@ -35,7 +35,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
 
     /** @param Closure(ParserResult): ParserResult $toSerializedAndBack */
     #[DataProvider('provideToSerializedAndBack')]
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testSerializeParserResultForQueryWithSqlWalker(Closure $toSerializedAndBack): void
     {
         $query = $this->_em

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -54,7 +54,7 @@ use DoctrineGlobalArticle;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group as TestGroup;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionClass;
 use stdClass;
 
@@ -1126,7 +1126,7 @@ class ClassMetadataTest extends OrmTestCase
         $metadata->addLifecycleCallback('foo', 'bar');
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testGettingAnFQCNForNullIsDeprecated(): void
     {
         $metadata = new ClassMetadata(self::class);
@@ -1165,7 +1165,7 @@ class ClassMetadataTest extends OrmTestCase
         );
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testDiscriminatorMapWithSameClassMultipleTimesDeprecated(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/3519');

--- a/tests/Tests/ORM/Mapping/TableMappingTest.php
+++ b/tests/Tests/ORM/Mapping/TableMappingTest.php
@@ -6,14 +6,14 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\Table;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 final class TableMappingTest extends TestCase
 {
     use VerifyDeprecations;
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testDeprecationOnIndexesPropertyIsTriggered(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');
@@ -21,7 +21,7 @@ final class TableMappingTest extends TestCase
         new Table(indexes: []);
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testDeprecationOnUniqueConstraintsPropertyIsTriggered(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11357');

--- a/tests/Tests/ORM/ORMSetupTest.php
+++ b/tests/Tests/ORM/ORMSetupTest.php
@@ -11,9 +11,9 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RequiresSetting;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -28,7 +28,7 @@ class ORMSetupTest extends TestCase
 {
     use VerifyDeprecations;
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testAttributeConfiguration(): void
     {
         if (PHP_VERSION_ID >= 80400) {
@@ -51,7 +51,7 @@ class ORMSetupTest extends TestCase
         self::assertInstanceOf(AttributeDriver::class, $config->getMetadataDriverImpl());
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testXMLConfiguration(): void
     {
         if (PHP_VERSION_ID >= 80400) {
@@ -104,7 +104,7 @@ class ORMSetupTest extends TestCase
     }
 
     #[Group('DDC-1350')]
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testConfigureProxyDir(): void
     {
         $config = ORMSetup::createAttributeMetadataConfiguration([], true, '/foo');

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -21,8 +21,8 @@ use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhp;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
@@ -247,7 +247,7 @@ class ProxyFactoryTest extends OrmTestCase
     }
 
     #[RequiresPhp('8.4')]
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testProxyFactoryTriggersDeprecationWhenNativeLazyObjectsAreDisabled(): void
     {
         $this->emMock->getConfiguration()->enableNativeLazyObjects(false);

--- a/tests/Tests/Proxy/AutoloaderTest.php
+++ b/tests/Tests/Proxy/AutoloaderTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Proxy;
 
 use Doctrine\ORM\Proxy\Autoloader;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 use function class_exists;
@@ -32,7 +32,7 @@ class AutoloaderTest extends TestCase
 
     /** @param class-string $className */
     #[DataProvider('dataResolveFile')]
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testResolveFile(
         string $proxyDir,
         string $proxyNamespace,
@@ -43,7 +43,7 @@ class AutoloaderTest extends TestCase
         self::assertEquals($expectedProxyFile, $actualProxyFile);
     }
 
-    #[WithoutErrorHandler]
+    #[IgnoreDeprecations]
     public function testAutoload(): void
     {
         if (file_exists(sys_get_temp_dir() . '/AutoloaderTestClass.php')) {


### PR DESCRIPTION
Rather than disabling the error handler, this attribute allows to be more fine-grained and ignore only the deprecations.