### PR TITLE
Mark callable parameters with @param-immediately-invoked-callable

### DIFF
--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -76,6 +76,7 @@ interface EntityManagerInterface extends ObjectManager
      * @return mixed The value returned from the closure.
      * @phpstan-return T
      *
+     * @param-immediately-invoked-callable $func
      * @template T
      */
     public function wrapInTransaction(callable $func): mixed;


### PR DESCRIPTION
This adds the [`@param-immediately-invoked-callable`](https://phpstan.org/writing-php-code/phpdocs-basics#callables) PHPStan annotation to all callable parameters that are invoked immediately.

### Changed methods

- `EntityManagerInterface::wrapInTransaction()` — callable is invoked immediately within the transaction
