### PR TITLE
Deprecate FieldMapping::$default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,11 @@ and directly start using native lazy objects.
 
 # Upgrade to 3.6
 
+## Deprecate `FieldMapping::$default`
+
+The `default` property of `Doctrine\ORM\Mapping\FieldMapping` is deprecated and
+will be removed in 4.0. Instead, use `FieldMapping::$options['default']`.
+
 ## Deprecate specifying `nullable` on columns that end up being used in a primary key
 
 Specifying `nullable` on join columns that are part of a primary key is

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2480,9 +2480,9 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         if (! isset($mapping['default'])) {
             if (in_array($mapping['type'], ['integer', 'bigint', 'smallint'], true)) {
-                $mapping['default'] = 1;
+                $mapping['options']['default'] = 1;
             } elseif ($mapping['type'] === 'datetime') {
-                $mapping['default'] = 'CURRENT_TIMESTAMP';
+                $mapping['options']['default'] = 'CURRENT_TIMESTAMP';
             } else {
                 throw MappingException::unsupportedOptimisticLockingType($this->name, $mapping['fieldName'], $mapping['type']);
             }

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -71,7 +71,9 @@ final class FieldMapping implements ArrayAccess
     public string|null $declaredField = null;
     public array|null $options        = null;
     public bool|null $version         = null;
-    public string|int|null $default   = null;
+
+    /** @deprecated Use options with 'default' key instead */
+    public string|int|null $default = null;
 
     /**
      * @param string $type       The type name of the mapped field. Can be one of

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -484,7 +484,9 @@ class SchemaTool
             $options['scale'] = $mapping->scale;
         }
 
+        /** @phpstan-ignore property.deprecated */
         if (isset($mapping->default)) {
+            /** @phpstan-ignore property.deprecated */
             $options['default'] = $mapping->default;
         }
 

--- a/tests/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -247,7 +247,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
             FieldMapping::fromMappingArray([
                 'columnDefinition' => 'foobar',
                 'columnName' => 'username',
-                'default' => 1,
+                'options' => ['default' => 1],
                 'fieldName' => 'name',
                 'length' => 124,
                 'type' => 'integer',


### PR DESCRIPTION
Its purpose is unclear since there is `FieldMapping::$options['default']` already.