### PR TITLE
Allow defining explicit identifier position

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -599,10 +599,13 @@ Example with partial indexes:
 ~~~~~
 
 The annotated instance variable will be marked as entity
-identifier, the primary key in the database. This attribute is a
-marker only and has no required or optional attributes. For
-entities that have multiple identifier columns each column has to
-be marked with ``#[Id]``.
+identifier, the primary key in the database. For entities that have
+multiple identifier columns each column has to be marked with ``#[Id]``.
+
+Optional parameters:
+
+-  **position**: Controls the order of fields in a composite identifier.
+   Lower values come first. If not specified, the default value is ``0``.
 
 Example:
 

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -321,6 +321,8 @@ Optional attributes:
 
 -  column - Name of the column in the database, defaults to the
    field name.
+-  position - Controls the order of fields in a composite identifier.
+   Lower values come first. If not specified, the default value is ``0``.
 
 Using the simplified definition above Doctrine will use no
 identifier strategy for this entity. That means you have to

--- a/docs/en/tutorials/composite-primary-keys.rst
+++ b/docs/en/tutorials/composite-primary-keys.rst
@@ -299,6 +299,50 @@ of products purchased and maybe even the current price.
         }
     }
 
+Controlling composite key order
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you need a specific field order for a composite identifier, you can set
+an explicit position on each identifier mapping. This applies to both primitive
+identifier fields and association-based identifiers. Lower values come first.
+
+.. configuration-block::
+
+    .. code-block:: attribute
+
+        <?php
+        namespace VehicleCatalogue\Model;
+
+        use Doctrine\ORM\Mapping as ORM;
+
+        #[ORM\Entity]
+        class Car
+        {
+            #[ORM\Id(position: 2)]
+            #[ORM\Column(type: 'string')]
+            private string $name;
+
+            #[ORM\Id(position: 1)]
+            #[ORM\Column(type: 'integer')]
+            private int $year;
+        }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                  https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+            <entity name="VehicleCatalogue\Model\Car">
+                <id name="name" type="string" position="2" />
+                <id name="year" type="integer" position="1" />
+            </entity>
+        </doctrine-mapping>
+
+If you omit ``position``, Doctrine uses ``0``. Identifier fields with the same
+position keep their declaration order.
 
 Performance Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -362,6 +362,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="position" type="xs:integer" default="0" />
     <xs:attribute name="type" type="orm:type" />
     <xs:attribute name="column" type="orm:columntoken" />
     <xs:attribute name="length" type="xs:NMTOKEN" />

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -45,6 +45,8 @@ use function count;
 use function defined;
 use function enum_exists;
 use function explode;
+use function func_get_arg;
+use function func_num_args;
 use function implode;
 use function in_array;
 use function interface_exists;
@@ -59,6 +61,7 @@ use function str_replace;
 use function strtolower;
 use function trait_exists;
 use function trim;
+use function usort;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata
@@ -327,6 +330,13 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * @phpstan-var list<string>
      */
     public array $identifier = [];
+
+    /**
+     * READ-ONLY: The position of each identifier field, used to control the order of composite primary key fields.
+     *
+     * @phpstan-var array<string, int>
+     */
+    public array $identifierPositions = [];
 
     /**
      * READ-ONLY: The inheritance mapping type used by the class.
@@ -729,6 +739,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             'fieldNames',
             'embeddedClasses',
             'identifier',
+            'identifierPositions',
             'isIdentifierComposite', // TODO: REMOVE
             'name',
             'namespace', // TODO: REMOVE
@@ -1241,7 +1252,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
 
             if (! in_array($mapping->fieldName, $this->identifier, true)) {
-                $this->identifier[] = $mapping->fieldName;
+                $this->registerIdentifierField($mapping->fieldName, $mapping->idPosition);
             }
 
             // Check for composite key
@@ -1344,7 +1355,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 }
 
                 assert(is_string($mapping['fieldName']));
-                $this->identifier[]              = $mapping['fieldName'];
+                $this->registerIdentifierField($mapping['fieldName'], $mapping['idPosition'] ?? null);
                 $this->containsForeignIdentifier = true;
             }
 
@@ -1360,6 +1371,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 );
             }
         }
+
+        unset($mapping['idPosition']);
 
         // Mandatory attributes for both sides
         // Mandatory: fieldName, targetEntity
@@ -1502,9 +1515,17 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *
      * @phpstan-param list<mixed> $identifier
      */
-    public function setIdentifier(array $identifier): void
+    public function setIdentifier(array $identifier/*, array $positions = []*/): void
     {
-        $this->identifier            = $identifier;
+        $positions = func_num_args() > 1 ? func_get_arg(1) : [];
+
+        $this->identifier          = [];
+        $this->identifierPositions = [];
+
+        foreach ($identifier as $fieldName) {
+            $this->registerIdentifierField($fieldName, $positions[$fieldName] ?? null);
+        }
+
         $this->isIdentifierComposite = (count($this->identifier) > 1);
     }
 
@@ -2721,5 +2742,16 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         }
 
         return $sequencePrefix;
+    }
+
+    private function registerIdentifierField(string $fieldName, int|null $idPosition): void
+    {
+        $this->identifier[]                    = $fieldName;
+        $this->identifierPositions[$fieldName] = $idPosition ?? 0;
+
+        usort(
+            $this->identifier,
+            fn (string $field1, string $field2) => $this->identifierPositions[$field1] <=> $this->identifierPositions[$field2],
+        );
     }
 }

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -141,7 +141,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $this->addInheritedFields($class, $parent);
             $this->addInheritedRelations($class, $parent);
             $this->addInheritedEmbeddedClasses($class, $parent);
-            $class->setIdentifier($parent->identifier);
+            $class->setIdentifier($parent->identifier, $parent->identifierPositions);
             $class->setVersioned($parent->isVersioned);
             $class->setVersionField($parent->versionField);
             $class->setDiscriminatorMap($parent->discriminatorMap);

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -318,8 +318,10 @@ class AttributeDriver implements MappingDriver
             if ($columnAttribute !== null) {
                 $mapping = $this->columnToArray($property->name, $columnAttribute);
 
-                if ($this->reader->getPropertyAttribute($property, Mapping\Id::class)) {
-                    $mapping['id'] = true;
+                $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
+                if ($idAttribute !== null) {
+                    $mapping['id']         = true;
+                    $mapping['idPosition'] = $idAttribute->position;
                 }
 
                 $generatedValueAttribute = $this->reader->getPropertyAttribute($property, Mapping\GeneratedValue::class);
@@ -358,8 +360,10 @@ class AttributeDriver implements MappingDriver
                     throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\OneToOne::class);
                 }
 
-                if ($this->reader->getPropertyAttribute($property, Mapping\Id::class)) {
-                    $mapping['id'] = true;
+                $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
+                if ($idAttribute !== null) {
+                    $mapping['id']         = true;
+                    $mapping['idPosition'] = $idAttribute->position;
                 }
 
                 $mapping['targetEntity']  = $oneToOneAttribute->targetEntity;
@@ -397,7 +401,8 @@ class AttributeDriver implements MappingDriver
                 $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
 
                 if ($idAttribute !== null) {
-                    $mapping['id'] = true;
+                    $mapping['id']         = true;
+                    $mapping['idPosition'] = $idAttribute->position;
                 }
 
                 $mapping['joinColumns']  = $joinColumns;

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use LogicException;
 use SimpleXMLElement;
 
+use function array_key_exists;
 use function assert;
 use function class_exists;
 use function constant;
@@ -287,13 +288,16 @@ class XmlDriver extends FileDriver
         // Evaluate <id ...> mappings
         $associationIds = [];
         foreach ($xmlRoot->id ?? [] as $idElement) {
+            $position = isset($idElement['position']) ? (int) $idElement['position'] : null;
+
             if (isset($idElement['association-key']) && $this->evaluateBoolean($idElement['association-key'])) {
-                $associationIds[(string) $idElement['name']] = true;
+                $associationIds[(string) $idElement['name']] = $position;
                 continue;
             }
 
-            $mapping       = $this->columnToArray($idElement);
-            $mapping['id'] = true;
+            $mapping               = $this->columnToArray($idElement);
+            $mapping['id']         = true;
+            $mapping['idPosition'] = $position;
 
             $metadata->mapField($mapping);
 
@@ -335,8 +339,9 @@ class XmlDriver extends FileDriver
                     $mapping['targetEntity'] = (string) $oneToOneElement['target-entity'];
                 }
 
-                if (isset($associationIds[$mapping['fieldName']])) {
-                    $mapping['id'] = true;
+                if (array_key_exists($mapping['fieldName'], $associationIds)) {
+                    $mapping['id']         = true;
+                    $mapping['idPosition'] = $associationIds[$mapping['fieldName']];
                 }
 
                 if (isset($oneToOneElement['fetch'])) {
@@ -439,8 +444,9 @@ class XmlDriver extends FileDriver
                     $mapping['targetEntity'] = (string) $manyToOneElement['target-entity'];
                 }
 
-                if (isset($associationIds[$mapping['fieldName']])) {
-                    $mapping['id'] = true;
+                if (array_key_exists($mapping['fieldName'], $associationIds)) {
+                    $mapping['id']         = true;
+                    $mapping['idPosition'] = $associationIds[$mapping['fieldName']];
                 }
 
                 if (isset($manyToOneElement['fetch'])) {

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -22,6 +22,7 @@ final class FieldMapping implements ArrayAccess
      * fields of an entity can have the id attribute, forming a composite key.
      */
     public bool|null $id                 = null;
+    public int|null $idPosition          = null;
     public bool|null $nullable           = null;
     public bool|null $notInsertable      = null;
     public bool|null $notUpdatable       = null;
@@ -96,6 +97,7 @@ final class FieldMapping implements ArrayAccess
      *     columnName: string,
      *     length?: int|null,
      *     id?: bool|null,
+     *     idPosition?: int|null,
      *     nullable?: bool|null,
      *     index?: bool|null,
      *     notInsertable?: bool|null,
@@ -150,6 +152,7 @@ final class FieldMapping implements ArrayAccess
 
         foreach (
             [
+                'idPosition',
                 'length',
                 'columnDefinition',
                 'generated',

--- a/src/Mapping/Id.php
+++ b/src/Mapping/Id.php
@@ -9,4 +9,8 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Id implements MappingAttribute
 {
+    public function __construct(
+        public readonly int $position = 0,
+    ) {
+    }
 }

--- a/tests/Tests/Models/CompositeIdWithPosition/CompositeIdEntity.php
+++ b/tests/Tests/Models/CompositeIdWithPosition/CompositeIdEntity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CompositeIdWithPosition;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class CompositeIdEntity extends CompositeIdMappedSuperclass
+{
+    #[ORM\Id(position: 3)]
+    #[ORM\Column(type: 'string')]
+    public string $third = '';
+}

--- a/tests/Tests/Models/CompositeIdWithPosition/CompositeIdMappedSuperclass.php
+++ b/tests/Tests/Models/CompositeIdWithPosition/CompositeIdMappedSuperclass.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CompositeIdWithPosition;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\MappedSuperclass]
+class CompositeIdMappedSuperclass
+{
+    #[ORM\Id(position: 2)]
+    #[ORM\Column(type: 'string')]
+    public string $second = '';
+
+    #[ORM\Id(position: 1)]
+    #[ORM\Column(type: 'integer')]
+    public int $first = 0;
+}

--- a/tests/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Mocks\AttributeDriverFactory;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\ORM\Mapping\Fixtures\AttributeEntityWithNestedJoinColumns;
+use Doctrine\Tests\ORM\Mapping\Fixtures\CompositeIdWithPosition;
 use InvalidArgumentException;
 use stdClass;
 
@@ -102,6 +103,15 @@ class AttributeDriverTest extends MappingDriverTestCase
             ],
             $metadata->associationMappings['assoc']->joinTable->inverseJoinColumns,
         );
+    }
+
+    public function testCompositeIdPositionOrdering(): void
+    {
+        $factory = $this->createClassMetadataFactory();
+
+        $metadata = $factory->getMetadataFor(CompositeIdWithPosition::class);
+
+        self::assertSame(['first', 'second'], $metadata->identifier);
     }
 
     public function testItThrowsWhenSettingReportFieldsWhereDeclaredToFalse(): void

--- a/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -31,6 +31,7 @@ use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\MetadataDriverMock;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CompositeIdWithPosition\CompositeIdEntity;
 use Doctrine\Tests\Models\DDC4006\DDC4006User;
 use Doctrine\Tests\Models\JoinedInheritanceType\AnotherChildClass;
 use Doctrine\Tests\Models\JoinedInheritanceType\ChildClass;
@@ -442,6 +443,19 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $userMetadata = $cmf->getMetadataFor(DDC4006User::class);
 
         self::assertTrue($userMetadata->isIdGeneratorIdentity());
+    }
+
+    public function testIdentifierPositionsAreInheritedFromMappedSuperclass(): void
+    {
+        $cmf    = new ClassMetadataFactory();
+        $driver = $this->createAttributeDriver([__DIR__ . '/../../Models/CompositeIdWithPosition/']);
+        $em     = $this->createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $metadata = $cmf->getMetadataFor(CompositeIdEntity::class);
+
+        self::assertSame(['first', 'second', 'third'], $metadata->identifier);
+        self::assertSame(['first' => 1, 'second' => 2, 'third' => 3], $metadata->identifierPositions);
     }
 
     public function testInvalidSubClassCase(): void

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1173,6 +1173,76 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->setDiscriminatorMap(['foo' => CMS\CmsUser::class, 'bar' => CMS\CmsUser::class]);
     }
+
+    public function testCompositeIdentifierOrderingByPosition(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'username', 'type' => 'string', 'id' => true, 'idPosition' => 2]);
+        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'id' => true, 'idPosition' => 1]);
+
+        self::assertSame(['name', 'username'], $cm->identifier);
+    }
+
+    public function testCompositeIdentifierSamePositionPreservesInsertionOrder(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'username', 'type' => 'string', 'id' => true, 'idPosition' => 1]);
+        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'id' => true, 'idPosition' => 1]);
+
+        self::assertSame(['username', 'name'], $cm->identifier);
+    }
+
+    public function testCompositeIdentifierDefaultPositionPreservesInsertionOrder(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'username', 'type' => 'string', 'id' => true]);
+        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'id' => true]);
+
+        self::assertSame(['username', 'name'], $cm->identifier);
+    }
+
+    public function testCompositeIdentifierPositionSurvivesSerialization(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'username', 'type' => 'string', 'id' => true, 'idPosition' => 2]);
+        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'id' => true, 'idPosition' => 1]);
+
+        $cm = unserialize(serialize($cm));
+        $cm->wakeupReflection(new RuntimeReflectionService());
+
+        self::assertSame(['name', 'username'], $cm->identifier);
+        self::assertSame(['username' => 2, 'name' => 1], $cm->identifierPositions);
+    }
+
+    public function testSetIdentifierSortsByPosition(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->setIdentifier(['username', 'name'], ['username' => 2, 'name' => 1]);
+
+        self::assertSame(['name', 'username'], $cm->identifier);
+        self::assertSame(['username' => 2, 'name' => 1], $cm->identifierPositions);
+    }
+
+    public function testSetIdentifierWithoutPositionsDefaultsToZero(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->setIdentifier(['username', 'name']);
+
+        self::assertSame(['username', 'name'], $cm->identifier);
+        self::assertSame(['username' => 0, 'name' => 0], $cm->identifierPositions);
+    }
 }
 
 #[MappedSuperclass]

--- a/tests/Tests/ORM/Mapping/FieldMappingTest.php
+++ b/tests/Tests/ORM/Mapping/FieldMappingTest.php
@@ -24,6 +24,7 @@ final class FieldMappingTest extends TestCase
 
         $mapping->length           = 255;
         $mapping->id               = true;
+        $mapping->idPosition       = 2;
         $mapping->nullable         = true;
         $mapping->notInsertable    = true;
         $mapping->notUpdatable     = true;
@@ -49,6 +50,7 @@ final class FieldMappingTest extends TestCase
 
         self::assertSame(255, $resurrectedMapping->length);
         self::assertTrue($resurrectedMapping->id);
+        self::assertSame(2, $resurrectedMapping->idPosition);
         self::assertTrue($resurrectedMapping->nullable);
         self::assertTrue($resurrectedMapping->notInsertable);
         self::assertTrue($resurrectedMapping->notUpdatable);

--- a/tests/Tests/ORM/Mapping/Fixtures/CompositeIdWithPosition.php
+++ b/tests/Tests/ORM/Mapping/Fixtures/CompositeIdWithPosition.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class CompositeIdWithPosition
+{
+    #[ORM\Id(position: 2)]
+    #[ORM\Column(type: 'string')]
+    public string $second = '';
+
+    #[ORM\Id(position: 1)]
+    #[ORM\Column(type: 'integer')]
+    public int $first = 0;
+}

--- a/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -29,6 +29,7 @@ use Doctrine\Tests\Models\Project\ProjectInvalidMapping;
 use Doctrine\Tests\Models\Project\ProjectName;
 use Doctrine\Tests\Models\ValueObjects\Name;
 use Doctrine\Tests\Models\ValueObjects\Person;
+use Doctrine\Tests\ORM\Mapping\Fixtures\CompositeIdWithPosition;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -90,6 +91,13 @@ class XmlMappingDriverTest extends MappingDriverTestCase
         self::assertArrayHasKey('article', $class->associationMappings);
 
         self::assertTrue($class->associationMappings['article']->id);
+    }
+
+    public function testCompositeIdPositionOrdering(): void
+    {
+        $class = $this->createClassMetadata(CompositeIdWithPosition::class);
+
+        self::assertSame(['first', 'second'], $class->identifier);
     }
 
     public function testEmbeddableMapping(): void

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.Fixtures.CompositeIdWithPosition.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.Fixtures.CompositeIdWithPosition.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\Fixtures\CompositeIdWithPosition">
+        <id name="second" type="string" position="2" />
+        <id name="first" type="integer" position="1" />
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -41,6 +41,7 @@ use Doctrine\Tests\Models\CMS\CmsEmployee;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CompositeIdWithPosition\CompositeIdEntity;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedChildClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedIdentityClass;
 use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedDerivedRootClass;
@@ -501,6 +502,29 @@ class SchemaToolTest extends OrmTestCase
         [$pkColumn] = $primaryKey->getColumnNames();
         self::assertTrue($pkColumn->getIdentifier()->isQuoted());
         self::assertSame('quoted-id', $pkColumn->getIdentifier()->getValue());
+    }
+
+    public function testCompositeIdPositionRespectedInSchema(): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $schema = $schemaTool->getSchemaFromMetadata(
+            [$em->getClassMetadata(CompositeIdEntity::class)],
+        );
+
+        $table = $schema->getTable('CompositeIdEntity');
+
+        if (class_exists(PrimaryKeyConstraintEditor::class)) {
+            $pkColumns = array_map(
+                static fn (UnqualifiedName $name) => $name->toString(),
+                $table->getPrimaryKeyConstraint()->getColumnNames(),
+            );
+        } else {
+            $pkColumns = self::getIndexedColumns($table->getPrimaryKey());
+        }
+
+        self::assertSame(['first', 'second', 'third'], $pkColumns);
     }
 
     /** @return string[] */


### PR DESCRIPTION
Currently, the order of fields in a composite primary key is determined by the order of properties in the entity.

This becomes more complicated when mapped superclasses are used. After PR #10764, the ordering changed so that parent fields now come before child fields, whereas previously it was the other way around. This resulted in the schema diff tool reporting differences.

This PR proposes adding a new `position` option to the `Id` mapping to allow explicitly defining the identifier order, for example:

```php
#[ORM\Entity]
class SomeClass
{
    #[ORM\Id(position: 0)]
    #[ORM\Column]
    private ?int $id1 = null;

    #[ORM\Id(position: 1)]
    #[ORM\Column]
    private ?int $id2 = null;
}
```

```xml
<entity name="App\Entity\SomeClass">
    <id name="id1" type="integer" position="1"/>
    <id name="id2" type="integer" position="2"/>
</entity>
```

This becomes especially useful when working with mapped superclasses, as the user can explicitly define the order of identifier fields regardless of which class they are in.