### PR TITLE
Fix result cache examples in docs

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1409,8 +1409,7 @@ Result Cache API:
 
     $query->setResultCacheDriver(new ApcCache());
 
-    $query->useResultCache(true)
-          ->setResultCacheLifeTime(3600);
+    $query->enableResultCache(3600);
 
     $result = $query->getResult(); // cache miss
 
@@ -1420,8 +1419,8 @@ Result Cache API:
     $query->setResultCacheId('my_query_result');
     $result = $query->getResult(); // saved in given result cache id.
 
-    // or call useResultCache() with all parameters:
-    $query->useResultCache(true, 3600, 'my_query_result');
+    // or call enableResultCache() with all parameters:
+    $query->enableResultCache(3600, 'my_query_result');
     $result = $query->getResult(); // cache hit!
 
     // Introspection

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -357,7 +357,7 @@ a querybuilder instance into a Query object:
 
     // Set additional Query options
     $query->setQueryHint('foo', 'bar');
-    $query->useResultCache('my_cache_id');
+    $query->enableResultCache(3600, 'my_custom_id');
 
     // Execute Query
     $result = $query->getResult();


### PR DESCRIPTION
The `useResultCache()` method was removed in version 3.