### PR TITLE
docs: fix typo `assocation` → `association` in attributes-reference.rst

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -57,7 +57,7 @@ Reference
 ~~~~~~~~~~~~~~~~~~~~~~
 
 In an inheritance hierarchy this attribute allows to override the
-assocation mapping definitions of the parent mappings. It needs to be nested
+association mapping definitions of the parent mappings. It needs to be nested
 within a ``#[AssociationOverrides]`` on the class level.
 
 Required parameters:


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docs/en/reference/attributes-reference.rst` (line ~60)
- Change: `assocation` → `association`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
