### PR TITLE
Ignore deprecation from DBAL

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -191,6 +191,7 @@ class SchemaTool
      */
     public function getSchemaFromMetadata(array $classes): Schema
     {
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7389');
         // Reminder for processed classes, used for hierarchies
         $processedClasses     = [];
         $eventManager         = $this->em->getEventManager();


### PR DESCRIPTION
Deprecations with this particular identifier are numerous and hard to address. Addressing them might require new configuration, or even new deprecations. I think we should address them in the next minor branch. Let us ignore them until that is the case.

We may still send changes addressing such deprecations when they emanate from tests.