### PR TITLE
Do not require an active transaction for `LockMode::NONE` in `Query::setLockMode()`

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -633,7 +633,7 @@ class Query extends AbstractQuery
      */
     public function setLockMode(LockMode|int $lockMode): self
     {
-        if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
+        if (in_array($lockMode, [LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if (! $this->em->getConnection()->isTransactionActive()) {
                 throw TransactionRequiredException::transactionRequired();
             }

--- a/tests/Tests/ORM/Query/QueryTest.php
+++ b/tests/Tests/ORM/Query/QueryTest.php
@@ -108,6 +108,15 @@ class QueryTest extends OrmTestCase
         ];
     }
 
+    public function testSetLockModeNoneDoesNotRequireTransaction(): void
+    {
+        $query = $this->entityManager->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1');
+        $query->setLockMode(LockMode::NONE);
+
+        self::assertSame(LockMode::NONE, $query->getLockMode());
+        self::assertSame(LockMode::NONE, $query->getHint(Query::HINT_LOCK_MODE));
+    }
+
     public function testFree(): void
     {
         $query = $this->entityManager->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1');


### PR DESCRIPTION
`LockMode::NONE` means "no lock", so it does not need an active transaction. `EntityManager::checkLockRequirements()` already only enforces a transaction for the pessimistic lock modes, but `Query::setLockMode()` also rejected NONE outside a transaction, making the two inconsistent.

Fixes #9499