### PR TITLE
Fix wrong table alias in inverse one-to-one JOIN with resolve_target_entities

### DIFF
--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1356,7 +1356,7 @@ class BasicEntityPersister implements EntityPersister
                     $sourceCol = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
                     $targetCol = $this->quoteStrategy->getReferencedJoinColumnName($joinColumn, $this->class, $this->platform);
 
-                    $joinCondition[] = $this->getSQLTableAlias($association->sourceEntity, $assocAlias) . '.' . $sourceCol . ' = '
+                    $joinCondition[] = $joinTableAlias . '.' . $sourceCol . ' = '
                         . $this->getSQLTableAlias($association->targetEntity) . '.' . $targetCol;
                 }
 

--- a/tests/Tests/Models/ResolveTargetOneToOne/AppVendor.php
+++ b/tests/Tests/Models/ResolveTargetOneToOne/AppVendor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ResolveTargetOneToOne;
+
+class AppVendor extends BaseVendor
+{
+}

--- a/tests/Tests/Models/ResolveTargetOneToOne/BaseVendor.php
+++ b/tests/Tests/Models/ResolveTargetOneToOne/BaseVendor.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ResolveTargetOneToOne;
+
+class BaseVendor implements VendorInterface
+{
+    protected int $id;
+
+    protected string $name;
+
+    protected Profile|null $profile = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Tests/Models/ResolveTargetOneToOne/Profile.php
+++ b/tests/Tests/Models/ResolveTargetOneToOne/Profile.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ResolveTargetOneToOne;
+
+class Profile
+{
+    protected int $id;
+
+    protected string $companyName;
+
+    protected VendorInterface|null $vendor = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Tests/Models/ResolveTargetOneToOne/VendorInterface.php
+++ b/tests/Tests/Models/ResolveTargetOneToOne/VendorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\ResolveTargetOneToOne;
+
+interface VendorInterface
+{
+    public function getId(): int;
+}

--- a/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.AppVendor.dcm.xml
+++ b/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.AppVendor.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<doctrine-mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+        http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\ResolveTargetOneToOne\AppVendor"
+            table="vendor">
+    </entity>
+</doctrine-mapping>

--- a/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.BaseVendor.dcm.xml
+++ b/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.BaseVendor.dcm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<doctrine-mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+        http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Doctrine\Tests\Models\ResolveTargetOneToOne\BaseVendor"
+                       table="vendor">
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="name" column="name" type="string"/>
+
+        <one-to-one field="profile"
+                    target-entity="Doctrine\Tests\Models\ResolveTargetOneToOne\Profile"
+                    inversed-by="vendor">
+            <join-column name="profile_id" referenced-column-name="id"/>
+        </one-to-one>
+    </mapped-superclass>
+</doctrine-mapping>

--- a/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.Profile.dcm.xml
+++ b/tests/Tests/Models/ResolveTargetOneToOne/xml/Doctrine.Tests.Models.ResolveTargetOneToOne.Profile.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<doctrine-mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+        http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\ResolveTargetOneToOne\Profile"
+            table="profile">
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="companyName" column="company_name" type="string"/>
+
+        <one-to-one field="vendor"
+                    target-entity="Doctrine\Tests\Models\ResolveTargetOneToOne\VendorInterface"
+                    mapped-by="profile"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterInverseOneToOneWithResolveTargetTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterInverseOneToOneWithResolveTargetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\Tests\Mocks\EntityManagerMock;
+use Doctrine\Tests\Models\ResolveTargetOneToOne\AppVendor;
+use Doctrine\Tests\Models\ResolveTargetOneToOne\BaseVendor;
+use Doctrine\Tests\Models\ResolveTargetOneToOne\Profile;
+use Doctrine\Tests\Models\ResolveTargetOneToOne\VendorInterface;
+use Doctrine\Tests\OrmTestCase;
+use ReflectionMethod;
+
+/**
+ * @see https://github.com/doctrine/orm/issues/12382
+ */
+class BasicEntityPersisterInverseOneToOneWithResolveTargetTest extends OrmTestCase
+{
+    private BasicEntityPersister $persister;
+
+    private EntityManagerMock $em;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->em = $this->getTestEntityManager();
+
+        $listener = new ResolveTargetEntityListener();
+        $listener->addResolveTargetEntity(VendorInterface::class, AppVendor::class, []);
+
+        $evm = $this->em->getEventManager();
+        $evm->addEventListener(Events::loadClassMetadata, $listener);
+
+        $xmlDir = __DIR__ . '/../../Models/ResolveTargetOneToOne/xml';
+        $this->em->getConfiguration()->setMetadataDriverImpl(new XmlDriver($xmlDir));
+
+        $this->em->getMetadataFactory()->getMetadataFor(Profile::class);
+        $this->em->getMetadataFactory()->getMetadataFor(AppVendor::class);
+
+        $vendorMeta = $this->em->getClassMetadata(AppVendor::class);
+        $profileAssoc = $vendorMeta->associationMappings['profile'];
+        assert($profileAssoc instanceof OneToOneOwningSideMapping);
+
+        // Simulate the condition where the owning association's sourceEntity
+        // retains the mapped-superclass class name. This happens in frameworks
+        // like Sylius where the mapped-superclass is defined via XML and the
+        // concrete entity via PHP attributes with a different mapping driver.
+        $profileAssoc->sourceEntity = BaseVendor::class;
+
+        $this->persister = new BasicEntityPersister($this->em, $this->em->getClassMetadata(Profile::class));
+    }
+
+    public function testInverseOneToOneJoinUsesCorrectTableAlias(): void
+    {
+        $method = new ReflectionMethod($this->persister, 'getSelectSQL');
+        $selectSQL = $method->invoke($this->persister, []);
+
+        self::assertStringContainsString('LEFT JOIN', $selectSQL);
+
+        preg_match('/LEFT JOIN vendor (\w+) ON (\w+)\.profile_id/', $selectSQL, $matches);
+
+        self::assertNotEmpty($matches, 'Could not find LEFT JOIN vendor ... ON ...profile_id pattern in SQL: ' . $selectSQL);
+        self::assertSame(
+            $matches[1],
+            $matches[2],
+            sprintf(
+                'Table alias mismatch in JOIN condition: table aliased as "%s" but ON clause references "%s". SQL: %s',
+                $matches[1],
+                $matches[2],
+                $selectSQL,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #12382

When eager-loading an inverse-side one-to-one association whose target entity is resolved via `ResolveTargetEntityListener` to a class extending a mapped-superclass, `BasicEntityPersister` generated an incorrect table alias in the JOIN condition.

The owning-side association's `sourceEntity` retained the mapped-superclass class name, which differed from the concrete entity's class name used to compute `$joinTableAlias`. This caused `getSQLTableAlias()` to generate a new alias instead of reusing the already-computed one, producing invalid SQL:

```sql
-- Before (broken): t23 doesn't exist
LEFT JOIN vendor t8 ON t23.profile_id = t0.id

-- After (fixed): uses the correct alias
LEFT JOIN vendor t8 ON t8.profile_id = t0.id
```

## Fix

On line 1359 of `BasicEntityPersister::getSelectColumnsSQL()`, replaced `$this->getSQLTableAlias($association->sourceEntity, $assocAlias)` with `$joinTableAlias`, which is already correctly computed on line 1333 using `$eagerEntity->name`.

## Conditions to trigger

All three must be true:

1. **Inverse-side one-to-one** (always eager-loaded by Doctrine)
2. **Target entity resolved via interface** using `ResolveTargetEntityListener`
3. **Resolved class extends a mapped-superclass** where the owning association is declared (so `$association->sourceEntity` differs from `$eagerEntity->name`)

## Test

Added a regression test that reproduces the alias mismatch by setting `sourceEntity` to the mapped-superclass name on the owning association, which is the condition observed in real-world Sylius/Symfony applications using mixed XML + attribute mapping drivers.