### PR TITLE
Remove obsolete VarExporter feature detection

### DIFF
--- a/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -16,7 +16,6 @@ use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionMethod;
-use Symfony\Component\VarExporter\Instantiator;
 use Symfony\Component\VarExporter\VarExporter;
 
 use function file_get_contents;
@@ -77,11 +76,6 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
                 return unserialize(serialize($parserResult));
             },
         ];
-
-        $instantiatorMethod = new ReflectionMethod(Instantiator::class, 'instantiate');
-        if ($instantiatorMethod->getReturnType() === null) {
-            self::markTestSkipped('symfony/var-exporter 5.4+ is required.');
-        }
 
         yield 'symfony/var-exporter' => [
             static function (ParserResult $parserResult): ParserResult {


### PR DESCRIPTION
We require VarExporter 6.3.9 or newer, so there should be no need for this questionable feature detection anymore.