### PR TITLE
12225 Fix hydration issue when using indexBy, SQL filter, and inheritance mapping

### DIFF
--- a/src/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/src/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -45,12 +45,20 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
     {
         $tableAlias   = $alias === 'r' ? '' : $alias;
         $fieldMapping = $class->fieldMappings[$field];
-        $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
         $sql          = sprintf(
             '%s.%s',
             $this->getSQLTableAlias($class->name, $tableAlias),
             $this->quoteStrategy->getColumnName($field, $class, $this->platform)
         );
+
+        $columnAlias = null;
+        if ($this->currentPersisterContext->rsm->hasColumnAliasByField($alias, $field)) {
+            $columnAlias = $this->currentPersisterContext->rsm->getColumnAliasByField($alias, $field);
+        }
+
+        if ($columnAlias === null) {
+            $columnAlias = $this->getSQLColumnAlias($fieldMapping['columnName']);
+        }
 
         $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field, $class->name);
 

--- a/src/Query/ResultSetMapping.php
+++ b/src/Query/ResultSetMapping.php
@@ -356,6 +356,10 @@ class ResultSetMapping
 
     public function hasColumnAliasByField(string $alias, string $fieldName): bool
     {
+        if (! isset($this->aliasMap[$alias])) {
+            return false;
+        }
+
         $declaringClass = $this->aliasMap[$alias];
 
         return isset($this->columnAliasMappings[$declaringClass][$alias][$fieldName]);

--- a/tests/Tests/DbalTypes/Rot13Type.php
+++ b/tests/Tests/DbalTypes/Rot13Type.php
@@ -18,8 +18,7 @@ class Rot13Type extends Type
     /**
      * {@inheritDoc}
      *
-     * @param string|null      $value
-     * @param AbstractPlatform $platform
+     * @param string|null $value
      *
      * @return string|null
      */
@@ -35,8 +34,7 @@ class Rot13Type extends Type
     /**
      * {@inheritDoc}
      *
-     * @param string|null      $value
-     * @param AbstractPlatform $platform
+     * @param string|null $value
      *
      * @return string|null
      */
@@ -52,9 +50,6 @@ class Rot13Type extends Type
     /**
      * {@inheritDoc}
      *
-     * @param array            $fieldDeclaration
-     * @param AbstractPlatform $platform
-     *
      * @return string
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
@@ -68,8 +63,6 @@ class Rot13Type extends Type
 
     /**
      * {@inheritDoc}
-     *
-     * @param AbstractPlatform $platform
      *
      * @return int|null
      */

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
@@ -35,6 +35,7 @@ use Doctrine\ORM\Mapping\Table;
 class AbstractDirectory
 {
     /**
+     * @var int
      * @Id
      * @GeneratedValue
      * @Column(name="id", type="integer")
@@ -42,32 +43,35 @@ class AbstractDirectory
     #[Id]
     #[GeneratedValue]
     #[Column(name: 'id', type: 'integer')]
-    private int $id;
+    private $id;
 
     /**
+     * @var string
      * @Column(name="dir_key", type="string")
      */
     #[Column(name: 'dir_key', type: 'string')]
-    private string $dirKey;
+    private $dirKey;
 
     /**
+     * @var DateTimeImmutable|null
      * @Column(name="deleted_at", type="datetime_immutable", nullable=true)
      */
     #[Column(name: 'deleted_at', type: 'datetime_immutable', nullable: true)]
-    private ?DateTimeImmutable $deletedAt = null;
+    private $deletedAt = null;
 
     /**
+     * @var AbstractDirectory|null
      * @ManyToOne(targetEntity=AbstractDirectory::class, fetch="LAZY", inversedBy="directories")
      */
     #[ManyToOne(targetEntity: self::class, fetch: 'LAZY', inversedBy: 'directories')]
-    private ?AbstractDirectory $parent = null;
+    private $parent = null;
 
     /**
      * @var Collection<string, self>
      * @OneToMany(mappedBy="parent", targetEntity=AbstractDirectory::class, fetch="EXTRA_LAZY", indexBy="dirKey")
      */
     #[OneToMany(mappedBy: 'parent', targetEntity: self::class, fetch: 'EXTRA_LAZY', indexBy: 'dirKey')]
-    private Collection $children;
+    private $children;
 
     public function __construct(string $dirKey)
     {

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
@@ -94,7 +94,7 @@ class AbstractDirectory
         return $this->deletedAt;
     }
 
-    public function setDeletedAt(?DateTimeImmutable $deletedAt): static
+    public function setDeletedAt(?DateTimeImmutable $deletedAt): AbstractDirectory
     {
         $this->deletedAt = $deletedAt;
 
@@ -106,7 +106,7 @@ class AbstractDirectory
         return $this->parent;
     }
 
-    public function setParent(?AbstractDirectory $parent): static
+    public function setParent(?AbstractDirectory $parent): AbstractDirectory
     {
         $this->parent = $parent;
 

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/AbstractDirectory.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12225;
+
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="gh_12225_directory", indexes={@Index(columns={"dir_key"})})
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="type", type="string")
+ * @DiscriminatorMap({"main" = ConcreteDirectory::class})
+ */
+#[Entity]
+#[Table(name: 'gh_12225_directory')]
+#[Index(columns: ['dir_key'])]
+#[InheritanceType('SINGLE_TABLE')]
+#[DiscriminatorColumn(name: 'type', type: 'string')]
+#[DiscriminatorMap(['main' => ConcreteDirectory::class])]
+class AbstractDirectory
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(name="id", type="integer")
+     */
+    #[Id]
+    #[GeneratedValue]
+    #[Column(name: 'id', type: 'integer')]
+    private int $id;
+
+    /**
+     * @Column(name="dir_key", type="string")
+     */
+    #[Column(name: 'dir_key', type: 'string')]
+    private string $dirKey;
+
+    /**
+     * @Column(name="deleted_at", type="datetime_immutable", nullable=true)
+     */
+    #[Column(name: 'deleted_at', type: 'datetime_immutable', nullable: true)]
+    private ?DateTimeImmutable $deletedAt = null;
+
+    /**
+     * @ManyToOne(targetEntity=AbstractDirectory::class, fetch="LAZY", inversedBy="directories")
+     */
+    #[ManyToOne(targetEntity: self::class, fetch: 'LAZY', inversedBy: 'directories')]
+    private ?AbstractDirectory $parent = null;
+
+    /**
+     * @var Collection<string, self>
+     * @OneToMany(mappedBy="parent", targetEntity=AbstractDirectory::class, fetch="EXTRA_LAZY", indexBy="dirKey")
+     */
+    #[OneToMany(mappedBy: 'parent', targetEntity: self::class, fetch: 'EXTRA_LAZY', indexBy: 'dirKey')]
+    private Collection $children;
+
+    public function __construct(string $dirKey)
+    {
+        $this->dirKey   = $dirKey;
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getDirKey(): string
+    {
+        return $this->dirKey;
+    }
+
+    public function getDeletedAt(): ?DateTimeImmutable
+    {
+        return $this->deletedAt;
+    }
+
+    public function setDeletedAt(?DateTimeImmutable $deletedAt): static
+    {
+        $this->deletedAt = $deletedAt;
+
+        return $this;
+    }
+
+    public function getParent(): ?AbstractDirectory
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?AbstractDirectory $parent): static
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<string, self>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/ConcreteDirectory.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/ConcreteDirectory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12225;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+#[Entity]
+class ConcreteDirectory extends AbstractDirectory
+{
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/GH12225Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/GH12225Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12225;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12225Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            AbstractDirectory::class,
+            ConcreteDirectory::class,
+        ]);
+    }
+
+    public function testHydrateWithIndexByFilterAndInheritanceMapping(): void
+    {
+        // Enable the filter
+        $this->_em->getConfiguration()->addFilter('my_filter', MyFilter::class);
+        $this->_em->getFilters()->enable('my_filter');
+
+        // Load entities into database
+        $parent = new ConcreteDirectory('parent');
+        $child  = (new ConcreteDirectory('child'))->setParent($parent);
+        $this->_em->persist($parent);
+        $this->_em->persist($child);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(AbstractDirectory::class);
+
+        // Fetch entities from database while changing filters
+        $this->_em->getFilters()->suspend('my_filter');
+        $directories = $repository->findBy(['parent' => null]);
+        $this->_em->getFilters()->restore('my_filter');
+
+        // Ensure we got the parent directory
+        self::assertCount(1, $directories);
+        self::assertEquals('parent', $directories[0]->getDirKey());
+
+        // Try to hydrate all children of the parent directory (toArray is important here to initialize the collection)
+        self::assertCount(1, $directories[0]->getChildren()->toArray());
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12225/MyFilter.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12225/MyFilter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH12225;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+class MyFilter extends SQLFilter
+{
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias): string
+    {
+        return $targetTableAlias . '.deleted_at IS NULL';
+    }
+}


### PR DESCRIPTION
As discussed in #12225 we get an "Uncaught ErrorException: Undefined array key" error when using trying to initialize a one-to-many collection with indexBy on entity with inheritance mapping and is enabling/disabling SQL filters.

This is an alternative solution instead of #12228 which follows how this was solved in #11792
(Instead of altering `ResultSetMapping::addIndexBy()` to use the last found column name, we prevent adding additional column names for the same field)

Fixes #12225