### PR TITLE
feat: Allow to unmark an entity as readonly

### DIFF
--- a/src/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/src/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -371,7 +371,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritDoc}
      */
-    public function loadById(array $identifier, object|null $entity = null): object|null
+    public function loadById(array $identifier, object|null $entity = null, bool $readOnly = false): object|null
     {
         $cacheKey   = new EntityCacheKey($this->class->rootEntityName, $identifier);
         $cacheEntry = $this->region->get($cacheKey);
@@ -391,7 +391,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             }
         }
 
-        $entity = $this->persister->loadById($identifier, $entity);
+        $entity = $this->persister->loadById($identifier, $entity, $readOnly);
 
         if ($entity === null) {
             return null;

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -112,9 +112,9 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
         $this->wrapped->lock($entity, $lockMode, $lockVersion);
     }
 
-    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null, bool $readOnly = false): object|null
     {
-        return $this->wrapped->find($className, $id, $lockMode, $lockVersion);
+        return $this->wrapped->find($className, $id, $lockMode, $lockVersion, $readOnly);
     }
 
     public function refresh(object $object, LockMode|int|null $lockMode = null): void

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -271,7 +271,7 @@ class EntityManager implements EntityManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function find($className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find($className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null, bool $readOnly = false): object|null
     {
         $class = $this->metadataFactory->getMetadataFor(ltrim($className, '\\'));
 
@@ -343,6 +343,10 @@ class EntityManager implements EntityManagerInterface
                     break;
             }
 
+            if (! $readOnly && $unitOfWork->isReadOnly($entity)) {
+                $unitOfWork->unmarkReadOnly($entity);
+            }
+
             return $entity; // Hit!
         }
 
@@ -350,7 +354,7 @@ class EntityManager implements EntityManagerInterface
 
         switch (true) {
             case $lockMode === LockMode::OPTIMISTIC:
-                $entity = $persister->load($sortedId);
+                $entity = $persister->load($sortedId, hints: [Query::HINT_READ_ONLY => $readOnly]);
 
                 if ($entity !== null) {
                     $unitOfWork->lock($entity, $lockMode, $lockVersion);
@@ -360,10 +364,10 @@ class EntityManager implements EntityManagerInterface
 
             case $lockMode === LockMode::PESSIMISTIC_READ:
             case $lockMode === LockMode::PESSIMISTIC_WRITE:
-                return $persister->load($sortedId, null, null, [], $lockMode);
+                return $persister->load($sortedId, null, null, [Query::HINT_READ_ONLY => $readOnly], $lockMode);
 
             default:
-                return $persister->loadById($sortedId);
+                return $persister->loadById($sortedId, readOnly: $readOnly);
         }
     }
 

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -130,7 +130,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @template T of object
      */
-    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null;
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null, bool $readOnly = false): object|null;
 
     /**
      * Refreshes the persistent state of an object from the database,

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -748,9 +748,9 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritDoc}
      */
-    public function loadById(array $identifier, object|null $entity = null): object|null
+    public function loadById(array $identifier, object|null $entity = null, bool $readOnly = false): object|null
     {
-        return $this->load($identifier, $entity);
+        return $this->load($identifier, $entity, hints: [Query::HINT_READ_ONLY => $readOnly]);
     }
 
     /**

--- a/src/Persisters/Entity/EntityPersister.php
+++ b/src/Persisters/Entity/EntityPersister.php
@@ -182,7 +182,7 @@ interface EntityPersister
      *
      * @todo Check parameters
      */
-    public function loadById(array $identifier, object|null $entity = null): object|null;
+    public function loadById(array $identifier, object|null $entity = null, bool $readOnly = false): object|null;
 
     /**
      * Loads an entity of this persister's mapped class as part of a single-valued

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -3080,9 +3080,6 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Marks an entity as read-only so that it will not be considered for updates during UnitOfWork#commit().
      *
-     * This operation cannot be undone as some parts of the UnitOfWork now keep gathering information
-     * on this object that might be necessary to perform a correct update.
-     *
      * @throws ORMInvalidArgumentException
      */
     public function markReadOnly(object $object): void
@@ -3092,6 +3089,21 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $this->readOnlyObjects[spl_object_id($object)] = true;
+    }
+
+    /**
+     * Unmarks an entity as read-only so that it will be considered for updates during UnitOfWork#commit()
+     * even if it was previously fetched as read-only.
+     *
+     * @throws ORMInvalidArgumentException
+     */
+    public function unmarkReadOnly(object $object): void
+    {
+        if (! $this->isInIdentityMap($object)) {
+            throw ORMInvalidArgumentException::readOnlyRequiresManagedEntity($object);
+        }
+
+        unset($this->readOnlyObjects[spl_object_id($object)]);
     }
 
     /**

--- a/tests/Performance/Mock/NonLoadingPersister.php
+++ b/tests/Performance/Mock/NonLoadingPersister.php
@@ -18,7 +18,7 @@ class NonLoadingPersister extends BasicEntityPersister
         $this->class = $class;
     }
 
-    public function loadById(array $identifier, object|null $entity = null): object|null
+    public function loadById(array $identifier, object|null $entity = null, bool $readOnly = false): object|null
     {
         return $entity ?? new ($this->class->name)();
     }

--- a/tests/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -163,9 +163,9 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
         return $this->realEntityManager->hasFilters();
     }
 
-    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null, bool $readOnly = false): object|null
     {
-        return $this->realEntityManager->find($className, $id, $lockMode, $lockVersion);
+        return $this->realEntityManager->find($className, $id, $lockMode, $lockVersion, $readOnly);
     }
 
     public function persist(object $object): void

--- a/tests/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Tests/ORM/Functional/ReadOnlyTest.php
@@ -128,7 +128,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
     }
 
-    public function testNotWriteableIfObjectWasKnownAsReadOnlyBefore(): void
+    public function testWriteableEvenIfObjectWasKnownAsReadOnlyBefore(): void
     {
         $user = new ReadOnlyEntity('Théo', 1234);
 
@@ -140,7 +140,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         $userIntoIdentityMap = $this->getWithReadOnlyHint($user->id, readOnly: true);
         $user                = $this->getWithoutReadOnlyHint($user->id);
 
-        self::assertTrue($this->_em->getUnitOfWork()->isReadOnly($user));
+        self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
     }
 
     private function getWithoutReadOnlyHint(int $id): ReadOnlyEntity

--- a/tests/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Tests/ORM/Functional/ReadOnlyTest.php
@@ -37,7 +37,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dbReadOnly = $this->_em->find(ReadOnlyEntity::class, $readOnly->id);
+        $dbReadOnly = $this->getWithoutReadOnlyHint($readOnly->id);
         self::assertEquals('Test1', $dbReadOnly->name);
         self::assertEquals(1234, $dbReadOnly->numericValue);
     }
@@ -77,13 +77,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = 'SELECT u FROM ' . ReadOnlyEntity::class . ' u WHERE u.id = ?1';
-
-        $query = $this->_em->createQuery($dql);
-        $query->setParameter(1, $user->id);
-        $query->setHint(Query::HINT_READ_ONLY, true);
-
-        $user = $query->getSingleResult();
+        $user = $this->getWithReadOnlyHint($user->id, readOnly: true);
 
         self::assertTrue($this->_em->getUnitOfWork()->isReadOnly($user));
     }
@@ -97,11 +91,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('SELECT u FROM ' . ReadOnlyEntity::class . ' u WHERE u.id = ?1');
-        $query->setParameter(1, $user->id);
-        $query->setHint(Query::HINT_READ_ONLY, false);
-
-        $user = $query->getSingleResult();
+        $user = $this->getWithReadOnlyHint($user->id, readOnly: false);
 
         self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
     }
@@ -117,13 +107,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
 
         $user = $this->_em->getReference(ReadOnlyEntity::class, $user->id);
 
-        $dql = 'SELECT u FROM ' . ReadOnlyEntity::class . ' u WHERE u.id = ?1';
-
-        $query = $this->_em->createQuery($dql);
-        $query->setParameter(1, $user->id);
-        $query->setHint(Query::HINT_READ_ONLY, true);
-
-        $user = $query->getSingleResult();
+        $user = $this->getWithReadOnlyHint($user->id, readOnly: true);
 
         self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
     }
@@ -137,17 +121,42 @@ class ReadOnlyTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $userIntoIdentityMap = $this->_em->find(ReadOnlyEntity::class, $user->id);
+        $userIntoIdentityMap = $this->getWithoutReadOnlyHint($user->id);
 
+        $user = $this->getWithReadOnlyHint($user->id, readOnly: true);
+
+        self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
+    }
+
+    public function testNotWriteableIfObjectWasKnownAsReadOnlyBefore(): void
+    {
+        $user = new ReadOnlyEntity('Théo', 1234);
+
+        $this->_em->persist($user);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $userIntoIdentityMap = $this->getWithReadOnlyHint($user->id, readOnly: true);
+        $user                = $this->getWithoutReadOnlyHint($user->id);
+
+        self::assertTrue($this->_em->getUnitOfWork()->isReadOnly($user));
+    }
+
+    private function getWithoutReadOnlyHint(int $id): ReadOnlyEntity
+    {
+        return $this->_em->find(ReadOnlyEntity::class, $id);
+    }
+
+    private function getWithReadOnlyHint(int $id, bool $readOnly): ReadOnlyEntity
+    {
         $dql = 'SELECT u FROM ' . ReadOnlyEntity::class . ' u WHERE u.id = ?1';
 
         $query = $this->_em->createQuery($dql);
-        $query->setParameter(1, $user->id);
-        $query->setHint(Query::HINT_READ_ONLY, true);
+        $query->setParameter(1, $id);
+        $query->setHint(Query::HINT_READ_ONLY, $readOnly);
 
-        $user = $query->getSingleResult();
-
-        self::assertFalse($this->_em->getUnitOfWork()->isReadOnly($user));
+        return $query->getSingleResult();
     }
 }
 


### PR DESCRIPTION
## Context

In https://github.com/doctrine/orm/pull/7936 the `Query::HINT_READ_ONLY` hint was introduced. This allows to fetch entities via Doctrine but without having them to take additional computation resources when computing the changeset in the unit of work.

When it was introduced, there was the question of what to do about a model for which the hint is set, but does not match how the entity was initially loaded. In other words, what should happen if you load an entity as readonly when it is already present as not readonly in the unit of work and vice-versa. At that time, the very reasonable decision of not challenging the state was made. In practice, this means if you fetched a entity as readonly and try to use it later, even if explicitly set with the hint readonly `false`, it will be kept as readonly (until you clear the unit of work at least).


## The problem

In practice, I think this is a bit limiting and IMO problematic in two ways.

A potential scenario is various services that may fetch entities for read/validation purposes: they consume the entities, but are not expected to modify them in any way. Fetching models as readonly at this levels allows to "warmup" the unit of work without bloating it later for when computing the changesets.

However, in that scenario, if a sub-sequent service wants to update a model, it cannot do so anymore unless we clear the entire unit of work. It is not ideal.

Another problem, is that any attempt at an update will silently fail.


## Possible solutions

In this PR I explored a fix. In the end it ends up introducing a feature which is allowing the entity manager to find an entity as readonly. I.e. if the entity is not in the unit of work yet, it will be fetched with the readonly hint. Otherwise, nothing is done*.

*: this is debatable but I think it is in the spirit of the current implementation of Doctrine towards readonly objects. Indeed, Doctrine doesn't go out of its way to make a entity readonly, i.e. in the end a user can still update the properties of the entity and they will simply be silently ignored during a flush. With that in mind, if you fetch a model as readonly but it was previously fetched as writable, there is no issue IMO.

Thanks to this feature, we can now unmark a model as readonly if it was previously readonly, but fetched as writable.

Now I am aware that even if everyone agrees with this change, the current implementation cannot land as is (either missing some tests or BC breaks), but I think it is better to present the bigger picture first.

If you are not happy with the whole thing, please at least consider being able to unmark an entity as readonly from the unit of work.