### PR TITLE
Initialize lazy ghost objects before persist

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -497,6 +497,10 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($this->entityInsertions as $entity) {
             $class = $this->em->getClassMetadata($entity::class);
 
+            if (PHP_VERSION_ID >= 80400 && $class->reflClass->isUninitializedLazyObject($entity)) {
+                $class->reflClass->initializeLazyObject($entity);
+            }
+
             $this->computeChangeSet($class, $entity);
         }
     }

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -74,6 +74,8 @@ use function spl_object_id;
 use function sprintf;
 use function strtolower;
 
+use const PHP_VERSION_ID;
+
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
  * "object-level" transaction and for writing out changes to the database

--- a/tests/Tests/ORM/Functional/StandardEntityPersisterTest.php
+++ b/tests/Tests/ORM/Functional/StandardEntityPersisterTest.php
@@ -11,6 +11,9 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use ReflectionClass;
+
+use const PHP_VERSION_ID;
 
 /**
  * Tests capabilities of the persister.
@@ -117,12 +120,12 @@ class StandardEntityPersisterTest extends OrmFunctionalTestCase
         }
 
         $initialized = false;
-        $reflector = new \ReflectionClass(CmsUser::class);
-        $lazyGhost = $reflector->newLazyGhost(function (CmsUser $object) use (&$initialized) {
-            $initialized = true;
+        $reflector   = new ReflectionClass(CmsUser::class);
+        $lazyGhost   = $reflector->newLazyGhost(static function (CmsUser $object) use (&$initialized): void {
+            $initialized      = true;
             $object->username = 'lazyGhost';
-            $object->name = 'LazyGhostInitialized';
-            $object->status = 'active';
+            $object->name     = 'LazyGhostInitialized';
+            $object->status   = 'active';
         });
 
         self::assertFalse($initialized, 'Lazy ghost should not be initialized before persist.');

--- a/tests/Tests/ORM/Functional/StandardEntityPersisterTest.php
+++ b/tests/Tests/ORM/Functional/StandardEntityPersisterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
@@ -19,6 +20,7 @@ class StandardEntityPersisterTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         $this->useModelSet('ecommerce');
+        $this->useModelSet('cms');
 
         parent::setUp();
     }
@@ -106,5 +108,30 @@ class StandardEntityPersisterTest extends OrmFunctionalTestCase
 
         // Persisted Product now must have 3 Feature items
         self::assertCount(3, $res[0]->getFeatures());
+    }
+
+    public function testPersistLazyGhost(): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Lazy objects are only available in PHP 8.4+.');
+        }
+
+        $initialized = false;
+        $reflector = new \ReflectionClass(CmsUser::class);
+        $lazyGhost = $reflector->newLazyGhost(function (CmsUser $object) use (&$initialized) {
+            $initialized = true;
+            $object->username = 'lazyGhost';
+            $object->name = 'LazyGhostInitialized';
+            $object->status = 'active';
+        });
+
+        self::assertFalse($initialized, 'Lazy ghost should not be initialized before persist.');
+        $this->_em->persist($lazyGhost);
+        $this->_em->flush();
+        self::assertTrue($initialized, 'Lazy ghost should be initialized during flush.');
+        $this->_em->clear();
+        $retrievedEntity = $this->_em->find(CmsUser::class, $lazyGhost->id);
+        self::assertNotNull($retrievedEntity);
+        self::assertEquals('LazyGhostInitialized', $retrievedEntity->name);
     }
 }


### PR DESCRIPTION
We've the use case inside API Platform where the JsonStreamer deserializes a JSON into a Lazy Ghost as while its not consumed (streaming) we don't need to initialize this object. Therefore at some point we try to persist an uninitialized lazy ghost and it'll likely throw "column title must not be null".


```php
    public function testPersistLazyGhost(): void 
    {
        if (PHP_VERSION_ID < 80400) {
            $this->markTestSkipped('Lazy objects are only available in PHP 8.4+.');
        }

        $initialized = false;
        $reflector = new \ReflectionClass(PersistentEntity::class);
        $lazyGhost = $reflector->newLazyGhost(function (PersistentEntity $object) use (&$initialized) {
            $initialized = true;
            $object->setName('LazyGhostInitialized');
        });

        self::assertFalse($initialized, 'Lazy ghost should not be initialized before persist.');
        $this->_em->persist($lazyGhost);
        $this->_em->flush();
        self::assertTrue($initialized, 'Lazy ghost should be initialized during flush.');
        $this->_em->clear();
        $retrievedEntity = $this->_em->find(PersistentEntity::class, $lazyGhost->getId());
        self::assertNotNull($retrievedEntity);
        self::assertEquals('LazyGhostInitialized', $retrievedEntity->name);
    }
```