### PR TITLE
Use symfony/deepclone when appropriate

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,6 +98,11 @@ jobs:
           extensions: "apcu, pdo, ${{ matrix.extension }}"
           coverage: "pcov"
           ini-values: "zend.assertions=1, apc.enable_cli=1"
+          tools: "pie"
+
+      - name: "Install deepclone extension"
+        run: sudo pie install symfony/deepclone
+        if: "${{ matrix.native_lazy == '0' && matrix.php-version != '8.1' }}"
 
       - name: "Allow dev dependencies"
         run: |

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/cache": "^5.4 || ^6.2 || ^7.0 || ^8.0"
     },
     "suggest": {
+        "ext-deepclone": "Improves performance when not using native lazy objects (Symfony 8.1+)",
         "ext-dom": "Provides support for XSD validation for XML mapping files",
         "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0"
     },

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -65,6 +65,8 @@ use function array_values;
 use function assert;
 use function count;
 use function current;
+use function deepclone_hydrate;
+use function extension_loaded;
 use function get_debug_type;
 use function implode;
 use function in_array;
@@ -2398,8 +2400,12 @@ class UnitOfWork implements PropertyChangedListener
                 } else {
                     $entity->__setInitialized(true);
 
-                    /** @phpstan-ignore staticMethod.deprecatedClass (migrating requires the symfony/deepclone PHP extension) */
-                    Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                    if (extension_loaded('deepclone')) {
+                        deepclone_hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                    } else {
+                        /** @phpstan-ignore staticMethod.deprecatedClass */
+                        Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
+                    }
                 }
             } else {
                 if (

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2398,6 +2398,7 @@ class UnitOfWork implements PropertyChangedListener
                 } else {
                     $entity->__setInitialized(true);
 
+                    /** @phpstan-ignore staticMethod.deprecatedClass (migrating requires the symfony/deepclone PHP extension) */
                     Hydrator::hydrate($entity, (array) $class->reflClass->newInstanceWithoutConstructor());
                 }
             } else {


### PR DESCRIPTION
Let's use `symfony/deepclone` when it is installed, instead of using the deprecated Hydrator class.

Note that this is in a codepath that is deprecated (when not using native lazy objects). Because of that, this extension will probably never become a requirement.