### PR TITLE
docs: fix typo `resetted` → `reset` in XmlDriver.php

### DIFF
--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -249,7 +249,7 @@ class XmlDriver extends FileDriver
         }
 
         // The mapping assignment is done in 2 times as a bug might occurs on some php/xml lib versions
-        // The internal SimpleXmlIterator get resetted, to this generate a duplicate field exception
+        // The internal SimpleXmlIterator get reset, to this generate a duplicate field exception
         // Evaluate <field ...> mappings
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $fieldMapping) {


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `src/Mapping/Driver/XmlDriver.php` (line ~252)
- Change: `resetted` → `reset`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
