### PR TITLE
[GH-9219] Add support for toIterable over mixed or scalar results.

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -21,7 +21,6 @@ use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Query\Parameter;
-use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use LogicException;

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -1144,10 +1144,6 @@ abstract class AbstractQuery
             throw new LogicException('Uninitialized result set mapping.');
         }
 
-        if ($rsm->isMixed && count($rsm->scalarMappings) > 0) {
-            throw QueryException::iterateWithMixedResultNotAllowed();
-        }
-
         $stmt = $this->_doExecute();
 
         return $this->_em->newHydrator($this->_hydrationMode)->toIterable($stmt, $rsm, $this->_hints);

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -25,10 +25,12 @@ use TypeError;
 use function array_map;
 use function array_merge;
 use function count;
+use function current;
 use function end;
 use function get_debug_type;
 use function in_array;
 use function is_array;
+use function is_object;
 use function sprintf;
 
 /**
@@ -201,7 +203,7 @@ abstract class AbstractHydrator
                     } else {
                         yield from $result;
                     }
-                } else if (is_object(current($result))) {
+                } elseif (is_object(current($result))) {
                     yield $result;
                 } else {
                     yield array_merge(...$result);

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -201,8 +201,10 @@ abstract class AbstractHydrator
                     } else {
                         yield from $result;
                     }
-                } else {
+                } else if (is_object(current($result))) {
                     yield $result;
+                } else {
+                    yield array_merge(...$result);
                 }
             }
         } finally {

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -417,7 +417,6 @@ class QueryTest extends OrmFunctionalTestCase
         $article2->text  = 'This is an introduction to Symfony 2.';
         $article2->setAuthor($author);
 
-
         $article3        = new CmsArticle();
         $article3->topic = 'lala 2';
         $article3->text  = 'This is an introduction to Symfony 2.';
@@ -431,7 +430,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('select a, a.topic, a.text from ' . CmsArticle::class . ' a');
+        $query  = $this->_em->createQuery('select a, a.topic, a.text from ' . CmsArticle::class . ' a');
         $result = $query->toIterable();
 
         $it = iterator_to_array($result);
@@ -458,7 +457,6 @@ class QueryTest extends OrmFunctionalTestCase
         $article2->text  = 'This is an introduction to Symfony 2.';
         $article2->setAuthor($author);
 
-
         $article3        = new CmsArticle();
         $article3->topic = 'lala 2';
         $article3->text  = 'This is an introduction to Symfony 2.';
@@ -472,7 +470,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('select a, u, a.topic, a.text from ' . CmsArticle::class . ' a, ' . CmsUser::class . ' u WHERE a.user = u ');
+        $query  = $this->_em->createQuery('select a, u, a.topic, a.text from ' . CmsArticle::class . ' a, ' . CmsUser::class . ' u WHERE a.user = u ');
         $result = $query->toIterable();
 
         $it = iterator_to_array($result);
@@ -485,7 +483,6 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertEquals('lala 2', $it[2][0]->topic);
         $this->assertEquals('beberlei', $it[2][1]->username);
     }
-
 
     public function testToIterableWithMixedResultIsNotAllowed3(): void
     {
@@ -503,7 +500,6 @@ class QueryTest extends OrmFunctionalTestCase
         $article2->text  = 'This is an introduction to Symfony 2.';
         $article2->setAuthor($author);
 
-
         $article3        = new CmsArticle();
         $article3->topic = 'lala 2';
         $article3->text  = 'This is an introduction to Symfony 2.';
@@ -517,7 +513,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('select a.topic, a.text from ' . CmsArticle::class . ' a ');
+        $query  = $this->_em->createQuery('select a.topic, a.text from ' . CmsArticle::class . ' a ');
         $result = $query->toIterable();
 
         $it = iterator_to_array($result);

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -401,7 +401,7 @@ class QueryTest extends OrmFunctionalTestCase
         }
     }
 
-    public function testToIterableWithMixedResultIsNotAllowed(): void
+    public function testToIterableWithMixedResultEntityScalars(): void
     {
         $author           = new CmsUser();
         $author->name     = 'Ben';
@@ -441,7 +441,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertEquals('lala 2', $it[2][0]->topic);
     }
 
-    public function testToIterableWithMixedResultIsNotAllowed2(): void
+    public function testToIterableWithMixedResultArbitraryJoinsScalars(): void
     {
         $author           = new CmsUser();
         $author->name     = 'Ben';
@@ -484,7 +484,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertEquals('beberlei', $it[2][1]->username);
     }
 
-    public function testToIterableWithMixedResultIsNotAllowed3(): void
+    public function testToIterableWithMixedResultScalarsOnly(): void
     {
         $author           = new CmsUser();
         $author->name     = 'Ben';

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -403,11 +403,130 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testToIterableWithMixedResultIsNotAllowed(): void
     {
-        $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('Iterating a query with mixed results (using scalars) is not supported.');
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
 
-        $query = $this->_em->createQuery('select a, a.topic from ' . CmsArticle::class . ' a');
-        $query->toIterable();
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('select a, a.topic, a.text from ' . CmsArticle::class . ' a');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+        $this->assertCount(3, $it);
+        $this->assertEquals('Doctrine 2', $it[0]['topic']);
+        $this->assertEquals('Doctrine 2', $it[0][0]->topic);
+        $this->assertEquals('lala 2', $it[2]['topic']);
+        $this->assertEquals('lala 2', $it[2][0]->topic);
+    }
+
+    public function testToIterableWithMixedResultIsNotAllowed2(): void
+    {
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('select a, u, a.topic, a.text from ' . CmsArticle::class . ' a, ' . CmsUser::class . ' u WHERE a.user = u ');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+
+        $this->assertCount(3, $it);
+        $this->assertEquals('Doctrine 2', $it[0]['topic']);
+        $this->assertEquals('Doctrine 2', $it[0][0]->topic);
+        $this->assertEquals('beberlei', $it[0][1]->username);
+        $this->assertEquals('lala 2', $it[2]['topic']);
+        $this->assertEquals('lala 2', $it[2][0]->topic);
+        $this->assertEquals('beberlei', $it[2][1]->username);
+    }
+
+
+    public function testToIterableWithMixedResultIsNotAllowed3(): void
+    {
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery('select a.topic, a.text from ' . CmsArticle::class . ' a ');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+
+        $this->assertEquals([
+            ['topic' => 'Doctrine 2', 'text' => 'This is an introduction to Doctrine 2.'],
+            ['topic' => 'Symfony 2', 'text' => 'This is an introduction to Symfony 2.'],
+            ['topic' => 'lala 2', 'text' => 'This is an introduction to Symfony 2.'],
+        ], $it);
     }
 
     public function testIterateResultClearEveryCycle(): void


### PR DESCRIPTION
`AbstractHydrator::hydrateRowData` will return `$result` in a very weird way based on combinations of objects, cross joined objects or scalar results. This is already "worked on" in `AbstractHydrator::toIterable` but it needs a bunch more molding to make scalar results and multiple object results work.

Fixes #9219
Fixes https://github.com/doctrine/orm/issues/8520