### PR TITLE
bugfix - add fieldAlias for entities in dto

### DIFF
--- a/src/Query/AST/EntityAsDtoArgumentExpression.php
+++ b/src/Query/AST/EntityAsDtoArgumentExpression.php
@@ -16,7 +16,11 @@ class EntityAsDtoArgumentExpression extends Node
     public function __construct(
         public mixed $expression,
         public string|null $identificationVariable,
+        public string|null $aliasVariable = null,
     ) {
+        if (! $aliasVariable) {
+            $this->aliasVariable = $expression;
+        }
     }
 
     public function dispatch(SqlWalker $walker): string

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1147,7 +1147,7 @@ final class Parser
             ];
         }
 
-        return new AST\EntityAsDtoArgumentExpression($expression, $identVariable);
+        return new AST\EntityAsDtoArgumentExpression($expression, $identVariable, $aliasResultVariable);
     }
 
     /**
@@ -1895,6 +1895,7 @@ final class Parser
             $expression = $this->NewObjectExpression();
         } elseif ($token->type === TokenType::T_IDENTIFIER && $peek->type !== TokenType::T_DOT && $peek->type !== TokenType::T_OPEN_PARENTHESIS) {
             $expression = $this->EntityAsDtoArgumentExpression();
+            $fieldAlias = $expression->aliasVariable;
         } else {
             $expression = $this->ScalarExpression();
         }

--- a/tests/Tests/Models/CMS/CmsUserDTONamedArgs.php
+++ b/tests/Tests/Models/CMS/CmsUserDTONamedArgs.php
@@ -13,6 +13,8 @@ class CmsUserDTONamedArgs
         public int|null $phonenumbers = null,
         public CmsAddressDTO|null $addressDto = null,
         public CmsAddressDTONamedArgs|null $addressDtoNamedArgs = null,
+        public CmsDumbDTO|null $dumb = null,
+        public CmsAddress|null $addressEntity = null,
     ) {
     }
 }

--- a/tests/Tests/Models/CMS/CmsUserDTOVariadicArg.php
+++ b/tests/Tests/Models/CMS/CmsUserDTOVariadicArg.php
@@ -10,12 +10,14 @@ class CmsUserDTOVariadicArg
     public string|null $email     = null;
     public string|null $address   = null;
     public int|null $phonenumbers = null;
+    public array $otherProperties = [];
 
     public function __construct(...$args)
     {
-        $this->name         = $args['name'] ?? null;
-        $this->email        = $args['email'] ?? null;
-        $this->phonenumbers = $args['phonenumbers'] ?? null;
-        $this->address      = $args['address'] ?? null;
+        $this->name            = $args['name'] ?? null;
+        $this->email           = $args['email'] ?? null;
+        $this->phonenumbers    = $args['phonenumbers'] ?? null;
+        $this->address         = $args['address'] ?? null;
+        $this->otherProperties = $args;
     }
 }

--- a/tests/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Tests/ORM/Functional/NewOperatorTest.php
@@ -1394,6 +1394,168 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertSame($this->fixtures[2]->email->email, $result[2]->val2->val2);
     }
 
+    public function testOnlyObjectInNamedDto(): void
+    {
+        $dql = '
+            SELECT
+                new named CmsUserDTOVariadicArg(
+                    a,
+                    new CmsDumbDTO(
+                        u.name,
+                        e.email
+                    ) as dumb
+                )
+            FROM
+                Doctrine\Tests\Models\CMS\CmsUser u
+            LEFT JOIN
+                u.email e
+            LEFT JOIN
+                u.address a
+            ORDER BY
+                u.name';
+
+        $query  = $this->getEntityManager()->createQuery($dql);
+        $result = $query->getResult();
+
+        self::assertCount(3, $result);
+
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[0]);
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[1]);
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[2]);
+
+        self::assertInstanceOf(CmsAddress::class, $result[0]->otherProperties['a']);
+        self::assertInstanceOf(CmsAddress::class, $result[1]->otherProperties['a']);
+        self::assertInstanceOf(CmsAddress::class, $result[2]->otherProperties['a']);
+
+        self::assertSame($this->fixtures[0]->address->city, $result[0]->otherProperties['a']->city);
+        self::assertSame($this->fixtures[1]->address->city, $result[1]->otherProperties['a']->city);
+        self::assertSame($this->fixtures[2]->address->city, $result[2]->otherProperties['a']->city);
+
+        self::assertSame($this->fixtures[0]->address->country, $result[0]->otherProperties['a']->country);
+        self::assertSame($this->fixtures[1]->address->country, $result[1]->otherProperties['a']->country);
+        self::assertSame($this->fixtures[2]->address->country, $result[2]->otherProperties['a']->country);
+
+        self::assertInstanceOf(CmsDumbDTO::class, $result[0]->otherProperties['dumb']);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[1]->otherProperties['dumb']);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[2]->otherProperties['dumb']);
+
+        self::assertSame($this->fixtures[0]->name, $result[0]->otherProperties['dumb']->val1);
+        self::assertSame($this->fixtures[1]->name, $result[1]->otherProperties['dumb']->val1);
+        self::assertSame($this->fixtures[2]->name, $result[2]->otherProperties['dumb']->val1);
+
+        self::assertSame($this->fixtures[0]->email->email, $result[0]->otherProperties['dumb']->val2);
+        self::assertSame($this->fixtures[1]->email->email, $result[1]->otherProperties['dumb']->val2);
+        self::assertSame($this->fixtures[2]->email->email, $result[2]->otherProperties['dumb']->val2);
+    }
+
+    public function testOnlyObjectInNamedDtoWithAlias(): void
+    {
+        $dql = '
+            SELECT
+                new named CmsUserDTOVariadicArg(
+                    a as addr,
+                    new CmsDumbDTO(
+                        u.name,
+                        e.email
+                    ) as dumb
+                )
+            FROM
+                Doctrine\Tests\Models\CMS\CmsUser u
+            LEFT JOIN
+                u.email e
+            LEFT JOIN
+                u.address a
+            ORDER BY
+                u.name';
+
+        $query  = $this->getEntityManager()->createQuery($dql);
+        $result = $query->getResult();
+
+        self::assertCount(3, $result);
+
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[0]);
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[1]);
+        self::assertInstanceOf(CmsUserDTOVariadicArg::class, $result[2]);
+
+        self::assertInstanceOf(CmsAddress::class, $result[0]->otherProperties['addr']);
+        self::assertInstanceOf(CmsAddress::class, $result[1]->otherProperties['addr']);
+        self::assertInstanceOf(CmsAddress::class, $result[2]->otherProperties['addr']);
+
+        self::assertSame($this->fixtures[0]->address->city, $result[0]->otherProperties['addr']->city);
+        self::assertSame($this->fixtures[1]->address->city, $result[1]->otherProperties['addr']->city);
+        self::assertSame($this->fixtures[2]->address->city, $result[2]->otherProperties['addr']->city);
+
+        self::assertSame($this->fixtures[0]->address->country, $result[0]->otherProperties['addr']->country);
+        self::assertSame($this->fixtures[1]->address->country, $result[1]->otherProperties['addr']->country);
+        self::assertSame($this->fixtures[2]->address->country, $result[2]->otherProperties['addr']->country);
+
+        self::assertInstanceOf(CmsDumbDTO::class, $result[0]->otherProperties['dumb']);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[1]->otherProperties['dumb']);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[2]->otherProperties['dumb']);
+
+        self::assertSame($this->fixtures[0]->name, $result[0]->otherProperties['dumb']->val1);
+        self::assertSame($this->fixtures[1]->name, $result[1]->otherProperties['dumb']->val1);
+        self::assertSame($this->fixtures[2]->name, $result[2]->otherProperties['dumb']->val1);
+
+        self::assertSame($this->fixtures[0]->email->email, $result[0]->otherProperties['dumb']->val2);
+        self::assertSame($this->fixtures[1]->email->email, $result[1]->otherProperties['dumb']->val2);
+        self::assertSame($this->fixtures[2]->email->email, $result[2]->otherProperties['dumb']->val2);
+    }
+
+    public function testOnlyObjectInNamedDtoWithSameNameAsTheProperties(): void
+    {
+        $dql = '
+            SELECT
+                new named CmsUserDTONamedArgs(
+                    addressEntity,
+                    new CmsDumbDTO(
+                        u.name,
+                        e.email
+                    ) as dumb
+                )
+            FROM
+                Doctrine\Tests\Models\CMS\CmsUser u
+            LEFT JOIN
+                u.email e
+            LEFT JOIN
+                u.address addressEntity
+            ORDER BY
+                u.name';
+
+        $query  = $this->getEntityManager()->createQuery($dql);
+        $result = $query->getResult();
+
+        self::assertCount(3, $result);
+
+        self::assertInstanceOf(CmsUserDTONamedArgs::class, $result[0]);
+        self::assertInstanceOf(CmsUserDTONamedArgs::class, $result[1]);
+        self::assertInstanceOf(CmsUserDTONamedArgs::class, $result[2]);
+
+        self::assertInstanceOf(CmsAddress::class, $result[0]->addressEntity);
+        self::assertInstanceOf(CmsAddress::class, $result[1]->addressEntity);
+        self::assertInstanceOf(CmsAddress::class, $result[2]->addressEntity);
+
+        self::assertSame($this->fixtures[0]->address->city, $result[0]->addressEntity->city);
+        self::assertSame($this->fixtures[1]->address->city, $result[1]->addressEntity->city);
+        self::assertSame($this->fixtures[2]->address->city, $result[2]->addressEntity->city);
+
+        self::assertSame($this->fixtures[0]->address->country, $result[0]->addressEntity->country);
+        self::assertSame($this->fixtures[1]->address->country, $result[1]->addressEntity->country);
+        self::assertSame($this->fixtures[2]->address->country, $result[2]->addressEntity->country);
+
+        self::assertInstanceOf(CmsDumbDTO::class, $result[0]->dumb);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[1]->dumb);
+        self::assertInstanceOf(CmsDumbDTO::class, $result[2]->dumb);
+
+        self::assertSame($this->fixtures[0]->name, $result[0]->dumb->val1);
+        self::assertSame($this->fixtures[1]->name, $result[1]->dumb->val1);
+        self::assertSame($this->fixtures[2]->name, $result[2]->dumb->val1);
+
+        self::assertSame($this->fixtures[0]->email->email, $result[0]->dumb->val2);
+        self::assertSame($this->fixtures[1]->email->email, $result[1]->dumb->val2);
+        self::assertSame($this->fixtures[2]->email->email, $result[2]->dumb->val2);
+    }
+
     public function testNamedArguments(): void
     {
         $dql = <<<'SQL'


### PR DESCRIPTION
from slack : 

> Hello, I'm playing with Doctrine ORM 3.5 and trying to use the SELECT NEW NAMED syntax to hydrate a DTO. I have a question about passing complete entity objects as constructor parameters; This works fine

```php
$qb->select(sprintf('NEW %s(
    p.id,
    p.name,
    p.level,
    ...,
    t,           // Type entity works
    p.nickname
)', PokemonDetailView::class))
->leftJoin('p.type', 't')
```

> But this doesn't

```
// Attempt 1: without AS
'NEW NAMED %s(..., t, ...)' 
// Error: Column name "t" does not match any property name

// Attempt 2: with AS
'NEW NAMED %s(..., t AS type, ...)'
// Error: Column name "t AS type" does not match any property name

// Attempt 3: only entity without AS, scalars with AS
'NEW NAMED %s(
    p.id AS id,
    p.name AS name,
    t,              // Entity without AS
    p.nickname AS nickname
)'
// Error: Column name "t" does not match any property name
```

> According to the [documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.5/reference/dql-doctrine-query-language.html#new-operator-syntax), "you can only pass scalar expressions or other Data Transfer Objects to the constructor." However, I'm able to pass entity objects successfully with positional SELECT NEW. Is this limitation also applicable to SELECT NEW NAMED, or is there a specific syntax I'm missing for passing entity objects with named parameters?`