### PR TITLE
Uninstall Guides when running the unit tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,6 +84,9 @@ jobs:
         run: "composer require doctrine/dbal ^${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version != 'default' }}"
 
+      - name: 'Uninstall phpDocumentor Guides'
+        run: composer remove --no-update --dev phpdocumentor/guides-cli
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
@@ -145,6 +148,9 @@ jobs:
 
       -   name: "Allow dev dependencies"
           run: composer config minimum-stability dev
+
+      -   name: 'Uninstall phpDocumentor Guides'
+          run: composer remove --no-update --dev phpdocumentor/guides-cli
 
       -   name: "Install dependencies with Composer"
           uses: "ramsey/composer-install@v3"


### PR DESCRIPTION
Currently Guides blocks the installation of some Symfony 7 and 8 components. I try to sort this out in phpDocumentor/guides#1270. Until that is merged, I'd like to uninstall Guides for our unit tests. We shouldn't need it for that anyway.