### PR TITLE
Reorganize read-only class check in UnitOfWork

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -590,6 +590,7 @@ class UnitOfWork implements PropertyChangedListener
 
         if ($class->isReadOnly) {
             $this->markReadOnly($entity);
+
             return;
         }
 
@@ -922,6 +923,7 @@ class UnitOfWork implements PropertyChangedListener
                 // Skip class if instances are read-only
                 if ($class->isReadOnly) {
                     $this->markReadOnly($entity);
+
                     continue;
                 }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -589,6 +589,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->computeScheduleInsertsChangeSets();
 
         if ($class->isReadOnly) {
+            $this->markReadOnly($entity);
             return;
         }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -897,11 +897,6 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($this->identityMap as $className => $entities) {
             $class = $this->em->getClassMetadata($className);
 
-            // Skip class if instances are read-only
-            if ($class->isReadOnly) {
-                continue;
-            }
-
             // If change tracking is explicit or happens through notification, then only compute
             // changes on entities of that type that are explicitly marked for synchronization.
             switch (true) {
@@ -920,6 +915,12 @@ class UnitOfWork implements PropertyChangedListener
             foreach ($entitiesToProcess as $entity) {
                 // Ignore uninitialized proxy objects
                 if ($this->isUninitializedObject($entity)) {
+                    continue;
+                }
+
+                // Skip class if instances are read-only
+                if ($class->isReadOnly) {
+                    $this->markReadOnly($entity);
                     continue;
                 }
 

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -1009,9 +1009,32 @@ class UnitOfWorkTest extends OrmTestCase
             self::assertSame('Commit failed', $e->getPrevious()->getMessage());
         }
     }
+
+    public function testIsReadOnlyReliability(): void
+    {
+        $entity = new ReadOnlyEntity();
+
+        $this->_unitOfWork->persist($entity);
+        $this->_unitOfWork->computeChangeSets();
+
+        self::assertTrue($this->_unitOfWork->isReadOnly($entity));
+    }
 }
 
-/** @Entity */
+
+/** @Entity(readOnly=true) */
+class ReadOnlyEntity
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+}
+
+    /** @Entity */
 class NotifyChangedEntity implements NotifyPropertyChanged
 {
     /** @phpstan-var list<PropertyChangedListener> */


### PR DESCRIPTION
Right now, calling `computeChangeSets` and thereafter trying to rely on `isReadOnly` does not work as expected. The state of `readOnlyObjects` internally did not sufficiently get updated. Thereby public method `isReadOnly` is not as reliable as expected.

This PR moves the check for read-only classes to a different location in the code to improve reliability of `isReadOnly`.

Taking the metadata to userland in order to check for a class to be readonly is not preferable, especially as `computeChangeSets` already is iterating over the metadata and entity objects.

## Expected behavior

Being able to reliably use `isReadOnly` to throw an exception in userland when a write to an entity is expected while these values won't be committed / flushed by the orm.