### PR TITLE
Avoid lazy object initialization when initializing read-only property

### DIFF
--- a/src/Mapping/PropertyAccessors/ReadonlyAccessor.php
+++ b/src/Mapping/PropertyAccessors/ReadonlyAccessor.php
@@ -10,6 +10,8 @@ use ReflectionProperty;
 
 use function sprintf;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 class ReadonlyAccessor implements PropertyAccessor
 {
@@ -26,7 +28,12 @@ class ReadonlyAccessor implements PropertyAccessor
 
     public function setValue(object $object, mixed $value): void
     {
-        if (! $this->reflectionProperty->isInitialized($object)) {
+        /* For lazy properties, skip the isInitialized() check
+           because it would trigger the initialization of the whole object. */
+        if (
+            PHP_VERSION_ID >= 80400 && $this->reflectionProperty->isLazy($object)
+            || ! $this->reflectionProperty->isInitialized($object)
+        ) {
             $this->parent->setValue($object, $value);
 
             return;

--- a/tests/Tests/ORM/Functional/Ticket/GH12166/GH12166Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12166/GH12166Test.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12166;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12166Test extends OrmFunctionalTestCase
+{
+    public function testProxyWithReadonlyIdIsNotInitializedImmediately(): void
+    {
+        $this->createSchemaForModels(LazyEntityWithReadonlyId::class);
+        $this->_em->persist(new LazyEntityWithReadonlyId(123, 'Test Name'));
+        $this->_em->flush();
+        $this->_em->clear();
+        $proxy = $this->_em->getReference(LazyEntityWithReadonlyId::class, 123);
+
+        $reflClass = $this->_em->getClassMetadata(LazyEntityWithReadonlyId::class)->reflClass;
+        self::assertTrue(
+            $this->isUninitializedObject($proxy),
+            'Proxy should remain uninitialized after creation',
+        );
+
+        $id = $proxy->getId();
+        self::assertSame(123, $id);
+        self::assertTrue(
+            $this->isUninitializedObject($proxy),
+            'Proxy should remain uninitialized after accessing ID',
+        );
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12166/LazyEntityWithReadonlyId.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12166/LazyEntityWithReadonlyId.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12166;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'gh12166_lazy_entity')]
+class LazyEntityWithReadonlyId
+{
+    #[Column(type: 'integer')]
+    #[Id]
+    private readonly int $id;
+
+    #[Column(type: 'string')]
+    private string $name;
+
+    public function __construct(int $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Initializing e.g. a readonly ID does not require loading any data from
the database. However, calling isInitialized() on the reflection of a
readonly property triggers the native lazy object initialization.
If we have a lazy property at hand, then the property cannot be initialized
already, so it is safe to skip the call.

Fixes #12166 