### PR TITLE
Fix broken AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED proxy setting.

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -404,14 +404,14 @@ EOPHP;
 
         $fileName = $this->getProxyFileName($class->getName(), $this->proxyDir);
 
-        $autogenerate = match ($this->autoGenerate) {
+        $needsGeneration = match ($this->autoGenerate) {
             self::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED => ! file_exists($fileName)
                 || filemtime($fileName) < filemtime($class->getReflectionClass()->getFileName()),
             self::AUTOGENERATE_FILE_NOT_EXISTS => ! file_exists($fileName),
             self::AUTOGENERATE_ALWAYS => true,
             default => false,
         };
-        if ($autogenerate) {
+        if ($needsGeneration) {
             $this->generateProxyClass($class, $fileName, $proxyClassName);
         }
 

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -404,20 +404,15 @@ EOPHP;
 
         $fileName = $this->getProxyFileName($class->getName(), $this->proxyDir);
 
-        switch ($this->autoGenerate) {
-            case self::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED:
-                if (file_exists($fileName) && filemtime($fileName) >= filemtime($class->getReflectionClass()->getFileName())) {
-                    break;
-                }
-                // no break
-            case self::AUTOGENERATE_FILE_NOT_EXISTS:
-                if (file_exists($fileName)) {
-                    break;
-                }
-                // no break
-            case self::AUTOGENERATE_ALWAYS:
-                $this->generateProxyClass($class, $fileName, $proxyClassName);
-                break;
+        $autogenerate = match ($this->autoGenerate) {
+            self::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED => ! file_exists($fileName)
+                || filemtime($fileName) < filemtime($class->getReflectionClass()->getFileName()),
+            self::AUTOGENERATE_FILE_NOT_EXISTS => ! file_exists($fileName),
+            self::AUTOGENERATE_ALWAYS => true,
+            default => false,
+        };
+        if ($autogenerate) {
+            $this->generateProxyClass($class, $fileName, $proxyClassName);
         }
 
         require $fileName;


### PR DESCRIPTION
This PR fixes the problem described by issue #11418 by replacing a buggy `switch` statement with a (hopefully) clearer and less problematic `match` statement. Apart from fixing the bug of the non-functioning `AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED` setting, this should cause no changes to behavior.

I apologize for not including a test case with this fix; because of the nature of the functionality (which depends on file modification times and results in disk writes), it is impractical to write a unit test without refactoring things to allow mocking. I thought keeping the change focused and simple was a greater priority, but I am open to discussing more complex changes if that would be desirable.

I am a first-time contributor, so please feel free to make suggestions, and please accept my apologies if I've overlooked or misunderstood anything from the contribution guidelines.