### PR TITLE
Backport #12222

### DIFF
--- a/tests/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Tests/ORM/Functional/QueryTest.php
@@ -430,7 +430,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query  = $this->_em->createQuery('select a, a.topic, a.text from ' . CmsArticle::class . ' a');
+        $query  = $this->_em->createQuery(
+            'select a, a.topic, a.text from ' . CmsArticle::class . ' a order by a.id asc'
+        );
         $result = $query->toIterable();
 
         $it = iterator_to_array($result);


### PR DESCRIPTION
## Add ORDER BY clause to SELECT query


The order of results is not guaranteed unless we do so, and the test can fail in some cases:

	There was 1 failure:

	1) Doctrine\Tests\ORM\Functional\QueryTest::testToIterableWithMixedResultArbitraryJoinsScalars
	Failed asserting that two strings are equal.
	--- Expected
	+++ Actual
	@@ @@
	-'Doctrine 2'
	+'lala 2'

	/home/runner/work/orm/orm/tests/Tests/ORM/Functional/QueryTest.php:481