### PR TITLE
Fix order by docs

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1056,7 +1056,7 @@ Example:
     <?php
     /**
      * @ManyToMany(targetEntity="Group")
-     * @OrderBy({"name" = "ASC"})
+     * @OrderBy({"name" = "ASC", "createdAt" = "DESC"})
      */
     private $groups;
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1060,9 +1060,9 @@ Example:
      */
     private $groups;
 
-The DQL Snippet in OrderBy is only allowed to consist of
-unqualified, unquoted field names and of an optional ASC/DESC
-positional statement. Multiple Fields are separated by a comma (,).
+The keys of the array are only allowed to consist of unqualified,
+unquoted field names. The values can be either ``ASC`` or ``DESC``.
+
 The referenced field names have to exist on the ``targetEntity``
 class of the ``@ManyToMany`` or ``@OneToMany`` annotation.
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -957,8 +957,8 @@ Example:
 .. code-block:: php
 
     <?php
-    #[ManyToMany(targetEntity: "Group")]
-    #[OrderBy(["name" => "ASC", "createdAt" => "DESC"])]
+    #[ManyToMany(targetEntity: 'Group')]
+    #[OrderBy(['name' => 'ASC', 'createdAt' => 'DESC'])]
     private $groups;
 
 The keys of the array are only allowed to consist of unqualified,

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -957,7 +957,7 @@ Example:
 .. code-block:: php
 
     <?php
-    #[ManyToMany(targetEntity: 'Group')]
+    #[ManyToMany(targetEntity: Group::class)]
     #[OrderBy(['name' => 'ASC', 'createdAt' => 'DESC'])]
     private $groups;
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -958,7 +958,7 @@ Example:
 
     <?php
     #[ManyToMany(targetEntity: "Group")]
-    #[OrderBy(["name" => "ASC"])]
+    #[OrderBy(["name" => "ASC", "createdAt" => "DESC"])]
     private $groups;
 
 The key in ``OrderBy`` is only allowed to consist of

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -961,9 +961,9 @@ Example:
     #[OrderBy(["name" => "ASC", "createdAt" => "DESC"])]
     private $groups;
 
-The key in ``OrderBy`` is only allowed to consist of
-unqualified, unquoted field names and of an optional ``ASC``/``DESC``
-positional statement. Multiple Fields are separated by a comma (,).
+The keys of the array are only allowed to consist of unqualified,
+unquoted field names and the values can be either ``ASC`` or``DESC``.
+
 The referenced field names have to exist on the ``targetEntity``
 class of the ``#[ManyToMany]`` or ``#[OneToMany]`` attribute.
 

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -143,6 +143,7 @@ of several common elements:
                 </cascade>
                 <order-by>
                     <order-by-field name="number" direction="ASC" />
+                    <order-by-field name="createdAt" direction="DESC" />
                 </order-by>
             </one-to-many>
 

--- a/docs/en/tutorials/ordered-associations.rst
+++ b/docs/en/tutorials/ordered-associations.rst
@@ -23,7 +23,7 @@ can specify the ``#[OrderBy]`` in the following way:
             // ...
 
             #[ManyToMany(targetEntity: Group::class)]
-            #[OrderBy(["name" => "ASC"])]
+            #[OrderBy(["name" => "ASC", "createdAt" => "DESC"])]
             private Collection $groups;
         }
 
@@ -37,7 +37,7 @@ can specify the ``#[OrderBy]`` in the following way:
 
             /**
              * @ManyToMany(targetEntity="Group")
-             * @OrderBy({"name" = "ASC"})
+             * @OrderBy({"name" = "ASC", "createdAt" = "DESC"})
              * @var Collection<int, Group>
              */
             private Collection $groups;
@@ -50,6 +50,7 @@ can specify the ``#[OrderBy]`` in the following way:
                 <many-to-many field="groups" target-entity="Group">
                     <order-by>
                         <order-by-field name="name" direction="ASC" />
+                        <order-by-field name="createdAt" direction="DESC" />
                     </order-by>
                 </many-to-many>
             </entity>
@@ -61,7 +62,7 @@ can specify the ``#[OrderBy]`` in the following way:
           type: entity
           manyToMany:
             groups:
-              orderBy: { 'name': 'ASC' }
+              orderBy: { 'name': 'ASC', 'createdAt': 'DESC' }
               targetEntity: Group
               joinTable:
                 name: users_groups

--- a/docs/en/tutorials/ordered-associations.rst
+++ b/docs/en/tutorials/ordered-associations.rst
@@ -23,7 +23,7 @@ can specify the ``#[OrderBy]`` in the following way:
             // ...
 
             #[ManyToMany(targetEntity: Group::class)]
-            #[OrderBy(["name" => "ASC", "createdAt" => "DESC"])]
+            #[OrderBy(['name' => 'ASC', 'createdAt' => 'DESC'])]
             private Collection $groups;
         }
 

--- a/docs/en/tutorials/ordered-associations.rst
+++ b/docs/en/tutorials/ordered-associations.rst
@@ -73,11 +73,13 @@ can specify the ``#[OrderBy]`` in the following way:
                   group_id:
                     referencedColumnName: id
 
-The DQL Snippet in OrderBy is only allowed to consist of
-unqualified, unquoted field names and of an optional ASC/DESC
-positional statement. Multiple Fields are separated by a comma (,).
-The referenced field names have to exist on the ``targetEntity``
-class of the ``#[ManyToMany]`` or ``#[OneToMany]`` attribute.
+The DQL Snippet representing the field is only allowed to consist of
+unqualified, unquoted field names. The direction can be either ``ASC``
+or ``DESC`` and is mandatory when using attributes, annotations or YAML.
+When using the XML driver, the direction defaults to ``ASC`` if not specified.
+
+The referenced field names have to exist on the ``targetEntity`` class
+of the ``#[ManyToMany]`` or ``#[OneToMany]`` attribute.
 
 The semantics of this feature can be described as follows:
 


### PR DESCRIPTION
They seem to imply that features that do not exist AFAIK, like being
able to specify a DQL snippet like this:

```php
     #[OrderBy("name ASC, createdAt DESC")]
```