### PR TITLE
[CursorPaginator] Fix cursor building when ordering by ManyToOne association

### DIFF
--- a/src/Tools/Pagination/CursorPaginator.php
+++ b/src/Tools/Pagination/CursorPaginator.php
@@ -325,7 +325,13 @@ final class CursorPaginator implements IteratorAggregate
             $fieldName     = $orderByItem->expression->field;
             $orderMetadata = $orderByItem->metadata ?? $metadata;
             $value         = $metadata?->getFieldValue($item, $fieldName) ?? $item->$fieldName;
-            $type          = PersisterHelper::getTypeOfField($fieldName, $orderMetadata, $em)[0];
+
+            if ($value !== null && $orderMetadata !== null && isset($orderMetadata->associationMappings[$fieldName])) {
+                $targetMetadata = $em->getClassMetadata($orderMetadata->associationMappings[$fieldName]->targetEntity);
+                $value          = $targetMetadata->getIdentifierValues($value)[$targetMetadata->getSingleIdentifierFieldName()] ?? null;
+            }
+
+            $type = PersisterHelper::getTypeOfField($fieldName, $orderMetadata, $em)[0];
 
             $result[$orderByItem->paramKey] = $connection->convertToDatabaseValue($value, $type);
         }

--- a/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
@@ -482,4 +482,32 @@ class CursorPaginatorTest extends OrmTestCase
 
         self::assertSame(1, $paginator->countPageItems());
     }
+
+    public function testGetNextCursorUnwrapsManyToOneAssociationToIdentifier(): void
+    {
+        $author            = new Author();
+        $author->id        = 42;
+        $blogPost1         = new BlogPost();
+        $blogPost1->author = $author;
+
+        $author2           = new Author();
+        $author2->id       = 43;
+        $blogPost2         = new BlogPost();
+        $blogPost2->author = $author2;
+
+        $this->hydrator->method('hydrateAll')->willReturn([$blogPost1, $blogPost2]);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b ORDER BY b.author ASC');
+
+        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
+        $paginator->paginate(null, 1);
+
+        self::assertTrue($paginator->hasNextPage());
+
+        $cursor = $paginator->getNextCursor();
+        self::assertSame(42, $cursor->getParameters()['b.author']);
+    }
 }


### PR DESCRIPTION
- `getParametersForItem()` was passing the associated entity directly to `convertToDatabaseValue()` when ordering by a `ManyToOne` association, causing a type mismatch exception (`Could not convert PHP value of type App\Entity\Author to type author_id`)
- Fix: unwrap the association to its identifier before type conversion
- Add a test covering this case

Fixes #12484