### PR TITLE
FIX: Handle int-backed enums for values stored as string values in MySQL ENUM columns

### DIFF
--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -604,6 +604,9 @@ abstract class AbstractHydrator
             );
         }
 
+        $reflection = new \ReflectionEnum($enumType);
+        $value =  $reflection->isBacked() && $reflection->getBackingType()?->getName() === 'int' ? (int) $value : $value;
+
         return $enumType::from($value);
     }
 }

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\UnitOfWork;
 use Generator;
 use LogicException;
 use ReflectionClass;
+use ReflectionEnum;
 
 use function array_key_exists;
 use function array_keys;
@@ -604,8 +605,8 @@ abstract class AbstractHydrator
             );
         }
 
-        $reflection = new \ReflectionEnum($enumType);
-        $value =  $reflection->isBacked() && $reflection->getBackingType()?->getName() === 'int' ? (int) $value : $value;
+        $reflection = new ReflectionEnum($enumType);
+        $value      =  $reflection->isBacked() && $reflection->getBackingType()->getName() === 'int' ? (int) $value : $value;
 
         return $enumType::from($value);
     }

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -598,15 +598,17 @@ abstract class AbstractHydrator
      */
     final protected function buildEnum(mixed $value, string $enumType): BackedEnum|array
     {
+        $reflection  = new ReflectionEnum($enumType);
+        $isIntBacked = $reflection->isBacked() && $reflection->getBackingType()->getName() === 'int';
+
         if (is_array($value)) {
             return array_map(
-                static fn ($value) => $enumType::from($value),
+                static fn ($value) => $enumType::from($isIntBacked ? (int) $value : $value),
                 $value,
             );
         }
 
-        $reflection = new ReflectionEnum($enumType);
-        $value      =  $reflection->isBacked() && $reflection->getBackingType()->getName() === 'int' ? (int) $value : $value;
+        $value = $isIntBacked ? (int) $value : $value;
 
         return $enumType::from($value);
     }

--- a/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use BackedEnum;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -12,6 +13,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Tests\Models\Enums\AccessLevel;
+use Doctrine\Tests\Models\Enums\UserStatus;
 use Doctrine\Tests\Models\Hydration\SimpleEntity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use LogicException;
@@ -144,6 +147,24 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
         $this->hydrator->hydrateAll($this->mockResult, $this->mockResultMapping);
     }
 
+    public function testEnumCastsIntegerBackedEnumValues(): void
+    {
+        $accessLevel = $this->hydrator->buildEnumForTesting('2', AccessLevel::class);
+        $userStatus  = $this->hydrator->buildEnumForTesting('active', UserStatus::class);
+
+        self::assertSame(AccessLevel::User, $accessLevel);
+        self::assertSame(UserStatus::Active, $userStatus);
+    }
+
+    public function testEnumCastsIntegerBackedEnumArrayValues(): void
+    {
+        $accessLevels = $this->hydrator->buildEnumForTesting(['1', '2'], AccessLevel::class);
+        $userStatus   = $this->hydrator->buildEnumForTesting(['active', 'inactive'], UserStatus::class);
+
+        self::assertSame([AccessLevel::Admin, AccessLevel::User], $accessLevels);
+        self::assertSame([UserStatus::Active, UserStatus::Inactive], $userStatus);
+    }
+
     public function testToIterableIfYieldAndBreakBeforeFinishAlwaysCleansUp(): void
     {
         $this->setUpEntitySchema([SimpleEntity::class]);
@@ -177,6 +198,11 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
 class DummyHydrator extends AbstractHydrator
 {
     public bool $throwException = false;
+
+    public function buildEnumForTesting(mixed $value, string $enumType): BackedEnum|array
+    {
+        return $this->buildEnum($value, $enumType);
+    }
 
     /** @return array{} */
     protected function hydrateAllData(): array


### PR DESCRIPTION
Related issue: doctrine#12274