### PR TITLE
Skip unset on hooked non-nullable properties to avoid PHP error

### DIFF
--- a/src/Mapping/PropertyAccessors/TypedNoDefaultPropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/TypedNoDefaultPropertyAccessor.php
@@ -11,6 +11,8 @@ use ReflectionProperty;
 use function assert;
 use function sprintf;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 class TypedNoDefaultPropertyAccessor implements PropertyAccessor
 {
@@ -38,6 +40,12 @@ class TypedNoDefaultPropertyAccessor implements PropertyAccessor
     public function setValue(object $object, mixed $value): void
     {
         if ($value === null) {
+            // Properties with hooks cannot be unset (PHP throws "Cannot unset hooked property").
+            // If the property has hooks, skip the unset and leave it initialized with its current value.
+            if (PHP_VERSION_ID >= 80400 && $this->reflectionProperty->hasHooks()) {
+                return;
+            }
+
             if ($this->unsetter === null) {
                 $propertyName   = $this->reflectionProperty->getName();
                 $this->unsetter = function () use ($propertyName): void {

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/TypedNoDefaultPropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/TypedNoDefaultPropertyAccessorTest.php
@@ -6,7 +6,9 @@ namespace Doctrine\Tests\ORM\Mapping\PropertyAccessors;
 
 use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use Doctrine\ORM\Mapping\PropertyAccessors\TypedNoDefaultPropertyAccessor;
+use Doctrine\Tests\Models\PropertyHooks\User;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 class TypedNoDefaultPropertyAccessorTest extends OrmTestCase
 {
@@ -34,6 +36,23 @@ class TypedNoDefaultPropertyAccessorTest extends OrmTestCase
 
         $accessor->setValue($object, null);
         $this->assertNull($accessor->getValue($object));
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testSetNullOnHookedPropertyDoesNotThrow(): void
+    {
+        $accessor = PropertyAccessorFactory::createPropertyAccessor(User::class, 'first');
+
+        $object = new User();
+        $accessor->setValue($object, 'Alice');
+        $this->assertEquals('Alice', $accessor->getValue($object));
+
+        // Setting null on a non-nullable hooked property should not throw.
+        // Doctrine calls this when uninitializing an entity (e.g. after delete).
+        $accessor->setValue($object, null);
+
+        // Property retains its previous value since unset is not possible on hooked properties.
+        $this->assertEquals('Alice', $accessor->getValue($object));
     }
 }
 


### PR DESCRIPTION
## Problem

When Doctrine deletes an entity (or uninitializes a property during lazy collection hydration), `TypedNoDefaultPropertyAccessor::setValue()` is called with `null`. For non-nullable typed properties, this triggers an `unset()` call via a bound closure to put the property back into an uninitialized state.

On PHP 8.4+, if the property has hooks, `unset()` throws:

```
Cannot unset hooked property EntityClass::$id
```

Example:

```php
#[ORM\Id]
#[ORM\Column]
public int $id {
    get => $this->id;
    set => $this->id = $value;
}

$em->remove($entity);
$em->flush(); // throws: Cannot unset hooked property
```

## Fix

Check for property hooks before attempting the `unset()`. If the property has hooks (`ReflectionProperty::hasHooks()`, available since PHP 8.4), skip the unset and return early. The property retains its current value, which is acceptable since the entity is no longer managed after deletion.

Fixes #12077