### PR TITLE
Explicitly set a cache in testDisablingXmlValidationIsPossible

### DIFF
--- a/tests/Tests/ORM/ORMSetupTest.php
+++ b/tests/Tests/ORM/ORMSetupTest.php
@@ -19,6 +19,7 @@ use ReflectionProperty;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 
 use function sys_get_temp_dir;
 
@@ -68,7 +69,7 @@ class ORMSetupTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        ORMSetup::createXMLMetadataConfig(paths: [], isXsdValidationEnabled: false);
+        ORMSetup::createXMLMetadataConfig(paths: [], cache: new NullAdapter(), isXsdValidationEnabled: false);
     }
 
     #[RequiresPhpExtension('apcu')]


### PR DESCRIPTION
This prevents our cache guesswork from kicking in which is irrelevant for this particular test.