### PR TITLE
Disable deprecation deduplication

### DIFF
--- a/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
+++ b/tests/Tests/ORM/Functional/ParserResultSerializationTest.php
@@ -88,6 +88,7 @@ class ParserResultSerializationTest extends OrmFunctionalTestCase
     }
 
     #[DataProvider('provideSerializedSingleSelectResults')]
+    #[IgnoreDeprecations]
     public function testUnserializeSingleSelectResult(string $serialized): void
     {
         $unserialized = unserialize($serialized);

--- a/tests/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Tests/ORM/Functional/PostLoadEventTest.php
@@ -209,7 +209,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
     public function testEventRaisedCorrectTimesWhenOtherEntityLoadedInEventHandler(): void
     {
         $eventManager = $this->_em->getEventManager();
-        $listener     = new PostLoadListenerLoadEntityInEventHandler();
+        $listener     = new PostLoadListenerLoadEntityInEventHandler(! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled());
         $eventManager->addEventListener([Events::postLoad], $listener);
 
         $this->_em->find(CmsUser::class, $this->userId);
@@ -265,11 +265,9 @@ class PostLoadListener
 
 class PostLoadListenerCheckAssociationsArePopulated
 {
-    /** @var bool */
-    public $checked = false;
+    public bool $checked = false;
 
-    /** @var bool */
-    public $populated = false;
+    public bool $populated = false;
 
     public function postLoad(PostLoadEventArgs $event): void
     {
@@ -287,13 +285,20 @@ class PostLoadListenerCheckAssociationsArePopulated
 
 class PostLoadListenerLoadEntityInEventHandler
 {
+    public function __construct(private bool $resolveClassName)
+    {
+    }
+
     /** @var array<class-string, int> */
     private array $firedByClasses = [];
 
     public function postLoad(PostLoadEventArgs $event): void
     {
         $object = $event->getObject();
-        $class  = DefaultProxyClassNameResolver::getClass($object);
+        $class  = $this->resolveClassName ?
+            DefaultProxyClassNameResolver::getClass($object) :
+            $object::class;
+
         if (! isset($this->firedByClasses[$class])) {
             $this->firedByClasses[$class] = 1;
         } else {

--- a/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1022,13 +1022,12 @@ class ObjectHydratorTest extends HydrationTestCase
             ],
         ];
 
+        $args = $this->entityManager->getConfiguration()->isNativeLazyObjectsEnabled() ?
+            [$this->entityManager] :
+            [$this->entityManager, sys_get_temp_dir(), 'Proxies', ProxyFactory::AUTOGENERATE_ALWAYS];
+
         // extending the proxy factory to spy on getProxy()
-        $proxyFactory = new class (
-            $this->entityManager,
-            sys_get_temp_dir(),
-            'Proxies',
-            ProxyFactory::AUTOGENERATE_ALWAYS,
-        ) extends ProxyFactory {
+        $proxyFactory = new class (...$args) extends ProxyFactory {
             public function getProxy(string $className, array $identifier): object
             {
                 TestCase::assertSame(ECommerceShipping::class, $className);
@@ -1076,13 +1075,12 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $proxyInstance = new ECommerceShipping();
 
+        $args = $this->entityManager->getConfiguration()->isNativeLazyObjectsEnabled() ?
+            [$this->entityManager] :
+            [$this->entityManager, sys_get_temp_dir(), 'Proxies', ProxyFactory::AUTOGENERATE_ALWAYS];
+
         // extending the proxy factory to spy on getProxy()
-        $proxyFactory = new class (
-            $this->entityManager,
-            sys_get_temp_dir(),
-            'Proxies',
-            ProxyFactory::AUTOGENERATE_ALWAYS,
-        ) extends ProxyFactory {
+        $proxyFactory = new class (...$args) extends ProxyFactory {
             public function getProxy(string $className, array $identifier): object
             {
                 TestCase::assertSame(ECommerceShipping::class, $className);

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -1132,7 +1132,6 @@ class User
                             'name' => 'user_id',
                             'referencedColumnName' => 'id',
                             'unique' => false,
-                            'nullable' => false,
                         ],
                     ],
                     'inverseJoinColumns' =>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.DDC807Entity.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.DDC807Entity.dcm.xml
@@ -6,15 +6,15 @@
 
     <entity name="Doctrine\Tests\ORM\Mapping\DDC807Entity" inheritance-type="SINGLE_TABLE">
         <discriminator-column name="dtype" column-definition="ENUM('ONE','TWO')"/>
-        
+
         <discriminator-map>
             <discriminator-mapping value="ONE" class="DDC807SubClasse1" />
-            <discriminator-mapping value="TWO" class="DDC807SubClasse1" />
+            <discriminator-mapping value="TWO" class="DDC807SubClasse2" />
         </discriminator-map>
 
         <id name="id">
             <generator strategy="NONE"/>
         </id>
     </entity>
-        
+
 </doctrine-mapping>

--- a/tests/Tests/ORM/ORMSetupTest.php
+++ b/tests/Tests/ORM/ORMSetupTest.php
@@ -75,6 +75,7 @@ class ORMSetupTest extends TestCase
     #[RequiresPhpExtension('apcu')]
     #[RequiresSetting('apc.enable_cli', '1')]
     #[RequiresSetting('apc.enabled', '1')]
+    #[IgnoreDeprecations]
     public function testCacheNamespaceShouldBeGeneratedForApcuWhenUsingLegacyConstructor(): void
     {
         if (PHP_VERSION_ID >= 80400) {

--- a/tests/Tests/ORM/Persisters/BinaryIdPersisterTest.php
+++ b/tests/Tests/ORM/Persisters/BinaryIdPersisterTest.php
@@ -68,7 +68,8 @@ final class BinaryIdPersisterTest extends OrmTestCase
             return $this->entityManager;
         }
 
-        $config = ORMSetup::createAttributeMetadataConfiguration(
+        $method = PHP_VERSION_ID >= 80400 ? 'createAttributeMetadataConfig' : 'createAttributeMetadataConfiguration';
+        $config = ORMSetup::$method(
             $this->getClassLocator(),
             isDevMode: true,
         );

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -281,6 +281,7 @@ class ProxyFactoryTest extends OrmTestCase
         );
     }
 
+    #[IgnoreDeprecations]
     public function testProxyFactoryThrowsIfLazyGhostsAreUnavailable(): void
     {
         if (method_exists(ProxyHelper::class, 'generateLazyGhost')) {

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -63,7 +63,15 @@ class ProxyFactoryTest extends OrmTestCase
         $this->emMock  = new EntityManagerMock($connection);
         $this->uowMock = new UnitOfWorkMock($this->emMock);
         $this->emMock->setUnitOfWork($this->uowMock);
-        $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', ProxyFactory::AUTOGENERATE_ALWAYS);
+        $args               = $this->emMock->getConfiguration()->isNativeLazyObjectsEnabled() ?
+            [$this->emMock] :
+            [
+                $this->emMock,
+                sys_get_temp_dir(),
+                'Proxies',
+                ProxyFactory::AUTOGENERATE_ALWAYS,
+            ];
+        $this->proxyFactory = new ProxyFactory(...$args);
     }
 
     public function testReferenceProxyDelegatesLoadingToThePersister(): void

--- a/tests/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Tests/ORM/Query/ParserResultTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\ResultSetMapping;
 use LogicException;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class ParserResultTest extends TestCase
@@ -28,6 +29,7 @@ class ParserResultTest extends TestCase
         self::assertInstanceOf(ResultSetMapping::class, $this->parserResult->getResultSetMapping());
     }
 
+    #[IgnoreDeprecations]
     public function testItThrowsWhenAttemptingToAccessTheExecutorBeforeItIsSet(): void
     {
         $this->expectException(LogicException::class);
@@ -38,6 +40,7 @@ class ParserResultTest extends TestCase
         $this->parserResult->getSqlExecutor();
     }
 
+    #[IgnoreDeprecations]
     public function testSetGetSqlExecutor(): void
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/11188');

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -324,7 +324,7 @@ class DDC1587ValidEntity2
 {
     #[Id]
     #[OneToOne(targetEntity: 'DDC1587ValidEntity1', inversedBy: 'identifier')]
-    #[JoinColumn(name: 'pk_agent', referencedColumnName: 'pk', nullable: false)]
+    #[JoinColumn(name: 'pk_agent', referencedColumnName: 'pk')]
     private DDC1587ValidEntity1 $agent;
 
     #[Column(name: 'num', type: 'string', length: 16, nullable: true)]

--- a/tests/Tests/TestInit.php
+++ b/tests/Tests/TestInit.php
@@ -8,14 +8,17 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests;
 
+use Doctrine\Deprecations\Deprecation;
 use Exception;
 
 use function date_default_timezone_set;
 use function error_reporting;
 use function file_exists;
+use function getenv;
 use function mkdir;
 
 use const E_ALL;
+use const PHP_VERSION_ID;
 
 error_reporting(E_ALL);
 date_default_timezone_set('UTC');
@@ -36,4 +39,10 @@ if (! file_exists(__DIR__ . '/Proxies') && ! mkdir(__DIR__ . '/Proxies')) {
 
 if (! file_exists(__DIR__ . '/ORM/Proxy/generated') && ! mkdir(__DIR__ . '/ORM/Proxy/generated')) {
     throw new Exception('Could not create ' . __DIR__ . '/ORM/Proxy/generated Folder.');
+}
+
+$enableNativeLazyObjects = getenv('ENABLE_NATIVE_LAZY_OBJECTS');
+
+if (PHP_VERSION_ID >= 80400 && ($enableNativeLazyObjects === false || $enableNativeLazyObjects === 'true')) {
+    Deprecation::withoutDeduplication();
 }


### PR DESCRIPTION
That feature should not be used together with `IgnoreDeprecation`, it can result in deprecations being hidden. The commits in this PR fix the deprecations that this revealed.