### PR TITLE
Add alternative to mutation

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -999,6 +999,15 @@ instance and class metadata.
         }
     }
 
+.. note::
+
+    Starting in ORM 3.6, the ``GenerateSchemaTableEventArgs`` class
+    provides ``setSchema()`` and ``setClassTable()`` methods to replace
+    the schema or table objects. These methods require ``doctrine/dbal``
+    ^4.5 or higher, which provides the Schema Editor API. If called with
+    an earlier DBAL version, a ``BadMethodCallException`` will be
+    thrown.
+
 postGenerateSchema
 ~~~~~~~~~~~~~~~~~~
 
@@ -1024,6 +1033,14 @@ and the EntityManager.
             $em = $eventArgs->getEntityManager();
         }
     }
+
+.. note::
+
+    Starting in ORM 3.6, the ``GenerateSchemaEventArgs`` class provides
+    a ``setSchema()`` method to replace the schema object. This method
+    requires ``doctrine/dbal`` ^4.5 or higher, which provides the Schema
+    Editor API. If called with an earlier DBAL version, a
+    ``BadMethodCallException`` will be thrown.
 
 .. _PrePersistEventArgs: https://github.com/doctrine/orm/blob/HEAD/src/Event/PrePersistEventArgs.php
 .. _PreRemoveEventArgs: https://github.com/doctrine/orm/blob/HEAD/src/Event/PreRemoveEventArgs.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3208,18 +3208,6 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addIndex\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addUniqueIndex\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
 			message: '#^Parameter \#2 \$columns of class Doctrine\\DBAL\\Schema\\Index constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -43,6 +43,10 @@ parameters:
             path: src/Mapping/Driver/DatabaseDriver.php
 
         -
+            message: '~^Call to an undefined method Doctrine\\DBAL\\Schema\\Table\:\:getObjectName\(\)\.$~'
+            path: src/Tools/SchemaTool.php
+
+        -
             message: '~^Call to an undefined method Doctrine\\DBAL\\Schema\\ForeignKeyConstraint::get.*\.$~'
             identifier: method.notFound
 

--- a/src/Tools/Event/GenerateSchemaEventArgs.php
+++ b/src/Tools/Event/GenerateSchemaEventArgs.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Event;
 
+use BadMethodCallException;
 use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
+
+use function method_exists;
 
 /**
  * Event Args used for the Events::postGenerateSchema event.
@@ -17,7 +20,7 @@ class GenerateSchemaEventArgs extends EventArgs
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly Schema $schema,
+        private Schema $schema,
     ) {
     }
 
@@ -29,5 +32,18 @@ class GenerateSchemaEventArgs extends EventArgs
     public function getSchema(): Schema
     {
         return $this->schema;
+    }
+
+    public function setSchema(Schema $schema): void
+    {
+        // @phpstan-ignore function.impossibleType (Checking for unreleased Schema::edit() API)
+        if (! method_exists(Schema::class, 'edit')) {
+            throw new BadMethodCallException(
+                'The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. '
+                . 'This feature requires doctrine/dbal ^4.5 or higher.',
+            );
+        }
+
+        $this->schema = $schema;
     }
 }

--- a/src/Tools/Event/GenerateSchemaTableEventArgs.php
+++ b/src/Tools/Event/GenerateSchemaTableEventArgs.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Event;
 
+use BadMethodCallException;
 use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\Mapping\ClassMetadata;
+
+use function method_exists;
 
 /**
  * Event Args used for the Events::postGenerateSchemaTable event.
@@ -16,10 +19,12 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class GenerateSchemaTableEventArgs extends EventArgs
 {
+    private bool $classTableWasMutated = false;
+
     public function __construct(
         private readonly ClassMetadata $classMetadata,
-        private readonly Schema $schema,
-        private readonly Table $classTable,
+        private Schema $schema,
+        private Table $classTable,
     ) {
     }
 
@@ -36,5 +41,37 @@ class GenerateSchemaTableEventArgs extends EventArgs
     public function getClassTable(): Table
     {
         return $this->classTable;
+    }
+
+    public function setSchema(Schema $schema): void
+    {
+        // @phpstan-ignore function.impossibleType (Checking for unreleased Schema::edit() API)
+        if (! method_exists(Schema::class, 'edit')) {
+            throw new BadMethodCallException(
+                'The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. '
+                . 'This feature requires doctrine/dbal ^4.5 or higher.',
+            );
+        }
+
+        $this->schema = $schema;
+    }
+
+    public function setClassTable(Table $classTable): void
+    {
+        // @phpstan-ignore function.impossibleType (Checking for unreleased Schema::edit() API)
+        if (! method_exists(Schema::class, 'edit')) {
+            throw new BadMethodCallException(
+                'The setClassTable() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. '
+                . 'This feature requires doctrine/dbal ^4.5 or higher.',
+            );
+        }
+
+        $this->classTable           = $classTable;
+        $this->classTableWasMutated = true;
+    }
+
+    public function classTableWasMutated(): bool
+    {
+        return $this->classTableWasMutated;
     }
 }

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -390,18 +390,40 @@ class SchemaTool
             }
 
             if ($eventManager->hasListeners(ToolEvents::postGenerateSchemaTable)) {
+                $tableEventArgs = new GenerateSchemaTableEventArgs($class, $schema, $table);
                 $eventManager->dispatchEvent(
                     ToolEvents::postGenerateSchemaTable,
-                    new GenerateSchemaTableEventArgs($class, $schema, $table),
+                    $tableEventArgs,
                 );
+
+                // Always retrieve the schema (listener may have mutated it)
+                $schema = $tableEventArgs->getSchema();
+
+                // If the listener mutated the table, we need to replace it in the schema
+                if ($tableEventArgs->classTableWasMutated()) {
+                    $originalTableName = $table->getObjectName();
+                    $newTable          = $tableEventArgs->getClassTable();
+
+                    // @phpstan-ignore method.notFound (Using unreleased Schema::edit() API)
+                    $schemaEditor = $schema->edit();
+                    $schemaEditor->dropTable($originalTableName);
+                    $schemaEditor->addTable($newTable);
+
+                    $schema = $schemaEditor->create();
+                    $table  = $newTable;
+                }
             }
         }
 
         if ($eventManager->hasListeners(ToolEvents::postGenerateSchema)) {
+            $schemaEventArgs = new GenerateSchemaEventArgs($this->em, $schema);
             $eventManager->dispatchEvent(
                 ToolEvents::postGenerateSchema,
-                new GenerateSchemaEventArgs($this->em, $schema),
+                $schemaEventArgs,
             );
+
+            // Always retrieve the schema (listener may have mutated it)
+            $schema = $schemaEventArgs->getSchema();
         }
 
         return $schema;

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table as DbalTable;
 use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Types;
@@ -52,6 +53,7 @@ use Doctrine\Tests\Models\GH10288\GH10288People;
 use Doctrine\Tests\Models\NullDefault\NullDefaultColumn;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 
 use function array_map;
 use function class_exists;
@@ -501,6 +503,62 @@ class SchemaToolTest extends OrmTestCase
         [$pkColumn] = $primaryKey->getColumnNames();
         self::assertTrue($pkColumn->getIdentifier()->isQuoted());
         self::assertSame('quoted-id', $pkColumn->getIdentifier()->getValue());
+    }
+
+    #[RequiresMethod(Schema::class, 'edit')]
+    public function testOverwritingSchemaInListener(): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $em->getEventManager()->addEventListener(
+            [ToolEvents::postGenerateSchemaTable, ToolEvents::postGenerateSchema],
+            new class () {
+                public function postGenerateSchemaTable(GenerateSchemaTableEventArgs $eventArgs): void
+                {
+                    $eventArgs->setSchema(new Schema());
+                }
+
+                public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs): void
+                {
+                    $eventArgs->setSchema(new Schema());
+                }
+            },
+        );
+        $schemaTool = new SchemaTool($em);
+
+        $schema = $schemaTool->getSchemaFromMetadata([$em->getClassMetadata(CmsAddress::class)]);
+
+        self::assertFalse(
+            $schema->hasTable('cms_address'),
+            'The original schema should have been overwritten by the listener, so cms_address table should not exist.',
+        );
+    }
+
+    #[RequiresMethod(Schema::class, 'edit')]
+    public function testOverwritingTableInListener(): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $em->getEventManager()->addEventListener(
+            [ToolEvents::postGenerateSchemaTable],
+            new class () {
+                public function postGenerateSchemaTable(GenerateSchemaTableEventArgs $eventArgs): void
+                {
+                    $eventArgs->setClassTable(new DbalTable('just_address'));
+                }
+            },
+        );
+        $schemaTool = new SchemaTool($em);
+
+        $schema = $schemaTool->getSchemaFromMetadata([$em->getClassMetadata(CmsAddress::class)]);
+        self::assertTrue(
+            $schema->hasTable('just_address'),
+            'The original table should have been overwritten by the listener, so just_address table should exist.',
+        );
+        self::assertFalse(
+            $schema->hasTable('cms_address'),
+            'The original table should have been overwritten by the listener, so cms_address table should not exist.',
+        );
     }
 
     /** @return string[] */


### PR DESCRIPTION
The existing schema event API forces user to resort on mutation, which is deprecated. Let's offer an alternative API.

Relates to https://github.com/symfony/symfony/pull/64351