### PR TITLE
UnitOfWork should run UPDATES in a specific order to avoid ShareLock deadlocks

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -73,7 +73,9 @@ use function is_object;
 use function reset;
 use function spl_object_id;
 use function sprintf;
+use function strcmp;
 use function strtolower;
+use function usort;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
@@ -401,7 +403,9 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             if ($this->entityUpdates) {
-                // Updates do not need to follow a particular order
+                // Updates are executed in a consistent order (class name, then entity ID (hash)) to eliminate deadlock
+                // risk in concurrent update transactions ("Process X waits for ShareLock on transaction Y; blocked
+                // by process Z").
                 $this->executeUpdates();
             }
 
@@ -1121,7 +1125,11 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeUpdates(): void
     {
-        foreach ($this->entityUpdates as $oid => $entity) {
+        $entities = $this->computeUpdateExecutionOrder();
+
+        foreach ($entities as $oid => $entity) {
+            $oid = spl_object_id($entity);
+
             $class            = $this->em->getClassMetadata($entity::class);
             $persister        = $this->getEntityPersister($class->name);
             $preUpdateInvoke  = $this->listenersInvoker->getSubscribedSystems($class, Events::preUpdate);
@@ -1253,6 +1261,31 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         return $sort->sort();
+    }
+
+    /** @return list<object> */
+    private function computeUpdateExecutionOrder(): array
+    {
+        $entities = $this->entityUpdates;
+
+        usort($entities, function (object $a, object $b): int {
+            // First, order alphabetically by the class name. If the class names are different, then return immediately.
+            $result = strcmp($a::class, $b::class);
+            if ($result !== 0) {
+                return $result;
+            }
+
+            // Second, when the objects are of the same class, then order them alphabetically by the "id hash". This
+            // covers multiple different cases of entity's id (think multicolumn ids or uuids). Note that ordering
+            // numerical strings alphabetically may result in the following order: "1", "100", "2" but that's fine.
+            // The point here is to have a consistent ordering, not that the (potential) numbers are in numeric order.
+            return strcmp(
+                $this->getIdHashByEntity($a),
+                $this->getIdHashByEntity($b),
+            );
+        });
+
+        return $entities;
     }
 
     /** @return list<object> */

--- a/tests/Tests/ORM/Functional/GH11345Test.php
+++ b/tests/Tests/ORM/Functional/GH11345Test.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Company\CompanyAuction;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\Models\Company\CompanyManager;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use RuntimeException;
+
+use function array_column;
+use function array_filter;
+use function array_values;
+use function str_starts_with;
+use function strtoupper;
+
+/**
+ * Functional tests for the order of the UPDATE sql statements during a flush() procedure.
+ *
+ * Covers: https://github.com/doctrine/orm/issues/11345
+ */
+class GH11345Test extends OrmFunctionalTestCase
+{
+    private int $employeeId;
+    private int $managerId;
+    private int $auction1Id;
+    private int $auction2Id;
+    private int $auction3Id;
+
+    protected function setUp(): void
+    {
+        $this->useModelSet('company');
+
+        parent::setUp();
+
+        $this->generateFixture();
+    }
+
+    public function testUpdateSqlStatementsAreIssuedInAlphabeticOrderByEntityClass(): void
+    {
+        // Load entities in an order that is not alphabetical
+        $manager  = $this->_em->find(CompanyManager::class, $this->managerId)
+            ?? throw new RuntimeException('Could not find expected entity');
+        $employee = $this->_em->find(CompanyEmployee::class, $this->employeeId)
+            ?? throw new RuntimeException('Could not find expected entity');
+        $auction  = $this->_em->find(CompanyAuction::class, $this->auction1Id)
+            ?? throw new RuntimeException('Could not find expected entity');
+
+        // Make some changes to the entities
+        $manager->setTitle('new title');
+        $employee->setSalary(100_000);
+        $auction->setData('new data');
+
+        // Reset the log so only the flush() queries are captured.
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->flush();
+
+        // Collect only UPDATE statements in execution order.
+        $updateSqls = array_values(array_filter(
+            array_column($this->getQueryLog()->queries, 'sql'),
+            static fn (string $sql) => str_starts_with(strtoupper($sql), 'UPDATE'),
+        ));
+
+        self::assertCount(3, $updateSqls);
+
+        // Assert that sqls were run in alphabetic order by the class names (which also results in the same order by the
+        // table names)
+        self::assertStringContainsString('company_auctions', $updateSqls[0]);
+        self::assertStringContainsString('company_employees', $updateSqls[1]);
+        self::assertStringContainsString('company_managers', $updateSqls[2]);
+    }
+
+    public function testUpdateSqlStatementsAreIssuedInAlphabeticOrderByEntityIdForSameClassName(): void
+    {
+        // Load entities in an order that is not alphabetical
+        $auction2 = $this->_em->find(CompanyAuction::class, $this->auction2Id)
+            ?? throw new RuntimeException('Could not find expected entity');
+        $auction1 = $this->_em->find(CompanyAuction::class, $this->auction1Id)
+            ?? throw new RuntimeException('Could not find expected entity');
+        $auction3 = $this->_em->find(CompanyAuction::class, $this->auction3Id)
+            ?? throw new RuntimeException('Could not find expected entity');
+
+        // Make some changes to the entities
+        $auction1->setData('new data');
+        $auction2->setData('new data');
+        $auction3->setData('new data');
+
+        // Reset the log so only the flush() queries are captured.
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->flush();
+
+        // Collect only UPDATE statements in execution order.
+        $updates = array_values(array_filter(
+            $this->getQueryLog()->queries,
+            static fn (array $q) => str_starts_with(strtoupper($q['sql']), 'UPDATE'),
+        ));
+
+        self::assertCount(3, $updates);
+
+        // Assert that the params of each UPDATE contain the expected ID in ascending order.
+        self::assertContains($this->auction1Id, $updates[0]['params']);
+        self::assertContains($this->auction2Id, $updates[1]['params']);
+        self::assertContains($this->auction3Id, $updates[2]['params']);
+    }
+
+    public function generateFixture(): void
+    {
+        $employee = new CompanyEmployee();
+        $employee->setName('name');
+        $employee->setDepartment('department');
+        $employee->setSalary(50_000);
+
+        $manager = new CompanyManager();
+        $manager->setName('manager name');
+        $manager->setDepartment('management');
+        $manager->setSalary(80_000);
+        $manager->setTitle('manager title');
+
+        $auction1 = new CompanyAuction();
+        $auction1->setData('lorem ipsum');
+
+        $auction2 = new CompanyAuction();
+        $auction2->setData('dolor sit');
+
+        $auction3 = new CompanyAuction();
+        $auction3->setData('dolor consectetur');
+
+        $this->_em->persist($employee);
+        $this->_em->persist($manager);
+        $this->_em->persist($auction1);
+        $this->_em->persist($auction2);
+        $this->_em->persist($auction3);
+        $this->_em->flush();
+
+        $this->employeeId = $employee->getId();
+        $this->managerId  = $manager->getId();
+        $this->auction1Id = $auction1->getId();
+        $this->auction2Id = $auction2->getId();
+        $this->auction3Id = $auction3->getId();
+
+        $this->_em->clear();
+    }
+}


### PR DESCRIPTION
This PR addresses the following ticket: https://github.com/doctrine/orm/issues/11345 but only in the "UPDATE part". I.e. the order of the DELETE sql statements has not been altered.

Note that the current "deadlocking behaviour" may be viewed by a lot of people as a feature, not a bug. It could be argued that in a lot of cases where developers don't "exclusively access & mutate" some of their entities, the current deadlocking behaviour was the last thing that was preventing those "sloppy pieces of code" from resulting in "strange data loss". I personally am taking this argument in and still would propose that this code change should be merged. Mainly because the ORM should not prevent concurrent updates if the devs want (intentionally or not) do them (especially when different columns of the same rows are being concurrently mutated, which is a valid use case).

I personally don't intend to do the "DELETE part" of the aforementioned GH ticket. I will close that ticket once this PR is (hopefully) merged because the current code change is sufficient for my own use cases.

---

For the record: I don't believe the failing `deprecations` testing fails on anything introduced by this PR.