### PR TITLE
Do not eagerly set metadata from `ResolveTargetEntityListener`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5020,12 +5020,6 @@ parameters:
 			path: src/Tools/ResolveTargetEntityListener.php
 
 		-
-			message: '#^Parameter \#1 \$className of method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory\<Doctrine\\ORM\\Mapping\\ClassMetadata\>\:\:setMetadataFor\(\) expects class\-string, \(int\|string\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/ResolveTargetEntityListener.php
-
-		-
 			message: '#^Call to function is_numeric\(\) with int\<0, max\> will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/src/Tools/ResolveTargetEntityListener.php
+++ b/src/Tools/ResolveTargetEntityListener.php
@@ -86,12 +86,6 @@ class ResolveTargetEntityListener implements EventSubscriber
             }
         }
 
-        foreach ($this->resolveTargetEntities as $interface => $data) {
-            if ($data['targetEntity'] === $cm->getName()) {
-                $args->getEntityManager()->getMetadataFactory()->setMetadataFor($interface, $cm);
-            }
-        }
-
         foreach ($cm->discriminatorMap as $value => $class) {
             if (isset($this->resolveTargetEntities[$class])) {
                 $cm->addDiscriminatorMapClass($value, $this->resolveTargetEntities[$class]['targetEntity']);

--- a/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12174Test extends OrmFunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10431'); // make test fail on 2.x; in 3.x, it would even throw
+
+        $resolveTargetEntity = new ResolveTargetEntityListener();
+
+        $resolveTargetEntity->addResolveTargetEntity(GH12174Smurf::class, GH12174BlueSmurf::class, []);
+
+        $this->_em->getEventManager()->addEventSubscriber($resolveTargetEntity);
+
+        $this->createSchemaForModels(
+            GH12174Smurf::class,
+            GH12174BlueSmurf::class,
+            GH12174PapaSmurf::class
+        );
+    }
+
+    public function testIt(): void
+    {
+        $smurf = $this->_em->getClassMetadata(GH12174Smurf::class);
+        self::assertTrue($smurf->isMappedSuperclass);
+        self::assertSame(GH12174Smurf::class, $smurf->getName());
+        self::assertSame(GH12174BlueSmurf::class, $smurf->getAssociationMapping('children')['targetEntity']);
+
+        $blue = $this->_em->getClassMetadata(GH12174BlueSmurf::class);
+        self::assertFalse($blue->isMappedSuperclass);
+        self::assertSame(GH12174BlueSmurf::class, $blue->getName());
+
+        $papa = $this->_em->getClassMetadata(GH12174PapaSmurf::class);
+        self::assertFalse($papa->isMappedSuperclass);
+        self::assertSame(GH12174PapaSmurf::class, $papa->getName());
+    }
+}
+
+/** @ORM\MappedSuperclass() */
+#[ORM\MappedSuperclass]
+class GH12174Smurf
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     * @var int
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(inversedBy="children", targetEntity="GH12174Smurf")
+     * @var GH12174Smurf
+     */
+    #[ManyToOne(inversedBy: 'children')]
+    private $parent;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH12174Smurf", mappedBy="parent")
+     * @var Collection
+     */
+    #[OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    private $children;
+}
+
+/** @ORM\Entity */
+#[ORM\Entity]
+class GH12174BlueSmurf extends GH12174Smurf
+{
+}
+
+/** @ORM\Entity */
+#[ORM\Entity]
+class GH12174PapaSmurf extends GH12174Smurf
+{
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
@@ -36,7 +36,7 @@ class GH12174Test extends OrmFunctionalTestCase
         );
     }
 
-    public function testIt(): void
+    public function testMappedSuperclassNameCanBeUsedToResolveTargetEntityClass(): void
     {
         $smurf = $this->_em->getClassMetadata(GH12174Smurf::class);
         self::assertTrue($smurf->isMappedSuperclass);


### PR DESCRIPTION
When using the `ResolveTargetEntityListener` to substitute `targetEntities` in association mappings, do not eagerly put the resolved (target) entity into the class metadata cache under the class name of the original entity.

#### Motivation

I have a library that wants to distribute a MappedSuperclass as the base for some functionality. It will be necessary that clients using the library will extend the MappedSuperclass to fill in some blanks, creating the first real `#[Entity]` instance of it.

This client-provided entity will be the primary means of working with the class. Thus, I was following the [note in the documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.5/reference/inheritance-mapping.html#mapped-superclasses:~:text=It%20is%2C%20however) and using the `ResolveTargetEntityListener` to declare that whenever an association refers to that mapped superclass, the particular entity class shall be used instead.

>  One-To-Many associations are not generally possible on a mapped superclass, since they require the "many" side to hold the foreign key.
> It is, however, possible to use the [ResolveTargetEntityListener](https://www.doctrine-project.org/projects/doctrine-orm/en/3.5/cookbook/resolve-target-entity-listener.html) to replace references to a mapped superclass with an entity class at runtime. As long as there is only one entity subclass inheriting from the mapped superclass and all references to the mapped superclass are resolved to that entity class at runtime, the mapped superclass can use One-To-Many associations and be named as the targetEntity on the owning sides.

#### Changes made

The `ResolveTargetEntityListener` primarily does what its name suggests: For newly loaded class metadata, it inspects all associations declared and replaces the `targetEntity` with new (resolved) values.

But additionally, when a loaded class is the target of such a resolution, it would also put the class metadata into the cache under the name of the original entity.

I think that extra step is wrong, and this PR removes it. It had the side effect that when other classes extending the MappedSuperclass were loaded _after_ the resolve target class has been seen for the first time, the metadata for those classes would not inherit from the mapped superclass anymore, but from the target entity class instead. In my real-life use case, this causes weird mapping errors down the road; as of ^3.0, it would throw a mapping exception asking to configure inheritance mapping. But note that there would be no inheritance between the entity classes at all.

#### More background

The documentation [describes the use of `ResolveTargetEntityListener`](https://www.doctrine-project.org/projects/doctrine-orm/en/3.5/cookbook/resolve-target-entity-listener.html) with an interface that is resolved to an entity class. For an interface, adding the extra metadata does not make a difference, since it never interferes with actual entity or mapped superclasses. 

The initial idea of adding a copy of the entity class metadata under the interface name came from commit 
9c7f3f27471b204a23a937578496388747ffb5d8 in #385. The goal was to make it possible to also find entities by interface names, like so:

```
$em->find('Foo\BarBundle\Entity\PersonInterface', 1);
```

It then [turned out that this only worked when the resolution had already been applied](https://github.com/doctrine/orm/pull/385#issuecomment-6658893). So, the new `onClassMetadataNotFound` event was added and the resolution map would be checked in that case as well (#1181). The inital code stayed in place, possibly giving a small performance gain.
