### PR TITLE
Experiment: Use comparator functions from a global registry for changeset detection

### DIFF
--- a/src/ComparatorRegistry.php
+++ b/src/ComparatorRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Doctrine\ORM;
+
+class ComparatorRegistry
+{
+    /** @param array<class-string, callable> */
+    private static array $callbacks = [];
+
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @param callable(T, object): ?int
+     */
+    public static function register(string $class, callable $callback): void
+    {
+        self::$callbacks[$class] = $callback;
+    }
+
+    public static function reset(): void
+    {
+        self::$callbacks = [];
+    }
+
+    public static function compare(object $a, object $b): ?int
+    {
+        foreach (self::$callbacks as $class => $callback) {
+            if (is_a($a, $class, false)) {
+                $result = $callback($a, $b);
+
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+            if (is_a($b, $class, false)) {
+                $result = $callback($b, $a);
+
+                if ($result !== null) {
+                    return -$result;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -683,6 +683,11 @@ class UnitOfWork implements PropertyChangedListener
                     continue;
                 }
 
+                // skip if Comparator from registry tells us that objects represent equal values
+                if (is_object($orgValue) && is_object($actualValue) && ComparatorRegistry::compare($orgValue, $actualValue) === 0) {
+                    continue;
+                }
+
                 // if regular field
                 if (! isset($class->associationMappings[$propName])) {
                     $changeSet[$propName] = [$orgValue, $actualValue];

--- a/tests/Tests/ORM/ComparatorRegistryTest.php
+++ b/tests/Tests/ORM/ComparatorRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\ORM\ComparatorRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ComparatorRegistryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ComparatorRegistry::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        ComparatorRegistry::reset();
+    }
+
+    #[Test]
+    public function compareDateTimeTypes(): void
+    {
+        ComparatorRegistry::register(\DateTimeInterface::class, function (\DateTimeInterface $a, object $b): ?int {
+            if ($b instanceof \DateTimeInterface) {
+                return $a <=> $b;
+            }
+        });
+
+        $nowMutable = new \DateTime();
+        $nowImmutable = \DateTimeImmutable::createFromMutable($nowMutable);
+        $yesterdayMutable = new \DateTime('yesterday');
+        $yesterdayImmutable = \DateTimeImmutable::createFromMutable($yesterdayMutable);
+
+        self::assertSame(null, ComparatorRegistry::compare($nowMutable, new \stdClass()));
+
+        self::assertSame(0, ComparatorRegistry::compare($nowMutable, $nowMutable));
+        self::assertSame(0, ComparatorRegistry::compare($nowMutable, $nowImmutable));
+        self::assertSame(0, ComparatorRegistry::compare($nowImmutable, $nowMutable));
+        self::assertSame(0, ComparatorRegistry::compare($nowImmutable, $nowImmutable));
+
+        self::assertSame(1, ComparatorRegistry::compare($nowMutable, $yesterdayMutable));
+        self::assertSame(1, ComparatorRegistry::compare($nowImmutable, $yesterdayMutable));
+        self::assertSame(1, ComparatorRegistry::compare($nowMutable, $yesterdayImmutable));
+        self::assertSame(1, ComparatorRegistry::compare($nowImmutable, $yesterdayImmutable));
+
+        self::assertSame(-1, ComparatorRegistry::compare($yesterdayMutable, $nowMutable));
+        self::assertSame(-1, ComparatorRegistry::compare($yesterdayMutable, $nowImmutable));
+        self::assertSame(-1, ComparatorRegistry::compare($yesterdayImmutable, $nowMutable));
+        self::assertSame(-1, ComparatorRegistry::compare($yesterdayImmutable, $nowImmutable));
+    }
+}

--- a/tests/Tests/ORM/Functional/ComparatorRegistryBasedChangeDetectionTest.php
+++ b/tests/Tests/ORM/Functional/ComparatorRegistryBasedChangeDetectionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\ComparatorRegistry;
+use Doctrine\Tests\Models\TypedProperties\UserTyped;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class ComparatorRegistryBasedChangeDetectionTest extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        ComparatorRegistry::reset();
+        parent::setUp();
+
+        $this->setUpEntitySchema([UserTyped::class]);
+    }
+
+    protected function tearDown(): void
+    {
+        ComparatorRegistry::reset();
+    }
+
+    public function testChangingDateTimeInstanceWithoutComparator(): void
+    {
+        $user = new UserTyped();
+        $user->dateTime = new \DateTime();
+        $this->initializeChangesetState($user);
+
+        $user->dateTime = clone $user->dateTime;
+        $this->recomputeChangeset($user);
+
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForUpdate($user));
+    }
+
+    public function testChangingDateTimeInstanceWithComparator(): void
+    {
+        ComparatorRegistry::register(\DateTimeInterface::class, function (\DateTimeInterface $a, object $b) {
+            if ($b instanceof \DateTimeInterface) {
+                return $a <=> $b;
+            }
+        });
+
+        $user = new UserTyped();
+        $user->dateTime = new \DateTime();
+        $this->initializeChangesetState($user);
+
+        $user->dateTime = clone $user->dateTime;
+        $this->recomputeChangeset($user);
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($user));
+    }
+
+    private function initializeChangesetState(object $entity): void
+    {
+        // Initialize UoW state
+        $this->_em->persist($entity);
+        $cm = $this->_em->getClassMetadata(get_class($entity));
+        $this->_em->getUnitOfWork()->computeChangeSet($cm, $entity);
+
+        // Run change set computation with no changes
+        $this->_em->getUnitOfWork()->computeChangeSet($cm, $entity);
+
+        // sanity check
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($entity));
+    }
+
+    private function recomputeChangeset(object $entity): void
+    {
+        $cm = $this->_em->getClassMetadata(get_class($entity));
+        $this->_em->getUnitOfWork()->computeChangeSet($cm, $entity);
+    }
+}

--- a/tests/Tests/ORM/Functional/ComparatorRegistryBasedChangeDetectionTest.php
+++ b/tests/Tests/ORM/Functional/ComparatorRegistryBasedChangeDetectionTest.php
@@ -53,6 +53,24 @@ class ComparatorRegistryBasedChangeDetectionTest extends OrmFunctionalTestCase
         self::assertFalse($this->_em->getUnitOfWork()->isScheduledForUpdate($user));
     }
 
+    public function testChangingMutableObject(): void
+    {
+        ComparatorRegistry::register(\DateTimeInterface::class, function (\DateTimeInterface $a, object $b) {
+            if ($b instanceof \DateTimeInterface) {
+                return $a <=> $b;
+            }
+        });
+
+        $user = new UserTyped();
+        $user->dateTime = new \DateTime();
+        $this->initializeChangesetState($user);
+
+        $user->dateTime->add(new \DateInterval('P7D'));
+        $this->recomputeChangeset($user);
+
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForUpdate($user));
+    }
+
     private function initializeChangesetState(object $entity): void
     {
         // Initialize UoW state


### PR DESCRIPTION
This is an experiment towards #5542. Can we have _something_ to do comparison of objects to get away from `===` checks in changeset computation, but also in Criteria comparisons and sorting (in `ClosureExpressionVisitor`)?

We cannot expect users to implement interfaces for this in their objects. For example, users might be bringing their own subclasses of `DateTime` (like Carbon or Chronos libraries) or get their `DateTime` objects e. g. from clock mocking libraries. So, these objects might be coming from very differnet places and the classes used or created cannot all implement Doctrine interfaces.

Thus, the mechanism for bringing in the comparisons has to be attached or brought to the objects from the outside. 

A global-state registry is not nice, but a very simple approach to start the discussion.

In this PR, comparators are registered based on class or interface names. Registration happens in order, and the first one matching an object at hand that returns a result different from `null` will win.

X-Ref https://github.com/doctrine/collections/pull/454
