### PR TITLE
[CursorPaginator] Harden against security concerns

### DIFF
--- a/src/Tools/Pagination/Cursor.php
+++ b/src/Tools/Pagination/Cursor.php
@@ -9,6 +9,9 @@ use JsonException;
 
 use function base64_decode;
 use function base64_encode;
+use function is_array;
+use function is_scalar;
+use function is_string;
 use function json_decode;
 use function json_encode;
 use function rtrim;
@@ -75,10 +78,14 @@ final class Cursor
      *
      * @see CursorWalker::buildCursorCondition() for the security model around cursor manipulation.
      *
-     * @throws InvalidCursor If decoding fails.
+     * @throws InvalidCursor If decoding fails or the payload is invalid.
      */
-    public static function fromEncodedString(string $encodedString): self
+    public static function fromEncodedString(mixed $encodedString): self
     {
+        if (! is_string($encodedString)) {
+            throw new InvalidCursor('(non-string value)');
+        }
+
         $decoded = base64_decode(strtr($encodedString, '-_', '+/'), strict: true);
 
         if ($decoded === false) {
@@ -86,14 +93,24 @@ final class Cursor
         }
 
         try {
-            $parameters = json_decode($decoded, associative: true, flags: JSON_THROW_ON_ERROR);
+            $parameters = json_decode($decoded, associative: true, depth: 2, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new InvalidCursor($encodedString, $e);
         }
 
-        $isNext = $parameters['_isNext'] ?? true;
+        if (! is_array($parameters)) {
+            throw new InvalidCursor($encodedString);
+        }
+
+        $isNext = (bool) ($parameters['_isNext'] ?? true);
 
         unset($parameters['_isNext']);
+
+        foreach ($parameters as $value) {
+            if (! is_scalar($value) && $value !== null) {
+                throw new InvalidCursor($encodedString);
+            }
+        }
 
         return new self($parameters, $isNext);
     }

--- a/src/Tools/Pagination/CursorPaginator.php
+++ b/src/Tools/Pagination/CursorPaginator.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Exception\InvalidCursor;
 use Doctrine\ORM\Utility\PersisterHelper;
 use IteratorAggregate;
 use LogicException;
@@ -22,6 +23,7 @@ use function array_reverse;
 use function array_slice;
 use function array_sum;
 use function count;
+use function is_string;
 
 /**
  * The cursor paginator handles cursor-based pagination for DQL queries.
@@ -77,17 +79,24 @@ final class CursorPaginator implements IteratorAggregate
     /**
      * Paginates the query with the given limit and optional cursor.
      *
-     * @param Cursor|string|null $cursor The cursor instance, encoded cursor string, null or empty string for the first page.
-     * @param int                $limit  The maximum number of results to return.
+     * @param mixed $cursor The cursor instance, encoded cursor string, null or empty string for the first page.
+     *                      Any other type (e.g. array) throws InvalidCursor.
+     * @param int   $limit  The maximum number of results to return.
      *
      * @return $this
+     *
+     * @throws InvalidCursor If $cursor is not a Cursor instance, a string, or null.
      */
-    public function paginate(Cursor|string|null $cursor, int $limit): self
+    public function paginate(mixed $cursor, int $limit): self
     {
         if ($cursor instanceof Cursor) {
             $this->cursor = $cursor;
+        } elseif ($cursor === null || (is_string($cursor) && $cursor === '')) {
+            $this->cursor = null;
+        } elseif (is_string($cursor)) {
+            $this->cursor = Cursor::fromEncodedString($cursor);
         } else {
-            $this->cursor = ! empty($cursor) ? Cursor::fromEncodedString($cursor) : null;
+            throw new InvalidCursor('(non-string value)');
         }
 
         $shouldReverse = $this->cursor?->isPrevious() ?? false;

--- a/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Cursor;
 use Doctrine\ORM\Tools\Pagination\CursorItem;
 use Doctrine\ORM\Tools\Pagination\CursorPaginator;
+use Doctrine\ORM\Tools\Pagination\Exception\InvalidCursor;
 use Doctrine\Tests\OrmTestCase;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -413,6 +414,17 @@ class CursorPaginatorTest extends OrmTestCase
 
         $this->expectException(LogicException::class);
         $paginator->countPageItems();
+    }
+
+    public function testPaginateThrowsInvalidCursorForNonStringNonCursorNonNull(): void
+    {
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
+
+        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
+
+        $this->expectException(InvalidCursor::class);
+        $paginator->paginate(['injected' => 'array'], 10);
     }
 
     public function testDefaultQueryProducesDuplicatesIsTrue(): void

--- a/tests/Tests/ORM/Tools/Pagination/CursorTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/CursorTest.php
@@ -95,4 +95,34 @@ class CursorTest extends TestCase
 
         self::assertSame(['id' => 1, '_isNext' => true], $cursor->toArray());
     }
+
+    public function testFromEncodedStringThrowsForNonStringInput(): void
+    {
+        $this->expectException(InvalidCursor::class);
+
+        Cursor::fromEncodedString(['injected' => 'array']);
+    }
+
+    public function testFromEncodedStringThrowsForNonScalarParameterValue(): void
+    {
+        $payload = rtrim(strtr(base64_encode((string) json_encode(['p.id' => [1, 2, 3], '_isNext' => true])), '+/', '-_'), '=');
+        $this->expectException(InvalidCursor::class);
+        Cursor::fromEncodedString($payload);
+    }
+
+    public function testFromEncodedStringCastsIsNextToBool(): void
+    {
+        $payload = rtrim(strtr(base64_encode((string) json_encode(['id' => 10, '_isNext' => 0])), '+/', '-_'), '=');
+        $cursor  = Cursor::fromEncodedString($payload);
+
+        self::assertFalse($cursor->isNext());
+        self::assertTrue($cursor->isPrevious());
+    }
+
+    public function testFromEncodedStringThrowsForNonArrayJson(): void
+    {
+        $payload = rtrim(strtr(base64_encode((string) json_encode('just-a-string')), '+/', '-_'), '=');
+        $this->expectException(InvalidCursor::class);
+        Cursor::fromEncodedString($payload);
+    }
 }


### PR DESCRIPTION
Closes #12478

-  now accepts `mixed` and throws `InvalidCursor` immediately if the payload is not a string
- Decoded cursor parameters are validated to be scalar or null; non-scalar values (e.g. injected arrays) throw `InvalidCursor`
- `_isNext` is explicitly cast to `bool` to prevent type-juggling issues
- `paginate()` now accepts `mixed` and throws `InvalidCursor` for any value that is not a `Cursor` instance, a string, or null
- `json_decode` depth reduced to 2 to limit DoS surface