### PR TITLE
Remove unnecessary check

### DIFF
--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -116,10 +116,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     protected function onNotFoundMetadata(string $className): ClassMetadata|null
     {
-        if (! $this->evm->hasListeners(Events::onClassMetadataNotFound)) {
-            return null;
-        }
-
         $eventArgs = new OnClassMetadataNotFoundEventArgs($className, $this->em);
 
         $this->evm->dispatchEvent(Events::onClassMetadataNotFound, $eventArgs);
@@ -245,10 +241,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         // During the following event, there may also be updates to the discriminator map as per GH-1257/GH-8402.
         // So, we must not discover the missing subclasses before that.
 
-        if ($this->evm->hasListeners(Events::loadClassMetadata)) {
-            $eventArgs = new LoadClassMetadataEventArgs($class, $this->em);
-            $this->evm->dispatchEvent(Events::loadClassMetadata, $eventArgs);
-        }
+        $this->evm->dispatchEvent(
+            Events::loadClassMetadata,
+            new LoadClassMetadataEventArgs($class, $this->em),
+        );
 
         $this->findAbstractEntityClassesNotListedInDiscriminatorMap($class);
 

--- a/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
+++ b/src/Tools/Console/Command/Debug/DebugEventManagerDoctrineCommand.php
@@ -62,7 +62,7 @@ EOT);
 
             ksort($allListeners);
         } else {
-            $listeners = $eventManager->hasListeners($eventName) ? $eventManager->getListeners($eventName) : [];
+            $listeners = $eventManager->getListeners($eventName);
             if (! $listeners) {
                 $io->info(sprintf('No listeners are configured for the "%s" event.', $eventName));
 

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -389,20 +389,16 @@ class SchemaTool
                 }
             }
 
-            if ($eventManager->hasListeners(ToolEvents::postGenerateSchemaTable)) {
-                $eventManager->dispatchEvent(
-                    ToolEvents::postGenerateSchemaTable,
-                    new GenerateSchemaTableEventArgs($class, $schema, $table),
-                );
-            }
-        }
-
-        if ($eventManager->hasListeners(ToolEvents::postGenerateSchema)) {
             $eventManager->dispatchEvent(
-                ToolEvents::postGenerateSchema,
-                new GenerateSchemaEventArgs($this->em, $schema),
+                ToolEvents::postGenerateSchemaTable,
+                new GenerateSchemaTableEventArgs($class, $schema, $table),
             );
         }
+
+        $eventManager->dispatchEvent(
+            ToolEvents::postGenerateSchema,
+            new GenerateSchemaEventArgs($this->em, $schema),
+        );
 
         return $schema;
     }

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2295,9 +2295,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->eagerLoadingCollections          =
         $this->orphanRemovals                   = [];
 
-        if ($this->evm->hasListeners(Events::onClear)) {
-            $this->evm->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));
-        }
+        $this->evm->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));
     }
 
     /**
@@ -3145,23 +3143,17 @@ class UnitOfWork implements PropertyChangedListener
 
     private function dispatchPreFlushEvent(): void
     {
-        if ($this->evm->hasListeners(Events::preFlush)) {
-            $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));
-        }
+        $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));
     }
 
     private function dispatchOnFlushEvent(): void
     {
-        if ($this->evm->hasListeners(Events::onFlush)) {
-            $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
-        }
+        $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
     }
 
     private function dispatchPostFlushEvent(): void
     {
-        if ($this->evm->hasListeners(Events::postFlush)) {
-            $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
-        }
+        $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
     }
 
     /**


### PR DESCRIPTION
`EventManager::dispatchEvent()` already performs a similar check.

Similar to https://github.com/doctrine/mongodb-odm/pull/2480

Just like @franmomu did in that PR, I kept it in https://github.com/doctrine/orm/blob/0bd839a720fb8d08502ae879bf485b9b56e45708/src/Mapping/ClassMetadataFactory.php#L118-L130

It's indeed easier to understand that way.

Relates to https://github.com/doctrine/event-manager/pull/100