### PR TITLE
Support Symfony Console 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/lexer": "^2 || ^3",
         "doctrine/persistence": "^2.4 || ^3",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.16"
     },
@@ -60,7 +60,7 @@
         "psr/log": "^1 || ^2 || ^3",
         "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2 || ^7.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >= 3.0"

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1113,7 +1113,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
         if ($flag && ! trait_exists(LazyGhostTrait::class)) {
             throw new LogicException(
                 'Lazy ghost objects cannot be enabled because the "symfony/var-exporter" library'
-                . ' version 6.2 or higher is not installed. Please run "composer require symfony/var-exporter:^6.2".'
+                . ' version 6.2 or 7 is not installed. Please run "composer require symfony/var-exporter:^6.4".'
             );
         }
 

--- a/src/Tools/Console/ApplicationCompatibility.php
+++ b/src/Tools/Console/ApplicationCompatibility.php
@@ -18,11 +18,12 @@ trait ApplicationCompatibility
 {
     private static function addCommandToApplication(Application $application, Command $command): ?Command
     {
+        // @phpstan-ignore function.alreadyNarrowedType (This method did not exist before Symfony 7.4)
         if (method_exists(Application::class, 'addCommand')) {
-            // @phpstan-ignore method.notFound (This method will be added in Symfony 7.4)
             return $application->addCommand($command);
         }
 
+        // @phpstan-ignore method.notFound
         return $application->add($command);
     }
 }

--- a/src/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/src/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -23,8 +23,7 @@ class CollectionRegionCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:region:collection')
              ->setDescription('Clear a second-level cache collection region')

--- a/src/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/src/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -23,8 +23,7 @@ class EntityRegionCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:region:entity')
              ->setDescription('Clear a second-level cache entity region')

--- a/src/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/src/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -21,8 +21,7 @@ class MetadataCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:metadata')
              ->setDescription('Clear all metadata cache of the various cache drivers')

--- a/src/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/src/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -30,8 +30,7 @@ class QueryCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:query')
              ->setDescription('Clear all query cache of the various cache drivers')

--- a/src/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/src/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -23,8 +23,7 @@ class QueryRegionCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:region:query')
              ->setDescription('Clear a second-level cache query region')

--- a/src/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/src/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -32,8 +32,7 @@ class ResultCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:clear-cache:result')
              ->setDescription('Clear all result cache of the various cache drivers')

--- a/src/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/src/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -75,8 +75,7 @@ class ConvertDoctrine1SchemaCommand extends Command
         $this->metadataExporter = $metadataExporter;
     }
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:convert-d1-schema')
              ->setAliases(['orm:convert:d1-schema'])

--- a/src/Tools/Console/Command/ConvertMappingCommand.php
+++ b/src/Tools/Console/Command/ConvertMappingCommand.php
@@ -40,8 +40,7 @@ class ConvertMappingCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:convert-mapping')
              ->setAliases(['orm:convert:mapping'])

--- a/src/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/src/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -22,8 +22,7 @@ class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:ensure-production-settings')
              ->setDescription('Verify that Doctrine is properly configured for a production environment')

--- a/src/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/src/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -31,8 +31,7 @@ class GenerateEntitiesCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:generate-entities')
              ->setAliases(['orm:generate:entities'])

--- a/src/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/src/Tools/Console/Command/GenerateProxiesCommand.php
@@ -29,8 +29,7 @@ class GenerateProxiesCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:generate-proxies')
              ->setAliases(['orm:generate:proxies'])

--- a/src/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/src/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -30,8 +30,7 @@ class GenerateRepositoriesCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:generate-repositories')
              ->setAliases(['orm:generate:repositories'])

--- a/src/Tools/Console/Command/InfoCommand.php
+++ b/src/Tools/Console/Command/InfoCommand.php
@@ -23,8 +23,7 @@ class InfoCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:info')
              ->setDescription('Show basic information about all mapped entities')

--- a/src/Tools/Console/Command/RunDqlCommand.php
+++ b/src/Tools/Console/Command/RunDqlCommand.php
@@ -30,8 +30,7 @@ class RunDqlCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:run-dql')
              ->setDescription('Executes arbitrary DQL directly from the command line')

--- a/src/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/src/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -27,6 +27,10 @@ abstract class AbstractCommand extends AbstractEntityManagerCommand
      */
     abstract protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas, SymfonyStyle $ui);
 
+    private function doConfigure(): void
+    {
+    }
+
     private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);

--- a/src/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/src/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,8 +20,9 @@ use function sprintf;
  */
 class CreateCommand extends AbstractCommand
 {
-    /** @return void */
-    protected function configure()
+    use CommandCompatibility;
+
+    private function doConfigure(): void
     {
         $this->setName('orm:schema-tool:create')
              ->setDescription('Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output')
@@ -42,6 +44,11 @@ on a global level:
     });
 EOT
              );
+    }
+
+    private function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        return parent::execute($input, $output);
     }
 
     /**

--- a/src/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/src/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,8 +21,9 @@ use function sprintf;
  */
 class DropCommand extends AbstractCommand
 {
-    /** @return void */
-    protected function configure()
+    use CommandCompatibility;
+
+    private function doConfigure(): void
     {
         $this->setName('orm:schema-tool:drop')
              ->setDescription('Drop the complete database schema of EntityManager Storage Connection or generate the corresponding SQL output')
@@ -46,6 +48,11 @@ on a global level:
     });
 EOT
              );
+    }
+
+    private function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        return parent::execute($input, $output);
     }
 
     /**

--- a/src/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/src/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
+use Doctrine\ORM\Tools\Console\CommandCompatibility;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -21,11 +22,12 @@ use function sprintf;
  */
 class UpdateCommand extends AbstractCommand
 {
+    use CommandCompatibility;
+
     /** @var string */
     protected $name = 'orm:schema-tool:update';
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName($this->name)
              ->setDescription('Executes (or dumps) the SQL needed to update the database schema to match the current mapping metadata')
@@ -70,6 +72,11 @@ on a global level:
     });
 EOT
              );
+    }
+
+    private function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        return parent::execute($input, $output);
     }
 
     /**

--- a/src/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/src/Tools/Console/Command/ValidateSchemaCommand.php
@@ -23,8 +23,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this->setName('orm:validate-schema')
              ->setDescription('Validate the mapping files')

--- a/src/Tools/Console/CommandCompatibility.php
+++ b/src/Tools/Console/CommandCompatibility.php
@@ -9,10 +9,32 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+// Symfony 8
+if ((new ReflectionMethod(Command::class, 'configure'))->hasReturnType()) {
     /** @internal */
     trait CommandCompatibility
     {
+        protected function configure(): void
+        {
+            $this->doConfigure();
+        }
+
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+// Symfony 7
+} elseif ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        /** @return void */
+        protected function configure()
+        {
+            $this->doConfigure();
+        }
+
         protected function execute(InputInterface $input, OutputInterface $output): int
         {
             return $this->doExecute($input, $output);
@@ -22,6 +44,12 @@ if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
     /** @internal */
     trait CommandCompatibility
     {
+        /** @return void */
+        protected function configure()
+        {
+            $this->doConfigure();
+        }
+
         /**
          * {@inheritDoc}
          *


### PR DESCRIPTION
* We can support Symfony Console 8 in ORM 2, so let's do that.
* We cannot use Symfony Cache 8 in our tests because it requires DBAL 4 which we don't support on ORM 2.
* We don't need to test against Symfony VarExporter 8 because all the features we use from that package have been removed in 8.0.