### PR TITLE
Fix DQL JOIN syntax in two test cases

### DIFF
--- a/tests/Tests/ORM/Query/ExprTest.php
+++ b/tests/Tests/ORM/Query/ExprTest.php
@@ -407,9 +407,9 @@ class ExprTest extends OrmTestCase
         self::assertEquals(['foo DESC', 'bar ASC'], $group->getParts());
 
         // Join
-        $join = new Expr\Join(Expr\Join::INNER_JOIN, 'f.bar', 'b', Expr\Join::ON, 'b.bar_id = 1', 'b.bar_id');
+        $join = new Expr\Join(Expr\Join::INNER_JOIN, 'f.bar', 'b', Expr\Join::WITH, 'b.bar_id = 1', 'b.bar_id');
         self::assertEquals(Expr\Join::INNER_JOIN, $join->getJoinType());
-        self::assertEquals(Expr\Join::ON, $join->getConditionType());
+        self::assertEquals(Expr\Join::WITH, $join->getConditionType());
         self::assertEquals('b.bar_id = 1', $join->getCondition());
         self::assertEquals('b.bar_id', $join->getIndexBy());
         self::assertEquals('f.bar', $join->getJoin());

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -160,11 +160,11 @@ class QueryBuilderTest extends OrmTestCase
         $qb
             ->select('u', 'a')
             ->from(CmsUser::class, 'u')
-            ->innerJoin('u.articles', 'a', Join::ON, $qb->expr()->eq('u.id', 'a.author_id'));
+            ->innerJoin(CmsArticle::class, 'a', Join::ON, $qb->expr()->eq('u.id', 'a.author_id'));
 
         $this->assertValidQueryBuilder(
             $qb,
-            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id'
+            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN Doctrine\Tests\Models\CMS\CmsArticle a ON u.id = a.author_id'
         );
     }
 


### PR DESCRIPTION
While reviewing #12198, we found these two examples of invalid DQL.

In fact, it did not matter to the tests since they were only testing the DQL
building and expression capabilities. But for clarity, maybe it's worthwhile
fixing the DQL anyway.
