### PR TITLE
security: add allowed_classes => false to SequenceGenerator::unserialize()

### DIFF
--- a/src/Id/SequenceGenerator.php
+++ b/src/Id/SequenceGenerator.php
@@ -100,7 +100,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
             self::class,
         );
 
-        $this->__unserialize(unserialize($serialized));
+        $this->__unserialize(unserialize($serialized, ['allowed_classes' => false]));
     }
 
     /** @param array<string, mixed> $data */


### PR DESCRIPTION
## Summary

The deprecated `Serializable::unserialize()` method in `SequenceGenerator` calls `unserialize($serialized)` without an `allowed_classes` restriction.

```php
// src/Id/SequenceGenerator.php  (before)
$this->__unserialize(unserialize($serialized));
```

The serialized payload is always the output of `__serialize()`, which returns only two scalar values:

```php
['allocationSize' => $this->allocationSize, 'sequenceName' => $this->sequenceName]
```

No object classes are expected. Without `allowed_classes => false`, a crafted serialized string supplied to the deprecated method could instantiate arbitrary autoloaded classes during deserialization (PHP Object Injection), potentially triggering a gadget chain.

## Fix

```php
$this->__unserialize(unserialize($serialized, ['allowed_classes' => false]));
```

This is safe because `__unserialize()` only reads `$data['sequenceName']` (string) and `$data['allocationSize']` (int).

## Notes

- The `Serializable` interface and its methods are already deprecated; this is a defense-in-depth fix to harden the remaining code path until it is removed in ORM 4.
- No behaviour change for legitimate data.
- The modern `__serialize()` / `__unserialize()` magic methods are not affected.