### PR TITLE
Add cursor-based pagination

### DIFF
--- a/docs/en/tutorials/pagination.rst
+++ b/docs/en/tutorials/pagination.rst
@@ -1,6 +1,41 @@
 Pagination
 ==========
 
+Doctrine ORM provides two pagination strategies for DQL queries. Both handle
+the low-level SQL plumbing, but they make different trade-offs:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Feature
+     - Offset ``Paginator``
+     - ``CursorPaginator``
+   * - Total count
+     - Yes
+     - No
+   * - Random access to page N
+     - Yes
+     - No
+   * - Stable under concurrent inserts/deletes
+     - No
+     - Yes
+   * - Performance on deep pages
+     - Degrades (OFFSET scan)
+     - Constant (index range scan)
+   * - Requires deterministic ORDER BY
+     - No
+     - Yes
+
+Choose the **Offset Paginator** when you need a total page count or want to
+let users jump to an arbitrary page number.
+
+Choose the **Cursor Paginator** when you need stable, high-performance
+pagination on large datasets and a simple previous/next navigation is
+sufficient.
+
+Offset-Based Pagination
+-----------------------
+
 Doctrine ORM ships with a Paginator for DQL queries. It
 has a very simple API and implements the SPL interfaces ``Countable`` and
 ``IteratorAggregate``.
@@ -58,3 +93,178 @@ In this way the `DISTINCT` keyword will be omitted and can bring important perfo
                            ->setHint(Paginator::HINT_ENABLE_DISTINCT, false)
                            ->setFirstResult(0)
                            ->setMaxResults(100);
+
+Cursor-Based Pagination
+-----------------------
+
+Doctrine ORM ships with a ``CursorPaginator`` for cursor-based pagination of DQL queries.
+Unlike offset-based pagination, cursor pagination uses opaque pointers (cursors) derived
+from the last seen row to fetch the next or previous page. This makes it stable and
+performant on large datasets — no matter how deep you paginate, the database always uses
+an index range scan instead of skipping rows.
+
+.. note::
+
+    Cursor pagination requires a **deterministic ``ORDER BY`` clause**. Every column
+    combination used for sorting must uniquely identify a position in the result set.
+    A common pattern is to sort by a timestamp and then by primary key as a tie-breaker.
+
+Basic Usage
+~~~~~~~~~~~
+
+The ``$cursor`` parameter is an opaque string produced by a previous call to
+``getNextCursorAsString()`` or ``getPreviousCursorAsString()``. On the first request
+it is ``null`` or an empty string ``''`` — both are treated identically as the first
+page. It is typically read from the incoming HTTP query string:
+
+.. code-block:: php
+
+    $cursor = $_GET['cursor'] ?? null; // null or '' on the first page
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Tools\CursorPagination\CursorPaginator;
+
+    $dql = 'SELECT p FROM BlogPost p ORDER BY p.createdAt DESC, p.id DESC';
+    $query = $entityManager->createQuery($dql);
+
+    $paginator = (new CursorPaginator($query))
+        ->paginate(cursor: $cursor, limit: 15);
+
+    foreach ($paginator as $post) {
+        echo $post->getTitle() . "\n";
+    }
+
+    echo $paginator->getPreviousCursorAsString(); // previous encoded cursor string
+    echo $paginator->getNextCursorAsString();     // next encoded cursor string
+
+Navigating Pages
+~~~~~~~~~~~~~~~~
+
+Pass the encoded cursor back on subsequent requests to move forward or backward:
+
+.. code-block:: php
+
+    <?php
+    // Next page
+    $paginator->paginate(15, $nextCursor);
+
+    // Previous page
+    $paginator->paginate(15, $previousCursor);
+
+The cursor is an encoded string containing the location at which the next query should begin fetching results, along with the navigation direction.
+
+API Reference
+~~~~~~~~~~~~~
+
+``CursorPaginator::paginate(?string $cursor, int $limit): self``
+    Executes the query and stores the results. Fetches ``$limit + 1`` rows to
+    detect whether a further page exists, then trims the extra row. Returns
+    ``$this`` for chaining.
+
+``CursorPaginator::getNextCursor(): Cursor``
+    Returns the ``Cursor`` object for the next page. Throws a ``LogicException``
+    if there is no next page — call ``hasNextPage()`` first.
+
+``CursorPaginator::getPreviousCursor(): Cursor``
+    Returns the ``Cursor`` object for the previous page. Throws a ``LogicException``
+    if there is no previous page — call ``hasPreviousPage()`` first.
+
+``CursorPaginator::getNextCursorAsString(): string``
+    Returns the encoded cursor to retrieve the next page. Throws a
+    ``LogicException`` if there is no next page — call ``hasNextPage()`` first.
+
+``CursorPaginator::getPreviousCursorAsString(): string``
+    Returns the encoded cursor to retrieve the previous page. Throws a
+    ``LogicException`` if there is no previous page — call ``hasPreviousPage()`` first.
+
+``CursorPaginator::hasNextPage(): bool``
+    Returns whether a next page is available.
+
+``CursorPaginator::hasPreviousPage(): bool``
+    Returns whether a previous page is available.
+
+``CursorPaginator::hasToPaginate(): bool``
+    Returns whether either a next or previous page exists (i.e. the result
+    set spans more than one page).
+
+``CursorPaginator::getValues(): array``
+    Returns the raw entity array for the current page.
+
+``CursorPaginator::getItems(): array``
+    Returns an array of ``CursorItem`` objects, each wrapping an entity and its
+    individual ``Cursor``. Useful when you need per-row cursors.
+
+``CursorPaginator::getCursorForItem(mixed $item, bool $isNext = true): Cursor``
+    Builds a ``Cursor`` pointing at a specific entity. ``$isNext = true`` means
+    "start *after* this item"; ``false`` means "start *before* this item".
+
+``CursorPaginator::count(): int``
+    Returns the number of items on the current page (implements ``Countable``).
+
+**Next page**
+
+.. code-block:: sql
+
+    SELECT ...
+    FROM   post p
+    WHERE  (p.created_at < :cursor_val_0)
+       OR  (p.created_at = :cursor_val_0 AND p.id < :cursor_id_1)
+    ORDER  BY p.created_at DESC, p.id DESC
+    LIMIT  16   -- limit + 1
+
+**Previous page**
+
+.. code-block:: sql
+
+    SELECT ...
+    FROM   post p
+    WHERE  (p.created_at > :cursor_val_0)
+       OR  (p.created_at = :cursor_val_0 AND p.id > :cursor_id_1)
+    ORDER  BY p.created_at ASC, p.id ASC   -- reversed
+    LIMIT  16
+
+HTML Template Example
+~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows how to render a paginated list with previous/next
+navigation links using the ``CursorPaginator`` in a PHP template:
+
+.. literalinclude:: pagination/cursor-pagination.php
+   :language: php
+
+Cursor Encoding
+~~~~~~~~~~~~~~~
+
+A cursor is serialized to a URL-safe string via ``Cursor::encodeToString()`` and
+deserialized back via the static ``Cursor::fromEncodedString()``. The format is a
+JSON object encoded with URL-safe Base64 (no padding):
+
+.. code-block:: json
+
+    {
+        "p.createdAt": "2024-01-15T10:30:00+00:00",
+        "p.id": 42,
+        "_isNext": true
+    }
+
+The ``_isNext`` flag distinguishes next-page cursors from previous-page cursors.
+All other keys are the DQL path expressions (``alias.field``) of the ``ORDER BY``
+columns, and their values are the database representations of the pivot row's
+field values.
+
+If you need a different serialization format (e.g. encryption), build it on top of
+a ``Cursor`` instance: call ``$cursor->toArray()`` to get the raw data, apply your
+own encoding, and reconstruct with ``new Cursor($parameters, $isNext)``.
+
+Limitations
+~~~~~~~~~~~
+
+- Every ``ORDER BY`` column must map to an entity field. Raw SQL expressions or
+  computed columns in ``ORDER BY`` are not supported.
+- ``COUNT`` queries are not available; cursor pagination does not know the total
+  number of results by design. If you need a total count, use the
+  offset-based ``Paginator`` described above.
+- The query must have at least one ``ORDER BY`` item; the paginator throws a
+  ``LogicException`` otherwise.

--- a/docs/en/tutorials/pagination/cursor-pagination.php
+++ b/docs/en/tutorials/pagination/cursor-pagination.php
@@ -1,0 +1,31 @@
+<?php
+
+use Doctrine\ORM\Tools\CursorPagination\CursorPaginator;
+
+$cursor = $_GET['cursor'] ?? null;
+
+$query = $entityManager->createQuery('SELECT p FROM BlogPost p ORDER BY p.createdAt DESC, p.id DESC');
+
+/** @var CursorPaginator<BlogPost> $paginator */
+$paginator = (new CursorPaginator($query))
+    ->paginate(cursor: $cursor, limit: 15);
+?>
+<p><?= $paginator->count() ?> result(s) on this page.</p>
+
+<ul>
+    <?php foreach ($paginator as $post): ?>
+        <li><?= escape($post->getTitle()) ?></li>
+    <?php endforeach ?>
+</ul>
+
+<?php if ($paginator->hasToPaginate()): ?>
+    <nav>
+        <?php if ($paginator->hasPreviousPage()): ?>
+            <a href="?cursor=<?= escape($paginator->getPreviousCursorAsString()) ?>">Previous</a>
+        <?php endif ?>
+
+        <?php if ($paginator->hasNextPage()): ?>
+            <a href="?cursor=<?= escape($paginator->getNextCursorAsString()) ?>">Next</a>
+        <?php endif ?>
+    </nav>
+<?php endif ?>

--- a/src/Tools/CursorPagination/Cursor.php
+++ b/src/Tools/CursorPagination/Cursor.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Tools\CursorPagination\Exception\InvalidCursor;
+use JsonException;
+
+use function base64_decode;
+use function base64_encode;
+use function json_decode;
+use function json_encode;
+use function rtrim;
+use function strtr;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Represents a cursor for cursor-based pagination.
+ *
+ * A cursor contains the parameters needed to fetch the next or previous page of results.
+ */
+final class Cursor
+{
+    /** @param array<string, scalar> $parameters */
+    public function __construct(
+        private readonly array $parameters,
+        private readonly bool $isNext = true,
+    ) {
+    }
+
+    /**
+     * @internal
+     *
+     * @return array<string, scalar>
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Returns whether the cursor is for navigating to the next page.
+     */
+    public function isNext(): bool
+    {
+        return $this->isNext;
+    }
+
+    /**
+     * Returns whether the cursor is for navigating to the previous page.
+     */
+    public function isPrevious(): bool
+    {
+        return ! $this->isNext;
+    }
+
+    /** @return array<string, scalar> */
+    public function toArray(): array
+    {
+        return [...$this->parameters, '_isNext' => $this->isNext];
+    }
+
+    /**
+     * Encodes the cursor to a URL-safe Base64 JSON string.
+     */
+    public function encodeToString(): string
+    {
+        return rtrim(strtr(base64_encode((string) json_encode($this->toArray())), '+/', '-_'), '=');
+    }
+
+    /**
+     * Decodes a cursor from an encoded string.
+     *
+     * @see CursorWalker::buildCursorCondition() for the security model around cursor manipulation.
+     *
+     * @throws InvalidCursor If decoding fails.
+     */
+    public static function fromEncodedString(string $encodedString): self
+    {
+        $decoded = base64_decode(strtr($encodedString, '-_', '+/'), strict: true);
+
+        if ($decoded === false) {
+            throw new InvalidCursor($encodedString);
+        }
+
+        try {
+            $parameters = json_decode($decoded, associative: true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidCursor($encodedString, $e);
+        }
+
+        $isNext = $parameters['_isNext'] ?? true;
+
+        unset($parameters['_isNext']);
+
+        return new self($parameters, $isNext);
+    }
+}

--- a/src/Tools/CursorPagination/CursorItem.php
+++ b/src/Tools/CursorPagination/CursorItem.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+/**
+ * Represents a paginated item with its associated cursor.
+ *
+ * @template T
+ */
+final class CursorItem
+{
+    /** @param T $value */
+    public function __construct(
+        private readonly mixed $value,
+        private readonly Cursor $cursor,
+    ) {
+    }
+
+    /** @return T */
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getCursor(): Cursor
+    {
+        return $this->cursor;
+    }
+}

--- a/src/Tools/CursorPagination/CursorOrderByItem.php
+++ b/src/Tools/CursorPagination/CursorOrderByItem.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\AST\PathExpression;
+
+/** @internal */
+final class CursorOrderByItem
+{
+    /** @param ClassMetadata<object>|null $metadata */
+    public function __construct(
+        public readonly PathExpression|string $expression,
+        public readonly OrderDirection $direction,
+        public readonly string $paramKey,
+        public readonly ClassMetadata|null $metadata = null,
+    ) {
+    }
+}

--- a/src/Tools/CursorPagination/CursorPaginator.php
+++ b/src/Tools/CursorPagination/CursorPaginator.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+use Countable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Utility\PersisterHelper;
+use IteratorAggregate;
+use LogicException;
+use Traversable;
+
+use function array_map;
+use function array_reverse;
+
+/**
+ * The cursor paginator handles cursor-based pagination for DQL queries.
+ *
+ * @template T
+ * @implements IteratorAggregate<mixed, T>
+ */
+final class CursorPaginator implements IteratorAggregate, Countable
+{
+    private readonly Query $query;
+    /** @var Collection<int, T>|null */
+    private Collection|null $items = null;
+
+    /** @var list<CursorOrderByItem>|null */
+    private array|null $orderByItems = null;
+
+    private bool $hasMore       = false;
+    private Cursor|null $cursor = null;
+
+    public function __construct(Query|QueryBuilder $query)
+    {
+        if ($query instanceof QueryBuilder) {
+            $query = $query->getQuery();
+        }
+
+        $this->query = $query;
+    }
+
+    /**
+     * Returns the query.
+     */
+    public function getQuery(): Query
+    {
+        return $this->query;
+    }
+
+    /**
+     * Paginates the query with the given limit and optional cursor.
+     *
+     * @param string|null $cursor The encoded cursor string, null or empty string for the first page.
+     * @param int         $limit  The maximum number of results to return.
+     *
+     * @return $this
+     */
+    public function paginate(string|null $cursor, int $limit): self
+    {
+        $this->cursor  = ! empty($cursor) ? Cursor::fromEncodedString($cursor) : null;
+        $shouldReverse = $this->cursor?->isPrevious() ?? false;
+
+        $query = $this->cloneQuery($this->query);
+
+        $this->appendTreeWalker($query);
+
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, $shouldReverse);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, $this->cursor?->getParameters() ?? []);
+
+        $query->setMaxResults($limit + 1);
+
+        $this->items   = new ArrayCollection($query->getResult());
+        $this->hasMore = $this->items->count() > $limit;
+        $this->items   = new ArrayCollection($this->items->slice(0, $limit));
+
+        $this->orderByItems = $query->getHint(CursorWalker::HINT_CURSOR_ORDER_BY_ITEMS) ?: [];
+
+        if ($this->cursor !== null && $this->cursor->isPrevious()) {
+            $this->items = new ArrayCollection(array_reverse($this->items->toArray(), true));
+        }
+
+        return $this;
+    }
+
+    private function cloneQuery(Query $query): Query
+    {
+        $cloneQuery = clone $query;
+
+        $cloneQuery->setParameters(clone $query->getParameters());
+        $cloneQuery->setCacheable(false);
+
+        foreach ($query->getHints() as $name => $value) {
+            $cloneQuery->setHint($name, $value);
+        }
+
+        return $cloneQuery;
+    }
+
+    /**
+     * Appends a custom tree walker to the tree walkers hint.
+     */
+    private function appendTreeWalker(Query $query): void
+    {
+        $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
+
+        if ($hints === false) {
+            $hints = [];
+        }
+
+        $hints[] = CursorWalker::class;
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, $hints);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<mixed, T>
+     */
+    public function getIterator(): Traversable
+    {
+        return $this->items->getIterator();
+    }
+
+    public function count(): int
+    {
+        return $this->items->count();
+    }
+
+    /**
+     * Returns whether there is a previous page.
+     */
+    public function hasPreviousPage(): bool
+    {
+        return $this->cursor !== null && ($this->cursor->isNext() || $this->hasMore);
+    }
+
+    /**
+     * Returns whether there is a next page.
+     */
+    public function hasNextPage(): bool
+    {
+        return $this->hasMore || ($this->cursor !== null && $this->cursor->isPrevious());
+    }
+
+    /**
+     * Returns the cursor object for the next page.
+     *
+     * @throws LogicException If there is no next page. Check {@see hasNextPage()} first.
+     */
+    public function getNextCursor(): Cursor
+    {
+        if ($this->items->isEmpty() || ! $this->hasNextPage()) {
+            throw new LogicException('There is no next page. Call hasNextPage() before getNextCursor().');
+        }
+
+        return $this->getCursorForItem($this->items->last());
+    }
+
+    /**
+     * Returns the cursor object for the previous page.
+     *
+     * @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first.
+     */
+    public function getPreviousCursor(): Cursor
+    {
+        if ($this->items->isEmpty() || ! $this->hasPreviousPage()) {
+            throw new LogicException('There is no previous page. Call hasPreviousPage() before getPreviousCursor().');
+        }
+
+        return $this->getCursorForItem($this->items->first(), false);
+    }
+
+    /**
+     * Returns the encoded cursor string for the next page.
+     *
+     * @throws LogicException If there is no next page. Check {@see hasNextPage()} first.
+     */
+    public function getNextCursorAsString(): string
+    {
+        return $this->getNextCursor()->encodeToString();
+    }
+
+    /**
+     * Returns the encoded cursor string for the previous page.
+     *
+     * @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first.
+     */
+    public function getPreviousCursorAsString(): string
+    {
+        return $this->getPreviousCursor()->encodeToString();
+    }
+
+    /**
+     * Returns the cursor for a given item.
+     *
+     * @param mixed $item   The item to create a cursor for.
+     * @param bool  $isNext Whether the cursor is for the next page.
+     *
+     * @throws Exception
+     * @throws QueryException
+     */
+    public function getCursorForItem(mixed $item, bool $isNext = true): Cursor
+    {
+        return new Cursor($this->getParametersForItem($item), $isNext);
+    }
+
+    /**
+     * Returns items wrapped with their associated cursors.
+     *
+     * @return array<int, CursorItem<T>>
+     *
+     * @throws Exception
+     * @throws QueryException
+     */
+    public function getItems(): array
+    {
+        return array_map(
+            fn (mixed $item) => new CursorItem($item, $this->getCursorForItem($item)),
+            $this->items->toArray(),
+        );
+    }
+
+    /**
+     * Returns the raw entity values.
+     *
+     * @return list<T>
+     */
+    public function getValues(): array
+    {
+        return $this->items->getValues();
+    }
+
+    /**
+     * Returns whether pagination is needed.
+     */
+    public function hasToPaginate(): bool
+    {
+        return $this->hasPreviousPage() || $this->hasNextPage();
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws Query\QueryException
+     * @throws Exception
+     */
+    private function getParametersForItem(mixed $item): array
+    {
+        $em         = $this->query->getEntityManager();
+        $connection = $em->getConnection();
+        $metadata   = $em->getMetadataFactory()->hasMetadataFor($item::class)
+            ? $em->getClassMetadata($item::class)
+            : null;
+
+        $result = [];
+
+        foreach ($this->orderByItems as $orderByItem) {
+            if (! $orderByItem->expression instanceof PathExpression) {
+                continue;
+            }
+
+            $fieldName     = $orderByItem->expression->field;
+            $orderMetadata = $orderByItem->metadata ?? $metadata;
+            $value         = $metadata?->getFieldValue($item, $fieldName) ?? $item->$fieldName;
+            $type          = PersisterHelper::getTypeOfField($fieldName, $orderMetadata, $em)[0];
+
+            $result[$orderByItem->paramKey] = $connection->convertToDatabaseValue($value, $type);
+        }
+
+        return $result;
+    }
+}

--- a/src/Tools/CursorPagination/CursorWalker.php
+++ b/src/Tools/CursorPagination/CursorWalker.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Query\AST\ComparisonExpression;
+use Doctrine\ORM\Query\AST\ConditionalExpression;
+use Doctrine\ORM\Query\AST\ConditionalPrimary;
+use Doctrine\ORM\Query\AST\ConditionalTerm;
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\OrderByClause;
+use Doctrine\ORM\Query\AST\OrderByItem;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\AST\WhereClause;
+use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+use LogicException;
+
+use function count;
+use function str_replace;
+
+/**
+ * @internal
+ *
+ * TreeWalker for cursor-based pagination.
+ *
+ * Responsibilities:
+ * - Extract ORDER BY columns from AST
+ * - Inject WHERE conditions for cursor navigation
+ * - Reverse ORDER BY direction for previous page navigation
+ */
+class CursorWalker extends TreeWalkerAdapter
+{
+    public const HINT_CURSOR_PARAMETERS     = 'doctrine.cursor.parameters';
+    public const HINT_CURSOR_REVERSE        = 'doctrine.cursor.reverse';
+    public const HINT_CURSOR_ORDER_BY_ITEMS = 'doctrine.cursor.order_by_items';
+
+    public function walkSelectStatement(SelectStatement $selectStatement): void
+    {
+        $query            = $this->_getQuery();
+        $shouldReverse    = $query->getHint(self::HINT_CURSOR_REVERSE) === true;
+        $cursorParameters = $query->getHint(self::HINT_CURSOR_PARAMETERS);
+
+        if (! isset($selectStatement->orderByClause)) {
+            throw new LogicException('No ORDER BY clause found. Cursor pagination requires a deterministic sort order.');
+        }
+
+        $orderByItems    = [];
+        $newOrderByItems = [];
+
+        foreach ($selectStatement->orderByClause->orderByItems as $orderByItem) {
+            $direction = OrderDirection::fromOrderByItem($orderByItem, $shouldReverse);
+
+            $paramKey = $this->getParameterKey($orderByItem->expression);
+            $metadata = $orderByItem->expression instanceof PathExpression
+                ? $this->getMetadataForDqlAlias($orderByItem->expression->identificationVariable)
+                : null;
+
+            $orderByItems[] = new CursorOrderByItem($orderByItem->expression, $direction, $paramKey, $metadata);
+
+            $newItem           = new OrderByItem($orderByItem->expression);
+            $newItem->type     = $direction->value;
+            $newOrderByItems[] = $newItem;
+        }
+
+        $selectStatement->orderByClause = new OrderByClause($newOrderByItems);
+
+        $query->setHint(self::HINT_CURSOR_ORDER_BY_ITEMS, $orderByItems);
+
+        if (empty($cursorParameters)) {
+            return;
+        }
+
+        $condition = $this->buildCursorCondition($orderByItems, $cursorParameters);
+
+        if ($condition === null) {
+            return;
+        }
+
+        $conditionalPrimary                        = new ConditionalPrimary();
+        $conditionalPrimary->conditionalExpression = $condition;
+
+        if ($selectStatement->whereClause !== null) {
+            if ($selectStatement->whereClause->conditionalExpression instanceof ConditionalTerm) {
+                $selectStatement->whereClause->conditionalExpression->conditionalFactors[] = $conditionalPrimary;
+            } elseif ($selectStatement->whereClause->conditionalExpression instanceof ConditionalPrimary) {
+                $selectStatement->whereClause->conditionalExpression = new ConditionalExpression(
+                    [
+                        new ConditionalTerm(
+                            [
+                                $selectStatement->whereClause->conditionalExpression,
+                                $conditionalPrimary,
+                            ],
+                        ),
+                    ],
+                );
+            } else {
+                $existingPrimary                                     = new ConditionalPrimary();
+                $existingPrimary->conditionalExpression              = $selectStatement->whereClause->conditionalExpression;
+                $selectStatement->whereClause->conditionalExpression = new ConditionalTerm(
+                    [
+                        $existingPrimary,
+                        $conditionalPrimary,
+                    ],
+                );
+            }
+        } else {
+            $selectStatement->whereClause = new WhereClause(
+                new ConditionalExpression(
+                    [new ConditionalTerm([$conditionalPrimary])],
+                ),
+            );
+        }
+    }
+
+    /**
+     * Recursively builds a cursor condition:
+     * (col1 > :val1) OR (col1 = :val1 AND col2 > :val2) OR ...
+     *
+     * @param list<CursorOrderByItem> $orderByItems
+     * @param array<string, mixed>    $cursorParameters
+     *
+     * @throws QueryException
+     */
+    private function buildCursorCondition(array $orderByItems, array $cursorParameters, int $index = 0): ConditionalExpression|null
+    {
+        if (! isset($orderByItems[$index])) {
+            return null;
+        }
+
+        $orderByItem = $orderByItems[$index];
+        $expression  = $orderByItem->expression;
+        $direction   = $orderByItem->direction;
+        $paramKey    = $orderByItem->paramKey;
+
+        $operator = $direction->operator();
+
+        $paramName  = str_replace('.', '_', $paramKey) . '_' . $index;
+        $paramValue = $cursorParameters[$paramKey] ?? null;
+
+        // Security note: $paramKey is derived from the DQL ORDER BY AST, not from the
+        // cursor payload. A tampered cursor can only influence the *values* used as pivot
+        // points, not the columns being filtered. All values are bound via setParameter(),
+        // so SQL injection is not possible. The worst a user can do is navigate to an
+        // arbitrary position in the result set, while remaining bound by the original
+        // query's WHERE constraints.
+        $this->_getQuery()->setParameter($paramName, $paramValue);
+
+        $comparisonExpr = new ComparisonExpression(
+            $expression,
+            $operator,
+            new InputParameter(':' . $paramName),
+        );
+
+        $comparisonPrimary                              = new ConditionalPrimary();
+        $comparisonPrimary->simpleConditionalExpression = $comparisonExpr;
+
+        if ($index === count($orderByItems) - 1) {
+            return new ConditionalExpression([new ConditionalTerm([$comparisonPrimary])]);
+        }
+
+        $nextCondition = $this->buildCursorCondition($orderByItems, $cursorParameters, $index + 1);
+
+        $equalityExpr = new ComparisonExpression(
+            $expression,
+            '=',
+            new InputParameter(':' . $paramName),
+        );
+
+        $equalityPrimary                              = new ConditionalPrimary();
+        $equalityPrimary->simpleConditionalExpression = $equalityExpr;
+
+        $nextPrimary                        = new ConditionalPrimary();
+        $nextPrimary->conditionalExpression = $nextCondition;
+
+        $andPrimary                        = new ConditionalPrimary();
+        $andPrimary->conditionalExpression = new ConditionalExpression([
+            new ConditionalTerm([$equalityPrimary, $nextPrimary]),
+        ]);
+
+        return new ConditionalExpression([
+            new ConditionalTerm([$comparisonPrimary]),
+            new ConditionalTerm([$andPrimary]),
+        ]);
+    }
+
+    /**
+     * Returns the parameter key for the given expression.
+     */
+    private function getParameterKey(mixed $expression): string
+    {
+        if ($expression instanceof PathExpression) {
+            return $expression->identificationVariable . '.' . $expression->field;
+        }
+
+        return (string) $expression;
+    }
+}

--- a/src/Tools/CursorPagination/Exception/InvalidCursor.php
+++ b/src/Tools/CursorPagination/Exception/InvalidCursor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination\Exception;
+
+use InvalidArgumentException;
+use Throwable;
+
+use function sprintf;
+
+final class InvalidCursor extends InvalidArgumentException
+{
+    public function __construct(string $cursor, Throwable|null $previous = null)
+    {
+        parent::__construct(
+            sprintf(
+                'The cursor "%s" could not be decoded.',
+                $cursor,
+            ),
+            previous: $previous,
+        );
+    }
+}

--- a/src/Tools/CursorPagination/OrderDirection.php
+++ b/src/Tools/CursorPagination/OrderDirection.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Query\AST\OrderByItem;
+
+/** @internal */
+enum OrderDirection: string
+{
+    case Ascending  = 'ASC';
+    case Descending = 'DESC';
+
+    public static function fromOrderByItem(OrderByItem $item, bool $reverse = false): self
+    {
+        $direction = $item->isAsc() ? self::Ascending : self::Descending;
+
+        return $reverse ? $direction->reversed() : $direction;
+    }
+
+    public function operator(): string
+    {
+        return match ($this) {
+            self::Ascending  => '>',
+            self::Descending => '<',
+        };
+    }
+
+    public function reversed(): self
+    {
+        return match ($this) {
+            self::Ascending  => self::Descending,
+            self::Descending => self::Ascending,
+        };
+    }
+}

--- a/tests/Tests/ORM/Tools/CursorPagination/CursorPaginationTestCase.php
+++ b/tests/Tests/ORM/Tools/CursorPagination/CursorPaginationTestCase.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\CursorPagination;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InverseJoinColumn;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\JoinTable;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\OrmTestCase;
+
+abstract class CursorPaginationTestCase extends OrmTestCase
+{
+    /** @var EntityManagerInterface */
+    public $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getTestEntityManager();
+    }
+}
+
+
+#[Entity]
+class MyBlogPost
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @var Author */
+    #[ManyToOne(targetEntity: 'Author')]
+    public $author;
+
+    /** @var Category */
+    #[ManyToOne(targetEntity: 'Category')]
+    public $category;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $title;
+}
+
+#[Entity]
+class MyAuthor
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+}
+
+#[Entity]
+class MyCategory
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+}
+
+
+#[Entity]
+class BlogPost
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @var Author */
+    #[ManyToOne(targetEntity: 'Author')]
+    public $author;
+
+    /** @var Category */
+    #[ManyToOne(targetEntity: 'Category')]
+    public $category;
+}
+
+#[Entity]
+class Author
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $name;
+}
+
+#[Entity]
+class Person
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $name;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $biography;
+}
+
+#[Entity]
+class Category
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+}
+
+
+#[Table(name: 'groups')]
+#[Entity]
+class Group
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @phpstan-var Collection<int, User> */
+    #[ManyToMany(targetEntity: 'User', mappedBy: 'groups')]
+    public $users;
+}
+
+#[Entity]
+class User
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @phpstan-var Collection<int, Group> */
+    #[JoinTable(name: 'user_group')]
+    #[JoinColumn(name: 'user_id', referencedColumnName: 'id')]
+    #[InverseJoinColumn(name: 'group_id', referencedColumnName: 'id')]
+    #[ManyToMany(targetEntity: 'Group', inversedBy: 'users')]
+    public $groups;
+
+    /** @var Avatar */
+    #[OneToOne(targetEntity: 'Avatar', mappedBy: 'user')]
+    public $avatar;
+}
+
+#[Entity]
+class Avatar
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public $id;
+
+    /** @var User */
+    #[OneToOne(targetEntity: 'User', inversedBy: 'avatar')]
+    #[JoinColumn(name: 'user_id', referencedColumnName: 'id')]
+    public $user;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $image;
+
+    /** @var int */
+    #[Column(type: 'integer')]
+    public $imageHeight;
+
+    /** @var int */
+    #[Column(type: 'integer')]
+    public $imageWidth;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $imageAltDesc;
+}
+
+#[MappedSuperclass]
+abstract class Identified
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    private int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}
+
+#[Entity]
+class Banner extends Identified
+{
+    /** @var string */
+    #[Column(type: 'string', length: 255)]
+    public $name;
+}

--- a/tests/Tests/ORM/Tools/CursorPagination/CursorPaginatorTest.php
+++ b/tests/Tests/ORM/Tools/CursorPagination/CursorPaginatorTest.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\CursorPagination;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\CursorPagination\Cursor;
+use Doctrine\ORM\Tools\CursorPagination\CursorItem;
+use Doctrine\ORM\Tools\CursorPagination\CursorPaginator;
+use Doctrine\Tests\OrmTestCase;
+use LogicException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+use function enum_exists;
+
+class CursorPaginatorTest extends OrmTestCase
+{
+    private Connection&MockObject $connection;
+    private EntityManagerInterface&MockObject $em;
+    private AbstractHydrator&MockObject $hydrator;
+
+    protected function setUp(): void
+    {
+        $platform = $this->getMockBuilder(AbstractPlatform::class)
+            ->setConstructorArgs(enum_exists(UnquotedIdentifierFolding::class) ? [UnquotedIdentifierFolding::UPPER] : [])
+            ->getMock();
+        $platform->method('supportsIdentityColumns')
+            ->willReturn(true);
+
+        $driver = $this->createMock(Driver::class);
+        $driver->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $this->connection = $this->getMockBuilder(Connection::class)
+            ->onlyMethods(['executeQuery'])
+            ->setConstructorArgs([[], $driver])
+            ->getMock();
+
+        $this->em = $this->getMockBuilder(EntityManagerDecorator::class)
+            ->onlyMethods(['newHydrator'])
+            ->setConstructorArgs([$this->createTestEntityManagerWithConnection($this->connection)])
+            ->getMock();
+
+        $this->hydrator = $this->createMock(AbstractHydrator::class);
+        $this->em->method('newHydrator')->willReturn($this->hydrator);
+    }
+
+    public function testPaginatorAcceptsQueryBuilder(): void
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('p')
+            ->from(BlogPost::class, 'p')
+            ->orderBy('p.id', 'ASC');
+
+        $paginator = new CursorPaginator($qb);
+
+        self::assertInstanceOf(Query::class, $paginator->getQuery());
+    }
+
+    public function testHasNextPageWhenMoreResultsExist(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+            (object) ['id' => 3],
+            (object) ['id' => 4],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 3);
+
+        self::assertTrue($paginator->hasNextPage());
+        self::assertFalse($paginator->hasPreviousPage());
+        self::assertCount(3, $paginator);
+    }
+
+    public function testHasNoPagesOnFirstPageWithoutMoreResults(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        self::assertFalse($paginator->hasPreviousPage());
+        self::assertFalse($paginator->hasNextPage());
+        self::assertFalse($paginator->hasToPaginate());
+    }
+
+    public function testGetNextCursorAsStringThrowsWhenNoNextPage(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $this->expectException(LogicException::class);
+        $paginator->getNextCursorAsString();
+    }
+
+    public function testGetPreviousCursorAsStringThrowsWhenNoPreviousPage(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $this->expectException(LogicException::class);
+        $paginator->getPreviousCursorAsString();
+    }
+
+    public function testGetNextCursorThrowsWhenNoNextPage(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $this->expectException(LogicException::class);
+        $paginator->getNextCursor();
+    }
+
+    public function testGetPreviousCursorThrowsWhenNoPreviousPage(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $this->expectException(LogicException::class);
+        $paginator->getPreviousCursor();
+    }
+
+    public function testGetNextCursorWhenMoreResultsExist(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 1);
+
+        $nextCursor = $paginator->getNextCursor();
+
+        self::assertTrue($nextCursor->isNext());
+    }
+
+    public function testGetNextCursorAsStringReturnsStringWhenNextPageExists(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 1);
+
+        self::assertIsString($paginator->getNextCursorAsString());
+    }
+
+    public function testGetPreviousCursorAsStringReturnsStringWhenPreviousPageExists(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $cursor    = (new Cursor(['p__id' => 1], true))->encodeToString();
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate($cursor, 10);
+
+        self::assertIsString($paginator->getPreviousCursorAsString());
+    }
+
+    public function testEmptyResultSet(): void
+    {
+        $this->hydrator->method('hydrateAll')->willReturn([]);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        self::assertCount(0, $paginator);
+        self::assertFalse($paginator->hasNextPage());
+        self::assertFalse($paginator->hasPreviousPage());
+    }
+
+    public function testIteratorReturnsItems(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $iteratedItems = [];
+        foreach ($paginator as $item) {
+            $iteratedItems[] = $item;
+        }
+
+        self::assertCount(2, $iteratedItems);
+    }
+
+    public function testGetValuesReturnsRawEntities(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $values = $paginator->getValues();
+
+        self::assertCount(2, $values);
+        self::assertSame($items[0], $values[0]);
+        self::assertSame($items[1], $values[1]);
+    }
+
+    public function testGetItemsReturnsCursorItems(): void
+    {
+        $items = [
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        $cursorItems = $paginator->getItems();
+
+        self::assertCount(2, $cursorItems);
+        self::assertInstanceOf(CursorItem::class, $cursorItems[0]);
+        self::assertSame($items[0], $cursorItems[0]->getValue());
+        self::assertInstanceOf(Cursor::class, $cursorItems[0]->getCursor());
+        self::assertSame($items[1], $cursorItems[1]->getValue());
+    }
+
+    public function testGetItemsReturnsEmptyArrayWhenNoResults(): void
+    {
+        $this->hydrator->method('hydrateAll')->willReturn([]);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        self::assertSame([], $paginator->getItems());
+        self::assertSame([], $paginator->getValues());
+    }
+
+    public function testPaginateWithEmptyCursorTreatedAsFirstPage(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate('', 10);
+
+        self::assertFalse($paginator->hasPreviousPage());
+        self::assertFalse($paginator->hasNextPage());
+    }
+
+    public function testPaginateWithPreviousCursorReversesItems(): void
+    {
+        $items = [
+            (object) ['id' => 3],
+            (object) ['id' => 2],
+            (object) ['id' => 1],
+        ];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+
+        $previousCursor = (new Cursor(['p__id' => 3], false))->encodeToString();
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate($previousCursor, 10);
+
+        $values = $paginator->getValues();
+        self::assertCount(3, $values);
+        self::assertSame(1, $values[0]->id);
+        self::assertSame(2, $values[1]->id);
+        self::assertSame(3, $values[2]->id);
+    }
+
+    public function testCloneQueryCopiesExistingHints(): void
+    {
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC');
+        $query->setHint('custom.hint', 'custom_value');
+
+        $paginator = new CursorPaginator($query);
+        $paginator->paginate(null, 10);
+
+        self::assertCount(1, $paginator);
+    }
+}

--- a/tests/Tests/ORM/Tools/CursorPagination/CursorTest.php
+++ b/tests/Tests/ORM/Tools/CursorPagination/CursorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Tools\CursorPagination\Cursor;
+use Doctrine\ORM\Tools\CursorPagination\Exception\InvalidCursor;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function base64_encode;
+use function json_encode;
+use function rtrim;
+use function strtr;
+
+class CursorTest extends TestCase
+{
+    public function testCursorIsFinal(): void
+    {
+        $reflection = new ReflectionClass(Cursor::class);
+
+        self::assertTrue($reflection->isFinal());
+    }
+
+    public function testEncodeAndDecode(): void
+    {
+        $parameters = ['id' => 10, 'name' => 'test'];
+        $cursor     = new Cursor($parameters, true);
+
+        $decoded = Cursor::fromEncodedString($cursor->encodeToString());
+
+        self::assertSame($parameters, $decoded->getParameters());
+        self::assertTrue($decoded->isNext());
+    }
+
+    public function testEncodeAndDecodeWithPreviousCursor(): void
+    {
+        $cursor = new Cursor(['id' => 10], false);
+
+        $decoded = Cursor::fromEncodedString($cursor->encodeToString());
+
+        self::assertTrue($decoded->isPrevious());
+    }
+
+    public function testEncodeProducesUrlSafeString(): void
+    {
+        $cursor  = new Cursor(['id' => 123456789, 'foo' => 'bar/baz+test']);
+        $encoded = $cursor->encodeToString();
+
+        self::assertStringNotContainsString('+', $encoded);
+        self::assertStringNotContainsString('/', $encoded);
+        self::assertStringNotContainsString('=', $encoded);
+    }
+
+    public function testFromEncodedStringThrowsForInvalidBase64(): void
+    {
+        $this->expectException(InvalidCursor::class);
+
+        Cursor::fromEncodedString('not-valid-base64!@#$');
+    }
+
+    public function testFromEncodedStringThrowsForInvalidJson(): void
+    {
+        $this->expectException(InvalidCursor::class);
+
+        Cursor::fromEncodedString(rtrim(strtr(base64_encode('not-json'), '+/', '-_'), '='));
+    }
+
+    public function testFromEncodedStringChainsPreviousExceptionForInvalidJson(): void
+    {
+        try {
+            Cursor::fromEncodedString(rtrim(strtr(base64_encode('not-json'), '+/', '-_'), '='));
+            self::fail('Expected InvalidCursor to be thrown.');
+        } catch (InvalidCursor $e) {
+            self::assertInstanceOf(JsonException::class, $e->getPrevious());
+        }
+    }
+
+    public function testFromEncodedStringDefaultsToNextWhenIsNextMissing(): void
+    {
+        $json    = json_encode(['id' => 10]);
+        $encoded = rtrim(strtr(base64_encode($json), '+/', '-_'), '=');
+
+        $cursor = Cursor::fromEncodedString($encoded);
+
+        self::assertTrue($cursor->isNext());
+    }
+
+    public function testToArray(): void
+    {
+        $cursor = new Cursor(['id' => 1], true);
+
+        self::assertSame(['id' => 1, '_isNext' => true], $cursor->toArray());
+    }
+}

--- a/tests/Tests/ORM/Tools/CursorPagination/CursorWalkerTest.php
+++ b/tests/Tests/ORM/Tools/CursorPagination/CursorWalkerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\CursorPagination;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\CursorPagination\CursorWalker;
+use LogicException;
+
+class CursorWalkerTest extends CursorPaginationTestCase
+{
+    public function testThrowsExceptionWithoutOrderBy(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No ORDER BY clause found. Cursor pagination requires a deterministic sort order.');
+
+        $query->getSQL();
+    }
+
+    public function testBasicQueryWithOrderBy(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, []);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ ORDER BY b0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testQueryWithReversedOrderBy(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, true);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, []);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ ORDER BY b0_.id DESC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testQueryWithMultipleOrderByColumnsReversed(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\MyBlogPost p ORDER BY p.title ASC, p.id DESC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, true);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, []);
+
+        self::assertEquals(
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, m0_.author_id AS author_id_2, m0_.category_id AS category_id_3 FROM MyBlogPost m0_ ORDER BY m0_.title DESC, m0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionSingleColumnAsc(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, ['p.id' => 10]);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE (b0_.id > ?) ORDER BY b0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionSingleColumnDesc(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p ORDER BY p.id DESC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, ['p.id' => 10]);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE (b0_.id < ?) ORDER BY b0_.id DESC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionWithExistingWhere(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p WHERE p.id > 5 ORDER BY p.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, ['p.id' => 10]);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE b0_.id > 5 AND (b0_.id > ?) ORDER BY b0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testQueryWithJoinAndOrderByJoinedEntity(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p, a FROM Doctrine\Tests\ORM\Tools\CursorPagination\BlogPost p JOIN p.author a ORDER BY a.name ASC, p.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, []);
+
+        self::assertEquals(
+            'SELECT b0_.id AS id_0, a1_.id AS id_1, a1_.name AS name_2, b0_.author_id AS author_id_3, b0_.category_id AS category_id_4 FROM BlogPost b0_ INNER JOIN Author a1_ ON b0_.author_id = a1_.id ORDER BY a1_.name ASC, b0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionMultipleColumnsDesc(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\MyBlogPost p ORDER BY p.title DESC, p.id DESC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, ['p.title' => 'Test', 'p.id' => 10]);
+
+        self::assertEquals(
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, m0_.author_id AS author_id_2, m0_.category_id AS category_id_3 FROM MyBlogPost m0_ WHERE (m0_.title < ? OR (m0_.title = ? AND (m0_.id < ?))) ORDER BY m0_.title DESC, m0_.id DESC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionMultipleColumnsAsc(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT a FROM Doctrine\Tests\ORM\Tools\CursorPagination\Author a ORDER BY a.name ASC, a.id ASC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, ['a.name' => 'John', 'a.id' => 5]);
+
+        self::assertEquals(
+            'SELECT a0_.id AS id_0, a0_.name AS name_1 FROM Author a0_ WHERE (a0_.name > ? OR (a0_.name = ? AND (a0_.id > ?))) ORDER BY a0_.name ASC, a0_.id ASC',
+            $query->getSQL(),
+        );
+    }
+
+    public function testCursorConditionThreeColumnsDesc(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\CursorPagination\Person p ORDER BY p.biography DESC, p.name DESC, p.id DESC',
+        );
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CursorWalker::class]);
+        $query->setHint(CursorWalker::HINT_CURSOR_REVERSE, false);
+        $query->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, [
+            'p.biography' => '2019-11-04',
+            'p.name' => 'test@example.com',
+            'p.id' => 529,
+        ]);
+
+        self::assertEquals(
+            'SELECT p0_.id AS id_0, p0_.name AS name_1, p0_.biography AS biography_2 FROM Person p0_ WHERE (p0_.biography < ? OR (p0_.biography = ? AND (p0_.name < ? OR (p0_.name = ? AND (p0_.id < ?))))) ORDER BY p0_.biography DESC, p0_.name DESC, p0_.id DESC',
+            $query->getSQL(),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces cursor-based (keyset) pagination as an alternative to the existing offset-based Paginator.

### Why cursor pagination?

  Offset-based pagination has well-known performance issues with large datasets:
  - OFFSET requires the database to scan and discard rows, making deep pages increasingly slow
  - Results can be inconsistent when data is inserted/deleted between page requests

  Cursor pagination solves these problems by:
  - Using indexed columns (typically the ORDER BY columns) to seek directly to the next page
  - Providing stable pagination even when underlying data changes

**Implementation**

  The implementation consists of three main classes:

  - `Cursor`: An immutable value object that encodes/decodes pagination state as a URL-safe base64 string
  - `CursorPaginator`: The main paginator class implementing IteratorAggregate and Countable
  - `CursorWalker`: A TreeWalkerAdapter that modifies the AST to inject cursor conditions and handle ORDER BY reversal for previous page navigation

  **Usage**

```php
<?php

use Doctrine\ORM\Tools\CursorPagination\CursorPaginator;

$cursor = $_GET['cursor'] ?? null;

$query = $entityManager->createQuery('SELECT p FROM BlogPost p ORDER BY p.createdAt DESC, p.id DESC');

/** @var CursorPaginator<BlogPost> $paginator */
$paginator = (new CursorPaginator($query))
    ->paginate(cursor: $cursor, limit: 15);
?>
<p><?= $paginator->count() ?> result(s) on this page.</p>

<ul>
    <?php foreach ($paginator as $post): ?>
        <li><?= escape($post->getTitle()) ?></li>
    <?php endforeach ?>
</ul>

<?php if ($paginator->hasToPaginate()): ?>
    <nav>
        <?php if ($paginator->hasPreviousPage()): ?>
            <a href="?cursor=<?= escape($paginator->getPreviousCursorAsString()) ?>">Previous</a>
        <?php endif ?>

        <?php if ($paginator->hasNextPage()): ?>
            <a href="?cursor=<?= escape($paginator->getNextCursorAsString()) ?>">Next</a>
        <?php endif ?>
    </nav>
<?php endif ?>

$hasNextPage = $paginator->hasNextPage();
$hasPreviousPage = $paginator->hasPreviousPage();
$hasToPaginate = $paginator->hasToPaginate();
$nextCursor = $paginator->getNextCursor();
$previousCursor = $paginator->getPreviousCursor();
```

**Navigation API**

  The paginator provides a complete API for building pagination UI:

| Method | Header |
|--------|--------|
| hasNextPage(): bool |  Whether more results exist after the current page |
| hasPreviousPage(): bool |  Whether results exist before the current page        |
| hasToPaginate(): bool |   Whether pagination controls should be displayed (has next or previous)  |
| getNextCursor(): ?Cursor |  Returns the cursor for the next page, or null if none     |
| getPreviousCursor(): ?Cursor | Returns the cursor for the previous page, or null if none | 

  **Requirements**

  - The query must have an ORDER BY clause (cursor pagination requires deterministic ordering)
  - For best performance, ORDER BY columns should be indexed

  **Notes**

  - Supports multiple ORDER BY columns with proper tie-breaking logic
  - Handles both forward (next) and backward (previous) navigation
  - Works with both Query and QueryBuilder

I hope you like this PR :)