### PR TITLE
fix: get raw value on uninitialized proxy

### DIFF
--- a/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
@@ -53,7 +53,10 @@ class RawValuePropertyAccessor implements PropertyAccessor
 
     public function getValue(object $object): mixed
     {
-        return $this->reflectionProperty->getRawValue($object);
+        if ($this->reflectionProperty->isInitialized($object)) {
+            return $this->reflectionProperty->getRawValue($object);
+        }
+        return null;
     }
 
     public function getUnderlyingReflector(): ReflectionProperty

--- a/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
@@ -53,7 +53,7 @@ class RawValuePropertyAccessor implements PropertyAccessor
 
     public function getValue(object $object): mixed
     {
-        return ((array) $object)[$this->key] ?? null;
+        return $this->reflectionProperty->getRawValue($object);
     }
 
     public function getUnderlyingReflector(): ReflectionProperty

--- a/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
@@ -8,8 +8,6 @@ use Doctrine\ORM\Proxy\InternalProxy;
 use LogicException;
 use ReflectionProperty;
 
-use function ltrim;
-
 use const PHP_VERSION_ID;
 
 /**
@@ -51,7 +49,6 @@ class RawValuePropertyAccessor implements PropertyAccessor
     public function getValue(object $object): mixed
     {
         if ($this->reflectionProperty->isInitialized($object)) {
-
             return $this->reflectionProperty->getRawValue($object);
         }
 

--- a/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
@@ -54,8 +54,10 @@ class RawValuePropertyAccessor implements PropertyAccessor
     public function getValue(object $object): mixed
     {
         if ($this->reflectionProperty->isInitialized($object)) {
+            
             return $this->reflectionProperty->getRawValue($object);
         }
+
         return null;
     }
 

--- a/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/RawValuePropertyAccessor.php
@@ -23,13 +23,10 @@ class RawValuePropertyAccessor implements PropertyAccessor
 {
     public static function fromReflectionProperty(ReflectionProperty $reflectionProperty): self
     {
-        $name = $reflectionProperty->getName();
-        $key  = $reflectionProperty->isPrivate() ? "\0" . ltrim($reflectionProperty->getDeclaringClass()->getName(), '\\') . "\0" . $name : ($reflectionProperty->isProtected() ? "\0*\0" . $name : $name);
-
-        return new self($reflectionProperty, $key);
+        return new self($reflectionProperty);
     }
 
-    private function __construct(private ReflectionProperty $reflectionProperty, private string $key)
+    private function __construct(private ReflectionProperty $reflectionProperty)
     {
         if (PHP_VERSION_ID < 80400) {
             throw new LogicException('This class requires PHP 8.4 or higher.');
@@ -54,7 +51,7 @@ class RawValuePropertyAccessor implements PropertyAccessor
     public function getValue(object $object): mixed
     {
         if ($this->reflectionProperty->isInitialized($object)) {
-            
+
             return $this->reflectionProperty->getRawValue($object);
         }
 

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
@@ -51,4 +51,17 @@ class RawValuePropertyAccessorTest extends OrmTestCase
         self::assertEquals('EN', $object->language);
         self::assertEquals('EN', $accessor->getValue($object));
     }
+
+    public function testGetValueOnProxy(): void
+    {
+        $reflector = new \ReflectionClass(User::class);
+        $object = $reflector->newLazyGhost(function (User $object) {
+            $object->id = 1;
+        });
+
+        $reflection = new ReflectionObject($object);
+        $accessor   = RawValuePropertyAccessor::fromReflectionProperty($reflection->getProperty('id'));
+
+        self::assertEquals(1, $accessor->getValue($object));
+    }
 }

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Mapping\PropertyAccessors\RawValuePropertyAccessor;
 use Doctrine\Tests\Models\PropertyHooks\User;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
-use ReflectionObject;
 use ReflectionClass;
+use ReflectionObject;
 
 use function trim;
 

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
@@ -53,7 +53,7 @@ class RawValuePropertyAccessorTest extends OrmTestCase
         self::assertEquals('EN', $accessor->getValue($object));
     }
 
-    public function testGetValueOnProxy(): void
+    public function testGetValueOnUninitializedProxy(): void
     {
         $reflector = new ReflectionClass(User::class);
         $object    = $reflector->newLazyGhost(static function (User $object): void {
@@ -64,5 +64,14 @@ class RawValuePropertyAccessorTest extends OrmTestCase
         $accessor   = RawValuePropertyAccessor::fromReflectionProperty($reflection->getProperty('id'));
 
         self::assertEquals(1, $accessor->getValue($object));
+    }
+
+    public function testGetValueBeforeInitialization(): void
+    {
+        $object     = new User();
+        $reflection = new ReflectionObject($object);
+        $accessor   = RawValuePropertyAccessor::fromReflectionProperty($reflection->getProperty('id'));
+
+        self::assertEquals(null, $accessor->getValue($object));
     }
 }

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
@@ -9,6 +9,7 @@ use Doctrine\Tests\Models\PropertyHooks\User;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use ReflectionObject;
+use ReflectionClass;
 
 use function trim;
 
@@ -54,8 +55,8 @@ class RawValuePropertyAccessorTest extends OrmTestCase
 
     public function testGetValueOnProxy(): void
     {
-        $reflector = new \ReflectionClass(User::class);
-        $object = $reflector->newLazyGhost(function (User $object) {
+        $reflector = new ReflectionClass(User::class);
+        $object    = $reflector->newLazyGhost(static function (User $object): void {
             $object->id = 1;
         });
 


### PR DESCRIPTION
The `RawValuePropertyAccessor` returns `null` from `getValue` if the accessed object is an uninitialized proxy. This leads to further problems. In my case, the `BasicEntityPersister::loadOneToManyCollection` function returns wrong objects if the parent is still an uninitialized proxy, because the query's `WHERE` clause tries to find rows where the ID is `NULL`.
