### PR TITLE
Fix collection order by behaviour in join with conditions

### DIFF
--- a/src/Query/AST/OrderByClause.php
+++ b/src/Query/AST/OrderByClause.php
@@ -13,11 +13,14 @@ class OrderByClause extends Node
 {
     /** @var OrderByItem[] */
     public $orderByItems = [];
+    /** @var bool */
+    public $includeCollectionOrderByItems = true;
 
     /** @param OrderByItem[] $orderByItems */
-    public function __construct(array $orderByItems)
+    public function __construct(array $orderByItems, bool $includeCollectionOrderByItems)
     {
-        $this->orderByItems = $orderByItems;
+        $this->orderByItems                  = $orderByItems;
+        $this->includeCollectionOrderByItems = $includeCollectionOrderByItems;
     }
 
     /**

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -160,6 +160,9 @@ class Parser
      */
     private $nestingLevel = 0;
 
+    /** @var int */
+    private $withJoinConditionNestingLevel = 0;
+
     /**
      * Any additional custom tree walkers that modify the AST.
      *
@@ -1466,7 +1469,7 @@ class Parser
             $orderByItems[] = $this->OrderByItem();
         }
 
-        return new AST\OrderByClause($orderByItems);
+        return new AST\OrderByClause($orderByItems, $this->withJoinConditionNestingLevel === 0);
     }
 
     /**
@@ -1772,7 +1775,13 @@ class Parser
         if ($adhocConditions) {
             $this->match(TokenType::T_WITH);
 
-            $join->conditionalExpression = $this->ConditionalExpression();
+            try {
+                $this->withJoinConditionNestingLevel++;
+
+                $join->conditionalExpression = $this->ConditionalExpression();
+            } finally {
+                $this->withJoinConditionNestingLevel--;
+            }
         }
 
         return $join;

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1229,9 +1229,12 @@ class SqlWalker implements TreeWalker
     {
         $orderByItems = array_map([$this, 'walkOrderByItem'], $orderByClause->orderByItems);
 
-        $collectionOrderByItems = $this->generateOrderedCollectionOrderByItems();
-        if ($collectionOrderByItems !== '') {
-            $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
+        if ($orderByClause->includeCollectionOrderByItems) {
+            $collectionOrderByItems = $this->generateOrderedCollectionOrderByItems();
+
+            if ($collectionOrderByItems !== '') {
+                $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
+            }
         }
 
         return ' ORDER BY ' . implode(', ', $orderByItems);

--- a/tests/Doctrine/Tests/ORM/Functional/OrderByJoinConditionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderByJoinConditionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use DateTimeImmutable;
+use Doctrine\Tests\Models\OrderByJoinCondition\VersionableEntity;
+use Doctrine\Tests\Models\OrderByJoinCondition\VersionEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function count;
+
+class OrderByJoinConditionTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(VersionableEntity::class, VersionEntity::class);
+
+        $this->generateFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->dropTableIfExists('version');
+        $this->dropTableIfExists('versionable');
+    }
+
+    public function testFetchAll(): void
+    {
+        /** @var VersionableEntity[] $versionables */
+        $versionables = $this->_em->createQueryBuilder()
+            ->select([
+                'versionable',
+                'version',
+            ])
+            ->from(VersionableEntity::class, 'versionable')
+            ->innerJoin('versionable.versions', 'version')
+            ->orderBy('versionable.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertCount(2, $versionables);
+
+        $this->assertVersionable($versionables[0], [23, 24, 21, 22]);
+        $this->assertVersionable($versionables[1], [13, 11, 12]);
+    }
+
+    public function testFetchWithJoinCondition(): void
+    {
+        $versionFqcn = VersionEntity::class;
+
+        $condition = 'version.id IN (SELECT v.id FROM ' . $versionFqcn . ' AS v WHERE v.versionDate > :date ORDER BY v.id DESC)';
+
+        /** @var VersionableEntity[] $versionables */
+        $versionables = $this->_em->createQueryBuilder()
+            ->select([
+                'versionable',
+                'version',
+            ])
+            ->from(VersionableEntity::class, 'versionable')
+            ->leftJoin('versionable.versions', 'version', 'WITH', $condition)
+            ->setParameter('date', new DateTimeImmutable('2025-03-01'))
+            ->orderBy('versionable.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertVersionable($versionables[0], [23, 24, 21]);
+        $this->assertVersionable($versionables[1], [13]);
+    }
+
+    private function generateFixture(): void
+    {
+        $versionable1 = new VersionableEntity(1);
+
+        $version11 = new VersionEntity(11);
+        $version11->setVersionDate(new DateTimeImmutable('2024-02-01'));
+        $version11->setVersionable($versionable1);
+
+        $version12 = new VersionEntity(12);
+        $version12->setVersionDate(new DateTimeImmutable('2024-01-01'));
+        $version12->setVersionable($versionable1);
+
+        $version13 = new VersionEntity(13);
+        $version13->setVersionDate(new DateTimeImmutable('2025-03-02'));
+        $version13->setVersionable($versionable1);
+
+        $versionable2 = new VersionableEntity(2);
+
+        $version21 = new VersionEntity(21);
+        $version21->setVersionDate(new DateTimeImmutable('2025-04-01'));
+        $version21->setVersionable($versionable2);
+
+        $version22 = new VersionEntity(22);
+        $version22->setVersionDate(new DateTimeImmutable('2025-03-01'));
+        $version22->setVersionable($versionable2);
+
+        $version23 = new VersionEntity(23);
+        $version23->setVersionDate(new DateTimeImmutable('2025-06-01'));
+        $version23->setVersionable($versionable2);
+
+        $version24 = new VersionEntity(24);
+        $version24->setVersionDate(new DateTimeImmutable('2025-05-01'));
+        $version24->setVersionable($versionable2);
+
+        $this->_em->persist($versionable1);
+        $this->_em->persist($version11);
+        $this->_em->persist($version12);
+        $this->_em->persist($version13);
+
+        $this->_em->persist($versionable2);
+        $this->_em->persist($version21);
+        $this->_em->persist($version22);
+        $this->_em->persist($version23);
+        $this->_em->persist($version24);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    private function assertVersionable(VersionableEntity $versionable, array $expectedIds): void
+    {
+        $versions = $versionable->getVersions();
+
+        $size = count($expectedIds);
+
+        $this->assertCount($size, $versions);
+
+        foreach ($expectedIds as $index => $expectedId) {
+            $version = $versions->get($index);
+
+            $this->assertInstanceOf(VersionEntity::class, $version);
+            $this->assertEquals($expectedId, $version->getId());
+        }
+    }
+}

--- a/tests/Tests/Models/OrderByJoinCondition/VersionEntity.php
+++ b/tests/Tests/Models/OrderByJoinCondition/VersionEntity.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OrderByJoinCondition;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="version")
+ */
+class VersionEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="VersionableEntity", inversedBy="versions")
+     *
+     * @var VersionableEntity|null
+     */
+    private $versionable = null;
+
+    /**
+     * @ORM\Column(type="datetime_immutable")
+     *
+     * @var DateTimeImmutable|null
+     */
+    private $versionDate;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getVersionable(): ?VersionableEntity
+    {
+        return $this->versionable;
+    }
+
+    public function setVersionable(?VersionableEntity $versionable): void
+    {
+        $this->versionable = $versionable;
+    }
+
+    public function setVersionDate(DateTimeImmutable $versionDate): void
+    {
+        $this->versionDate = $versionDate;
+    }
+
+    public function getVersionDate(): ?DateTimeImmutable
+    {
+        return $this->versionDate;
+    }
+}

--- a/tests/Tests/Models/OrderByJoinCondition/VersionableEntity.php
+++ b/tests/Tests/Models/OrderByJoinCondition/VersionableEntity.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OrderByJoinCondition;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ReadableCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="versionable")
+ */
+class VersionableEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="VersionEntity", mappedBy="versionable")
+     * @ORM\OrderBy({"versionDate" = "DESC"})
+     *
+     * @var Collection|null
+     */
+    private $versions = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return ReadableCollection<array-key, VersionEntity>
+     */
+    public function getVersions() // phpcs:ignore
+    {
+        if ($this->versions === null) {
+            $this->versions = new ArrayCollection();
+        }
+
+        return $this->versions;
+    }
+
+    public function addVersion(VersionEntity $versionEntity): void
+    {
+        if (! $this->getVersions()->contains($versionEntity)) {
+            $this->getVersions()->add($versionEntity);
+
+            $versionEntity->setVersionable($this);
+        }
+    }
+
+    public function removeVersion(VersionEntity $versionEntity): void
+    {
+        if ($this->getVersions()->contains($versionEntity)) {
+            $this->getVersions()->removeElement($versionEntity);
+
+            $versionEntity->setVersionable(null);
+        }
+    }
+}


### PR DESCRIPTION
We discovered an odd behaviour regarding subselects in join `WITH` conditions including an `ORDER BY` statement, where the corresponding association has an `#[OrderBy(...)]` attribute:

```php
/**
 * @ORM\Entity
 * @ORM\Table(name="versionable")
 */
class VersionableEntity
{
    // ...

    /**
     * @ORM\OneToMany(targetEntity="VersionEntity", mappedBy="versionable")
     * @ORM\OrderBy({"versionDate" = "DESC"})
     */
    private Collection|null $versions = null;

   // ...
}
```

```php
/**
 * @ORM\Entity
 * @ORM\Table(name="version")
 */
class VersionEntity
{
    // ...

    /**
     * @ORM\ManyToOne(targetEntity="VersionableEntity", inversedBy="versions")
     */
    private VersionableEntity|null $versionable = null;

    // ...
}
```

```php
$versionFqcn = VersionEntity::class;

$condition = <<<DQL
    version.id IN (
        SELECT v.id
        FROM $versionFqcn AS v
        WHERE v.versionDate < :date
        ORDER BY v.id DESC
    )
DQL;

$query = $this->_em->createQueryBuilder()
    ->select([
        'versionable',
        'version'
    ])
    ->from(VersionableEntity::class, 'versionable')
    ->leftJoin('versionable.versions', 'version', 'WITH', $condition)
    ->setParameter('date', new \DateTimeImmutable('2025-01-01'))
    ->getQuery();
```

The above query builder will produce the following SQL query:

```sql
SELECT v0_.id             AS id_0,
       v1_.id             AS id_1,
       v1_.versiondate    AS versiondate_2,
       v1_.versionable_id AS versionable_id_3
FROM versionable v0_
         LEFT JOIN version v1_ ON v0_.id = v1_.versionable_id AND (v1_.id in (SELECT v2_.id
                                                                              FROM version v2_
                                                                              WHERE v2_.versiondate < ?
                                                                              ORDER BY v2_.id DESC,
                                                                                       v1_.versiondate DESC))
```

**Mind the second column in the subselect's `ORDER BY` statement (`v1_.versiondate DESC`).** We would expect the following query instead:

```sql
SELECT v0_.id             AS id_0,
       v1_.id             AS id_1,
       v1_.versiondate    AS versiondate_2,
       v1_.versionable_id AS versionable_id_3
FROM versionable v0_
         LEFT JOIN version v1_ ON v0_.id = v1_.versionable_id AND (v1_.id in (SELECT v2_.id
                                                                              FROM version v2_
                                                                              WHERE v2_.versiondate < ?
                                                                              ORDER BY v2_.id DESC))
ORDER BY v1_.versiondate DESC
```

This behaviour is not just wrong, it also can lead to bad performance and invalid SQL.

Fixes https://github.com/doctrine/orm/issues/12438.