### PR TITLE
Leverage event manager interfaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,18 @@ At this point, we recommend upgrading to PHP 8.4 first and then directly from
 ORM 2.19 to 3.5 and up so that you can skip the lazy ghost proxy generation
 and directly start using native lazy objects.
 
+# Upgrade to 3.7
+
+The return type of the following methods has been changed from
+`Doctrine\Common\EventManager` to `Doctrine\Common\EventManagerInterface`:
+
+- `Doctrine\ORM\Decorator\EntityManagerDecorator::getEventManager()`
+- `Doctrine\ORM\EntityManager::getEventManager()`
+- `Doctrine\ORM\EntityManagerInterface::getEventManager()`
+
+All three methods continue to return an instance of `EventManager`, however
+relying on that is deprecated and will no longer be the guaranteed in 4.0.
+
 # Upgrade to 3.6
 
 ## Deprecate using string expression for default values in mappings

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/collections": "^2.2",
         "doctrine/dbal": "^3.8.2 || ^4",
         "doctrine/deprecations": "^0.5.3 || ^1",
-        "doctrine/event-manager": "^1.2 || ^2",
+        "doctrine/event-manager": "^2.1.1",
         "doctrine/inflector": "^1.4 || ^2.0",
         "doctrine/instantiator": "^1.3 || ^2",
         "doctrine/lexer": "^3",

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Decorator;
 
 use DateTimeInterface;
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
@@ -122,7 +122,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
         $this->wrapped->refresh($object, $lockMode);
     }
 
-    public function getEventManager(): EventManager
+    public function getEventManager(): EventManagerInterface
     {
         return $this->wrapped->getEventManager();
     }

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM;
 use BackedEnum;
 use DateTimeInterface;
 use Doctrine\Common\EventManager;
+use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Exception\EntityManagerClosed;
@@ -511,7 +512,7 @@ class EntityManager implements EntityManagerInterface
             && ! $this->unitOfWork->isScheduledForDelete($object);
     }
 
-    public function getEventManager(): EventManager
+    public function getEventManager(): EventManagerInterface
     {
         return $this->eventManager;
     }

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use DateTimeInterface;
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Exception\ORMException;
@@ -180,9 +180,9 @@ interface EntityManagerInterface extends ObjectManager
     public function lock(object $entity, LockMode|int $lockMode, DateTimeInterface|int|null $lockVersion = null): void;
 
     /**
-     * Gets the EventManager used by the EntityManager.
+     * Gets the EventManagerInterface used by the EntityManager.
      */
-    public function getEventManager(): EventManager;
+    public function getEventManager(): EventManagerInterface;
 
     /**
      * Gets the Configuration used by the EntityManager.

--- a/src/Event/ListenersInvoker.php
+++ b/src/Event/ListenersInvoker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventDispatcher;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
@@ -23,13 +23,13 @@ class ListenersInvoker
     /** The Entity listener resolver. */
     private readonly EntityListenerResolver $resolver;
 
-    /** The EventManager used for dispatching events. */
-    private readonly EventManager $eventManager;
+    /** The EventDispatcher used for dispatching events. */
+    private readonly EventDispatcher $eventDispatcher;
 
     public function __construct(EntityManagerInterface $em)
     {
-        $this->eventManager = $em->getEventManager();
-        $this->resolver     = $em->getConfiguration()->getEntityListenerResolver();
+        $this->eventDispatcher = $em->getEventManager();
+        $this->resolver        = $em->getConfiguration()->getEntityListenerResolver();
     }
 
     /**
@@ -52,7 +52,7 @@ class ListenersInvoker
             $invoke |= self::INVOKE_LISTENERS;
         }
 
-        if ($this->eventManager->hasListeners($eventName)) {
+        if ($this->eventDispatcher->hasListeners($eventName)) {
             $invoke |= self::INVOKE_MANAGER;
         }
 
@@ -92,7 +92,7 @@ class ListenersInvoker
         }
 
         if ($invoke & self::INVOKE_MANAGER) {
-            $this->eventManager->dispatchEvent($eventName, $event);
+            $this->eventDispatcher->dispatchEvent($eventName, $event);
         }
     }
 }

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventDispatcher;
 use Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
@@ -55,7 +55,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private EntityManagerInterface|null $em       = null;
     private AbstractPlatform|null $targetPlatform = null;
     private MappingDriver|null $driver            = null;
-    private EventManager|null $evm                = null;
+    private EventDispatcher|null $eventDispatcher = null;
 
     /** @var mixed[] */
     private array $embeddablesActiveNesting = [];
@@ -109,16 +109,16 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     protected function initialize(): void
     {
-        $this->driver      = $this->em->getConfiguration()->getMetadataDriverImpl();
-        $this->evm         = $this->em->getEventManager();
-        $this->initialized = true;
+        $this->driver          = $this->em->getConfiguration()->getMetadataDriverImpl();
+        $this->eventDispatcher = $this->em->getEventManager();
+        $this->initialized     = true;
     }
 
     protected function onNotFoundMetadata(string $className): ClassMetadata|null
     {
         $eventArgs = new OnClassMetadataNotFoundEventArgs($className, $this->em);
 
-        $this->evm->dispatchEvent(Events::onClassMetadataNotFound, $eventArgs);
+        $this->eventDispatcher->dispatchEvent(Events::onClassMetadataNotFound, $eventArgs);
         $classMetadata = $eventArgs->getFoundMetadata();
         assert($classMetadata instanceof ClassMetadata || $classMetadata === null);
 
@@ -241,7 +241,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         // During the following event, there may also be updates to the discriminator map as per GH-1257/GH-8402.
         // So, we must not discover the missing subclasses before that.
 
-        $this->evm->dispatchEvent(
+        $this->eventDispatcher->dispatchEvent(
             Events::loadClassMetadata,
             new LoadClassMetadataEventArgs($class, $this->em),
         );

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -8,7 +8,7 @@ use BackedEnum;
 use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventDispatcher;
 use Doctrine\DBAL;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\LockMode;
@@ -261,9 +261,9 @@ class UnitOfWork implements PropertyChangedListener
     private array $collectionPersisters = [];
 
     /**
-     * The EventManager used for dispatching events.
+     * The EventDispatcher used for dispatching events.
      */
-    private readonly EventManager $evm;
+    private readonly EventDispatcher $eventDispatcher;
 
     /**
      * The ListenersInvoker used for dispatching events.
@@ -314,7 +314,7 @@ class UnitOfWork implements PropertyChangedListener
     public function __construct(
         private readonly EntityManagerInterface $em,
     ) {
-        $this->evm                      = $em->getEventManager();
+        $this->eventDispatcher          = $em->getEventManager();
         $this->listenersInvoker         = new ListenersInvoker($em);
         $this->hasCache                 = $em->getConfiguration()->isSecondLevelCacheEnabled();
         $this->identifierFlattener      = new IdentifierFlattener($this, $em->getMetadataFactory());
@@ -2295,7 +2295,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->eagerLoadingCollections          =
         $this->orphanRemovals                   = [];
 
-        $this->evm->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));
+        $this->eventDispatcher->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));
     }
 
     /**
@@ -3143,17 +3143,17 @@ class UnitOfWork implements PropertyChangedListener
 
     private function dispatchPreFlushEvent(): void
     {
-        $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));
+        $this->eventDispatcher->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));
     }
 
     private function dispatchOnFlushEvent(): void
     {
-        $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
+        $this->eventDispatcher->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
     }
 
     private function dispatchPostFlushEvent(): void
     {
-        $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
+        $this->eventDispatcher->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
     }
 
     /**


### PR DESCRIPTION
Note that this involves dropping support for doctrine/event-manager 1.x, and given that v2 only requires PHP 8.1, I think that is fine.

Related to https://github.com/doctrine/orm/pull/12361

Note that I did not find a way to let the users know that type declarations of `EventManager` were going to be changed with `EventManagerInterface`. Should I maybe use phpdoc for that (for return type declarations)?

EDIT: I've tried that, but PHPStan still gives precedence to the native return type, so it feels pointless.