### PR TITLE
Add commands for inspecting configured listeners

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -96,6 +96,10 @@ The following Commands are currently available:
 -  ``orm:schema-tool:update`` Processes the schema and either
    update the database schema of EntityManager Storage Connection or
    generate the SQL output.
+-  ``orm:debug:event-manager`` Lists event listeners for an entity
+   manager, optionally filtered by event name.
+-  ``orm:debug:entity-listeners`` Lists entity listeners for a given
+   entity, optionally filtered by event name.
 
 The following alias is defined:
 

--- a/src/Tools/Console/Command/Debug/AbstractCommand.php
+++ b/src/Tools/Console/Command/Debug/AbstractCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console\Command\Debug;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\Command\Command;
+
+use function assert;
+
+abstract class AbstractCommand extends Command
+{
+    public function __construct(private readonly ManagerRegistry $managerRegistry)
+    {
+        parent::__construct();
+    }
+
+    protected function getEntityManager(string $name): EntityManagerInterface
+    {
+        $manager = $this->getManagerRegistry()->getManager($name);
+
+        assert($manager instanceof EntityManagerInterface);
+
+        return $manager;
+    }
+
+    protected function getManagerRegistry(): ManagerRegistry
+    {
+        return $this->managerRegistry;
+    }
+}

--- a/src/Tools/Console/Command/Debug/AbstractCommand.php
+++ b/src/Tools/Console/Command/Debug/AbstractCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 
 use function assert;
 
+/** @internal */
 abstract class AbstractCommand extends Command
 {
     public function __construct(private readonly ManagerRegistry $managerRegistry)
@@ -17,7 +18,7 @@ abstract class AbstractCommand extends Command
         parent::__construct();
     }
 
-    protected function getEntityManager(string $name): EntityManagerInterface
+    final protected function getEntityManager(string $name): EntityManagerInterface
     {
         $manager = $this->getManagerRegistry()->getManager($name);
 
@@ -26,7 +27,7 @@ abstract class AbstractCommand extends Command
         return $manager;
     }
 
-    protected function getManagerRegistry(): ManagerRegistry
+    final protected function getManagerRegistry(): ManagerRegistry
     {
         return $this->managerRegistry;
     }

--- a/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console\Command\Debug;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function array_keys;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function assert;
+use function class_exists;
+use function ksort;
+use function ltrim;
+use function sort;
+use function sprintf;
+
+final class DebugEntityListenersDoctrineCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('orm:debug:entity-listeners')
+            ->setDescription('Lists entity listeners for a given entity')
+            ->addArgument('entity', InputArgument::OPTIONAL, 'The fully-qualified entity class name')
+            ->addArgument('event', InputArgument::OPTIONAL, 'The event name to filter by (e.g. postPersist)')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command lists all entity listeners for a given entity:
+
+    <info>php %command.full_name% 'App\Entity\User'</info>
+
+To show only listeners for a specific event, pass the event name:
+
+    <info>php %command.full_name% 'App\Entity\User' postPersist</info>
+EOT);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var class-string|null $entityName */
+        $entityName = $input->getArgument('entity');
+
+        if ($entityName === null) {
+            /** @var class-string $entityName */
+            $entityName = $io->choice('Which entity do you want to list listeners for?', $this->listAllEntities());
+        }
+
+        $entityName    = ltrim($entityName, '\\');
+        $entityManager = $this->getManagerRegistry()->getManagerForClass($entityName);
+
+        if ($entityManager === null) {
+            $io->error(sprintf('No entity manager found for class "%s".', $entityName));
+
+            return self::FAILURE;
+        }
+
+        $classMetadata = $entityManager->getClassMetadata($entityName);
+        assert($classMetadata instanceof ClassMetadata);
+
+        $eventName = $input->getArgument('event');
+
+        $allListeners = $eventName === null
+            ? $classMetadata->entityListeners
+            : [$eventName => $classMetadata->entityListeners[$eventName] ?? []];
+
+        ksort($allListeners);
+
+        $io->title(sprintf('Entity listeners for <info>%s</info>', $entityName));
+
+        if (! $allListeners) {
+            $io->text('No listeners are configured for this entity.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($allListeners as $event => $listeners) {
+            $io->section(sprintf('"%s" event', $event));
+
+            if (! $listeners) {
+                $io->text('No listeners are configured for this event.');
+                continue;
+            }
+
+            $rows = [];
+            foreach ($listeners as $order => $listener) {
+                $rows[] = [sprintf('#%d', ++$order), sprintf('%s::%s()', $listener['class'], $listener['method'])];
+            }
+
+            $io->table(['Order', 'Listener'], $rows);
+        }
+
+        return self::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('entity')) {
+            $suggestions->suggestValues($this->listAllEntities());
+
+            return;
+        }
+
+        if ($input->mustSuggestArgumentValuesFor('event')) {
+            $entityName = ltrim($input->getArgument('entity'), '\\');
+
+            if (! class_exists($entityName)) {
+                return;
+            }
+
+            $entityManager = $this->getManagerRegistry()->getManagerForClass($entityName);
+
+            if ($entityManager === null) {
+                return;
+            }
+
+            $classMetadata = $entityManager->getClassMetadata($entityName);
+            assert($classMetadata instanceof ClassMetadata);
+
+            $suggestions->suggestValues(array_keys($classMetadata->entityListeners));
+
+            return;
+        }
+    }
+
+    /** @return list<class-string> */
+    private function listAllEntities(): array
+    {
+        $entities = [];
+        foreach (array_keys($this->getManagerRegistry()->getManagerNames()) as $managerName) {
+            $entities[] = $this->getEntityManager($managerName)->getConfiguration()->getMetadataDriverImpl()->getAllClassNames();
+        }
+
+        $entities = array_values(array_unique(array_merge(...$entities)));
+
+        sort($entities);
+
+        return $entities;
+    }
+}

--- a/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
@@ -51,8 +51,16 @@ EOT);
         $entityName = $input->getArgument('entity');
 
         if ($entityName === null) {
+            $choices = $this->listAllEntities();
+
+            if ($choices === []) {
+                $io->error('No entities are configured.');
+
+                return self::FAILURE;
+            }
+
             /** @var class-string $entityName */
-            $entityName = $io->choice('Which entity do you want to list listeners for?', $this->listAllEntities());
+            $entityName = $io->choice('Which entity do you want to list listeners for?', $choices);
         }
 
         $entityName    = ltrim($entityName, '\\');

--- a/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommand.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Tools\Console\Command\Debug;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -77,35 +78,39 @@ EOT);
 
         $eventName = $input->getArgument('event');
 
-        $allListeners = $eventName === null
-            ? $classMetadata->entityListeners
-            : [$eventName => $classMetadata->entityListeners[$eventName] ?? []];
+        if ($eventName === null) {
+            $allListeners = $classMetadata->entityListeners;
+            if (! $allListeners) {
+                $io->info(sprintf('No listeners are configured for the "%s" entity.', $entityName));
 
-        ksort($allListeners);
+                return self::SUCCESS;
+            }
+
+            ksort($allListeners);
+        } else {
+            if (! isset($classMetadata->entityListeners[$eventName])) {
+                $io->info(sprintf('No listeners are configured for the "%s" event.', $eventName));
+
+                return self::SUCCESS;
+            }
+
+            $allListeners = [$eventName => $classMetadata->entityListeners[$eventName]];
+        }
 
         $io->title(sprintf('Entity listeners for <info>%s</info>', $entityName));
 
-        if (! $allListeners) {
-            $io->text('No listeners are configured for this entity.');
-
-            return self::SUCCESS;
-        }
-
+        $rows = [];
         foreach ($allListeners as $event => $listeners) {
-            $io->section(sprintf('"%s" event', $event));
-
-            if (! $listeners) {
-                $io->text('No listeners are configured for this event.');
-                continue;
+            if ($rows) {
+                $rows[] = new TableSeparator();
             }
 
-            $rows = [];
             foreach ($listeners as $order => $listener) {
-                $rows[] = [sprintf('#%d', ++$order), sprintf('%s::%s()', $listener['class'], $listener['method'])];
+                $rows[] = [$order === 0 ? $event : '', sprintf('#%d', ++$order), sprintf('%s::%s()', $listener['class'], $listener['method'])];
             }
-
-            $io->table(['Order', 'Listener'], $rows);
         }
+
+        $io->table(['Event', 'Order', 'Listener'], $rows);
 
         return self::SUCCESS;
     }

--- a/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Console\Command\Debug;
+
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function array_keys;
+use function array_values;
+use function ksort;
+use function method_exists;
+use function sprintf;
+
+final class DebugEventManagerDoctrineCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('orm:debug:event-manager')
+            ->setDescription('Lists event listeners for an entity manager')
+            ->addArgument('event', InputArgument::OPTIONAL, 'The event name to filter by (e.g. postPersist)')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command lists all event listeners for the default entity manager:
+
+    <info>php %command.full_name%</info>
+
+You can also specify an entity manager:
+
+    <info>php %command.full_name% --em=default</info>
+
+To show only listeners for a specific event, pass the event name as an argument:
+
+    <info>php %command.full_name% postPersist</info>
+EOT);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $entityManagerName = $input->getOption('em') ?: $this->getManagerRegistry()->getDefaultManagerName();
+        $eventManager      = $this->getEntityManager($entityManagerName)->getEventManager();
+
+        $eventName = $input->getArgument('event');
+
+        $allListeners = $eventName === null
+            ? $eventManager->getAllListeners()
+            : [$eventName => $eventManager->hasListeners($eventName) ? $eventManager->getListeners($eventName) : []];
+
+        ksort($allListeners);
+
+        $io->title(sprintf('Event listeners for <info>%s</info> entity manager', $entityManagerName));
+
+        if (! $allListeners) {
+            $io->text('No listeners are configured for this entity manager.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($allListeners as $event => $listeners) {
+            $io->section(sprintf('"%s" event', $event));
+
+            if (! $listeners) {
+                $io->text('No listeners are configured for this event.');
+                continue;
+            }
+
+            $rows = [];
+            foreach (array_values($listeners) as $order => $listener) {
+                $method = method_exists($listener, '__invoke') ? '__invoke' : $event;
+                $rows[] = [sprintf('#%d', ++$order), sprintf('%s::%s()', $listener::class, $method)];
+            }
+
+            $io->table(['Order', 'Listener'], $rows);
+        }
+
+        return self::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('event')) {
+            $entityManagerName = $input->getOption('em') ?: $this->getManagerRegistry()->getDefaultManagerName();
+            $eventManager      = $this->getEntityManager($entityManagerName)->getEventManager();
+
+            $suggestions->suggestValues(array_keys($eventManager->getAllListeners()));
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('em')) {
+            $suggestions->suggestValues(array_keys($this->getManagerRegistry()->getManagerNames()));
+
+            return;
+        }
+    }
+}

--- a/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools\Console\Command\Debug;
 
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -51,36 +52,41 @@ EOT);
 
         $eventName = $input->getArgument('event');
 
-        $allListeners = $eventName === null
-            ? $eventManager->getAllListeners()
-            : [$eventName => $eventManager->hasListeners($eventName) ? $eventManager->getListeners($eventName) : []];
+        if ($eventName === null) {
+            $allListeners = $eventManager->getAllListeners();
+            if (! $allListeners) {
+                $io->info(sprintf('No listeners are configured for the "%s" entity manager.', $entityManagerName));
 
-        ksort($allListeners);
+                return self::SUCCESS;
+            }
+
+            ksort($allListeners);
+        } else {
+            $listeners = $eventManager->hasListeners($eventName) ? $eventManager->getListeners($eventName) : [];
+            if (! $listeners) {
+                $io->info(sprintf('No listeners are configured for the "%s" event.', $eventName));
+
+                return self::SUCCESS;
+            }
+
+            $allListeners = [$eventName => $listeners];
+        }
 
         $io->title(sprintf('Event listeners for <info>%s</info> entity manager', $entityManagerName));
 
-        if (! $allListeners) {
-            $io->text('No listeners are configured for this entity manager.');
-
-            return self::SUCCESS;
-        }
-
+        $rows = [];
         foreach ($allListeners as $event => $listeners) {
-            $io->section(sprintf('"%s" event', $event));
-
-            if (! $listeners) {
-                $io->text('No listeners are configured for this event.');
-                continue;
+            if ($rows) {
+                $rows[] = new TableSeparator();
             }
 
-            $rows = [];
             foreach (array_values($listeners) as $order => $listener) {
                 $method = method_exists($listener, '__invoke') ? '__invoke' : $event;
-                $rows[] = [sprintf('#%d', ++$order), sprintf('%s::%s()', $listener::class, $method)];
+                $rows[] = [$order === 0 ? $event : '', sprintf('#%d', ++$order), sprintf('%s::%s()', $listener::class, $method)];
             }
-
-            $io->table(['Order', 'Listener'], $rows);
         }
+
+        $io->table(['Event', 'Order', 'Listener'], $rows);
 
         return self::SUCCESS;
     }

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
@@ -53,24 +53,14 @@ class DebugEntityListenersDoctrineCommandTest extends TestCase
 Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
 ===========================================================================================================
 
-"postPersist" event
--------------------
-
- ------- ------------------------------------------------------------------------------------ 
-  Order   Listener                                                                            
- ------- ------------------------------------------------------------------------------------ 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
- ------- ------------------------------------------------------------------------------------ 
-
-"preUpdate" event
------------------
-
- ------- ---------------------------------------------------------------------------------- 
-  Order   Listener                                                                          
- ------- ---------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()  
-  #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()   
- ------- ---------------------------------------------------------------------------------- 
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  Event         Order   Listener                                                                            
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  postPersist   #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  preUpdate     #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()    
+                #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()     
+ ------------- ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -89,14 +79,11 @@ TXT
 Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
 ===========================================================================================================
 
-"postPersist" event
--------------------
-
- ------- ------------------------------------------------------------------------------------ 
-  Order   Listener                                                                            
- ------- ------------------------------------------------------------------------------------ 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
- ------- ------------------------------------------------------------------------------------ 
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  Event         Order   Listener                                                                            
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  postPersist   #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------------- ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -112,13 +99,8 @@ TXT
 
         self::assertSame(<<<'TXT'
 
-Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
-===========================================================================================================
+ [INFO] No listeners are configured for the "preRemove" event.                                                          
 
-"preRemove" event
------------------
-
- No listeners are configured for this event.
 
 TXT
             , $commandTester->getDisplay(true));

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
+use Doctrine\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommand;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DebugEntityListenersDoctrineCommandTest extends TestCase
+{
+    use ApplicationCompatibility;
+
+    private DebugEntityListenersDoctrineCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application   = new Application();
+        $this->command = new DebugEntityListenersDoctrineCommand($this->getMockManagerRegistry());
+
+        self::addCommandToApplication($application, $this->command);
+    }
+
+    public function testExecute(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName(), 'entity' => self::class],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
+===========================================================================================================
+
+"postPersists" event
+--------------------
+
+ ------- ------------------------------------------------------------------------------------- 
+  Order   Listener                                                                             
+ ------- ------------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
+ ------- ------------------------------------------------------------------------------------- 
+
+"preUpdate" event
+-----------------
+
+ ------- ---------------------------------------------------------------------------------- 
+  Order   Listener                                                                          
+ ------- ---------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()  
+  #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()   
+ ------- ---------------------------------------------------------------------------------- 
+
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    public function testExecuteWithEvent(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName(), 'entity' => self::class, 'event' => 'postPersists'],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
+===========================================================================================================
+
+"postPersists" event
+--------------------
+
+ ------- ------------------------------------------------------------------------------------- 
+  Order   Listener                                                                             
+ ------- ------------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
+ ------- ------------------------------------------------------------------------------------- 
+
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    public function testExecuteWithMissingEvent(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName(), 'entity' => self::class, 'event' => 'preRemove'],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
+===========================================================================================================
+
+"preRemove" event
+-----------------
+
+ No listeners are configured for this event.
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    /** @return MockObject&ManagerRegistry */
+    private function getMockManagerRegistry(): MockObject
+    {
+        $mappingDriverMock = $this->createMock(MappingDriver::class);
+        $mappingDriverMock->method('getAllClassNames')->willReturn([self::class]);
+
+        $config = new Configuration();
+        $config->setMetadataDriverImpl($mappingDriverMock);
+
+        $classMetadata = new ClassMetadata(self::class);
+        $classMetadata->addEntityListener('preUpdate', FooListener::class, 'preUpdate');
+        $classMetadata->addEntityListener('preUpdate', BarListener::class, '__invoke');
+        $classMetadata->addEntityListener('postPersists', BazListener::class, 'postPersists');
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $emMock->method('getConfiguration')->willReturn($config);
+        $emMock->method('getClassMetadata')->willReturn($classMetadata);
+
+        $doctrineMock = $this->createMock(ManagerRegistry::class);
+        $doctrineMock->method('getManagerNames')->willReturn(['default']);
+        $doctrineMock->method('getManager')->willReturn($emMock);
+        $doctrineMock->method('getManagerForClass')->willReturn($emMock);
+
+        return $doctrineMock;
+    }
+}

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEntityListenersDoctrineCommandTest.php
@@ -14,10 +14,16 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_map;
 
 class DebugEntityListenersDoctrineCommandTest extends TestCase
 {
@@ -47,14 +53,14 @@ class DebugEntityListenersDoctrineCommandTest extends TestCase
 Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
 ===========================================================================================================
 
-"postPersists" event
---------------------
+"postPersist" event
+-------------------
 
- ------- ------------------------------------------------------------------------------------- 
-  Order   Listener                                                                             
- ------- ------------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
- ------- ------------------------------------------------------------------------------------- 
+ ------- ------------------------------------------------------------------------------------ 
+  Order   Listener                                                                            
+ ------- ------------------------------------------------------------------------------------ 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------- ------------------------------------------------------------------------------------ 
 
 "preUpdate" event
 -----------------
@@ -75,7 +81,7 @@ TXT
     {
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(
-            ['command' => $this->command->getName(), 'entity' => self::class, 'event' => 'postPersists'],
+            ['command' => $this->command->getName(), 'entity' => self::class, 'event' => 'postPersist'],
         );
 
         self::assertSame(<<<'TXT'
@@ -83,14 +89,14 @@ TXT
 Entity listeners for Doctrine\Tests\ORM\Tools\Console\Command\Debug\DebugEntityListenersDoctrineCommandTest
 ===========================================================================================================
 
-"postPersists" event
---------------------
+"postPersist" event
+-------------------
 
- ------- ------------------------------------------------------------------------------------- 
-  Order   Listener                                                                             
- ------- ------------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
- ------- ------------------------------------------------------------------------------------- 
+ ------- ------------------------------------------------------------------------------------ 
+  Order   Listener                                                                            
+ ------- ------------------------------------------------------------------------------------ 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -118,8 +124,26 @@ TXT
             , $commandTester->getDisplay(true));
     }
 
+    /**
+     * @param list<string> $args
+     * @param list<string> $expectedSuggestions
+     */
+    #[TestWith([['console'], 1, [self::class]])]
+    #[TestWith([['console', self::class], 2, ['preUpdate', 'postPersist']])]
+    #[TestWith([['console', 'NonExistentEntity'], 2, []])]
+    public function testComplete(array $args, int $currentIndex, array $expectedSuggestions): void
+    {
+        $input = CompletionInput::fromTokens($args, $currentIndex);
+        $input->bind($this->command->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->command->complete($input, $suggestions);
+
+        self::assertSame($expectedSuggestions, array_map(static fn (Suggestion $suggestion) => $suggestion->getValue(), $suggestions->getValueSuggestions()));
+    }
+
     /** @return MockObject&ManagerRegistry */
-    private function getMockManagerRegistry(): MockObject
+    private function getMockManagerRegistry(): ManagerRegistry
     {
         $mappingDriverMock = $this->createMock(MappingDriver::class);
         $mappingDriverMock->method('getAllClassNames')->willReturn([self::class]);
@@ -130,14 +154,14 @@ TXT
         $classMetadata = new ClassMetadata(self::class);
         $classMetadata->addEntityListener('preUpdate', FooListener::class, 'preUpdate');
         $classMetadata->addEntityListener('preUpdate', BarListener::class, '__invoke');
-        $classMetadata->addEntityListener('postPersists', BazListener::class, 'postPersists');
+        $classMetadata->addEntityListener('postPersist', BazListener::class, 'postPersist');
 
         $emMock = $this->createMock(EntityManagerInterface::class);
         $emMock->method('getConfiguration')->willReturn($config);
         $emMock->method('getClassMetadata')->willReturn($classMetadata);
 
         $doctrineMock = $this->createMock(ManagerRegistry::class);
-        $doctrineMock->method('getManagerNames')->willReturn(['default']);
+        $doctrineMock->method('getManagerNames')->willReturn(['default' => 'entity_manager.default']);
         $doctrineMock->method('getManager')->willReturn($emMock);
         $doctrineMock->method('getManagerForClass')->willReturn($emMock);
 

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
@@ -51,24 +51,14 @@ class DebugEventManagerDoctrineCommandTest extends TestCase
 Event listeners for default entity manager
 ==========================================
 
-"postPersist" event
--------------------
-
- ------- ------------------------------------------------------------------------------------ 
-  Order   Listener                                                                            
- ------- ------------------------------------------------------------------------------------ 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
- ------- ------------------------------------------------------------------------------------ 
-
-"preUpdate" event
------------------
-
- ------- ---------------------------------------------------------------------------------- 
-  Order   Listener                                                                          
- ------- ---------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()  
-  #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()   
- ------- ---------------------------------------------------------------------------------- 
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  Event         Order   Listener                                                                            
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  postPersist   #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  preUpdate     #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()    
+                #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()     
+ ------------- ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -87,14 +77,11 @@ TXT
 Event listeners for default entity manager
 ==========================================
 
-"postPersist" event
--------------------
-
- ------- ------------------------------------------------------------------------------------ 
-  Order   Listener                                                                            
- ------- ------------------------------------------------------------------------------------ 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
- ------- ------------------------------------------------------------------------------------ 
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  Event         Order   Listener                                                                            
+ ------------- ------- ------------------------------------------------------------------------------------ 
+  postPersist   #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------------- ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -110,13 +97,8 @@ TXT
 
         self::assertSame(<<<'TXT'
 
-Event listeners for default entity manager
-==========================================
+ [INFO] No listeners are configured for the "preRemove" event.                                                          
 
-"preRemove" event
------------------
-
- No listeners are configured for this event.
 
 TXT
             , $commandTester->getDisplay(true));

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug;
+
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
+use Doctrine\ORM\Tools\Console\Command\Debug\DebugEventManagerDoctrineCommand;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener;
+use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DebugEventManagerDoctrineCommandTest extends TestCase
+{
+    use ApplicationCompatibility;
+
+    private DebugEventManagerDoctrineCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application   = new Application();
+        $this->command = new DebugEventManagerDoctrineCommand($this->getMockManagerRegistry());
+
+        self::addCommandToApplication($application, $this->command);
+    }
+
+    public function testExecute(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName()],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Event listeners for default entity manager
+==========================================
+
+"postPersists" event
+--------------------
+
+ ------- ------------------------------------------------------------------------------------- 
+  Order   Listener                                                                             
+ ------- ------------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
+ ------- ------------------------------------------------------------------------------------- 
+
+"preUpdate" event
+-----------------
+
+ ------- ---------------------------------------------------------------------------------- 
+  Order   Listener                                                                          
+ ------- ---------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener::preUpdate()  
+  #2      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener::__invoke()   
+ ------- ---------------------------------------------------------------------------------- 
+
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    public function testExecuteWithEvent(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName(), 'event' => 'postPersists'],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Event listeners for default entity manager
+==========================================
+
+"postPersists" event
+--------------------
+
+ ------- ------------------------------------------------------------------------------------- 
+  Order   Listener                                                                             
+ ------- ------------------------------------------------------------------------------------- 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
+ ------- ------------------------------------------------------------------------------------- 
+
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    public function testExecuteWithMissingEvent(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(
+            ['command' => $this->command->getName(), 'event' => 'preRemove'],
+        );
+
+        self::assertSame(<<<'TXT'
+
+Event listeners for default entity manager
+==========================================
+
+"preRemove" event
+-----------------
+
+ No listeners are configured for this event.
+
+TXT
+            , $commandTester->getDisplay(true));
+    }
+
+    /** @return MockObject&ManagerRegistry */
+    private function getMockManagerRegistry(): MockObject
+    {
+        $eventManager = new EventManager();
+        $eventManager->addEventListener('preUpdate', new FooListener());
+        $eventManager->addEventListener('preUpdate', new BarListener());
+        $eventManager->addEventListener('postPersists', new BazListener());
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $emMock->method('getEventManager')->willReturn($eventManager);
+
+        $doctrineMock = $this->createMock(ManagerRegistry::class);
+        $doctrineMock->method('getDefaultManagerName')->willReturn('default');
+        $doctrineMock->method('getManager')->willReturn($emMock);
+
+        return $doctrineMock;
+    }
+}

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommandTest.php
@@ -12,10 +12,16 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BarListener;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener;
 use Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\FooListener;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_map;
 
 class DebugEventManagerDoctrineCommandTest extends TestCase
 {
@@ -45,14 +51,14 @@ class DebugEventManagerDoctrineCommandTest extends TestCase
 Event listeners for default entity manager
 ==========================================
 
-"postPersists" event
---------------------
+"postPersist" event
+-------------------
 
- ------- ------------------------------------------------------------------------------------- 
-  Order   Listener                                                                             
- ------- ------------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
- ------- ------------------------------------------------------------------------------------- 
+ ------- ------------------------------------------------------------------------------------ 
+  Order   Listener                                                                            
+ ------- ------------------------------------------------------------------------------------ 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------- ------------------------------------------------------------------------------------ 
 
 "preUpdate" event
 -----------------
@@ -73,7 +79,7 @@ TXT
     {
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(
-            ['command' => $this->command->getName(), 'event' => 'postPersists'],
+            ['command' => $this->command->getName(), 'event' => 'postPersist'],
         );
 
         self::assertSame(<<<'TXT'
@@ -81,14 +87,14 @@ TXT
 Event listeners for default entity manager
 ==========================================
 
-"postPersists" event
---------------------
+"postPersist" event
+-------------------
 
- ------- ------------------------------------------------------------------------------------- 
-  Order   Listener                                                                             
- ------- ------------------------------------------------------------------------------------- 
-  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersists()  
- ------- ------------------------------------------------------------------------------------- 
+ ------- ------------------------------------------------------------------------------------ 
+  Order   Listener                                                                            
+ ------- ------------------------------------------------------------------------------------ 
+  #1      Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures\BazListener::postPersist()  
+ ------- ------------------------------------------------------------------------------------ 
 
 
 TXT
@@ -116,13 +122,30 @@ TXT
             , $commandTester->getDisplay(true));
     }
 
+    /**
+     * @param list<string> $args
+     * @param list<string> $expectedSuggestions
+     */
+    #[TestWith([['console'], 1, ['preUpdate', 'postPersist']])]
+    #[TestWith([['console', '--em'], 1, ['default']])]
+    public function testComplete(array $args, int $currentIndex, array $expectedSuggestions): void
+    {
+        $input = CompletionInput::fromTokens($args, $currentIndex);
+        $input->bind($this->command->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->command->complete($input, $suggestions);
+
+        self::assertSame($expectedSuggestions, array_map(static fn (Suggestion $suggestion) => $suggestion->getValue(), $suggestions->getValueSuggestions()));
+    }
+
     /** @return MockObject&ManagerRegistry */
-    private function getMockManagerRegistry(): MockObject
+    private function getMockManagerRegistry(): ManagerRegistry
     {
         $eventManager = new EventManager();
         $eventManager->addEventListener('preUpdate', new FooListener());
         $eventManager->addEventListener('preUpdate', new BarListener());
-        $eventManager->addEventListener('postPersists', new BazListener());
+        $eventManager->addEventListener('postPersist', new BazListener());
 
         $emMock = $this->createMock(EntityManagerInterface::class);
         $emMock->method('getEventManager')->willReturn($eventManager);
@@ -130,6 +153,7 @@ TXT
         $doctrineMock = $this->createMock(ManagerRegistry::class);
         $doctrineMock->method('getDefaultManagerName')->willReturn('default');
         $doctrineMock->method('getManager')->willReturn($emMock);
+        $doctrineMock->method('getManagerNames')->willReturn(['default' => 'entity_manager.default']);
 
         return $doctrineMock;
     }

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BarListener.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BarListener.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures;
+
+class BarListener
+{
+    public function __invoke(): void
+    {
+    }
+}

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BazListener.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BazListener.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures;
+
+class BazListener
+{
+    public function postPersists(): void
+    {
+    }
+}

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BazListener.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/BazListener.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures;
 
 class BazListener
 {
-    public function postPersists(): void
+    public function postPersist(): void
     {
     }
 }

--- a/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/FooListener.php
+++ b/tests/Tests/ORM/Tools/Console/Command/Debug/Fixtures/FooListener.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\Debug\Fixtures;
+
+class FooListener
+{
+    public function preUpdate(): void
+    {
+    }
+}


### PR DESCRIPTION
Related to https://github.com/doctrine/DoctrineBundle/pull/2032

Similar to Symfony's `debug:event-dispatcher` command, this PR adds two new commands to inspect configured Doctrine event/entity listeners:

* `orm:debug:event-manager` — lists event listeners registered in the Doctrine EventManager for a given entity manager (optionally filter by event).
* `orm:debug:entity-listeners` — lists entity listeners configured for a given entity class (optionally filter by event).