### PR TITLE
SchemaValidator should report inverseBy targeting a different entity

### DIFF
--- a/src/Tools/SchemaValidator.php
+++ b/src/Tools/SchemaValidator.php
@@ -194,6 +194,12 @@ class SchemaValidator
                         $ce[] = 'If association ' . $class->name . '#' . $fieldName . ' is many-to-many, then the inversed ' .
                                 'side ' . $targetMetadata->name . '#' . $assoc->inversedBy . ' has to be many-to-many as well.';
                     }
+
+                    if (! is_a($targetAssoc->targetEntity, $assoc->sourceEntity, true)) {
+                        $ce[] = 'The association ' . $class->name . '#' . $fieldName . ' refers to the inverse side ' .
+                                $assoc->targetEntity . '#' . $assoc->inversedBy . ' which targets a different entity (' .
+                                $targetAssoc->targetEntity . ').';
+                    }
                 }
             }
 

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -239,6 +239,21 @@ class SchemaValidatorTest extends OrmTestCase
             $this->validator->validateClass($class),
         );
     }
+
+    public function testOwningSideInversedByTargetsDifferentEntity(): void
+    {
+        $class = $this->em->getClassMetadata(MultipleInversedByOwner2::class);
+        $ce    = $this->validator->validateClass($class);
+
+        self::assertEquals(
+            [
+                'The association Doctrine\Tests\ORM\Tools\MultipleInversedByOwner2#target refers to the inverse side '
+                . 'Doctrine\Tests\ORM\Tools\MultipleInversedByInverse#owners which targets a different entity '
+                . '(Doctrine\Tests\ORM\Tools\MultipleInversedByOwner1).',
+            ],
+            $ce,
+        );
+    }
 }
 
 #[MappedSuperclass]
@@ -557,4 +572,41 @@ class InvalidMappedSuperClass
     /** @phpstan-var Collection<int, self> */
     #[ManyToMany(targetEntity: 'InvalidMappedSuperClass', mappedBy: 'invalid')]
     private $selfWhatever;
+}
+
+#[Entity]
+class MultipleInversedByOwner1
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int $id;
+
+    #[ManyToOne(targetEntity: MultipleInversedByInverse::class, inversedBy: 'owners')]
+    public MultipleInversedByInverse $target;
+}
+
+#[Entity]
+class MultipleInversedByOwner2
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int $id;
+
+    #[ManyToOne(targetEntity: MultipleInversedByInverse::class, inversedBy: 'owners')]
+    public MultipleInversedByInverse $target;
+}
+
+#[Entity]
+class MultipleInversedByInverse
+{
+    #[Id]
+    #[Column]
+    #[GeneratedValue]
+    public int $id;
+
+    /** @var Collection<int, MultipleInversedByOwner1> */
+    #[OneToMany(targetEntity: MultipleInversedByOwner1::class, mappedBy: 'target')]
+    public Collection $owners;
 }


### PR DESCRIPTION
| Q           | A          |
|-------------|------------|
| Type        | Bug fix    |
| BC Break    | no         |

#### Summary

`SchemaValidator` already checks several aspects of an `inversedBy` mapping (existence of the inverse field, `mappedBy` reciprocity, many-to-many symmetry), but it did not verify that the inverse association actually targets the owning entity.

When two distinct owning entities both declare `inversedBy: 'owners'` toward the same inverse entity, but the inverse only declares one `OneToMany` (e.g. mapped to `Owner1`), the second mapping (`Owner2`) is silently broken — `SchemaValidator` returned no error.

#### Fix

Add a check in `SchemaValidator::validateClass()` that emits an error when `targetAssoc->targetEntity` is not a subclass of (or the same as) `assoc->sourceEntity`:

> The association A#field refers to the inverse side B#inv which targets a different entity (C).

#### Test

`SchemaValidatorTest::testOwningSideInversedByTargetsDifferentEntity` covers the scenario with three new fixtures (`MultipleInversedByOwner1`, `MultipleInversedByOwner2`, `MultipleInversedByInverse`).