### PR TITLE
Avoid passing arrays to get_class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4234,12 +4234,6 @@ parameters:
 			path: src/Tools/Console/Command/MappingDescribeCommand.php
 
 		-
-			message: '#^Parameter \#1 \$entityListeners of method Doctrine\\ORM\\Tools\\Console\\Command\\MappingDescribeCommand\:\:formatEntityListeners\(\) expects list\<object\>, array\<string, list\<array\{class\: class\-string, method\: string\}\>\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/Console/Command/MappingDescribeCommand.php
-
-		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(class\-string\)\: bool\)\|null, Closure\(mixed\)\: \(0\|1\|false\) given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Tools/Console/Command/MappingDescribeCommand.php
+++ b/src/Tools/Console/Command/MappingDescribeCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 use function array_filter;
-use function array_map;
 use function array_merge;
 use function count;
 use function current;
@@ -271,13 +270,21 @@ EOT
     /**
      * Format the entity listeners
      *
-     * @phpstan-param list<object> $entityListeners
+     * @phpstan-param array<string, list<array{class: class-string, method: string}>> $entityListeners
      *
      * @return string[]
      * @phpstan-return array{0: string, 1: string}
      */
     private function formatEntityListeners(array $entityListeners): array
     {
-        return $this->formatField('Entity listeners', array_map('get_class', $entityListeners));
+        $listeners = [];
+
+        foreach ($entityListeners as $eventName => $eventListeners) {
+            foreach ($eventListeners as $listener) {
+                $listeners[] = sprintf('%s: %s::%s', $eventName, $listener['class'], $listener['method']);
+            }
+        }
+
+        return $this->formatField('Entity listeners', $listeners);
     }
 }

--- a/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Tools\Console\ApplicationCompatibility;
 use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\Tests\Models\Cache\AttractionInfo;
+use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -78,5 +79,23 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
                 'entityName' => 'AttractionFooBar',
             ]
         );
+    }
+
+    public function testShowEntityWithEntityListeners(): void
+    {
+        $this->tester->execute(
+            [
+                'command'    => $this->command->getName(),
+                'entityName' => CmsAddress::class,
+            ]
+        );
+
+        $display = $this->tester->getDisplay();
+
+        self::assertStringContainsString(CmsAddress::class, $display);
+        self::assertStringContainsString('Entity listeners', $display);
+        self::assertStringContainsString('CmsAddressListener', $display);
+        self::assertStringContainsString('postPersist', $display);
+        self::assertStringContainsString('prePersist', $display);
     }
 }


### PR DESCRIPTION
The phpdoc of `ClassMetadata::entityListeners` helped PHPStan point this out to us, yet we ignored that error.

Fixes #12392 