### PR TITLE
Docs: fix typos and grammar across reference docs

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -279,7 +279,7 @@ requests.
 Connection
 ----------
 
-The ``$connection`` passed as the first argument to he constructor of
+The ``$connection`` passed as the first argument to the constructor of
 ``EntityManager`` has to be an instance of ``Doctrine\DBAL\Connection``.
 You can use the factory ``Doctrine\DBAL\DriverManager::getConnection()``
 to create such a connection. The DBAL configuration is explained in the

--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -168,7 +168,7 @@ recommended, at least not as long as an entity instance still holds
 references to proxy objects or is still managed by an EntityManager.
 By default, serializing proxy objects does not initialize them. On
 unserialization, resulting objects are detached from the entity
-manager and cannot be initialiazed anymore. You can implement the
+manager and cannot be initialized anymore. You can implement the
 ``__serialize()`` method if you want to change that behavior, but
 then you need to ensure that you won't generate large serialized
 object graphs and take care of circular associations.

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -30,7 +30,7 @@ table alias of the SQL table of the entity.
 
 For the filter to correctly function, the following rules must be followed. Failure to do so will lead to unexpected results from the query cache.
   1. Parameters for the query should be set on the filter object by ``SQLFilter#setParameter()`` before the filter is used by the ORM ( i.e. do not set parameters inside ``SQLFilter#addFilterConstraint()`` function ).
-  2. The filter must be deterministic. Don't change the values base on external inputs.
+  2. The filter must be deterministic. Don't change the values based on external inputs.
 
 The ``SQLFilter#getParameter()`` function takes care of the proper quoting of parameters.
 

--- a/docs/en/reference/second-level-cache.rst
+++ b/docs/en/reference/second-level-cache.rst
@@ -630,7 +630,7 @@ DELETE / UPDATE queries
 DQL UPDATE / DELETE statements are ported directly into a database and bypass
 the second-level cache.
 Entities that are already cached will NOT be invalidated.
-However the cached data could be evicted using the cache API or an special query hint.
+However the cached data could be evicted using the cache API or a special query hint.
 
 
 Execute the ``UPDATE`` and invalidate ``all cache entries`` using ``Query::HINT_CACHE_EVICT``

--- a/docs/en/reference/second-level-cache.rst
+++ b/docs/en/reference/second-level-cache.rst
@@ -44,7 +44,7 @@ Something like below for an entity region:
 
 
 If the entity holds a collection that also needs to be cached.
-An collection region could look something like:
+A collection region could look something like:
 
 .. code-block:: php
 

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -118,7 +118,7 @@ entity might look like this:
         }
     }
 
-Now the possiblity of mass-assignment exists on this entity and can
+Now the possibility of mass-assignment exists on this entity and can
 be exploited by attackers to set the "isAdmin" flag to true on any
 object when you pass the whole request data to this method like:
 


### PR DESCRIPTION
Summary
- Minor typo and grammar fixes in the reference documentation.
- No code or behavior changes.

Scope
- Documentation only.

Touched sections
- advanced-configuration.rst (EntityManager constructor article)
- architecture.rst (initialized in serialization paragraph)
- filters.rst (determinism rule wording)
- security.rst (mass-assignment paragraph)
- second-level-cache.rst (collection region example; article in eviction sentence)