### PR TITLE
Remove FieldMapping::$default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Remove `FieldMapping::$default`
+
+The `default` property of `Doctrine\ORM\Mapping\FieldMapping` has been removed.
+Use `FieldMapping::$options['default']` instead.
+
 ## BC BREAK: throw on `nullable` on columns that end up being used in a primary key
 
 Specifying `nullable` on join columns that are part of a primary key is

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -68,9 +68,6 @@ final class FieldMapping
     public array|null $options        = null;
     public bool|null $version         = null;
 
-    /** @deprecated Use options with 'default' key instead */
-    public string|int|null $default = null;
-
     /**
      * @param string $type       The type name of the mapped field. Can be one of
      *                           Doctrine's mapping types or a custom mapping type.
@@ -158,7 +155,6 @@ final class FieldMapping
                 'declared',
                 'declaredField',
                 'options',
-                'default',
             ] as $key
         ) {
             if ($this->$key !== null) {

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -484,12 +484,6 @@ class SchemaTool
             $options['scale'] = $mapping->scale;
         }
 
-        /** @phpstan-ignore property.deprecated */
-        if (isset($mapping->default)) {
-            /** @phpstan-ignore property.deprecated */
-            $options['default'] = $mapping->default;
-        }
-
         if (isset($mapping->columnDefinition)) {
             $options['columnDefinition'] = $mapping->columnDefinition;
         }

--- a/tests/Tests/ORM/Mapping/FieldMappingTest.php
+++ b/tests/Tests/ORM/Mapping/FieldMappingTest.php
@@ -41,7 +41,6 @@ final class FieldMappingTest extends TestCase
         $mapping->declaredField    = 'id';
         $mapping->options          = ['foo' => 'bar'];
         $mapping->version          = true;
-        $mapping->default          = 'foo';
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof FieldMapping);
@@ -65,6 +64,5 @@ final class FieldMappingTest extends TestCase
         self::assertSame('id', $resurrectedMapping->declaredField);
         self::assertSame(['foo' => 'bar'], $resurrectedMapping->options);
         self::assertTrue($resurrectedMapping->version);
-        self::assertSame('foo', $resurrectedMapping->default);
     }
 }


### PR DESCRIPTION
It has been deprecated in favor of `$options['default']`.