### PR TITLE
Unify memberOf method signature in Criteria class

### DIFF
--- a/src/Query/QueryExpressionVisitor.php
+++ b/src/Query/QueryExpressionVisitor.php
@@ -143,7 +143,13 @@ class QueryExpressionVisitor extends ExpressionVisitor
                 return $this->expr->like($field, $placeholder);
 
             case Comparison::MEMBER_OF:
-                return $this->expr->isMemberOf($comparison->getField(), $comparison->getValue()->getValue());
+                if (str_starts_with($comparison->getField(), ':')) {
+                    return $this->expr->isMemberOf($comparison->getField(), $comparison->getValue()->getValue());
+                }
+
+                $this->parameters[] = $parameter;
+
+                return $this->expr->isMemberOf($placeholder, $field);
 
             case Comparison::STARTS_WITH:
                 $parameter->setValue($parameter->getValue() . '%', $parameter->getType());

--- a/tests/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -63,7 +63,9 @@ class QueryExpressionVisitorTest extends TestCase
             [$cb->notIn('field', ['value']), $qb->notIn('o.field', ':field'), new Parameter('field', ['value'])],
 
             [$cb->contains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')],
+
             [$cb->memberOf(':field', 'o.field'), $qb->isMemberOf(':field', 'o.field')],
+            [$cb->memberOf('field', 'value'), $qb->isMemberOf(':field', 'o.field'), new Parameter('field', 'value')],
 
             [$cb->startsWith('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', 'value%')],
             [$cb->endsWith('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value')],


### PR DESCRIPTION
Standardized the `memberOf` method in `Criteria` class to match the signature pattern of other methods.

Changed `memberOf` parameter order to `('field', 'value')` like other `Criteria` methods. Previously it used `(':parameter', 'alias.field')` which was inconsistent.

Consistency across the `Criteria` API. Better developer experience when using `QueryBuilder`. Follows principle of least surprise.

Fully backward compatible.

Example:
```php
use Doctrine\ORM\QueryBuilder;

$group = 1;

$qb = new QueryBuilder();
$qb
   ->from(User::class, 'u0')
    ->where($qb->expr->eq('name', 'Test'))
    // Old approach
    ->andWhere($qb->expr->memberOf(':group', 'u0.groups'))
    ->setParameter('group', $group)
    // New approach
    ->andWhere($qb->expr->memberOf('groups', $group))
;
```

Reopening: previous PR https://github.com/doctrine/orm/pull/11981 closed due to branch deletion
