### PR TITLE
Fix Cache::MODE_REFRESH not writing to query cache

### DIFF
--- a/src/Cache/DefaultQueryCache.php
+++ b/src/Cache/DefaultQueryCache.php
@@ -215,7 +215,7 @@ class DefaultQueryCache implements QueryCache
             throw FeatureNotImplemented::partialEntities();
         }
 
-        if (! ($key->cacheMode & Cache::MODE_PUT)) {
+        if (! ($key->cacheMode & Cache::MODE_PUT) && ! ($key->cacheMode & Cache::MODE_REFRESH)) {
             return false;
         }
 

--- a/tests/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -496,6 +496,28 @@ class DefaultQueryCacheTest extends OrmTestCase
         self::assertFalse($this->queryCache->put($key, $rsm, $result));
     }
 
+    public function testRefreshModeWritesToCache(): void
+    {
+        $result   = [];
+        $rsm      = new ResultSetMappingBuilder($this->em);
+        $metadata = $this->em->getClassMetadata(Country::class);
+        $key      = new QueryCacheKey('query.key1', 0, Cache::MODE_REFRESH);
+
+        $rsm->addRootEntityFromClassMetadata(Country::class, 'c');
+
+        for ($i = 0; $i < 2; $i++) {
+            $name     = 'Country ' . $i;
+            $entity   = new Country($name);
+            $result[] = $entity;
+
+            $metadata->setFieldValue($entity, 'id', $i);
+            $this->em->getUnitOfWork()->registerManaged($entity, ['id' => $i], ['name' => $name]);
+        }
+
+        self::assertTrue($this->queryCache->put($key, $rsm, $result));
+        self::assertArrayHasKey('put', $this->region->calls);
+    }
+
     public function testGetShouldIgnoreOldQueryCacheEntryResult(): void
     {
         $rsm      = new ResultSetMappingBuilder($this->em);


### PR DESCRIPTION
## Problem

`DefaultQueryCache::put()` always returns false and does not write to the cache when `Cache::MODE_REFRESH` is used.

The guard on line 218 checks whether `MODE_PUT` is set in the cache mode bitmask:

```php
if (! ($key->cacheMode & Cache::MODE_PUT)) {
    return false;
}
```

The constants are:
- `MODE_GET = 1` (binary: 001)
- `MODE_PUT = 2` (binary: 010)
- `MODE_NORMAL = 3` (binary: 011)
- `MODE_REFRESH = 4` (binary: 100)

Since `MODE_REFRESH` (4) and `MODE_PUT` (2) have no overlapping bits, the bitwise AND always returns 0 for refresh mode and the method exits early without writing anything.

The rest of the `put()` method already has correct `MODE_REFRESH` handling at lines 239, 312, and 333 - it just never gets reached.

According to the docs and code comments, `MODE_REFRESH` is defined as:

> The query will never read items from the cache, but will refresh items to the cache as it reads them from the database.

## Fix

Extended the early-return guard to also skip early exit when `MODE_REFRESH` is set.

```diff
-if (! ($key->cacheMode & Cache::MODE_PUT)) {
+if (! ($key->cacheMode & Cache::MODE_PUT) && ! ($key->cacheMode & Cache::MODE_REFRESH)) {
```

Fixes #11836