### PR TITLE
Avoid triggering a deprecation notice in doctrine/collections

### DIFF
--- a/phpstan-persistence2.neon
+++ b/phpstan-persistence2.neon
@@ -110,3 +110,9 @@ parameters:
             message: '#injectObjectManager#'
             identifier: 'method.deprecatedInterface'
             path: src/UnitOfWork.php
+
+        -
+            message: '#^Static method Doctrine\\Common\\Collections\\Criteria\:\:create\(\) invoked with 1 parameter, 0 required\.$#'
+            identifier: arguments.count
+            count: 3
+            path: src/Persisters/Collection/OneToManyPersister.php

--- a/src/Persisters/Collection/OneToManyPersister.php
+++ b/src/Persisters/Collection/OneToManyPersister.php
@@ -103,7 +103,6 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        // @phpstan-ignore arguments.count
         $criteria = Criteria::create(true)->where(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
 
         return $persister->count($criteria);
@@ -136,7 +135,6 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        // @phpstan-ignore arguments.count
         $criteria = Criteria::create(true);
 
         $criteria->andWhere(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
@@ -160,7 +158,6 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        // @phpstan-ignore arguments.count
         $criteria = Criteria::create(true)->where(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
 
         return $persister->exists($element, $criteria);

--- a/src/Persisters/Collection/OneToManyPersister.php
+++ b/src/Persisters/Collection/OneToManyPersister.php
@@ -103,7 +103,8 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        $criteria = new Criteria(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
+        // @phpstan-ignore arguments.count
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
 
         return $persister->count($criteria);
     }
@@ -135,7 +136,8 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        $criteria = new Criteria();
+        // @phpstan-ignore arguments.count
+        $criteria = Criteria::create(true);
 
         $criteria->andWhere(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
         $criteria->andWhere(Criteria::expr()->eq($mapping['indexBy'], $key));
@@ -158,7 +160,8 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        $criteria = new Criteria(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
+        // @phpstan-ignore arguments.count
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
 
         return $persister->exists($element, $criteria);
     }

--- a/tests/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
+++ b/tests/Tests/ORM/Cache/Persister/Entity/EntityPersisterTestCase.php
@@ -143,7 +143,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
     public function testInvokeExpandCriteriaParameters(): void
     {
         $persister = $this->createPersisterDefault();
-        $criteria  = new Criteria();
+        $criteria  = Criteria::create(true);
 
         $this->entityPersister->expects(self::once())
             ->method('expandCriteriaParameters')
@@ -313,7 +313,7 @@ abstract class EntityPersisterTestCase extends OrmTestCase
         $rsm       = new ResultSetMappingBuilder($this->em);
         $persister = $this->createPersisterDefault();
         $entity    = new Country('Foo');
-        $criteria  = new Criteria();
+        $criteria  = Criteria::create(true);
 
         $this->em->getUnitOfWork()->registerManaged($entity, ['id' => 1], ['id' => 1, 'name' => 'Foo']);
         $rsm->addEntityResult(Country::class, 'c');

--- a/tests/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -494,13 +494,13 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $repository = $this->_em->getRepository(CompanyEmployee::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('department', 'IT')
         ));
         self::assertCount(1, $users);
 
         $repository = $this->_em->getRepository(CompanyManager::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('department', 'IT')
         ));
         self::assertCount(1, $users);

--- a/tests/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
+++ b/tests/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
@@ -66,7 +66,7 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(DateTimeModel::class);
-        $dates      = $repository->matching(new Criteria(
+        $dates      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->lte('datetime', new DateTime('today'))
         ));
 
@@ -98,7 +98,7 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
         $this->loadNullFieldFixtures();
         $repository = $this->_em->getRepository(DateTimeModel::class);
 
-        $dates = $repository->matching(new Criteria(
+        $dates = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->isNull('time')
         ));
 
@@ -110,7 +110,7 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
         $this->loadNullFieldFixtures();
         $repository = $this->_em->getRepository(DateTimeModel::class);
 
-        $dates = $repository->matching(new Criteria(
+        $dates = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('time', null)
         ));
 
@@ -122,7 +122,7 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
         $this->loadNullFieldFixtures();
         $repository = $this->_em->getRepository(DateTimeModel::class);
 
-        $dates = $repository->matching(new Criteria(
+        $dates = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->neq('time', null)
         ));
 
@@ -134,14 +134,14 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
         $this->loadFixture();
         $repository = $this->_em->getRepository(DateTimeModel::class);
 
-        $dates = $repository->matching(new Criteria());
+        $dates = $repository->matching(Criteria::create(true));
 
         self::assertFalse($dates->isInitialized());
         self::assertCount(3, $dates);
         self::assertFalse($dates->isInitialized());
 
         // Test it can work even with a constraint
-        $dates = $repository->matching(new Criteria(
+        $dates = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->lte('datetime', new DateTime('today'))
         ));
 
@@ -169,7 +169,7 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->andWhere($criteria->expr()->contains('content', 'Criteria'));
 
         $user   = $this->_em->find(User::class, $user->id);

--- a/tests/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -734,7 +734,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria());
+        $users      = $repository->matching(Criteria::create(true));
 
         self::assertCount(4, $users);
     }
@@ -745,7 +745,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('username', 'beberlei')
         ));
 
@@ -758,7 +758,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->neq('username', 'beberlei')
         ));
 
@@ -771,7 +771,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->in('username', ['beberlei', 'gblanco'])
         ));
 
@@ -784,7 +784,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->notIn('username', ['beberlei', 'gblanco', 'asm89'])
         ));
 
@@ -797,7 +797,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $firstUserId = $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->lt('id', $firstUserId + 1)
         ));
 
@@ -810,7 +810,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $firstUserId = $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->lte('id', $firstUserId + 1)
         ));
 
@@ -823,7 +823,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $firstUserId = $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->gt('id', $firstUserId)
         ));
 
@@ -836,7 +836,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $firstUserId = $this->loadFixture();
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $users      = $repository->matching(new Criteria(
+        $users      = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->gte('id', $firstUserId)
         ));
 
@@ -850,7 +850,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $user = $this->_em->find(CmsUser::class, $userId);
 
-        $criteria = new Criteria(
+        $criteria = Criteria::create(true)->where(
             Criteria::expr()->eq('user', $user)
         );
 
@@ -871,7 +871,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $user = $this->_em->find(CmsUser::class, $userId);
 
-        $criteria = new Criteria(
+        $criteria = Criteria::create(true)->where(
             Criteria::expr()->in('user', [$user])
         );
 
@@ -891,13 +891,13 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository(CmsUser::class);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->contains('name', 'Foobar')));
+        $users = $repository->matching(Criteria::create(true)->where(Criteria::expr()->contains('name', 'Foobar')));
         self::assertCount(0, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->contains('name', 'Rom')));
+        $users = $repository->matching(Criteria::create(true)->where(Criteria::expr()->contains('name', 'Rom')));
         self::assertCount(1, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->contains('status', 'dev')));
+        $users = $repository->matching(Criteria::create(true)->where(Criteria::expr()->contains('status', 'dev')));
         self::assertCount(2, $users);
     }
 
@@ -907,13 +907,19 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository(CmsUser::class);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->startsWith('name', 'Foo')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->startsWith('name', 'Foo')
+        ));
         self::assertCount(0, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->startsWith('name', 'R')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->startsWith('name', 'R')
+        ));
         self::assertCount(1, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->startsWith('status', 'de')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->startsWith('status', 'de')
+        ));
         self::assertCount(2, $users);
     }
 
@@ -923,13 +929,19 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository(CmsUser::class);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->endsWith('name', 'foo')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->endsWith('name', 'foo')
+        ));
         self::assertCount(0, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->endsWith('name', 'oman')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->endsWith('name', 'oman')
+        ));
         self::assertCount(1, $users);
 
-        $users = $repository->matching(new Criteria(Criteria::expr()->endsWith('status', 'ev')));
+        $users = $repository->matching(Criteria::create(true)->where(
+            Criteria::expr()->endsWith('status', 'ev')
+        ));
         self::assertCount(2, $users);
     }
 
@@ -939,8 +951,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $fixtures       = $this->loadFixtureUserEmail();
         $user           = $this->_em->find(CmsUser::class, $fixtures[0]->id);
         $repository     = $this->_em->getRepository(CmsUser::class);
-        $criteriaIsNull = Criteria::create()->where(Criteria::expr()->isNull('email'));
-        $criteriaEqNull = Criteria::create()->where(Criteria::expr()->eq('email', null));
+        $criteriaIsNull = Criteria::create(true)->where(Criteria::expr()->isNull('email'));
+        $criteriaEqNull = Criteria::create(true)->where(Criteria::expr()->eq('email', null));
 
         $user->setEmail(null);
         $this->_em->persist($user);
@@ -997,7 +1009,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->expectExceptionMessage('Unrecognized field: ');
 
         $repository = $this->_em->getRepository(CmsUser::class);
-        $result     = $repository->matching(new Criteria(
+        $result     = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1', 'beberlei')
         ));
 

--- a/tests/Tests/ORM/Functional/EnumTest.php
+++ b/tests/Tests/ORM/Functional/EnumTest.php
@@ -557,7 +557,7 @@ EXCEPTION
         $library = $this->_em->find(Library::class, $library->id);
         self::assertFalse($library->books->isInitialized(), 'Pre-condition: lazy collection');
 
-        $result = $library->books->matching(Criteria::create()->where($comparison));
+        $result = $library->books->matching(Criteria::create(true)->where($comparison));
 
         self::assertCount(1, $result);
         self::assertSame($nonfictionBook->id, $result[0]->id);
@@ -588,7 +588,7 @@ EXCEPTION
         $category = $this->_em->find(BookCategory::class, $category->id);
         self::assertFalse($category->books->isInitialized(), 'Pre-condition: lazy collection');
 
-        $result = $category->books->matching(Criteria::create()->where($comparison));
+        $result = $category->books->matching(Criteria::create(true)->where($comparison));
 
         self::assertCount(1, $result);
         self::assertSame($nonfictionBook->id, $result[0]->id);

--- a/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -437,7 +437,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
 
         $user = $this->_em->find(get_class($user), $user->id);
 
-        $criteria = Criteria::create()
+        $criteria = Criteria::create(true)
             ->orderBy(['name' => class_exists(Order::class) ? Order::Ascending : Criteria::ASC]);
 
         self::assertEquals(
@@ -479,7 +479,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
 
         $user = $this->_em->find(get_class($user), $user->id);
 
-        $criteria = Criteria::create()
+        $criteria = Criteria::create(true)
             ->orderBy(['name' => class_exists(Order::class) ? Order::Ascending : Criteria::ASC]);
 
         self::assertEquals(
@@ -504,7 +504,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->setMaxResults(1);
+        $criteria = Criteria::create(true)->setMaxResults(1);
         $result   = $groups->matching($criteria);
 
         self::assertCount(1, $result);
@@ -522,7 +522,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->setFirstResult(1);
+        $criteria = Criteria::create(true)->setFirstResult(1);
         $result   = $groups->matching($criteria);
 
         self::assertCount(1, $result);
@@ -543,7 +543,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->setFirstResult(1)->setMaxResults(3);
+        $criteria = Criteria::create(true)->setFirstResult(1)->setMaxResults(3);
         $result   = $groups->matching($criteria);
 
         self::assertCount(3, $result);
@@ -567,7 +567,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->where(Criteria::expr()->eq('name', (string) 'Developers_0'));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq('name', (string) 'Developers_0'));
         $result   = $groups->matching($criteria);
 
         self::assertCount(1, $result);
@@ -588,7 +588,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->where(Criteria::expr()->in('name', ['Developers_1']));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->in('name', ['Developers_1']));
         $result   = $groups->matching($criteria);
 
         self::assertCount(1, $result);
@@ -607,7 +607,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups;
         self::assertFalse($user->groups->isInitialized(), 'Pre-condition: lazy collection');
 
-        $criteria = Criteria::create()->where(Criteria::expr()->notIn('name', ['Developers_0']));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->notIn('name', ['Developers_0']));
         $result   = $groups->matching($criteria);
 
         self::assertCount(1, $result);

--- a/tests/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -166,14 +166,14 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $product  = $this->_em->find(ECommerceProduct::class, $this->product->getId());
         $features = $product->getFeatures();
 
-        $results = $features->matching(new Criteria(
+        $results = $features->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('description', 'Model writing tutorial')
         ));
 
         self::assertInstanceOf(Collection::class, $results);
         self::assertCount(1, $results);
 
-        $results = $features->matching(new Criteria());
+        $results = $features->matching(Criteria::create(true));
 
         self::assertInstanceOf(Collection::class, $results);
         self::assertCount(2, $results);
@@ -192,7 +192,7 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $features = $product->getFeatures();
         $features->add($thirdFeature);
 
-        $results = $features->matching(new Criteria(
+        $results = $features->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('description', 'Model writing tutorial')
         ));
 
@@ -210,14 +210,14 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $thirdFeature->setDescription('Third feature');
         $product->addFeature($thirdFeature);
 
-        $results = $features->matching(new Criteria(
+        $results = $features->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('description', 'Third feature')
         ));
 
         self::assertInstanceOf(Collection::class, $results);
         self::assertCount(1, $results);
 
-        $results = $features->matching(new Criteria());
+        $results = $features->matching(Criteria::create(true));
 
         self::assertInstanceOf(Collection::class, $results);
         self::assertCount(3, $results);

--- a/tests/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
+++ b/tests/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
@@ -80,7 +80,7 @@ class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
         $repository = $this->_em->getRepository(User::class);
 
         $user   = $repository->findOneBy(['name' => 'ngal']);
-        $tweets = $user->tweets->matching(new Criteria());
+        $tweets = $user->tweets->matching(Criteria::create(true));
 
         self::assertInstanceOf(LazyCriteriaCollection::class, $tweets);
         self::assertFalse($tweets->isInitialized());
@@ -88,7 +88,7 @@ class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
         self::assertFalse($tweets->isInitialized());
 
         // Make sure it works with constraints
-        $tweets = $user->tweets->matching(new Criteria(
+        $tweets = $user->tweets->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('content', 'Foo')
         ));
 
@@ -117,7 +117,7 @@ class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
 
         $parent = $this->_em->find(OwningManyToManyExtraLazyEntity::class, $parent->id2);
 
-        $criteria = Criteria::create()->where(Criteria::expr()->eq('id1', 'Bob'));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq('id1', 'Bob'));
 
         $result = $parent->associatedEntities->matching($criteria);
 

--- a/tests/Tests/ORM/Functional/PersistentCollectionTest.php
+++ b/tests/Tests/ORM/Functional/PersistentCollectionTest.php
@@ -90,7 +90,7 @@ class PersistentCollectionTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $collectionHolder = $this->_em->find(PersistentCollectionHolder::class, $collectionHolder->getId());
         $collectionHolder->getCollection()->matching($criteria);

--- a/tests/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
+++ b/tests/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
@@ -25,7 +25,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
         $repository = $this->_em->getRepository(Country::class);
         $this->getQueryLog()->reset()->enable();
         $name    = $this->countries[0]->getName();
-        $result1 = $repository->matching(new Criteria(
+        $result1 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $name)
         ));
 
@@ -40,7 +40,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
 
         $this->_em->clear();
 
-        $result2 = $repository->matching(new Criteria(
+        $result2 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $name)
         ));
 
@@ -64,7 +64,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
 
         $repository = $this->_em->getRepository(Country::class);
         $this->getQueryLog()->reset()->enable();
-        $result1 = $repository->matching(new Criteria(
+        $result1 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $this->countries[0]->getName())
         ));
 
@@ -78,7 +78,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
 
         $this->_em->clear();
 
-        $result2 = $repository->matching(new Criteria(
+        $result2 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $this->countries[0]->getName())
         ));
 
@@ -93,7 +93,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
         self::assertEquals($this->countries[0]->getId(), $result2[0]->getId());
         self::assertEquals($this->countries[0]->getName(), $result2[0]->getName());
 
-        $result3 = $repository->matching(new Criteria(
+        $result3 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $this->countries[1]->getName())
         ));
 
@@ -108,7 +108,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
         self::assertEquals($this->countries[1]->getId(), $result3[0]->getId());
         self::assertEquals($this->countries[1]->getName(), $result3[0]->getName());
 
-        $result4 = $repository->matching(new Criteria(
+        $result4 = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $this->countries[1]->getName())
         ));
 
@@ -133,7 +133,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
         $itemName = $this->states[0]->getCities()->get(0)->getName();
         $this->getQueryLog()->reset()->enable();
         $collection = $entity->getCities();
-        $matching   = $collection->matching(new Criteria(
+        $matching   = $collection->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $itemName)
         ));
 
@@ -146,7 +146,7 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheFunctionalTestCase
         $entity = $this->_em->find(State::class, $this->states[0]->getId());
         $this->getQueryLog()->reset()->enable();
         $collection = $entity->getCities();
-        $matching   = $collection->matching(new Criteria(
+        $matching   = $collection->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('name', $itemName)
         ));
 

--- a/tests/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -360,13 +360,13 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
         $this->loadFullFixture();
 
         $repository = $this->_em->getRepository(CompanyContract::class);
-        $contracts  = $repository->matching(new Criteria(
+        $contracts  = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('salesPerson', $this->salesPerson)
         ));
         self::assertCount(3, $contracts);
 
         $repository = $this->_em->getRepository(CompanyFixContract::class);
-        $contracts  = $repository->matching(new Criteria(
+        $contracts  = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('salesPerson', $this->salesPerson)
         ));
         self::assertCount(1, $contracts);
@@ -382,7 +382,7 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
         $this->expectException(MatchingAssociationFieldRequiresObject::class);
         $this->expectExceptionMessage('annot match on Doctrine\Tests\Models\Company\CompanyContract::salesPerson with a non-object value.');
 
-        $contracts = $repository->matching(new Criteria(
+        $contracts = $repository->matching(Criteria::create(true)->where(
             Criteria::expr()->eq('salesPerson', $this->salesPerson->getId())
         ));
 

--- a/tests/Tests/ORM/Functional/Ticket/DDC2106Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2106Test.php
@@ -38,7 +38,7 @@ class DDC2106Test extends OrmFunctionalTestCase
         $entityWithoutId = new DDC2106Entity();
         $this->_em->persist($entityWithoutId);
 
-        $criteria = Criteria::create()->where(Criteria::expr()->eq('parent', $entityWithoutId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq('parent', $entityWithoutId));
 
         self::assertCount(0, $entity->children->matching($criteria));
     }

--- a/tests/Tests/ORM/Functional/Ticket/DDC3719Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC3719Test.php
@@ -43,7 +43,7 @@ class DDC3719Test extends OrmFunctionalTestCase
         $contracts = $manager->managedContracts;
         self::assertCount(2, $contracts);
 
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
         $criteria->where(Criteria::expr()->eq('completed', true));
 
         $completedContracts = $contracts->matching($criteria);

--- a/tests/Tests/ORM/Functional/Ticket/GH6740Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH6740Test.php
@@ -51,7 +51,7 @@ final class GH6740Test extends OrmFunctionalTestCase
     public function testCollectionFilteringLteOperator(): void
     {
         $product  = $this->_em->find(ECommerceProduct::class, $this->productId);
-        $criteria = Criteria::create()->where(Criteria::expr()->lte('id', $this->secondCategoryId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->lte('id', $this->secondCategoryId));
 
         self::assertCount(2, $product->getCategories()->matching($criteria));
     }
@@ -60,7 +60,7 @@ final class GH6740Test extends OrmFunctionalTestCase
     public function testCollectionFilteringLtOperator(): void
     {
         $product  = $this->_em->find(ECommerceProduct::class, $this->productId);
-        $criteria = Criteria::create()->where(Criteria::expr()->lt('id', $this->secondCategoryId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->lt('id', $this->secondCategoryId));
 
         self::assertCount(1, $product->getCategories()->matching($criteria));
     }
@@ -69,7 +69,7 @@ final class GH6740Test extends OrmFunctionalTestCase
     public function testCollectionFilteringGteOperator(): void
     {
         $product  = $this->_em->find(ECommerceProduct::class, $this->productId);
-        $criteria = Criteria::create()->where(Criteria::expr()->gte('id', $this->firstCategoryId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->gte('id', $this->firstCategoryId));
 
         self::assertCount(2, $product->getCategories()->matching($criteria));
     }
@@ -78,7 +78,7 @@ final class GH6740Test extends OrmFunctionalTestCase
     public function testCollectionFilteringGtOperator(): void
     {
         $product  = $this->_em->find(ECommerceProduct::class, $this->productId);
-        $criteria = Criteria::create()->where(Criteria::expr()->gt('id', $this->firstCategoryId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->gt('id', $this->firstCategoryId));
 
         self::assertCount(1, $product->getCategories()->matching($criteria));
     }
@@ -87,7 +87,7 @@ final class GH6740Test extends OrmFunctionalTestCase
     public function testCollectionFilteringEqualsOperator(): void
     {
         $product  = $this->_em->find(ECommerceProduct::class, $this->productId);
-        $criteria = Criteria::create()->where(Criteria::expr()->eq('id', $this->firstCategoryId));
+        $criteria = Criteria::create(true)->where(Criteria::expr()->eq('id', $this->firstCategoryId));
 
         self::assertCount(1, $product->getCategories()->matching($criteria));
     }

--- a/tests/Tests/ORM/Functional/Ticket/GH7717Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7717Test.php
@@ -40,6 +40,8 @@ final class GH7717Test extends OrmFunctionalTestCase
 
         $parent = $this->_em->find(GH7717Parent::class, 1);
 
-        $this->assertCount(1, $parent->children->matching(new Criteria(Criteria::expr()->isNull('nullableProperty'))));
+        $this->assertCount(1, $parent->children->matching(Criteria::create(true)->where(
+            Criteria::expr()->isNull('nullableProperty')
+        )));
     }
 }

--- a/tests/Tests/ORM/Functional/Ticket/GH7737Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7737Test.php
@@ -41,7 +41,7 @@ class GH7737Test extends OrmFunctionalTestCase
         $query = $this->_em->createQueryBuilder()
             ->select('person')
             ->from(GH7737Person::class, 'person')
-            ->addCriteria(Criteria::create()->where(Criteria::expr()->memberOf(':group', 'person.groups')))
+            ->addCriteria(Criteria::create(true)->where(Criteria::expr()->memberOf(':group', 'person.groups')))
             ->getQuery();
 
         $group1   = $this->_em->find(GH7737Group::class, 1);

--- a/tests/Tests/ORM/Functional/Ticket/GH7767Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7767Test.php
@@ -44,7 +44,7 @@ class GH7767Test extends OrmFunctionalTestCase
         $parent = $this->_em->find(GH7767ParentEntity::class, 1);
         assert($parent instanceof GH7767ParentEntity);
 
-        $children = $parent->getChildren()->matching(Criteria::create());
+        $children = $parent->getChildren()->matching(Criteria::create(true));
 
         self::assertEquals(100, $children[0]->position);
         self::assertEquals(200, $children[1]->position);
@@ -57,7 +57,7 @@ class GH7767Test extends OrmFunctionalTestCase
         assert($parent instanceof GH7767ParentEntity);
 
         $children = $parent->getChildren()->matching(
-            Criteria::create()->orderBy(['position' => class_exists(Order::class) ? Order::Descending : 'DESC'])
+            Criteria::create(true)->orderBy(['position' => class_exists(Order::class) ? Order::Descending : 'DESC'])
         );
 
         self::assertEquals(300, $children[0]->position);

--- a/tests/Tests/ORM/Functional/Ticket/GH7836Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7836Test.php
@@ -44,7 +44,7 @@ class GH7836Test extends OrmFunctionalTestCase
         $parent = $this->_em->find(GH7836ParentEntity::class, 1);
         assert($parent instanceof GH7836ParentEntity);
 
-        $children = $parent->getChildren()->matching(Criteria::create());
+        $children = $parent->getChildren()->matching(Criteria::create(true));
 
         self::assertSame(100, $children[0]->position);
         self::assertSame('bar', $children[0]->name);
@@ -60,7 +60,7 @@ class GH7836Test extends OrmFunctionalTestCase
         assert($parent instanceof GH7836ParentEntity);
 
         $children = $parent->getChildren()->matching(
-            Criteria::create()->orderBy(
+            Criteria::create(true)->orderBy(
                 class_exists(Order::class)
                     ? ['position' => Order::Descending, 'name' => Order::Ascending]
                     : ['position' => 'DESC', 'name' => 'ASC']
@@ -81,7 +81,7 @@ class GH7836Test extends OrmFunctionalTestCase
         assert($parent instanceof GH7836ParentEntity);
 
         $children = $parent->getChildren()->matching(
-            Criteria::create()->orderBy(
+            Criteria::create(true)->orderBy(
                 class_exists(Order::class)
                     ? ['name' => Order::Ascending, 'position' => Order::Ascending]
                     : ['name' => 'ASC', 'position' => 'ASC']

--- a/tests/Tests/ORM/Functional/Ticket/GH9109Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9109Test.php
@@ -66,7 +66,7 @@ class GH9109Test extends OrmFunctionalTestCase
         self::assertEquals($userLastName, $user->getLastName());
 
         // assert NOT QUOTED will WORK with Criteria
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('lastName', $userLastName));
         $user = $persistedProduct->getBuyers()->matching($criteria)->first();
         self::assertInstanceOf(GH9109User::class, $user);
@@ -78,7 +78,7 @@ class GH9109Test extends OrmFunctionalTestCase
         self::assertEquals($userFirstName, $user->getFirstName());
 
         // assert QUOTED will WORK with Criteria
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('firstName', $userFirstName));
         $user = $persistedProduct->getBuyers()->matching($criteria)->first();
         self::assertInstanceOf(GH9109User::class, $user);

--- a/tests/Tests/ORM/Functional/ValueConversionType/ManyToManyCriteriaMatchingTest.php
+++ b/tests/Tests/ORM/Functional/ValueConversionType/ManyToManyCriteriaMatchingTest.php
@@ -49,7 +49,7 @@ class ManyToManyCriteriaMatchingTest extends OrmFunctionalTestCase
         $associated = $this->_em->find(InversedManyToManyEntity::class, 'associated');
         self::assertFalse($associated->associatedEntities->isInitialized(), 'Pre-condition: lazy collection');
 
-        $result = $associated->associatedEntities->matching(Criteria::create()->where($comparison));
+        $result = $associated->associatedEntities->matching(Criteria::create(true)->where($comparison));
 
         $l = $this->getQueryLog();
 

--- a/tests/Tests/ORM/Functional/ValueConversionType/OneToManyCriteriaMatchingTest.php
+++ b/tests/Tests/ORM/Functional/ValueConversionType/OneToManyCriteriaMatchingTest.php
@@ -49,7 +49,7 @@ class OneToManyCriteriaMatchingTest extends OrmFunctionalTestCase
         $entityWithCollection = $this->_em->find(InversedOneToManyEntity::class, 'associated');
         self::assertFalse($entityWithCollection->associatedEntities->isInitialized(), 'Pre-condition: lazy collection');
 
-        $result = $entityWithCollection->associatedEntities->matching(Criteria::create()->where($comparison));
+        $result = $entityWithCollection->associatedEntities->matching(Criteria::create(true)->where($comparison));
 
         $l = $this->getQueryLog();
 

--- a/tests/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\LazyCriteriaCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 /** @covers \Doctrine\ORM\LazyCriteriaCollection */
 class LazyCriteriaCollectionTest extends TestCase
@@ -27,7 +26,7 @@ class LazyCriteriaCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->persister              = $this->createMock(EntityPersister::class);
-        $this->criteria               = new Criteria();
+        $this->criteria               = Criteria::create(true);
         $this->lazyCriteriaCollection = new LazyCriteriaCollection($this->persister, $this->criteria);
     }
 
@@ -68,9 +67,9 @@ class LazyCriteriaCollectionTest extends TestCase
 
     public function testMatchingUsesThePersisterOnlyOnce(): void
     {
-        $foo = new stdClass();
-        $bar = new stdClass();
-        $baz = new stdClass();
+        $foo = new LazyCriteriaCollectionTestObject();
+        $bar = new LazyCriteriaCollectionTestObject();
+        $baz = new LazyCriteriaCollectionTestObject();
 
         $foo->val = 'foo';
         $bar->val = 'bar';
@@ -83,7 +82,7 @@ class LazyCriteriaCollectionTest extends TestCase
             ->with($this->criteria)
             ->willReturn([$foo, $bar, $baz]);
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $criteria->andWhere($criteria->expr()->eq('val', 'foo'));
 
@@ -125,4 +124,10 @@ class LazyCriteriaCollectionTest extends TestCase
 
         self::assertFalse($this->lazyCriteriaCollection->isEmpty());
     }
+}
+
+class LazyCriteriaCollectionTestObject
+{
+    /** @var mixed */
+    public $val;
 }

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
@@ -49,7 +49,7 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
         $country = new Country('IT', 'Italy');
         $admin1  = new Admin1(10, 'Rome', $country);
 
-        $criteria = Criteria::create();
+        $criteria = Criteria::create(true);
         $criteria->andWhere(Criteria::expr()->eq('admin1', $admin1));
 
         [$values, $types] = $this->persister->expandCriteriaParameters($criteria);

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -162,7 +162,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
         self::assertEquals('SELECT COUNT(*) FROM "not-a-simple-entity" t0 WHERE t0."simple-entity-value" = ?', $statement);
 
         // Using a criteria object
-        $criteria  = new Criteria(Criteria::expr()->eq('value', 'bar'));
+        $criteria  = Criteria::create(true)->where(Criteria::expr()->eq('value', 'bar'));
         $statement = $persister->getCountSQL($criteria);
         self::assertEquals('SELECT COUNT(*) FROM "not-a-simple-entity" t0 WHERE t0."simple-entity-value" = ?', $statement);
     }

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -476,7 +476,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('u')
             ->from(CmsUser::class, 'u');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field', 'value'));
 
         $qb->addCriteria($criteria);
@@ -490,7 +490,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->andX(
             $criteria->expr()->eq('field', 'value1'),
             $criteria->expr()->eq('field', 'value2')
@@ -509,7 +509,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('field', 'value2'));
 
@@ -526,7 +526,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field1', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('field2', 'value2'));
 
@@ -543,7 +543,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field1', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('field2', 'value2'));
 
@@ -560,7 +560,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field1', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('field1', 'value2'));
 
@@ -577,7 +577,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('u')
             ->from(CmsUser::class, 'u');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->orderBy(['field' => class_exists(Order::class) ? Order::Descending : Criteria::DESC]);
 
         $qb->addCriteria($criteria);
@@ -594,7 +594,7 @@ class QueryBuilderTest extends OrmTestCase
             ->from(CmsUser::class, 'u')
             ->join('u.article', 'a');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->orderBy(['a.field' => class_exists(Order::class) ? Order::Descending : Criteria::DESC]);
 
         $qb->addCriteria($criteria);
@@ -609,7 +609,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('u')
             ->from(CmsUser::class, 'u');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->setFirstResult(2);
         $criteria->setMaxResults(10);
 
@@ -627,7 +627,7 @@ class QueryBuilderTest extends OrmTestCase
             ->setFirstResult(2)
             ->setMaxResults(10);
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
 
         $qb->addCriteria($criteria);
 
@@ -932,7 +932,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
         $qb->join('alias1.articles', 'alias2');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('field', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('alias2.field', 'value2'));
 
@@ -950,7 +950,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
         $qb->join('alias1.articles', 'alias2');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('alias1.field', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('alias2.field', 'value2'));
 
@@ -968,7 +968,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
         $qb->join('alias1.articles', 'alias2');
 
-        $criteria = new Criteria();
+        $criteria = Criteria::create(true);
         $criteria->where($criteria->expr()->eq('alias1.field', 'value1'));
         $criteria->andWhere($criteria->expr()->gt('alias2.field', 'value2'));
         $criteria->andWhere($criteria->expr()->lt('alias2.field', 'value3'));


### PR DESCRIPTION
This updates the code to avoid triggering the deprecation introduced in https://github.com/doctrine/collections/pull/472.

Closes #12237.