### PR TITLE
fix: Do not change readonly id when deleting (#9538)

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -35,6 +35,7 @@ use Doctrine\ORM\Internal\UnitOfWork\InsertBatch;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Mapping\PropertyAccessors\ReadonlyAccessor;
 use Doctrine\ORM\Mapping\ToManyInverseSideMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
@@ -1176,7 +1177,10 @@ class UnitOfWork implements PropertyChangedListener
             // Entity with this $oid after deletion treated as NEW, even if the $oid
             // is obtained by a new entity because the old one went out of scope.
             //$this->entityStates[$oid] = self::STATE_NEW;
-            if (! $class->isIdentifierNatural()) {
+            if (
+                ! $class->isIdentifierNatural() &&
+                ! $class->propertyAccessors[$class->identifier[0]] instanceof ReadonlyAccessor
+            ) {
                 $class->propertyAccessors[$class->identifier[0]]->setValue($entity, null);
             }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH9538Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9538Test.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH9538Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH9538EntityA::class,
+        ]);
+    }
+
+    public function testCanRemoveEntityWithReadonlyId(): void
+    {
+        $this->_em->persist($entity = new GH9538EntityA());
+        $this->_em->flush();
+        $this->_em->remove($entity);
+        $this->_em->flush();
+        $this->expectNotToPerformAssertions();
+    }
+}
+
+#[Entity]
+class GH9538EntityA
+{
+    #[Column(type: 'integer')]
+    #[Id]
+    #[GeneratedValue(strategy: 'AUTO')]
+    public readonly int $id;
+}


### PR DESCRIPTION
Fixes #9538 by not resetting the ID of objects which have a readonly identifier to null.
This will cause those to not be seen as new objectes (will be STATE_DETACHED). However, this is in my understanding not a problem as entities with readonly ID cannot be reused anyways.
If those need to be seen as NEW for some practical reason, we could also persist the NEW state in entityStates (which the commented line just above the resetting does).

Additional notes:
From the commit commenting that line out, it is not entirely clear to me why that change was made (setting id to null rather than persisting the state). Persisting the state instead of setting the id to null does not seem to cause any trouble with all tests passing (apart from maybe a slight memory leak).

This does not touch the issues #9505.