### PR TITLE
Add missing ORDER BY clause

### DIFF
--- a/tests/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Tests/ORM/Functional/PaginationTest.php
@@ -673,7 +673,7 @@ SQL
 
     public function testDifferentResultLengthsDoNotRequireExtraQueryCacheEntries(): void
     {
-        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id >= :id';
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id >= :id ORDER BY u.id';
         $query = $this->_em->createQuery($dql);
         $query->setMaxResults(10);
 

--- a/tests/Tests/ORM/Functional/Ticket/DDC1452Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1452Test.php
@@ -49,7 +49,7 @@ class DDC1452Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql     = 'SELECT a, b, ba FROM ' . __NAMESPACE__ . '\DDC1452EntityA AS a LEFT JOIN a.entitiesB AS b LEFT JOIN b.entityATo AS ba';
+        $dql     = 'SELECT a, b, ba FROM ' . __NAMESPACE__ . '\DDC1452EntityA AS a LEFT JOIN a.entitiesB AS b LEFT JOIN b.entityATo AS ba ORDER BY a.id';
         $results = $this->_em->createQuery($dql)->setMaxResults(1)->getResult();
 
         self::assertSame($results[0], $results[0]->entitiesB[0]->entityAFrom);


### PR DESCRIPTION
This causes transient failures with PostgreSQL. Order is not guaranteed.