### PR TITLE
docs: add xml example for Single Table Inheritance mapping

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -232,6 +232,23 @@ Example:
             // ...
         }
 
+    .. code-block:: xml
+
+        <doctrine-mapping>
+          <entity name="MyProject\Model\Person" inheritance-type="SINGLE_TABLE">
+            <discriminator-column name="discr" type="string" />
+            <discriminator-map>
+                <discriminator-mapping value="person" class="MyProject\Model\Person"/>
+                <discriminator-mapping value="employee" class="MyProject\Model\Employee"/>
+            </discriminator-map>
+          </entity>
+        </doctrine-mapping>
+
+        <doctrine-mapping>
+            <entity name="MyProject\Model\Employee">
+            </entity>
+        </doctrine-mapping>
+
     .. code-block:: yaml
 
         MyProject\Model\Person:


### PR DESCRIPTION
Hello,

I have implement a single table inheritance on a project where the mapping is in xml. I see that there is no example in the documentation. So I write the documentation.

I see that in 3.5.x we have only the annotation in the example. Is there a plan to merge them to keep the documentation ? Or should we contribute it manually ?