### PR TITLE
docs: fix typo `programatically` → `programmatically` in php-mapping.rst

### DIFF
--- a/docs/en/reference/php-mapping.rst
+++ b/docs/en/reference/php-mapping.rst
@@ -9,7 +9,7 @@ Static Function
 ---------------
 
 In addition to other drivers using configuration languages you can also
-programatically specify your mapping information inside of a static function
+programmatically specify your mapping information inside of a static function
 defined on the entity class itself.
 
 This is useful for cases where you want to keep your entity and mapping


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docs/en/reference/php-mapping.rst` (line ~12)
- Change: `programatically` → `programmatically`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
