### PR TITLE
Add deprecation messages for methods that were only annotated as being `@deprecated`

### DIFF
--- a/src/Query/Exec/SingleSelectExecutor.php
+++ b/src/Query/Exec/SingleSelectExecutor.php
@@ -6,11 +6,14 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Result;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * Executor that executes the SQL statement for simple DQL SELECT statements.
+ *
+ * @deprecated This class is no longer needed by the ORM and will be removed in 4.0.
  *
  * @link        www.doctrine-project.org
  */
@@ -18,6 +21,13 @@ class SingleSelectExecutor extends AbstractSqlExecutor
 {
     public function __construct(SelectStatement $AST, SqlWalker $sqlWalker)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/11188/',
+            'The %s is no longer needed by the ORM and will be removed in 4.0',
+            self::class,
+        );
+
         $this->sqlStatements = $sqlWalker->walkSelectStatement($AST);
     }
 

--- a/src/Query/ParserResult.php
+++ b/src/Query/ParserResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\Exec\SqlFinalizer;
@@ -71,20 +72,36 @@ class ParserResult
     /**
      * Sets the SQL executor that should be used for this ParserResult.
      *
-     * @deprecated
+     * @deprecated The SqlExecutor will be removed from ParserResult in 4.0. Provide a SqlFinalizer instead that can create the executor.
      */
     public function setSqlExecutor(AbstractSqlExecutor $executor): void
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/11188',
+            'The SqlExecutor will be removed from %s in 4.0. Provide a %s instead that can create the executor.',
+            self::class,
+            SqlFinalizer::class,
+        );
+
         $this->sqlExecutor = $executor;
     }
 
     /**
      * Gets the SQL executor used by this ParserResult.
      *
-     * @deprecated
+     * @deprecated The SqlExecutor will be removed from ParserResult in 4.0. Provide a SqlFinalizer instead that can create the executor.
      */
     public function getSqlExecutor(): AbstractSqlExecutor
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/11188',
+            'The SqlExecutor will be removed from %s in 4.0. Provide a %s instead that can create the executor.',
+            self::class,
+            SqlFinalizer::class,
+        );
+
         if ($this->sqlExecutor === null) {
             throw new LogicException(sprintf(
                 'Executor not set yet. Call %s::setSqlExecutor() first.',

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\QuoteStrategy;
@@ -230,6 +231,14 @@ class SqlWalker
      */
     public function getExecutor(AST\SelectStatement|AST\UpdateStatement|AST\DeleteStatement $statement): Exec\AbstractSqlExecutor
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/pull/11188/',
+            'Output walkers should implement %s. That way, the %s method is no longer needed and will be removed in 4.0',
+            OutputWalker::class,
+            __METHOD__,
+        );
+
         return match (true) {
             $statement instanceof AST\UpdateStatement => $this->createUpdateStatementExecutor($statement),
             $statement instanceof AST\DeleteStatement => $this->createDeleteStatementExecutor($statement),

--- a/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Closure;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\FinalizedSelectExecutor;
 use Doctrine\ORM\Query\Exec\PreparedExecutorFinalizer;
@@ -26,6 +27,8 @@ use function unserialize;
 
 class ParserResultSerializationTest extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $this->useModelSet('company');
@@ -98,6 +101,8 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(ParserResult::class, $unserialized);
         $this->assertInstanceOf(ResultSetMapping::class, $unserialized->getResultSetMapping());
         $this->assertEquals(['name' => [0]], $unserialized->getParameterMappings());
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11188');
         $this->assertInstanceOf(SingleSelectExecutor::class, $unserialized->getSqlExecutor());
         $this->assertIsString($unserialized->getSqlExecutor()->getSqlStatements());
     }

--- a/tests/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Tests/ORM/Functional/QueryCacheTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\Exec\SqlFinalizer;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\Depends;
@@ -130,8 +131,11 @@ class QueryCacheTest extends OrmFunctionalTestCase
             }
         };
 
+        $sqlFinalizerMock = $this->createMock(SqlFinalizer::class);
+        $sqlFinalizerMock->method('createExecutor')->with($query)->willReturn($sqlExecutorStub);
+
         $parserResultMock = new ParserResult();
-        $parserResultMock->setSqlExecutor($sqlExecutorStub);
+        $parserResultMock->setSqlFinalizer($sqlFinalizerMock);
 
         $cache = $this->createMock(CacheItemPoolInterface::class);
 

--- a/tests/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Tests/ORM/Query/ParserResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -12,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 class ParserResultTest extends TestCase
 {
+    use VerifyDeprecations;
+
     /** @var ParserResult */
     public $parserResult;
 
@@ -37,6 +40,8 @@ class ParserResultTest extends TestCase
 
     public function testSetGetSqlExecutor(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11188');
+
         $executor = $this->createMock(AbstractSqlExecutor::class);
         $this->parserResult->setSqlExecutor($executor);
         self::assertSame($executor, $this->parserResult->getSqlExecutor());


### PR DESCRIPTION
This PR triggers deprecation notices for methods and class constructors that were only annotated as being `@deprecated` in #11188.

These methods will be removed in 4.0.0 via #12195.