### PR TITLE
QueryFactory suggestion

### DIFF
--- a/src/Tools/QueryFactory/QueryFactory.php
+++ b/src/Tools/QueryFactory/QueryFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\QueryFactory;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Expr as Expr;
+use Doctrine\ORM\QueryBuilder;
+
+class QueryFactory
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager
+    )
+    {
+    }
+
+    public function createQuery(RuleSetInterface $ruleSet): Query
+    {
+        return $this->createQueryBuilder($ruleSet)->getQuery();
+    }
+
+    public function createQueryBuilder(RuleSetInterface $ruleSet): QueryBuilder
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->from($ruleSet->getEntityClass(), $ruleSet->getRootAlias())
+            ->select($ruleSet->getRootAlias());
+
+        foreach ($ruleSet->getRules() as $key => $rule) {
+            match($rule::class) {
+                Expr\Andx::class, Expr\Orx::class => $qb->add('where', $rule),
+                Expr\OrderBy::class => $qb->add('orderBy', $rule),
+                Expr\GroupBy::class => $qb->add('groupBy', $rule),
+                Expr\Join::class => $this->processJoins($qb, $rule),
+                Expr\Select::class => $qb->add('select', $rule),
+                default => throw new QueryFactoryUnexpectedValueException("Wrong rule on $key"),
+            };
+        }
+
+        $qb->setParameters($ruleSet->getParameters());
+
+        return $qb;
+    }
+
+    private function processJoins(QueryBuilder $qb, Expr\Join $join): void
+    {
+        $fn = strtolower($join->getJoinType()) . 'Join';
+        $qb->$fn(
+            $join->getJoin(),
+            $join->getAlias(),
+            $join->getConditionType(),
+            $join->getCondition(),
+            $join->getIndexBy()
+        );
+    }
+}

--- a/src/Tools/QueryFactory/QueryFactoryUnexpectedValueException.php
+++ b/src/Tools/QueryFactory/QueryFactoryUnexpectedValueException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\QueryFactory;
+
+class QueryFactoryUnexpectedValueException extends \UnexpectedValueException
+{
+}

--- a/src/Tools/QueryFactory/RuleSetInterface.php
+++ b/src/Tools/QueryFactory/RuleSetInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\QueryFactory;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\Expr\Base;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\Query\Parameter;
+
+interface RuleSetInterface
+{
+    public function getEntityClass(): string;
+
+    /**
+     * @return array<Base|Join>
+     */
+    public function getRules(): array;
+    public function getRootAlias(): string;
+
+    /**
+     * @return ArrayCollection<int, Parameter>
+     */
+    public function getParameters(): ArrayCollection;
+}


### PR DESCRIPTION
I want to suggest factories for Query (QueryBuilder). Now it's only a preview and if it gets interest, I'll continue working on.

We already have a perfect QueryBuilder, but we don't have tools for business requests.
So if I have a task, get all dogs belonging to a group of clients, I need to do something like this:
```php       
$this->entityManager->createQueryBuilder()
            ->select('s')
            ->from(Animal::class, 'a')
            ->innerJoin('a.clients', 'c')
            ->andWhere('c.group = :clientGroupId')
            ->andWhere('a.type = :type')
            ->setParameter('type', 'dog')
            ->setParameter('clientGroupId', 5)
            ->getQuery()
            ->getResult();
```
But I think that a good idea to use a business logic object:
```php
class ClientGroupDogs implements RuleSetInterface
{
    public function __construct(
        private int $clientGroupId
    )
    {
    }

    public function getEntityClass(): string
    {
        return Animal::class;
    }

    public function getRules(): array
    {
        return [
            new Expr\Join(Expr\Join::INNER_JOIN, 'a.client', 'c'),
            new Expr\Andx('c.group = :clientGroupId'),
            new Expr\Andx('a.type = :type')
        ];
    }

    public function getRootAlias(): string
    {
        return 'a';
    }

    public function getParameters(): ArrayCollection
    {
        return new ArrayCollection([
            new Parameter('clientGroupId', $this->clientGroupId),
            new Parameter('type', 'dog')
        ]);
    }
}
```
So we have:
```php
$this->queryFactory->createQuery(new ClientGroupDogs(5))->getResult();
```
In this case, we can do a clear repository.

Please discuss.

