### PR TITLE
Fix documentation about default values

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -254,6 +254,21 @@ Here is a complete list of ``Column``s attributes (all optional):
 - ``options``: Key-value pairs of options that get passed
   to the underlying database platform when generating DDL statements.
 
+Specifying default values
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While it is possible to specify default values for properties in your
+PHP class, Doctrine also allows you to specify default values for
+database columns using the ``default`` key in the ``options`` array of
+the ``Column`` attribute.
+
+.. configuration-block::
+   .. literalinclude:: basic-mapping/DefaultValues.php
+       :language: attribute
+
+   .. literalinclude:: basic-mapping/default-values.xml
+       :language: xml
+
 .. _reference-php-mapping-types:
 
 PHP Types Mapping

--- a/docs/en/reference/basic-mapping/DefaultValues.php
+++ b/docs/en/reference/basic-mapping/DefaultValues.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class Message
+{
+    #[Column(options: ['default' => 'Hello World!'])]
+    private string $text;
+}

--- a/docs/en/reference/basic-mapping/default-values.xml
+++ b/docs/en/reference/basic-mapping/default-values.xml
@@ -1,0 +1,9 @@
+<doctrine-mapping>
+  <entity name="Message">
+    <field name="text">
+      <options>
+        <option name="default">Hello World!</option>
+      </options>
+    </field>
+  </entity>
+</doctrine-mapping>

--- a/docs/en/reference/faq.rst
+++ b/docs/en/reference/faq.rst
@@ -18,30 +18,6 @@ In your mapping configuration, the column definition (for example, the
 the ``charset`` and ``collation``. The default values are ``utf8`` and
 ``utf8_unicode_ci``, respectively.
 
-Entity Classes
---------------
-
-How can I add default values to a column?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Doctrine does not support to set the default values in columns through the "DEFAULT" keyword in SQL.
-This is not necessary however, you can just use your class properties as default values. These are then used
-upon insert:
-
-.. code-block:: php
-
-    class User
-    {
-        private const STATUS_DISABLED = 0;
-        private const STATUS_ENABLED = 1;
-
-        private string $algorithm = "sha1";
-        /** @var self::STATUS_* */
-        private int $status = self::STATUS_DISABLED;
-    }
-
-.
-
 Mapping
 -------
 


### PR DESCRIPTION
Saying it is not possible to get Doctrine to use the `DEFAULT` SQL keyword is wrong.