### PR TITLE
Extend underscore naming strategy for camelCase properties with uppercase sequences

### DIFF
--- a/src/Mapping/UnderscoreNamingStrategy.php
+++ b/src/Mapping/UnderscoreNamingStrategy.php
@@ -97,7 +97,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
 
     private function underscore(string $string): string
     {
-        $string = preg_replace('/(?<=[a-z0-9])([A-Z])/', '_$1', $string);
+        $string = preg_replace('/(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])/', '_$1$2', $string);
 
         if ($this->case === CASE_UPPER) {
             return strtoupper($string);

--- a/tests/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -99,6 +99,7 @@ class NamingStrategyTest extends OrmTestCase
             [self::underscoreNamingUpper(), 'SOME_PROPERTY', 'SOME_PROPERTY', 'Some\Class'],
             [self::underscoreNamingUpper(), 'BASE64_ENCODED', 'base64Encoded', 'Some\Class'],
             [self::underscoreNamingUpper(), 'BASE64ENCODED', 'base64encoded', 'Some\Class'],
+            [self::underscoreNamingLower(), 'some_x_property', 'someXProperty', 'Some\Class'],
 
             // CustomPascalNamingStrategy
             [self::customNaming(), 'SomeProperty', 'someProperty', 'Some\Class'],


### PR DESCRIPTION
The current underscore naming strategy incorrectly converts camelCase property names that contain two consecutive uppercase letters. Examples below:

**Before:**
```
$myXVariable → my_xvariable
$allowedXAmount → allowed_xamount
```

**After:**
```
$myXVariable → my_x_variable
$allowedXAmount → allowed_x_amount
```

Previously, this required explicitly specifying the column name in the mapping. This change adjusts the regex  to handle uppercase sequences while preserving existing behavior for other cases.
