### PR TITLE
Raise proper exception for invalid arguments in Base::add()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3568,12 +3568,6 @@ parameters:
 			path: src/Query/Exec/SingleTableDeleteUpdateExecutor.php
 
 		-
-			message: '#^PHPDoc type array\<string\> of property Doctrine\\ORM\\Query\\Expr\\Andx\:\:\$allowedClasses is not covariant with PHPDoc type list\<class\-string\> of overridden property Doctrine\\ORM\\Query\\Expr\\Base\:\:\$allowedClasses\.$#'
-			identifier: property.phpDocType
-			count: 1
-			path: src/Query/Expr/Andx.php
-
-		-
 			message: '#^Cannot cast object\|string to string\.$#'
 			identifier: cast.string
 			count: 1
@@ -3584,18 +3578,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: src/Query/Expr/Func.php
-
-		-
-			message: '#^PHPDoc type array\<string\> of property Doctrine\\ORM\\Query\\Expr\\Orx\:\:\$allowedClasses is not covariant with PHPDoc type list\<class\-string\> of overridden property Doctrine\\ORM\\Query\\Expr\\Base\:\:\$allowedClasses\.$#'
-			identifier: property.phpDocType
-			count: 1
-			path: src/Query/Expr/Orx.php
-
-		-
-			message: '#^PHPDoc type array\<string\> of property Doctrine\\ORM\\Query\\Expr\\Select\:\:\$allowedClasses is not covariant with PHPDoc type list\<class\-string\> of overridden property Doctrine\\ORM\\Query\\Expr\\Base\:\:\$allowedClasses\.$#'
-			identifier: property.phpDocType
-			count: 1
-			path: src/Query/Expr/Select.php
 
 		-
 			message: '#^Property Doctrine\\ORM\\Query\\Filter\\SQLFilter\:\:\$parameters \(array\<string, array\{type\: string, value\: mixed, is_list\: bool\}\>\) does not accept non\-empty\-array\<string, array\{value\: mixed, type\: int\|string, is_list\: bool\}\>\.$#'

--- a/src/Query/Expr/Andx.php
+++ b/src/Query/Expr/Andx.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use Stringable;
+
 /**
  * Expression class for building DQL and parts.
  *
@@ -14,7 +16,7 @@ class Andx extends Composite
     /** @var string */
     protected $separator = ' AND ';
 
-    /** @var string[] */
+    /** @var list<class-string<Stringable>> */
     protected $allowedClasses = [
         Comparison::class,
         Func::class,

--- a/src/Query/Expr/Base.php
+++ b/src/Query/Expr/Base.php
@@ -12,6 +12,7 @@ use function get_class;
 use function get_debug_type;
 use function implode;
 use function in_array;
+use function is_object;
 use function is_string;
 use function sprintf;
 
@@ -31,7 +32,7 @@ abstract class Base
     /** @var string */
     protected $postSeparator = ')';
 
-    /** @var list<class-string> */
+    /** @var list<class-string<Stringable>> */
     protected $allowedClasses = [];
 
     /** @var list<string|Stringable> */
@@ -59,7 +60,7 @@ abstract class Base
     }
 
     /**
-     * @param mixed $arg
+     * @param string|Stringable|null $arg
      *
      * @return $this
      *
@@ -69,7 +70,8 @@ abstract class Base
     {
         if ($arg !== null && (! $arg instanceof self || $arg->count() > 0)) {
             // If we decide to keep Expr\Base instances, we can use this check
-            if (! is_string($arg) && ! in_array(get_class($arg), $this->allowedClasses, true)) {
+            // @phpstan-ignore function.alreadyNarrowedType (input validation)
+            if (! is_string($arg) && ! (is_object($arg) && in_array(get_class($arg), $this->allowedClasses, true))) {
                 throw new InvalidArgumentException(sprintf(
                     "Expression of type '%s' not allowed in this context.",
                     get_debug_type($arg)

--- a/src/Query/Expr/Orx.php
+++ b/src/Query/Expr/Orx.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use Stringable;
+
 /**
  * Expression class for building DQL OR clauses.
  *
@@ -14,7 +16,7 @@ class Orx extends Composite
     /** @var string */
     protected $separator = ' OR ';
 
-    /** @var string[] */
+    /** @var list<class-string<Stringable>> */
     protected $allowedClasses = [
         Comparison::class,
         Func::class,

--- a/src/Query/Expr/Select.php
+++ b/src/Query/Expr/Select.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use Stringable;
+
 /**
  * Expression class for building DQL select statements.
  *
@@ -17,7 +19,7 @@ class Select extends Base
     /** @var string */
     protected $postSeparator = '';
 
-    /** @var string[] */
+    /** @var list<class-string<Stringable>> */
     protected $allowedClasses = [Func::class];
 
     /** @phpstan-var list<string|Func> */

--- a/tests/Tests/ORM/Query/ExprTest.php
+++ b/tests/Tests/ORM/Query/ExprTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmTestCase;
 use Generator;
+use InvalidArgumentException;
 
 /**
  * Test case for the DQL Expr class used for generating DQL snippets through
@@ -366,9 +367,29 @@ class ExprTest extends OrmTestCase
 
     public function testAddThrowsException(): void
     {
-        $this->expectException('InvalidArgumentException');
         $orExpr = $this->expr->orX();
+        $this->expectException(InvalidArgumentException::class);
         $orExpr->add($this->expr->quot(5, 2));
+    }
+
+    /**
+     * @param mixed $arg
+     *
+     * @dataProvider provideInvalidTypesForAdd
+     */
+    public function testAddThrowsExceptionOnInvalidType($arg): void
+    {
+        $orExpr = $this->expr->orX();
+        $this->expectException(InvalidArgumentException::class);
+        $orExpr->add($arg);
+    }
+
+    /** @return Generator<string, array{mixed}> */
+    public function provideInvalidTypesForAdd(): Generator
+    {
+        yield 'integer 1' => [1];
+        yield 'object' => [(object) ['foo' => 'bar']];
+        yield 'array' => [['foo' => 'bar']];
     }
 
     /** @group DDC-1683 */


### PR DESCRIPTION
Fixes #12393 

We can only pass strings or an instance of one of the allow-listed stringable classes. Currently, we get a `TypeError` caused by a broken `get_class()` call if we pass something else (like an integer).