### PR TITLE
Use TableEditor::setOptions() when schema editor exists

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -434,8 +434,13 @@ class SchemaTool
             }
 
             if (isset($class->table['options'])) {
-                foreach ($class->table['options'] as $key => $val) {
-                    $table->addOption($key, $val);
+                /** @phpstan-ignore function.impossibleType (method existence depends on DBAL version) */
+                if (method_exists(Schema::class, 'edit')) {
+                    $table = $table->edit()->setOptions($class->table['options'])->create();
+                } else {
+                    foreach ($class->table['options'] as $key => $val) {
+                        $table->addOption($key, $val);
+                    }
                 }
             }
 


### PR DESCRIPTION
When the `SchemaEditor` API exists, it is possible to use the `TableEditor` API to create a new table object, and then to edit the schema to replace the original table with the new one.