### PR TITLE
Paginator with output walker returns count 0 when the query has previously been executed

### DIFF
--- a/docs/en/cookbook/dql-custom-walkers.rst
+++ b/docs/en/cookbook/dql-custom-walkers.rst
@@ -101,8 +101,16 @@ The ``Paginate::count(Query $query)`` looks like:
     {
         static public function count(Query $query)
         {
-            /** @var Query $countQuery */
-            $countQuery = clone $query;
+            /*
+               To avoid changing the $query passed into the method and to make sure a possibly existing
+               ResultSetMapping is discarded, we create a new query object any copy relevant data over.
+            */
+            $countQuery = new Query($query->getEntityManager());
+            $countQuery->setDQL($query->getDQL());
+            $countQuery->setParameters(clone $query->getParameters());
+            foreach ($query->getHints() as $name => $value) {
+                $countQuery->setHint($name, $value);
+            }
 
             $countQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('DoctrineExtensions\Paginate\CountSqlWalker'));
             $countQuery->setFirstResult(null)->setMaxResults(null);
@@ -111,7 +119,7 @@ The ``Paginate::count(Query $query)`` looks like:
         }
     }
 
-It clones the query, resets the limit clause first and max results
+This resets the limit clause first and max results
 and registers the ``CountSqlWalker`` custom tree walker which
 will modify the AST to execute a count query. The walkers
 implementation is:

--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -233,7 +233,7 @@ class Paginator implements Countable, IteratorAggregate
             a potentially existing result set mapping (either set directly by the user,
             or taken from the parser result from a previous invocation of Query::parse())
             to the new query object. This is fine, since we are going to completely change the
-            select clause anyway, so a previously existing result set mapping (RSM) is probably wrong anyway.
+            select clause, so a previously existing result set mapping (RSM) is probably wrong anyway.
             In the case of using output walkers, we are even creating a new RSM down below.
             In the case of using a tree walker, we want to have a new RSM created by the parser.
         */

--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -228,7 +228,22 @@ class Paginator implements Countable, IteratorAggregate
      */
     private function getCountQuery(): Query
     {
-        $countQuery = $this->cloneQuery($this->query);
+        /*
+            As opposed to using self::cloneQuery, the following code does not transfer
+            a potentially existing result set mapping (either set directly by the user,
+            or taken from the parser result from a previous invocation of Query::parse())
+            to the new query object. This is fine, since we are going to completely change the
+            select clause anyway, so a previously existing result set mapping (RSM) is probably wrong anyway.
+            In the case of using output walkers, we are even creating a new RSM down below.
+            In the case of using a tree walker, we want to have a new RSM created by the parser.
+        */
+        $countQuery = new Query($this->query->getEntityManager());
+        $countQuery->setDQL($this->query->getDQL());
+        $countQuery->setParameters(clone $this->query->getParameters());
+        $countQuery->setCacheable(false);
+        foreach ($this->query->getHints() as $name => $value) {
+            $countQuery->setHint($name, $value);
+        }
 
         if (! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
             $countQuery->setHint(CountWalker::HINT_DISTINCT, true);

--- a/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
@@ -26,7 +26,7 @@ final class GH12183Test extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public function testPaginatorCountWithOutputWalkerAfterQueryHasBeenExecuted(): void
+    public function testPaginatorCountWithTreeWalkerAfterQueryHasBeenExecuted(): void
     {
         $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a');
 

--- a/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
@@ -19,7 +19,7 @@ final class GH12183Test extends OrmFunctionalTestCase
         $article = new CmsArticle();
 
         $article->topic = 'Loomings';
-        $article->text = 'Call me Ishmael.';
+        $article->text  = 'Call me Ishmael.';
 
         $this->_em->persist($article);
         $this->_em->flush();

--- a/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12183Test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH12183Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+
+        $article = new CmsArticle();
+
+        $article->topic = 'Loomings';
+        $article->text = 'Call me Ishmael.';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testPaginatorCountWithOutputWalkerAfterQueryHasBeenExecuted(): void
+    {
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a');
+
+        // Paginator::count is right when the query has not yet been executed
+        $paginator = new Paginator($query);
+        $paginator->setUseOutputWalkers(false);
+        self::assertSame(1, $paginator->count());
+
+        // Execute the query
+        $result = $query->getResult();
+        self::assertCount(1, $result);
+
+        $paginator = new Paginator($query);
+        $paginator->setUseOutputWalkers(false);
+        self::assertSame(1, $paginator->count());
+    }
+}


### PR DESCRIPTION
When the `Paginator` creates the dedicated count query, it starts with a clone of the query underlying the pagination.

If that query has previously been executed, it contains a result set mapping (RSM) in the `AbstractQuery::$_resultSetMapping` property. That RSM may have been provided by the user, or, more probably, will have been created by the DQL parser when the query was first analyzed.

Either way, the RSM does not match or accurately reflect the actual count query. The count query modifies at least the select clause through either an output or a tree walker. That change needs to be reflected in the RSM for hydration to work correctly.

In the output walker case, the code in `Paginator::getCountQuery` even creates and sets a new RSM explicitly. In the tree walker case, the RSM was not taken care of.

My current suggestion is not to clone the query in preparation for counting the items, but instead create a copy of the query to start with. This will leave the RSM as `null` in the new query.

I was wondering whether there might be any good reasons to keep the existing RSM since it might have been provided by the user. But, since we modify the query and completely replace the select clause with the scalar expression for counting the rows, I don't see how any pre-existing RSM could apply to the new query.

Nevertheless, reviewers might want to take a step back and consider other options we might have to fix this:

* `Query::__clone` marks a query as dirty when it is cloned. Should a dirty query drop its RSM to make sure it is re-created upon the next `parse()`?
* Should we make a difference between RSMs provided by the client and those derived by the parser? Maybe only put user-provided ones in the `$_resultSetMapping` property and keep/use them unconditionally, but treat parser-derived RSMs differently and forget about them as soon as the query gets dirty?