### PR TITLE
Address default expression deprecation

### DIFF
--- a/tests/Tests/ORM/Functional/DefaultTimeExpressionTest.php
+++ b/tests/Tests/ORM/Functional/DefaultTimeExpressionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class DefaultTimeExpressionTest extends OrmFunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    public function testUsingTimeRelatedDefaultExpressionCausesNoDbalDeprecation(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $this->createSchemaForModels(TimeEntity::class);
+    }
+}
+
+#[ORM\Entity]
+class TimeEntity
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    public int $id;
+
+    #[ORM\Column(options: ['default' => 'CURRENT_TIMESTAMP'])]
+    public DateTime $createdAt;
+
+    #[ORM\Column(options: ['default' => 'CURRENT_TIMESTAMP'])]
+    public DateTimeImmutable $createdAtImmutable;
+
+    #[ORM\Column(options: ['default' => 'CURRENT_TIME'])]
+    public DateTime $createdTime;
+
+    #[ORM\Column(options: ['default' => 'CURRENT_DATE'])]
+    public DateTime $createdDate;
+}


### PR DESCRIPTION
This addresses the deprecation introduced in
https://github.com/doctrine/dbal/pull/7195

A follow-up should be to deprecate not using these value objects in field mappings, so that we do not just reproduce the same checks that the DBAL wants to remove.

Relates to #12252