### PR TITLE
Revert "Fix fields of transient classes being considered duplicate with `reportFieldsWhereDeclared` (#11769)"

### DIFF
--- a/src/Mapping/Driver/ReflectionBasedDriver.php
+++ b/src/Mapping/Driver/ReflectionBasedDriver.php
@@ -32,12 +32,7 @@ trait ReflectionBasedDriver
                 || $metadata->isInheritedEmbeddedClass($property->name);
         }
 
-        /** @var class-string $declaringClass */
         $declaringClass = $property->class;
-
-        if ($this->isTransient($declaringClass)) {
-            return isset($metadata->fieldMappings[$property->name]);
-        }
 
         if (
             isset($metadata->fieldMappings[$property->name]['declared'])

--- a/tests/Tests/ORM/Functional/Ticket/GH10450Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10450Test.php
@@ -32,15 +32,6 @@ class GH10450Test extends OrmTestCase
         yield 'Entity class that redeclares a protected field inherited from a base entity' => [GH10450EntityChildProtected::class];
         yield 'Entity class that redeclares a protected field inherited from a mapped superclass' => [GH10450MappedSuperclassChildProtected::class];
     }
-
-    public function testFieldsOfTransientClassesAreNotConsideredDuplicate(): void
-    {
-        $em = $this->getTestEntityManager();
-
-        $metadata = $em->getClassMetadata(GH10450Cat::class);
-
-        self::assertArrayHasKey('id', $metadata->fieldMappings);
-    }
 }
 
 /**
@@ -187,39 +178,4 @@ class GH10450MappedSuperclassChildProtected extends GH10450BaseMappedSuperclassP
      * @var string
      */
     protected $field;
-}
-
-abstract class GH10450AbstractEntity
-{
-    /**
-     * @ORM\Column(type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     *
-     * @var int
-     */
-    protected $id;
-}
-
-/**
- * @ORM\Entity
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorMap({ "cat": "GH10450Cat" })
- * @ORM\DiscriminatorColumn(name="type")
- */
-abstract class GH10450Animal extends GH10450AbstractEntity
-{
-    /**
-     * @ORM\Column(type="text", name="base")
-     *
-     * @var string
-     */
-    private $field;
-}
-
-/**
- * @ORM\Entity
- */
-class GH10450Cat extends GH10450Animal
-{
 }


### PR DESCRIPTION
Following up on https://github.com/doctrine/orm/pull/11769#issuecomment-3254415994, I would like to revert the changes made in 4feaa470af4de8799a1e9e3db87191bac74b7a46 (#11769).

Basically, it is wrong to allow fields from transient classes to be parsed and used for mapping configuration. This has happened and worked in the past, although it was never really endorsed or officially allowed by the documentation. 

By adding the `reportFieldsWhereDeclared` opt-in switch (#10455), we were starting to enforce stricter configuration checks that help us to prevent other, strange errors further down the road. So, 4feaa470af4de8799a1e9e3db87191bac74b7a46 was a step in the wrong direction.
