### PR TITLE
Deprecate string default expressions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,95 @@ and directly start using native lazy objects.
 
 # Upgrade to 3.6
 
+## Deprecate using string expression for default values in mappings
+
+Using a string expression for default values in field mappings is deprecated.
+Use `Doctrine\DBAL\Schema\DefaultExpression` instances instead.
+
+Here is how to address this deprecation when mapping entities using PHP attributes:
+
+```diff
+ use DateTime;
++use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
++use Doctrine\DBAL\Schema\DefaultExpression\CurrentTime;
++use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
+ use Doctrine\ORM\Mapping as ORM;
+
+ #[ORM\Entity]
+ final class TimeEntity
+ {
+     #[ORM\Id]
+     #[ORM\Column]
+     public int $id;
+
+-    #[ORM\Column(options: ['default' => 'CURRENT_TIMESTAMP'], insertable: false, updatable: false)]
++    #[ORM\Column(options: ['default' => new CurrentTimestamp()], insertable: false, updatable: false)]
+     public DateTime $createdAt;
+
+-    #[ORM\Column(options: ['default' => 'CURRENT_TIME'], insertable: false, updatable: false)]
++    #[ORM\Column(options: ['default' => new CurrentTime()], insertable: false, updatable: false)]
+     public DateTime $createdTime;
+
+-    #[ORM\Column(options: ['default' => 'CURRENT_DATE'], insertable: false, updatable: false)]
++    #[ORM\Column(options: ['default' => new CurrentDate()], insertable: false, updatable: false)]
+     public DateTime $createdDate;
+ }
+```
+
+Here is how to do the same when mapping entities using XML:
+
+```diff
+ <?xml version="1.0" encoding="UTF-8"?>
+
+ <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                           https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+     <entity name="Doctrine\Tests\ORM\Functional\XmlTimeEntity">
+         <id name="id" type="integer" column="id">
+             <generator strategy="AUTO"/>
+         </id>
+
+         <field name="createdAt" type="datetime" insertable="false" updatable="false">
+             <options>
+-                <option name="default">CURRENT_TIMESTAMP</option>
++                <option name="default">
++                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
++                </option>
+             </options>
+         </field>
+
+         <field name="createdAtImmutable" type="datetime_immutable" insertable="false" updatable="false">
+             <options>
+-                <option name="default">CURRENT_TIMESTAMP</option>
++                <option name="default">
++                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
++                </option>
+             </options>
+         </field>
+
+         <field name="createdTime" type="time" insertable="false" updatable="false">
+             <options>
+-                <option name="default">CURRENT_TIME</option>
++                <option name="default">
++                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTime"/>
++                </option>
+             </options>
+         </field>
+         <field name="createdDate" type="date" insertable="false" updatable="false">
+             <options>
+-                <option name="default">CURRENT_DATE</option>
++                <option name="default">
++                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentDate"/>
++                </option>
+             </options>
+         </field>
+     </entity>
+ </doctrine-mapping>
+```
+
+
 ## Deprecate `FieldMapping::$default`
 
 The `default` property of `Doctrine\ORM\Mapping\FieldMapping` is deprecated and

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -190,6 +190,22 @@ PHP class, Doctrine also allows you to specify default values for
 database columns using the ``default`` key in the ``options`` array of
 the ``Column`` attribute.
 
+When using XML, you can specify object instances using the ``<object>``
+element:
+
+.. code-block:: xml
+
+    <field name="createdAt" type="datetime" insertable="false" updatable="false">
+        <options>
+            <option name="default">
+                <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
+            </option>
+        </options>
+    </field>
+
+The ``<object>`` element requires a ``class`` attribute specifying the
+fully qualified class name to instantiate.
+
 .. configuration-block::
    .. literalinclude:: basic-mapping/DefaultValues.php
        :language: attribute

--- a/docs/en/reference/basic-mapping/DefaultValues.php
+++ b/docs/en/reference/basic-mapping/DefaultValues.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use DateTime;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 
@@ -12,4 +14,7 @@ class Message
 {
     #[Column(options: ['default' => 'Hello World!'])]
     private string $text;
+
+    #[Column(options: ['default' => new CurrentTimestamp()], insertable: false, updatable: false)]
+    private DateTime $createdAt;
 }

--- a/docs/en/reference/basic-mapping/default-values.xml
+++ b/docs/en/reference/basic-mapping/default-values.xml
@@ -5,5 +5,12 @@
         <option name="default">Hello World!</option>
       </options>
     </field>
+    <field name="createdAt" insertable="false" updatable="false">
+      <options>
+        <option name="default">
+            <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
+        </option>
+      </options>
+    </field>
   </entity>
 </doctrine-mapping>

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -155,10 +155,20 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:complexType name="object">
+    <xs:attribute name="class" type="xs:string" use="required"/>
+    <xs:anyAttribute namespace="##other"/>
+  </xs:complexType>
+
   <xs:complexType name="option" mixed="true">
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="option" type="orm:option"/>
-      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    <xs:choice minOccurs="0" maxOccurs="1">
+      <xs:element name="object" type="orm:object"/>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="option" type="orm:option"/>
+          <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+        </xs:choice>
+      </xs:sequence>
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
     <xs:anyAttribute namespace="##other"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1441,7 +1441,7 @@ parameters:
 			path: src/Mapping/Driver/XmlDriver.php
 
 		-
-			message: '#^Parameter \#1 \$columnDef of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:setDiscriminatorColumn\(\) expects array\{name\: string\|null, fieldName\?\: string\|null, type\?\: string\|null, length\?\: int\|null, columnDefinition\?\: string\|null, enumType\?\: class\-string\<BackedEnum\>\|null, options\?\: array\<string, mixed\>\|null\}\|Doctrine\\ORM\\Mapping\\DiscriminatorColumnMapping\|null, array\{name\: string\|null, type\: string, length\: int, columnDefinition\: string\|null, enumType\: string\|null, options\?\: array\<int\|string, array\<int\|string, mixed\>\|bool\|string\>\} given\.$#'
+			message: '#^Parameter \#1 \$columnDef of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:setDiscriminatorColumn\(\) expects array\{name\: string\|null, fieldName\?\: string\|null, type\?\: string\|null, length\?\: int\|null, columnDefinition\?\: string\|null, enumType\?\: class\-string\<BackedEnum\>\|null, options\?\: array\<string, mixed\>\|null\}\|Doctrine\\ORM\\Mapping\\DiscriminatorColumnMapping\|null, array\{name\: string\|null, type\: string, length\: int, columnDefinition\: string\|null, enumType\: string\|null, options\?\: array\<int\|string, array\<int\|string, mixed\>\|bool\|object\|string\>\} given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/Driver/XmlDriver.php
@@ -1471,7 +1471,7 @@ parameters:
 			path: src/Mapping/Driver/XmlDriver.php
 
 		-
-			message: '#^Property Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:\$table \(array\{name\: string, schema\?\: string, indexes\?\: array, uniqueConstraints\?\: array, options\?\: array\<string, mixed\>, quoted\?\: bool\}\) does not accept array\{name\: string, schema\?\: string, indexes\?\: array, uniqueConstraints\?\: array, options\: array\<int\|string, array\<int\|string, mixed\>\|bool\|string\>, quoted\?\: bool\}\.$#'
+			message: '#^Property Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:\$table \(array\{name\: string, schema\?\: string, indexes\?\: array, uniqueConstraints\?\: array, options\?\: array\<string, mixed\>, quoted\?\: bool\}\) does not accept array\{name\: string, schema\?\: string, indexes\?\: array, uniqueConstraints\?\: array, options\: array\<int\|string, array\<int\|string, mixed\>\|bool\|object\|string\>, quoted\?\: bool\}\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Mapping/Driver/XmlDriver.php

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -16,6 +16,7 @@ use LogicException;
 use SimpleXMLElement;
 
 use function assert;
+use function class_exists;
 use function constant;
 use function count;
 use function defined;
@@ -656,15 +657,30 @@ class XmlDriver extends FileDriver
      * Parses (nested) option elements.
      *
      * @return mixed[] The options array.
-     * @phpstan-return array<int|string, array<int|string, mixed|string>|bool|string>
+     * @phpstan-return array<int|string, array<int|string, mixed|string>|bool|string|object>
      */
     private function parseOptions(SimpleXMLElement|null $options): array
     {
         $array = [];
 
         foreach ($options ?? [] as $option) {
+            $value = null;
             if ($option->count()) {
-                $value = $this->parseOptions($option->children());
+                // Check if this option contains an <object> element
+                $children         = $option->children();
+                $hasObjectElement = false;
+
+                foreach ($children as $child) {
+                    if ($child->getName() === 'object') {
+                        $value            = $this->parseObjectElement($child);
+                        $hasObjectElement = true;
+                        break;
+                    }
+                }
+
+                if (! $hasObjectElement) {
+                    $value = $this->parseOptions($children);
+                }
             } else {
                 $value = (string) $option;
             }
@@ -682,6 +698,33 @@ class XmlDriver extends FileDriver
         }
 
         return $array;
+    }
+
+    /**
+     * Parses an <object> element and returns the instantiated object.
+     *
+     * @param SimpleXMLElement $objectElement The XML element.
+     *
+     * @return object The instantiated object.
+     *
+     * @throws MappingException If the object specification is invalid.
+     * @throws InvalidArgumentException If the class does not exist.
+     */
+    private function parseObjectElement(SimpleXMLElement $objectElement): object
+    {
+        $attributes = $objectElement->attributes();
+
+        if (! isset($attributes->class)) {
+            throw MappingException::missingRequiredOption('object', 'class');
+        }
+
+        $className = (string) $attributes->class;
+
+        if (! class_exists($className)) {
+            throw new InvalidArgumentException(sprintf('Class "%s" does not exist', $className));
+        }
+
+        return new $className();
     }
 
     /**

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -507,6 +508,16 @@ class SchemaTool
                 ], true)
                 && $options['default'] === $this->platform->getCurrentTimestampSQL()
             ) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/12252',
+                    <<<'DEPRECATION'
+                    Using "%s" as a default value for datetime fields is deprecated and
+                    will not be supported in Doctrine ORM 4.0.
+                    Pass a `Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp` instance instead.
+                    DEPRECATION,
+                    $this->platform->getCurrentTimestampSQL(),
+                );
                 $options['default'] = new CurrentTimestamp();
             }
 
@@ -514,6 +525,16 @@ class SchemaTool
                 in_array($mapping->type, [Types::TIME_MUTABLE, Types::TIME_IMMUTABLE], true)
                 && $options['default'] === $this->platform->getCurrentTimeSQL()
             ) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/12252',
+                    <<<'DEPRECATION'
+                    Using "%s" as a default value for time fields is deprecated and
+                    will not be supported in Doctrine ORM 4.0.
+                    Pass a `Doctrine\DBAL\Schema\DefaultExpression\CurrentTime` instance instead.
+                    DEPRECATION,
+                    $this->platform->getCurrentTimeSQL(),
+                );
                 $options['default'] = new CurrentTime();
             }
 
@@ -521,6 +542,16 @@ class SchemaTool
                 in_array($mapping->type, [Types::DATE_MUTABLE, Types::DATE_IMMUTABLE], true)
                 && $options['default'] === $this->platform->getCurrentDateSQL()
             ) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/12252',
+                    <<<'DEPRECATION'
+                    Using "%s" as a default value for date fields is deprecated and
+                    will not be supported in Doctrine ORM 4.0.
+                    Pass a `Doctrine\DBAL\Schema\DefaultExpression\CurrentDate` instance instead.
+                    DEPRECATION,
+                    $this->platform->getCurrentDateSQL(),
+                );
                 $options['default'] = new CurrentDate();
             }
         }

--- a/tests/Tests/ORM/Functional/DefaultTimeExpressionTest.php
+++ b/tests/Tests/ORM/Functional/DefaultTimeExpressionTest.php
@@ -6,20 +6,148 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\DefaultExpression;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTime;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+
+use function interface_exists;
 
 class DefaultTimeExpressionTest extends OrmFunctionalTestCase
 {
     use VerifyDeprecations;
 
-    public function testUsingTimeRelatedDefaultExpressionCausesNoDbalDeprecation(): void
+    #[IgnoreDeprecations]
+    #[RequiresMethod(DefaultExpression::class, 'toSQL')]
+    public function testUsingTimeRelatedDefaultExpressionCausesAnOrmDeprecationAndNoDbalDeprecation(): void
     {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if (
+            $platform->getCurrentTimestampSQL() !== 'CURRENT_TIMESTAMP'
+            || $platform->getCurrentTimeSQL() !== 'CURRENT_TIME'
+            || $platform->getCurrentDateSQL() !== 'CURRENT_DATE'
+        ) {
+            $this->markTestSkipped(
+                'This test requires platforms to support exactly CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE.',
+            );
+        }
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped(
+                'MySQL platform does not support CURRENT_TIME or CURRENT_DATE as default expression.',
+            );
+        }
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12252');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $this->createSchemaForModels(LegacyTimeEntity::class);
+        $this->_em->persist($entity = new LegacyTimeEntity());
+        $this->_em->flush();
+        $this->_em->find(LegacyTimeEntity::class, $entity->id);
+    }
+
+    public function testNoDeprecationsAreTrownWhenTheyCannotBeAddressed(): void
+    {
+        if (interface_exists(DefaultExpression::class)) {
+            $this->markTestSkipped(
+                'This test requires Doctrine DBAL 4.3 or lower.',
+            );
+        }
+
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if (
+            $platform->getCurrentTimestampSQL() !== 'CURRENT_TIMESTAMP'
+            || $platform->getCurrentTimeSQL() !== 'CURRENT_TIME'
+            || $platform->getCurrentDateSQL() !== 'CURRENT_DATE'
+        ) {
+            $this->markTestSkipped(
+                'This test requires platforms to support exactly CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE.',
+            );
+        }
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped(
+                'MySQL platform does not support CURRENT_TIME or CURRENT_DATE as default expression.',
+            );
+        }
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12252');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $this->createSchemaForModels(LegacyTimeEntity::class);
+        $this->_em->persist($entity = new LegacyTimeEntity());
+        $this->_em->flush();
+        $this->_em->find(LegacyTimeEntity::class, $entity->id);
+    }
+
+    #[RequiresMethod(DefaultExpression::class, 'toSQL')]
+    public function testUsingDefaultExpressionInstancesCausesNoDeprecation(): void
+    {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped('MySQL platform does not support CURRENT_TIME or CURRENT_DATE as default expression.');
+        }
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12252');
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
 
         $this->createSchemaForModels(TimeEntity::class);
+        $this->_em->persist($entity = new TimeEntity());
+        $this->_em->flush();
+        $this->_em->find(TimeEntity::class, $entity->id);
     }
+}
+
+#[ORM\Entity]
+class LegacyTimeEntity
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Column(
+        type: Types::DATETIME_MUTABLE,
+        options: ['default' => 'CURRENT_TIMESTAMP'],
+        insertable: false,
+        updatable: false,
+    )]
+    public DateTime $createdAt;
+
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        options: ['default' => 'CURRENT_TIMESTAMP'],
+        insertable: false,
+        updatable: false,
+    )]
+    public DateTimeImmutable $createdAtImmutable;
+
+    #[ORM\Column(
+        type: Types::TIME_MUTABLE,
+        options: ['default' => 'CURRENT_TIME'],
+        insertable: false,
+        updatable: false,
+    )]
+    public DateTime $createdTime;
+
+    #[ORM\Column(
+        type: Types::DATE_MUTABLE,
+        options: ['default' => 'CURRENT_DATE'],
+        insertable: false,
+        updatable: false,
+    )]
+    public DateTime $createdDate;
 }
 
 #[ORM\Entity]
@@ -27,17 +155,38 @@ class TimeEntity
 {
     #[ORM\Id]
     #[ORM\Column]
+    #[ORM\GeneratedValue]
     public int $id;
 
-    #[ORM\Column(options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(
+        type: Types::DATETIME_MUTABLE,
+        options: ['default' => new CurrentTimestamp()],
+        insertable: false,
+        updatable: false,
+    )]
     public DateTime $createdAt;
 
-    #[ORM\Column(options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        options: ['default' => new CurrentTimestamp()],
+        insertable: false,
+        updatable: false,
+    )]
     public DateTimeImmutable $createdAtImmutable;
 
-    #[ORM\Column(options: ['default' => 'CURRENT_TIME'])]
+    #[ORM\Column(
+        type: Types::TIME_MUTABLE,
+        options: ['default' => new CurrentTime()],
+        insertable: false,
+        updatable: false,
+    )]
     public DateTime $createdTime;
 
-    #[ORM\Column(options: ['default' => 'CURRENT_DATE'])]
+    #[ORM\Column(
+        type: Types::DATE_MUTABLE,
+        options: ['default' => new CurrentDate()],
+        insertable: false,
+        updatable: false,
+    )]
     public DateTime $createdDate;
 }

--- a/tests/Tests/ORM/Functional/DefaultTimeExpressionXmlTest.php
+++ b/tests/Tests/ORM/Functional/DefaultTimeExpressionXmlTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\DefaultExpression;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+
+class DefaultTimeExpressionXmlTest extends OrmFunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    #[IgnoreDeprecations]
+    #[RequiresMethod(DefaultExpression::class, 'toSQL')]
+    public function testUsingTimeRelatedDefaultExpressionCausesAnOrmDeprecationAndNoDbalDeprecation(): void
+    {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if (
+            $platform->getCurrentTimestampSQL() !== 'CURRENT_TIMESTAMP'
+            || $platform->getCurrentTimeSQL() !== 'CURRENT_TIME'
+            || $platform->getCurrentDateSQL() !== 'CURRENT_DATE'
+        ) {
+            $this->markTestSkipped('Platform does not use standard SQL for current time expressions.');
+        }
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped(
+                'MySQL platform does not support CURRENT_TIME or CURRENT_DATE as default expression.',
+            );
+        }
+
+        $this->_em         = $this->getEntityManager(
+            mappingDriver: new XmlDriver(__DIR__ . '/../Mapping/xml/'),
+        );
+        $this->_schemaTool = new SchemaTool($this->_em);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12252');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $this->createSchemaForModels(XmlLegacyTimeEntity::class);
+        $this->_em->persist($entity = new XmlLegacyTimeEntity());
+        $this->_em->flush();
+        $this->_em->find(XmlLegacyTimeEntity::class, $entity->id);
+    }
+
+    #[RequiresMethod(DefaultExpression::class, 'toSQL')]
+    public function testUsingDefaultExpressionInstancesCausesNoDeprecationXmlDriver(): void
+    {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped(
+                'MySQL platform does not support CURRENT_TIME or CURRENT_DATE as default expression.',
+            );
+        }
+
+        $this->_em         = $this->getEntityManager(
+            mappingDriver: new XmlDriver(__DIR__ . '/../Mapping/xml/'),
+        );
+        $this->_schemaTool = new SchemaTool($this->_em);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12252');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $this->createSchemaForModels(XmlTimeEntity::class);
+        $this->_em->persist($entity = new XmlTimeEntity());
+        $this->_em->flush();
+        $this->_em->clear();
+        $this->_em->find(XmlTimeEntity::class, $entity->id);
+    }
+}
+
+class XmlLegacyTimeEntity
+{
+    public int $id;
+
+    public DateTime $createdAt;
+    public DateTimeImmutable $createdAtImmutable;
+    public DateTime $createdTime;
+    public DateTime $createdDate;
+}
+
+class XmlTimeEntity
+{
+    public int $id;
+
+    public DateTime $createdAt;
+    public DateTimeImmutable $createdAtImmutable;
+    public DateTime $createdTime;
+    public DateTime $createdDate;
+}

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Functional.XmlLegacyTimeEntity.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Functional.XmlLegacyTimeEntity.dcm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Functional\XmlLegacyTimeEntity">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="createdAt" type="datetime" insertable="false" updatable="false">
+            <options>
+                <option name="default">CURRENT_TIMESTAMP</option>
+            </options>
+        </field>
+
+        <field name="createdAtImmutable" type="datetime_immutable" insertable="false" updatable="false">
+            <options>
+                <option name="default">CURRENT_TIMESTAMP</option>
+            </options>
+        </field>
+
+        <field name="createdTime" type="time" insertable="false" updatable="false">
+            <options>
+                <option name="default">CURRENT_TIME</option>
+            </options>
+        </field>
+        <field name="createdDate" type="date" insertable="false" updatable="false">
+            <options>
+                <option name="default">CURRENT_DATE</option>
+            </options>
+        </field>
+    </entity>
+</doctrine-mapping>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Functional.XmlTimeEntity.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Functional.XmlTimeEntity.dcm.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Functional\XmlTimeEntity">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="createdAt" type="datetime" insertable="false" updatable="false">
+            <options>
+                <option name="default">
+                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
+                </option>
+            </options>
+        </field>
+
+        <field name="createdAtImmutable" type="datetime_immutable" insertable="false" updatable="false">
+            <options>
+                <option name="default">
+                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp"/>
+                </option>
+            </options>
+        </field>
+
+        <field name="createdTime" type="time" insertable="false" updatable="false">
+            <options>
+                <option name="default">
+                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentTime"/>
+                </option>
+            </options>
+        </field>
+        <field name="createdDate" type="date" insertable="false" updatable="false">
+            <options>
+                <option name="default">
+                    <object class="Doctrine\DBAL\Schema\DefaultExpression\CurrentDate"/>
+                </option>
+            </options>
+        </field>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
Right now, the ORM handles the conversion of strings that happen to be default expressions for date, time and datetime columns into the corresponding value objects.

Let us allow users to specify these value objects directly, and deprecate relying on the aforementioned conversion.