### PR TITLE
fix: handling of empty array in SQL condition generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "doctrine/coding-standard": "^9.0.2 || ^14.0",
         "phpbench/phpbench": "^0.16.10 || ^1.0",
         "phpstan/extension-installer": "~1.1.0 || ^1.4",
-        "phpstan/phpstan": "~1.4.10 || 2.1.22",
+        "phpstan/phpstan": "~1.4.10 || 2.1.23",
         "phpstan/phpstan-deprecation-rules": "^1 || ^2",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
         "psr/log": "^1 || ^2 || ^3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1057,6 +1057,12 @@ parameters:
 			path: src/Internal/HydrationCompleteHandler.php
 
 		-
+			message: '#^Offset int\|null might not exist on array\<int, object\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Internal/StronglyConnectedComponents.php
+
+		-
 			message: '#^Property Doctrine\\ORM\\Internal\\StronglyConnectedComponents\:\:\$representingNodes \(array\<int, object\>\) does not accept array\<int\|string, object\>\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -3594,7 +3600,7 @@ parameters:
 		-
 			message: '#^Property Doctrine\\ORM\\Query\\Filter\\SQLFilter\:\:\$parameters \(array\<string, array\{type\: string, value\: mixed, is_list\: bool\}\>\) does not accept non\-empty\-array\<string, array\{value\: mixed, type\: int\|string, is_list\: bool\}\>\.$#'
 			identifier: assign.propertyType
-			count: 1
+			count: 2
 			path: src/Query/Filter/SQLFilter.php
 
 		-
@@ -4174,12 +4180,6 @@ parameters:
 			path: src/Tools/Console/Command/ConvertMappingCommand.php
 
 		-
-			message: '#^Parameter \#2 \$destPath of method Doctrine\\ORM\\Tools\\Console\\Command\\ConvertMappingCommand\:\:getExporter\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/Console/Command/ConvertMappingCommand.php
-
-		-
 			message: '#^Access to an undefined property Doctrine\\Persistence\\Mapping\\ClassMetadata\:\:\$name\.$#'
 			identifier: property.notFound
 			count: 1
@@ -4204,12 +4204,6 @@ parameters:
 			path: src/Tools/Console/Command/GenerateEntitiesCommand.php
 
 		-
-			message: '#^Parameter \#2 \$outputDirectory of method Doctrine\\ORM\\Tools\\EntityGenerator\:\:generate\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/Console/Command/GenerateEntitiesCommand.php
-
-		-
 			message: '#^Access to an undefined property Doctrine\\Persistence\\Mapping\\ClassMetadata\:\:\$name\.$#'
 			identifier: property.notFound
 			count: 1
@@ -4228,12 +4222,6 @@ parameters:
 			path: src/Tools/Console/Command/GenerateProxiesCommand.php
 
 		-
-			message: '#^Parameter \#2 \$proxyDir of method Doctrine\\ORM\\Proxy\\ProxyFactory\:\:generateProxyClasses\(\) expects string\|null, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/Console/Command/GenerateProxiesCommand.php
-
-		-
 			message: '#^Access to an undefined property Doctrine\\Persistence\\Mapping\\ClassMetadata\:\:\$customRepositoryClassName\.$#'
 			identifier: property.notFound
 			count: 1
@@ -4247,12 +4235,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$filename of function is_writable expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/Console/Command/GenerateRepositoriesCommand.php
-
-		-
-			message: '#^Parameter \#2 \$outputDirectory of method Doctrine\\ORM\\Tools\\EntityRepositoryGenerator\:\:writeEntityRepositoryClass\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Tools/Console/Command/GenerateRepositoriesCommand.php

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1753,6 +1753,11 @@ class BasicEntityPersister implements EntityPersister
                     $value = [$value];
                 }
 
+                if (empty($value)) {
+                    $selectedColumns[] = $column . ' IN (NULL)';
+                    continue;
+                }
+
                 $nullKeys      = array_keys($value, null, true);
                 $nonNullValues = array_diff_key($value, array_flip($nullKeys));
 
@@ -1760,6 +1765,7 @@ class BasicEntityPersister implements EntityPersister
 
                 $in = $column . ' ' . sprintf(self::$comparisonMap[$comparison], $placeholders);
 
+                // @phpstan-ignore if.alwaysTrue (false positive)
                 if ($nullKeys) {
                     if ($nonNullValues) {
                         $selectedColumns[] = sprintf('(%s OR %s IS NULL)', $in, $column);

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1753,7 +1753,7 @@ class BasicEntityPersister implements EntityPersister
                     $value = [$value];
                 }
 
-                if (empty($value)) {
+                if ($value === []) {
                     $selectedColumns[] = $column . ' IN (NULL)';
                     continue;
                 }

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1765,7 +1765,6 @@ class BasicEntityPersister implements EntityPersister
 
                 $in = $column . ' ' . sprintf(self::$comparisonMap[$comparison], $placeholders);
 
-                // @phpstan-ignore if.alwaysTrue (false positive)
                 if ($nullKeys) {
                     if ($nonNullValues) {
                         $selectedColumns[] = sprintf('(%s OR %s IS NULL)', $in, $column);

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1754,7 +1754,7 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 if ($value === []) {
-                    $selectedColumns[] = $column . ' IN (NULL)';
+                    $selectedColumns[] = '1=0';
                     continue;
                 }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH12254Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12254Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12254Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH12254EntityA::class,
+        ]);
+
+        $this->_em->persist(new GH12254EntityA());
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testFindByEmptyArrayShouldReturnEmptyArray(): void
+    {
+        // pretend we are starting afresh
+        $this->_em = $this->getEntityManager();
+        $result    = $this->_em->getRepository(GH12254EntityA::class)->findBy(['id' => []]);
+        $this->assertEmpty($result);
+    }
+}
+
+/**
+ * @Entity()
+ */
+class GH12254EntityA
+{
+    /**
+     * @Column(type="integer")
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    public $id;
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12254Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12254Test.php
@@ -32,6 +32,13 @@ class GH12254Test extends OrmFunctionalTestCase
         $result    = $this->_em->getRepository(GH12254EntityA::class)->findBy(['id' => []]);
         $this->assertEmpty($result);
     }
+
+    public function testFindByInNullableField(): void
+    {
+        $this->_em = $this->getEntityManager();
+        $result    = $this->_em->getRepository(GH12254EntityA::class)->findBy(['name' => []]);
+        $this->assertEmpty($result);
+    }
 }
 
 /**
@@ -46,4 +53,10 @@ class GH12254EntityA
      * @var int
      */
     public $id;
+
+    /**
+     * @Column(type="string", nullable=true)
+     * @var string|null
+     */
+    public $name = null;
 }

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -153,6 +153,15 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
         );
     }
 
+    /** @group GH12254 */
+    public function testSelectConditionStatementWithValuesIsEmptyArray(): void
+    {
+        self::assertEquals(
+            't0.id IN (NULL)',
+            $this->persister->getSelectConditionStatementSQL('id', [])
+        );
+    }
+
     public function testCountCondition(): void
     {
         $persister = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(NonAlphaColumnsEntity::class));

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -129,7 +129,10 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
         self::assertEquals('test IS NOT NULL', $statement);
     }
 
-    /** @group DDC-3056 */
+    /**
+     * @group DDC-3056
+     * @group GH12254
+     */
     public function testSelectConditionStatementWithMultipleValuesContainingNull(): void
     {
         self::assertEquals(
@@ -151,13 +154,9 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
             '(t0.id IN (?, ?) OR t0.id IS NULL)',
             $this->persister->getSelectConditionStatementSQL('id', [123, null, 234])
         );
-    }
 
-    /** @group GH12254 */
-    public function testSelectConditionStatementWithValuesIsEmptyArray(): void
-    {
         self::assertEquals(
-            't0.id IN (NULL)',
+            '1=0',
             $this->persister->getSelectConditionStatementSQL('id', [])
         );
     }


### PR DESCRIPTION
Fix a regression introduced in #12190: `$repository->findBy(['uuid' => []]` should be a valid expression and return an empty result.

Fixes #12245, with additional discussion at https://github.com/doctrine/orm/pull/12190#issuecomment-3455298734.