### PR TITLE
Add hints to QueryBuilder

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -555,6 +555,24 @@ using ``addCriteria``:
     $qb->addCriteria($criteria);
     // then execute your query like normal
 
+Adding hints to a Query
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also set query hints to a QueryBuilder by using ``setHint``:
+
+.. code-block:: php
+
+    <?php
+    // ...
+
+    // $qb instanceof QueryBuilder
+    $qb->setHint('hintName', 'hintValue');
+    // then execute your query like normal
+
+The query hint can hold anything the usual query hints can hold
+except null. Those hints will be applied to the query when the
+query is created.
+
 Low Level API
 ^^^^^^^^^^^^^
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -118,6 +118,13 @@ class QueryBuilder implements Stringable
     private int $boundCounter = 0;
 
     /**
+     * The hints to set on the query.
+     *
+     * @var array<string, string|int|bool|iterable<mixed>|object>
+     */
+    private array $hints = [];
+
+    /**
      * Initializes a new <tt>QueryBuilder</tt> that uses the given <tt>EntityManager</tt>.
      *
      * @param EntityManagerInterface $em The EntityManager to use.
@@ -208,6 +215,39 @@ class QueryBuilder implements Stringable
         return $this;
     }
 
+    /** @return array<string, string|int|bool|iterable<mixed>|object> */
+    public function getHints(): array
+    {
+        return $this->hints;
+    }
+
+    /**
+     * Gets the value of a query hint. If the hint name is not recognized, FALSE is returned.
+     *
+     * @return mixed The value of the hint or FALSE, if the hint name is not recognized.
+     */
+    public function getHint(string $name): mixed
+    {
+        return $this->hints[$name] ?? false;
+    }
+
+    public function hasHint(string $name): bool
+    {
+        return isset($this->hints[$name]);
+    }
+
+    /**
+     * Adds hints for the query.
+     *
+     * @return $this
+     */
+    public function setHint(string $name, mixed $value): static
+    {
+        $this->hints[$name] = $value;
+
+        return $this;
+    }
+
     /** @phpstan-return Cache::MODE_*|null */
     public function getCacheMode(): int|null
     {
@@ -286,6 +326,10 @@ class QueryBuilder implements Stringable
 
         if ($this->cacheRegion) {
             $query->setCacheRegion($this->cacheRegion);
+        }
+
+        foreach ($this->hints as $name => $value) {
+            $query->setHint($name, $value);
         }
 
         return $query;

--- a/tests/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Tests/ORM/QueryBuilderTest.php
@@ -24,6 +24,7 @@ use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
@@ -1374,5 +1375,100 @@ class QueryBuilderTest extends OrmTestCase
         };
 
         $qb->test();
+    }
+
+    #[DataProvider('provideHint')]
+    public function testSingleHint(mixed $expected): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'u')
+            ->select('u.id', 'u.username')
+            ->setHint('foo', $expected);
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        $query = $qb->getQuery();
+        self::assertTrue($query->hasHint('foo'));
+        self::assertEquals($expected, $query->getHint('foo'));
+    }
+
+    public static function provideHint(): array
+    {
+        return [
+            ['bar'],
+            [new CmsUser()],
+            [['a','b','c']],
+            [1],
+            [true],
+        ];
+    }
+
+    public function testMultipleHints(): void
+    {
+        $object = new CmsUser();
+        $qb     = $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'u')
+            ->select('u.id', 'u.username')
+            ->setHint('string', 'bar')
+            ->setHint('object', $object)
+            ->setHint('array', ['a', 'b', 'c'])
+            ->setHint('int', 5)
+            ->setHint('bool', true);
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        $query = $qb->getQuery();
+        self::assertTrue($query->hasHint('string'));
+        self::assertTrue($query->hasHint('object'));
+        self::assertTrue($query->hasHint('array'));
+        self::assertTrue($query->hasHint('int'));
+        self::assertTrue($query->hasHint('bool'));
+
+        self::assertEquals('bar', $query->getHint('string'));
+        self::assertInstanceOf(CmsUser::class, $query->getHint('object'));
+        self::assertEquals(['a', 'b', 'c'], $query->getHint('array'));
+        self::assertEquals(5, $query->getHint('int'));
+        self::assertTrue($query->getHint('bool'));
+    }
+
+    public function testHasHint(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'u')
+            ->select('u.id', 'u.username')
+            ->setHint('foo', 'bar');
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        self::assertTrue($qb->hasHint('foo'));
+    }
+
+    public function testGetHint(): void
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'u')
+            ->select('u.id', 'u.username')
+            ->setHint('foo', 'bar');
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        self::assertEquals('bar', $qb->getHint('foo'));
+    }
+
+    public function testGetHints(): void
+    {
+        $object = new CmsUser();
+        $qb     = $this->entityManager->createQueryBuilder()
+            ->delete(CmsUser::class, 'u')
+            ->select('u.id', 'u.username')
+            ->setHint('string', 'bar')
+            ->setHint('object', $object)
+            ->setHint('array', ['a', 'b', 'c'])
+            ->setHint('int', 5)
+            ->setHint('bool', true);
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        self::assertCount(5, $qb->getHints('foo'));
     }
 }


### PR DESCRIPTION
### Context
Doctrine offers with the Query class to add hints to the query which open the door to some more features regarding customizing queries. Currently hints can only be set on the query itself which covers 99% of cases to utilize that feature but in some cases only the QueryBuilder is available.

### The problem
When working with a custom SqlOutputWalker a hint needs to be set on the query to trigger the walker and apply the logic to the query. In some instances that is impossible like e.g. when working with Symfony Form Extensions where only the QueryBuilder is available and yes you could also call get query but prebuilding the query is not always an option because of a lot of side effects and other sql manipulation. 
Other devs also mentioned this option as a nice to have in #11849 or [symfony #37582](https://github.com/symfony/symfony/issues/37582).

### Possible solution
In this PR I explore the implementation of  a hint param in the QueryBuilder to hold hints that should be applied to the query when it is created.

I am unsure what I could possibly break and hope that this suggestion at least opens up the discussion to widen the possibilities of hints.