### PR TITLE
Fix collection order by behaviour in join with conditions in 3.6.x

### DIFF
--- a/src/Query/AST/OrderByClause.php
+++ b/src/Query/AST/OrderByClause.php
@@ -14,8 +14,10 @@ use Doctrine\ORM\Query\SqlWalker;
 class OrderByClause extends Node
 {
     /** @param OrderByItem[] $orderByItems */
-    public function __construct(public array $orderByItems)
-    {
+    public function __construct(
+        public array $orderByItems,
+        public bool $includeCollectionOrderByItems = true,
+    ) {
     }
 
     public function dispatch(SqlWalker $walker): string

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -149,6 +149,11 @@ final class Parser
     private int $nestingLevel = 0;
 
     /**
+     * Keeps the nesting level of subqueries in JOIN WITH conditions.
+     */
+    private int $withJoinConditionNestingLevel = 0;
+
+    /**
      * Any additional custom tree walkers that modify the AST.
      *
      * @var list<class-string<TreeWalker>>
@@ -1384,7 +1389,7 @@ final class Parser
             $orderByItems[] = $this->OrderByItem();
         }
 
-        return new AST\OrderByClause($orderByItems);
+        return new AST\OrderByClause($orderByItems, $this->withJoinConditionNestingLevel === 0);
     }
 
     /**
@@ -1650,7 +1655,14 @@ final class Parser
 
             if ($this->lexer->isNextToken(TokenType::T_WITH)) {
                 $this->match(TokenType::T_WITH);
-                $conditionalExpression = $this->ConditionalExpression();
+
+                try {
+                    $this->withJoinConditionNestingLevel++;
+
+                    $conditionalExpression = $this->ConditionalExpression();
+                } finally {
+                    $this->withJoinConditionNestingLevel--;
+                }
             }
         } else {
             $joinDeclaration         = $this->RangeVariableDeclaration();

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1099,9 +1099,11 @@ class SqlWalker
     {
         $orderByItems = array_map($this->walkOrderByItem(...), $orderByClause->orderByItems);
 
-        $collectionOrderByItems = $this->generateOrderedCollectionOrderByItems();
-        if ($collectionOrderByItems !== '') {
-            $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
+        if ($orderByClause->includeCollectionOrderByItems) {
+            $collectionOrderByItems = $this->generateOrderedCollectionOrderByItems();
+            if ($collectionOrderByItems !== '') {
+                $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
+            }
         }
 
         return ' ORDER BY ' . implode(', ', $orderByItems);

--- a/tests/Tests/Models/GH12438/VersionEntity.php
+++ b/tests/Tests/Models/GH12438/VersionEntity.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH12438;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'version')]
+class VersionEntity
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    private $id;
+
+    /** @var VersionableEntity|null */
+    #[ManyToOne(targetEntity: VersionableEntity::class, inversedBy: 'versions')]
+    private $versionable = null;
+
+    /** @var DateTimeImmutable|null */
+    #[Column(type: 'datetime_immutable')]
+    private $versionDate;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getVersionable(): VersionableEntity|null
+    {
+        return $this->versionable;
+    }
+
+    public function setVersionable(VersionableEntity|null $versionable): void
+    {
+        $this->versionable = $versionable;
+    }
+
+    public function setVersionDate(DateTimeImmutable $versionDate): void
+    {
+        $this->versionDate = $versionDate;
+    }
+
+    public function getVersionDate(): DateTimeImmutable|null
+    {
+        return $this->versionDate;
+    }
+}

--- a/tests/Tests/Models/GH12438/VersionableEntity.php
+++ b/tests/Tests/Models/GH12438/VersionableEntity.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH12438;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ReadableCollection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OrderBy;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'versionable')]
+class VersionableEntity
+{
+    /** @var int */
+    #[Id]
+    #[Column(type: 'integer')]
+    private $id;
+
+    /** @var Collection|null */
+    #[OneToMany(targetEntity: VersionEntity::class, mappedBy: 'versionable')]
+    #[OrderBy(['versionDate' => 'DESC'])]
+    private $versions = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /** @return ReadableCollection<array-key, VersionEntity> */
+    public function getVersions() // phpcs:ignore
+    {
+        if ($this->versions === null) {
+            $this->versions = new ArrayCollection();
+        }
+
+        return $this->versions;
+    }
+
+    public function addVersion(VersionEntity $versionEntity): void
+    {
+        if (! $this->getVersions()->contains($versionEntity)) {
+            $this->getVersions()->add($versionEntity);
+
+            $versionEntity->setVersionable($this);
+        }
+    }
+
+    public function removeVersion(VersionEntity $versionEntity): void
+    {
+        if ($this->getVersions()->contains($versionEntity)) {
+            $this->getVersions()->removeElement($versionEntity);
+
+            $versionEntity->setVersionable(null);
+        }
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12438Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12438Test.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\Tests\Models\GH12438\VersionableEntity;
+use Doctrine\Tests\Models\GH12438\VersionEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function count;
+
+class GH12438Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(VersionableEntity::class, VersionEntity::class);
+
+        $this->generateFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->dropTableIfExists('version');
+        $this->dropTableIfExists('versionable');
+    }
+
+    public function testFetchAll(): void
+    {
+        /** @var VersionableEntity[] $versionables */
+        $versionables = $this->_em->createQueryBuilder()
+            ->select([
+                'versionable',
+                'version',
+            ])
+            ->from(VersionableEntity::class, 'versionable')
+            ->innerJoin('versionable.versions', 'version')
+            ->orderBy('versionable.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertCount(2, $versionables);
+
+        $this->assertVersionable($versionables[0], [23, 24, 21, 22]);
+        $this->assertVersionable($versionables[1], [13, 11, 12]);
+    }
+
+    public function testFetchWithJoinCondition(): void
+    {
+        $versionFqcn = VersionEntity::class;
+
+        $condition = 'version.id IN (SELECT v.id FROM ' . $versionFqcn . ' AS v WHERE v.versionDate > :date ORDER BY v.id DESC)';
+
+        /** @var VersionableEntity[] $versionables */
+        $versionables = $this->_em->createQueryBuilder()
+            ->select([
+                'versionable',
+                'version',
+            ])
+            ->from(VersionableEntity::class, 'versionable')
+            ->leftJoin('versionable.versions', 'version', Expr\Join::WITH, $condition)
+            ->setParameter('date', new DateTimeImmutable('2025-03-01'))
+            ->orderBy('versionable.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $this->assertVersionable($versionables[0], [23, 24, 21]);
+        $this->assertVersionable($versionables[1], [13]);
+    }
+
+    public function testFetchWithJoinConditionWithoutAssociation(): void
+    {
+        $versionFqcn = VersionEntity::class;
+
+        $condition = 'version.id IN (SELECT v.id FROM ' . $versionFqcn . ' AS v WHERE v.versionDate > :date ORDER BY v.id DESC)';
+
+        /** @var VersionableEntity[] $versionables */
+        $versionables = $this->_em->createQueryBuilder()
+            ->distinct()
+            ->select('version.id')
+            ->from(VersionableEntity::class, 'versionable')
+            ->leftJoin($versionFqcn, 'version', Expr\Join::ON, $condition)
+            ->setParameter('date', new DateTimeImmutable('2025-03-01'))
+            ->orderBy('version.id', 'ASC')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        $this->assertIsArray($versionables);
+        $this->assertCount(4, $versionables);
+        $this->assertEquals([13, 21, 23, 24], $versionables);
+    }
+
+    private function generateFixture(): void
+    {
+        $versionable1 = new VersionableEntity(1);
+
+        $version11 = new VersionEntity(11);
+        $version11->setVersionDate(new DateTimeImmutable('2024-02-01'));
+        $version11->setVersionable($versionable1);
+
+        $version12 = new VersionEntity(12);
+        $version12->setVersionDate(new DateTimeImmutable('2024-01-01'));
+        $version12->setVersionable($versionable1);
+
+        $version13 = new VersionEntity(13);
+        $version13->setVersionDate(new DateTimeImmutable('2025-03-02'));
+        $version13->setVersionable($versionable1);
+
+        $versionable2 = new VersionableEntity(2);
+
+        $version21 = new VersionEntity(21);
+        $version21->setVersionDate(new DateTimeImmutable('2025-04-01'));
+        $version21->setVersionable($versionable2);
+
+        $version22 = new VersionEntity(22);
+        $version22->setVersionDate(new DateTimeImmutable('2025-03-01'));
+        $version22->setVersionable($versionable2);
+
+        $version23 = new VersionEntity(23);
+        $version23->setVersionDate(new DateTimeImmutable('2025-06-01'));
+        $version23->setVersionable($versionable2);
+
+        $version24 = new VersionEntity(24);
+        $version24->setVersionDate(new DateTimeImmutable('2025-05-01'));
+        $version24->setVersionable($versionable2);
+
+        $this->_em->persist($versionable1);
+        $this->_em->persist($version11);
+        $this->_em->persist($version12);
+        $this->_em->persist($version13);
+
+        $this->_em->persist($versionable2);
+        $this->_em->persist($version21);
+        $this->_em->persist($version22);
+        $this->_em->persist($version23);
+        $this->_em->persist($version24);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    private function assertVersionable(VersionableEntity $versionable, array $expectedIds): void
+    {
+        $versions = $versionable->getVersions();
+
+        $size = count($expectedIds);
+
+        $this->assertCount($size, $versions);
+
+        foreach ($expectedIds as $index => $expectedId) {
+            $version = $versions->get($index);
+
+            $this->assertInstanceOf(VersionEntity::class, $version);
+            $this->assertEquals($expectedId, $version->getId());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/doctrine/orm/issues/12438.

Follow-up to https://github.com/doctrine/orm/pull/12437

We discovered an odd behaviour regarding subselects in join `WITH` conditions including an `ORDER BY` statement, where the corresponding association has an `#[OrderBy(...)]` attribute:

```php
/**
 * @ORM\Entity
 * @ORM\Table(name="versionable")
 */
class VersionableEntity
{
    // ...

    /**
     * @ORM\OneToMany(targetEntity="VersionEntity", mappedBy="versionable")
     * @ORM\OrderBy({"versionDate" = "DESC"})
     */
    private Collection|null $versions = null;

   // ...
}
```

```php
/**
 * @ORM\Entity
 * @ORM\Table(name="version")
 */
class VersionEntity
{
    // ...

    /**
     * @ORM\ManyToOne(targetEntity="VersionableEntity", inversedBy="versions")
     */
    private VersionableEntity|null $versionable = null;

    // ...
}
```

```php
$versionFqcn = VersionEntity::class;

$condition = <<<DQL
    version.id IN (
        SELECT v.id
        FROM $versionFqcn AS v
        WHERE v.versionDate < :date
        ORDER BY v.id DESC
    )
DQL;

$query = $this->_em->createQueryBuilder()
    ->select([
        'versionable',
        'version'
    ])
    ->from(VersionableEntity::class, 'versionable')
    ->leftJoin('versionable.versions', 'version', 'WITH', $condition)
    ->setParameter('date', new \DateTimeImmutable('2025-01-01'))
    ->getQuery();
```

The above query builder will produce the following SQL query:

```sql
SELECT v0_.id             AS id_0,
       v1_.id             AS id_1,
       v1_.versiondate    AS versiondate_2,
       v1_.versionable_id AS versionable_id_3
FROM versionable v0_
         LEFT JOIN version v1_ ON v0_.id = v1_.versionable_id AND (v1_.id in (SELECT v2_.id
                                                                              FROM version v2_
                                                                              WHERE v2_.versiondate < ?
                                                                              ORDER BY v2_.id DESC,
                                                                                       v1_.versiondate DESC))
```

**Mind the second column in the subselect's `ORDER BY` statement (`v1_.versiondate DESC`).** We would expect the following query instead:

```sql
SELECT v0_.id             AS id_0,
       v1_.id             AS id_1,
       v1_.versiondate    AS versiondate_2,
       v1_.versionable_id AS versionable_id_3
FROM versionable v0_
         LEFT JOIN version v1_ ON v0_.id = v1_.versionable_id AND (v1_.id in (SELECT v2_.id
                                                                              FROM version v2_
                                                                              WHERE v2_.versiondate < ?
                                                                              ORDER BY v2_.id DESC))
ORDER BY v1_.versiondate DESC
```

This behaviour is not just wrong, it also can lead to bad performance and invalid SQL.