### PR TITLE
Stop using deprecated Collections constants

### DIFF
--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Driver;
 
-use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Order;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
@@ -21,7 +19,6 @@ use function assert;
 use function constant;
 use function count;
 use function defined;
-use function enum_exists;
 use function explode;
 use function extension_loaded;
 use function file_get_contents;
@@ -409,10 +406,7 @@ class XmlDriver extends FileDriver
                 if (isset($oneToManyElement->{'order-by'})) {
                     $orderBy = [];
                     foreach ($oneToManyElement->{'order-by'}->{'order-by-field'} ?? [] as $orderByField) {
-                        $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
-                            ? (string) $orderByField['direction']
-                            // @phpstan-ignore classConstant.deprecated
-                            : (enum_exists(Order::class) ? Order::Ascending->value : Criteria::ASC);
+                        $orderBy[(string) $orderByField['name']] = (string) ($orderByField['direction'] ?? 'ASC');
                     }
 
                     $mapping['orderBy'] = $orderBy;
@@ -538,10 +532,7 @@ class XmlDriver extends FileDriver
                 if (isset($manyToManyElement->{'order-by'})) {
                     $orderBy = [];
                     foreach ($manyToManyElement->{'order-by'}->{'order-by-field'} ?? [] as $orderByField) {
-                        $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
-                            ? (string) $orderByField['direction']
-                            // @phpstan-ignore classConstant.deprecated
-                            : (enum_exists(Order::class) ? Order::Ascending->value : Criteria::ASC);
+                        $orderBy[(string) $orderByField['name']] = (string) ($orderByField['direction'] ?? 'ASC');
                     }
 
                     $mapping['orderBy'] = $orderBy;

--- a/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -17,7 +17,6 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\Group;
 
 use function assert;
-use function class_exists;
 use function get_class;
 
 /**
@@ -438,7 +437,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $user = $this->_em->find($user::class, $user->id);
 
         $criteria = Criteria::create()
-            ->orderBy(['name' => class_exists(Order::class) ? Order::Ascending : Criteria::ASC]);
+            ->orderBy(['name' => Order::Ascending]);
 
         self::assertEquals(
             ['A', 'B', 'C', 'Developers_0'],
@@ -478,7 +477,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $user = $this->_em->find($user::class, $user->id);
 
         $criteria = Criteria::create()
-            ->orderBy(['name' => class_exists(Order::class) ? Order::Ascending : Criteria::ASC]);
+            ->orderBy(['name' => Order::Ascending]);
 
         self::assertEquals(
             ['A', 'B', 'C'],

--- a/tests/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Type;
@@ -146,7 +145,7 @@ class GH7820Test extends OrmFunctionalTestCase
     {
         $query = $this->_em->getRepository(GH7820Line::class)
             ->createQueryBuilder('l')
-            ->orderBy('l.lineNumber', Criteria::ASC)
+            ->orderBy('l.lineNumber', 'ASC')
             ->setMaxResults(100);
 
         return array_map(static fn (GH7820Line $line): string => $line->toString(), iterator_to_array(new Paginator($query)));

--- a/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -255,8 +254,8 @@ class XmlMappingDriverTest extends MappingDriverTestCase
         $class->initializeReflection(new RuntimeReflectionService());
         $driver->loadMetadataForClass(GH7141Article::class, $class);
 
-        self::assertEquals(
-            Criteria::ASC,
+        self::assertSame(
+            'ASC',
             $class->getMetadataValue('associationMappings')['tags']->orderBy['position'],
         );
     }
@@ -269,8 +268,8 @@ class XmlMappingDriverTest extends MappingDriverTestCase
         $driver = $this->loadDriver();
         $driver->loadMetadataForClass(GH7316Article::class, $class);
 
-        self::assertEquals(
-            Criteria::ASC,
+        self::assertSame(
+            'ASC',
             $class->getMetadataValue('associationMappings')['tags']->orderBy['position'],
         );
     }

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -30,7 +30,6 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 use function array_filter;
-use function class_exists;
 
 /**
  * Test case for the QueryBuilder class used to build DQL query string in a
@@ -615,7 +614,7 @@ class QueryBuilderTest extends OrmTestCase
             ->from(CmsUser::class, 'u');
 
         $criteria = new Criteria();
-        $criteria->orderBy(['field' => class_exists(Order::class) ? Order::Descending : Criteria::DESC]);
+        $criteria->orderBy(['field' => Order::Descending]);
 
         $qb->addCriteria($criteria);
 
@@ -632,7 +631,7 @@ class QueryBuilderTest extends OrmTestCase
             ->join('u.article', 'a');
 
         $criteria = new Criteria();
-        $criteria->orderBy(['a.field' => class_exists(Order::class) ? Order::Descending : Criteria::DESC]);
+        $criteria->orderBy(['a.field' => Order::Descending]);
 
         $qb->addCriteria($criteria);
 


### PR DESCRIPTION
The new `Order` enum should always be available, so we can remove the conditional fallback logic everywhere.