### PR TITLE
2.20.x

### DIFF
--- a/docs/en/reference/limitations-and-known-issues.rst
+++ b/docs/en/reference/limitations-and-known-issues.rst
@@ -187,6 +187,14 @@ internally by the ORM currently refers to fields by their name only, without tak
 class containing the field into consideration. This makes it impossible to keep separate
 mapping configuration for both fields.
 
+Apart from that, in the case of having multiple ``private`` fields of the same name within
+the class hierarchy an entity or mapped superclass, the Collection filtering API cannot determine
+the right field to look at. Even if only one of these fields is actually mapped, the ``ArrayCollection``
+will not be able to tell, since it does not have access to any metadata.
+
+Thus, to avoid problems in this regard, it is best to avoid having multiple ``private`` fields of the
+same name in class hierarchies containing entity and mapped superclasses.
+
 Known Issues
 ------------
 

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -21,7 +21,6 @@ use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\Query\Parameter;
-use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use LogicException;
@@ -1142,10 +1141,6 @@ abstract class AbstractQuery
         $rsm = $this->getResultSetMapping();
         if ($rsm === null) {
             throw new LogicException('Uninitialized result set mapping.');
-        }
-
-        if ($rsm->isMixed && count($rsm->scalarMappings) > 0) {
-            throw QueryException::iterateWithMixedResultNotAllowed();
         }
 
         $stmt = $this->_doExecute();

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -25,10 +25,12 @@ use TypeError;
 use function array_map;
 use function array_merge;
 use function count;
+use function current;
 use function end;
 use function get_debug_type;
 use function in_array;
 use function is_array;
+use function is_object;
 use function sprintf;
 
 /**
@@ -201,8 +203,10 @@ abstract class AbstractHydrator
                     } else {
                         yield from $result;
                     }
-                } else {
+                } elseif (is_object(current($result))) {
                     yield $result;
+                } else {
+                    yield array_merge(...$result);
                 }
             }
         } finally {

--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -401,13 +401,128 @@ class QueryTest extends OrmFunctionalTestCase
         }
     }
 
-    public function testToIterableWithMixedResultIsNotAllowed(): void
+    public function testToIterableWithMixedResultEntityScalars(): void
     {
-        $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('Iterating a query with mixed results (using scalars) is not supported.');
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
 
-        $query = $this->_em->createQuery('select a, a.topic from ' . CmsArticle::class . ' a');
-        $query->toIterable();
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query  = $this->_em->createQuery('select a, a.topic, a.text from ' . CmsArticle::class . ' a');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+        $this->assertCount(3, $it);
+        $this->assertEquals('Doctrine 2', $it[0]['topic']);
+        $this->assertEquals('Doctrine 2', $it[0][0]->topic);
+        $this->assertEquals('lala 2', $it[2]['topic']);
+        $this->assertEquals('lala 2', $it[2][0]->topic);
+    }
+
+    public function testToIterableWithMixedResultArbitraryJoinsScalars(): void
+    {
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query  = $this->_em->createQuery('select a, u, a.topic, a.text from ' . CmsArticle::class . ' a, ' . CmsUser::class . ' u WHERE a.user = u ');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+
+        $this->assertCount(3, $it);
+        $this->assertEquals('Doctrine 2', $it[0]['topic']);
+        $this->assertEquals('Doctrine 2', $it[0][0]->topic);
+        $this->assertEquals('beberlei', $it[0][1]->username);
+        $this->assertEquals('lala 2', $it[2]['topic']);
+        $this->assertEquals('lala 2', $it[2][0]->topic);
+        $this->assertEquals('beberlei', $it[2][1]->username);
+    }
+
+    public function testToIterableWithMixedResultScalarsOnly(): void
+    {
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
+        $author->username = 'beberlei';
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Doctrine 2';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
+        $article1->setAuthor($author);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Symfony 2';
+        $article2->text  = 'This is an introduction to Symfony 2.';
+        $article2->setAuthor($author);
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'lala 2';
+        $article3->text  = 'This is an introduction to Symfony 2.';
+        $article3->setAuthor($author);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+        $this->_em->persist($article3);
+        $this->_em->persist($author);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query  = $this->_em->createQuery('select a.topic, a.text from ' . CmsArticle::class . ' a ');
+        $result = $query->toIterable();
+
+        $it = iterator_to_array($result);
+
+        $this->assertEquals([
+            ['topic' => 'Doctrine 2', 'text' => 'This is an introduction to Doctrine 2.'],
+            ['topic' => 'Symfony 2', 'text' => 'This is an introduction to Symfony 2.'],
+            ['topic' => 'lala 2', 'text' => 'This is an introduction to Symfony 2.'],
+        ], $it);
     }
 
     public function testIterateResultClearEveryCycle(): void

--- a/tests/Tests/ORM/Query/ExprTest.php
+++ b/tests/Tests/ORM/Query/ExprTest.php
@@ -407,9 +407,9 @@ class ExprTest extends OrmTestCase
         self::assertEquals(['foo DESC', 'bar ASC'], $group->getParts());
 
         // Join
-        $join = new Expr\Join(Expr\Join::INNER_JOIN, 'f.bar', 'b', Expr\Join::ON, 'b.bar_id = 1', 'b.bar_id');
+        $join = new Expr\Join(Expr\Join::INNER_JOIN, 'f.bar', 'b', Expr\Join::WITH, 'b.bar_id = 1', 'b.bar_id');
         self::assertEquals(Expr\Join::INNER_JOIN, $join->getJoinType());
-        self::assertEquals(Expr\Join::ON, $join->getConditionType());
+        self::assertEquals(Expr\Join::WITH, $join->getConditionType());
         self::assertEquals('b.bar_id = 1', $join->getCondition());
         self::assertEquals('b.bar_id', $join->getIndexBy());
         self::assertEquals('f.bar', $join->getJoin());

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -160,11 +160,11 @@ class QueryBuilderTest extends OrmTestCase
         $qb
             ->select('u', 'a')
             ->from(CmsUser::class, 'u')
-            ->innerJoin('u.articles', 'a', Join::ON, $qb->expr()->eq('u.id', 'a.author_id'));
+            ->innerJoin(CmsArticle::class, 'a', Join::ON, $qb->expr()->eq('u.id', 'a.author_id'));
 
         $this->assertValidQueryBuilder(
             $qb,
-            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id'
+            'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN Doctrine\Tests\Models\CMS\CmsArticle a ON u.id = a.author_id'
         );
     }
 


### PR DESCRIPTION
- **Fix DQL JOIN syntax in two test cases**
- **[GH-9219] Add support for toIterable over mixed or scalar results. (#12187)**
- **Add a recommendation not to use multiple private fields of the same name in entity hierarchies**
