### PR TITLE
Handle quoted PK columns properly on DBAL 4

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3268,24 +3268,6 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:setPrimaryKey\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#1 \$value of static method Doctrine\\DBAL\\Schema\\Name\\Identifier\:\:unquoted\(\) expects non\-empty\-string, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#2 \$columnNames of class Doctrine\\DBAL\\Schema\\PrimaryKeyConstraint constructor expects non\-empty\-list\<Doctrine\\DBAL\\Schema\\Name\\UnqualifiedName\>, list\<Doctrine\\DBAL\\Schema\\Name\\UnqualifiedName\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
 			message: '#^Parameter \#2 \$columns of class Doctrine\\DBAL\\Schema\\Index constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3293,6 +3275,18 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$localColumnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addForeignKeyConstraint\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \#2 \$primaryKeyColumns of method Doctrine\\ORM\\Tools\\SchemaTool\:\:addPrimaryKeyConstraint\(\) expects non\-empty\-array\<non\-empty\-string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \#2 \$primaryKeyColumns of method Doctrine\\ORM\\Tools\\SchemaTool\:\:addPrimaryKeyConstraint\(\) expects non\-empty\-array\<non\-empty\-string\>, non\-empty\-list\<string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Tools/SchemaTool.php

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -35,6 +35,10 @@ parameters:
             path: src/Tools/SchemaTool.php
 
         -
+            message: '~^Call to static method quoted\(\) on an unknown class Doctrine\\DBAL\\Schema\\Name\\Identifier\.$~'
+            path: src/Tools/SchemaTool.php
+
+        -
             message: '~^Call to an undefined method Doctrine\\DBAL\\Schema\\ForeignKeyConstraint::get.*\.$~'
             identifier: method.notFound
 

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -39,6 +39,7 @@ use function array_filter;
 use function array_flip;
 use function array_intersect_key;
 use function array_map;
+use function array_values;
 use function assert;
 use function class_exists;
 use function count;
@@ -47,6 +48,7 @@ use function implode;
 use function in_array;
 use function is_numeric;
 use function method_exists;
+use function preg_match;
 use function strtolower;
 
 /**
@@ -971,20 +973,26 @@ class SchemaTool
         }
     }
 
-    /** @param string[] $primaryKeyColumns */
+    /** @param non-empty-array<non-empty-string> $primaryKeyColumns */
     private function addPrimaryKeyConstraint(Table $table, array $primaryKeyColumns): void
     {
-        if (class_exists(PrimaryKeyConstraint::class)) {
-            $primaryKeyColumnNames = [];
+        if (! class_exists(PrimaryKeyConstraint::class)) {
+            $table->setPrimaryKey(array_values($primaryKeyColumns));
 
-            foreach ($primaryKeyColumns as $primaryKeyColumn) {
+            return;
+        }
+
+        $primaryKeyColumnNames = [];
+
+        foreach ($primaryKeyColumns as $primaryKeyColumn) {
+            if (preg_match('/^"(.+)"$/', $primaryKeyColumn, $matches) === 1) {
+                $primaryKeyColumnNames[] = new UnqualifiedName(Identifier::quoted($matches[1]));
+            } else {
                 $primaryKeyColumnNames[] = new UnqualifiedName(Identifier::unquoted($primaryKeyColumn));
             }
-
-            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, $primaryKeyColumnNames, true));
-        } else {
-            $table->setPrimaryKey($primaryKeyColumns);
         }
+
+        $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, $primaryKeyColumnNames, true));
     }
 
     /** @return string[] */

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Index as DbalIndex;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Table as DbalTable;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -432,6 +433,41 @@ class SchemaToolTest extends OrmTestCase
         self::assertSame(['field', 'anotherField'], self::getIndexedColumns($tableIndex));
     }
 
+    public function testQuotedIdentifiers(): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $classes    = [$em->getClassMetadata(QuotedEntity::class)];
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('quoted-table'), 'Table quoted-table should exist.');
+
+        $table = $schema->getTable('quoted-table');
+
+        self::assertTrue($table->hasIndex('IDX_AA2790FB50D14D90'));
+
+        // DBAL < 4.3
+        if (! class_exists(PrimaryKeyConstraint::class)) {
+            self::assertTrue($table->isQuoted(), 'The table name must be quoted.');
+            self::assertTrue($table->hasIndex('primary'), 'Table should have a primary key.');
+
+            return;
+        }
+
+        $objectName = $table->getObjectName();
+        self::assertTrue($objectName->getUnqualifiedName()->isQuoted());
+        self::assertSame('quoted-table', $objectName->getUnqualifiedName()->getValue());
+
+        $primaryKey = $table->getPrimaryKeyConstraint();
+        self::assertNotNull($primaryKey);
+        self::assertCount(1, $primaryKey->getColumnNames());
+
+        [$pkColumn] = $primaryKey->getColumnNames();
+        self::assertTrue($pkColumn->getIdentifier()->isQuoted());
+        self::assertSame('quoted-id', $pkColumn->getIdentifier()->getValue());
+    }
+
     /** @return string[] */
     private static function getIndexedColumns(DbalIndex $index): array
     {
@@ -673,4 +709,17 @@ class IncorrectUniqueConstraintByFieldEntity
             ],
         );
     }
+}
+
+#[Entity]
+#[Table(name: '`quoted-table`')]
+#[Index(columns: ['`quoted-name`'])]
+class QuotedEntity
+{
+    #[Id]
+    #[Column(name: '`quoted-id`')]
+    public int $id = 0;
+
+    #[Column(name: '`quoted-name`')]
+    public string $name = '';
 }


### PR DESCRIPTION
When we configure a primary key with quoted columns on DBAL 4, we currently get an unquoted identifier with quotes embedded in it. After this change, we should have an actual quoted identifier.