### PR TITLE
Make default string length of 255 configurable in SchemaTool.

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -723,4 +723,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         return $this->attributes['fetchModeSubselectBatchSize'] ?? 100;
     }
+
+    public function setDefaultStringTypeSchemaLength(int|null $length = null): void
+    {
+        $this->attributes['defaultStringTypeSchemaLength'] = $length;
+    }
+
+    public function getDefaultStringTypeSchemaLength(): ?int
+    {
+        return $this->attributes['defaultStringTypeSchemaLength'] ?? 255;
+    }
 }

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -409,7 +409,7 @@ class SchemaTool
 
         if (strtolower($discrColumn->type) === 'string' && ! isset($discrColumn->length)) {
             $discrColumn->type   = 'string';
-            $discrColumn->length = 255;
+            $discrColumn->length = $this->em->getConfiguration()->getDefaultStringTypeSchemaLength();
         }
 
         $options = [
@@ -456,6 +456,7 @@ class SchemaTool
 
         $options            = [];
         $options['length']  = $mapping->length ?? null;
+
         $options['notnull'] = isset($mapping->nullable) ? ! $mapping->nullable : true;
         if ($class->isInheritanceTypeSingleTable() && $class->parentClasses) {
             $options['notnull'] = false;
@@ -465,7 +466,7 @@ class SchemaTool
         $options['platformOptions']['version'] = $class->isVersioned && $class->versionField === $mapping->fieldName;
 
         if (strtolower($columnType) === 'string' && $options['length'] === null) {
-            $options['length'] = 255;
+            $options['length'] = $this->em->getConfiguration()->getDefaultStringTypeSchemaLength();
         }
 
         if (isset($mapping->precision)) {


### PR DESCRIPTION
Unsure about the problem space yet, since our assumption was that ORM does not set the default to 255 yet, but apparently it does here in SchemaTool for type === 'string'.

Fixes #12205 