### PR TITLE
Change phpdocumentor version constraint

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -24,4 +24,4 @@ on:
 
 jobs:
   coding-standards:
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@12.0.0"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,4 +17,4 @@ on:
 jobs:
   documentation:
     name: "Documentation"
-    uses: "doctrine/.github/.github/workflows/documentation.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/documentation.yml@12.0.0"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@12.0.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/docs/composer.json
+++ b/docs/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "phpdocumentor/guides-cli": "1.7.1",
-        "phpdocumentor/filesystem": "1.7.1"
+        "phpdocumentor/guides-cli": "^1.9",
+        "phpdocumentor/filesystem": "^1.9"
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12174Test.php
@@ -61,6 +61,7 @@ class GH12174Smurf
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
+     *
      * @var int
      */
     #[ORM\Id]
@@ -70,6 +71,7 @@ class GH12174Smurf
 
     /**
      * @ORM\ManyToOne(inversedBy="children", targetEntity="GH12174Smurf")
+     *
      * @var GH12174Smurf
      */
     #[ManyToOne(inversedBy: 'children')]
@@ -77,6 +79,7 @@ class GH12174Smurf
 
     /**
      * @ORM\OneToMany(targetEntity="GH12174Smurf", mappedBy="parent")
+     *
      * @var Collection
      */
     #[OneToMany(targetEntity: self::class, mappedBy: 'parent')]


### PR DESCRIPTION
It should be less maintenance if we do not pin it down too much, and it is closes to what the website uses.