### PR TITLE
Update phpstan-dbal2 to phpstan-dbal3 in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,6 @@ phpcs.xml.dist export-ignore
 phpbench.json export-ignore
 phpstan.neon export-ignore
 phpstan-baseline.neon export-ignore
-phpstan-dbal2.neon export-ignore
+phpstan-dbal3.neon export-ignore
 phpstan-params.neon export-ignore
 phpstan-persistence2.neon export-ignore


### PR DESCRIPTION
- Currently, The archive targets other than src/ are as follow


```
gh api repos/doctrine/orm/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
SECURITY.md
UPGRADE.md
composer.json
doctrine-mapping.xsd
phpstan-dbal3.neon
```
- With this PR, The archive targets other than src/ will be as follows:

```
 gh api repos/sasezaki/orm/tarball/sasezaki-patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
SECURITY.md
UPGRADE.md
composer.json
doctrine-mapping.xsd
```