### PR TITLE
Set default value of OrderByClause::__construct() second argument in 2.20.x

### DIFF
--- a/src/Query/AST/OrderByClause.php
+++ b/src/Query/AST/OrderByClause.php
@@ -17,7 +17,7 @@ class OrderByClause extends Node
     public $includeCollectionOrderByItems = true;
 
     /** @param OrderByItem[] $orderByItems */
-    public function __construct(array $orderByItems, bool $includeCollectionOrderByItems)
+    public function __construct(array $orderByItems, bool $includeCollectionOrderByItems = true)
     {
         $this->orderByItems                  = $orderByItems;
         $this->includeCollectionOrderByItems = $includeCollectionOrderByItems;


### PR DESCRIPTION
Fixes #12465

`OrderByClause::__construct()` lost its single-argument signature in `2.20.11` (after https://github.com/doctrine/orm/pull/12437), breaking every caller that constructed the AST node directly. This is a BC break shipped in a patch release: `2.20.10` accepted one argument, `2.20.11` requires two.

The same fix was backported from the `3.6.x` branch ([#12456]), but on `3.6.x` the second parameter was added **with a default value** preserving BC, and on the `2.20.x` backport that default was dropped.

This PR re-aligns `2.20.x` with `3.6.x` by adding `= true` to the `$includeCollectionOrderByItems` parameter, same behaviour, no BC break.