### PR TITLE
Escape library as a table name in tests (#12170)

### DIFF
--- a/tests/Tests/Models/Enums/Library.php
+++ b/tests/Tests/Models/Enums/Library.php
@@ -11,8 +11,10 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
 
 #[Entity]
+#[Table('`library`')]
 class Library
 {
     #[Id]


### PR DESCRIPTION
It is a reserved word since MySQL 9.2:
https://dev.mysql.com/doc/refman/9.2/en/create-library.html

Fixes #12170 