### PR TITLE
docs: fix typo `Explictly` → `Explicitly` in UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1062,7 +1062,7 @@ The output walker must not base its workings on the query `firstResult`/`maxResu
 Any operation dependent on `firstResult`/`maxResult` should take place within the `SqlFinalizer::createExecutor()`
 method. Details can be found at https://github.com/doctrine/orm/pull/11188.
 
-## Explictly forbid property hooks
+## Explicitly forbid property hooks
 
 Property hooks are not supported yet by Doctrine ORM. Until support is added,
 they are explicitly forbidden because the support would result in a breaking


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `UPGRADE.md` (line ~1065)
- Change: `Explictly` → `Explicitly`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
