### PR TITLE
docs: fix EntityManager transactional reference to wrapInTransaction

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -114,7 +114,7 @@ functionally equivalent to the previously shown code looks as follows:
     });
 
 The difference between ``Connection#transactional($func)`` and
-``EntityManager#transactional($func)`` is that the latter
+``EntityManager#wrapInTransaction($func)`` is that the latter
 abstraction flushes the ``EntityManager`` prior to transaction
 commit and in case of an exception the ``EntityManager`` gets closed
 in addition to the transaction rollback.


### PR DESCRIPTION
Fixes #12443

## What changed

`docs/en/reference/transactions-and-concurrency.rst` compares the behavior of `Connection#transactional` and `EntityManager#transactional` — but `EntityManager` no longer has `transactional` (it's `wrapInTransaction` since 3.0). The inconsistency is local to one sentence; the code block immediately above already uses `$em->wrapInTransaction(...)`, so the text paragraph just needed to match.

Before:

> The difference between ``Connection#transactional($func)`` and ``EntityManager#transactional($func)`` is that the latter ...

After:

> The difference between ``Connection#transactional($func)`` and ``EntityManager#wrapInTransaction($func)`` is that the latter ...

One-line docs diff, no code changes.
