### PR TITLE
Remove internal from Property accessor

### DIFF
--- a/src/Mapping/PropertyAccessors/PropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/PropertyAccessor.php
@@ -14,8 +14,6 @@ use ReflectionProperty;
  *
  * This abstraction over ReflectionProperty is necessary, because for several features of either Doctrine or PHP, we
  * need to handle edge cases in reflection at a central location in the code.
- *
- * @internal
  */
 interface PropertyAccessor
 {


### PR DESCRIPTION
Hi @beberlei 

In https://github.com/doctrine/orm/pull/11659 you introduce PropertyAccessor as a way to replace reflFields,
but the interface is internal.

Static analysis like PHPStan/Psalm does report internal class/methods because basically it means
- The interface could be removed anytime
- Some method could be removed anytime

And so we cannot rely on setValue/getValue.

Since we were able to use "freely" reflfields, I assume it should be the same for propertyAccessors.

As an exemple https://github.com/sonata-project/EntityAuditBundle use it a lot.