### PR TITLE
[RFC] Expose EntityRepository::expr()

### DIFF
--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Repository\Exception\InvalidMagicMethodCall;
 use Doctrine\Persistence\ObjectRepository;
@@ -183,6 +184,11 @@ class EntityRepository implements ObjectRepository, Selectable
     protected function getEntityManager(): EntityManagerInterface
     {
         return $this->em;
+    }
+
+    final protected function expr(): Expr
+    {
+        return $this->em->getExpressionBuilder();
     }
 
     /** @phpstan-return ClassMetadata<T> */

--- a/tests/Tests/ORM/EntityRepositoryTest.php
+++ b/tests/Tests/ORM/EntityRepositoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Expr;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EntityRepository::class)]
+class EntityRepositoryTest extends TestCase
+{
+    public function testExpr(): void
+    {
+        $expr = static::createStub(Expr::class);
+
+        $em = static::createStub(EntityManagerInterface::class);
+        $em->method('getExpressionBuilder')->willReturn($expr);
+
+        $metadata = new ClassMetadata('foo');
+
+        $repository = new class ($em, $metadata) extends EntityRepository {
+            public function testExpr(): void
+            {
+                TestCase::assertSame($this->getEntityManager()->getExpressionBuilder(), $this->expr());
+            }
+        };
+
+        $repository->testExpr();
+    }
+}


### PR DESCRIPTION
Previously
```
$qb = $this->createQueryBuilder();
$qb
      ->select('u')
      ->from('User', 'u')
      ->where($qb->expr()->eq('u.id', 1));
```
Now
```
$this
     ->createQueryBuilder()
      ->select('u')
      ->from('User', 'u')
      ->where($this->expr()->eq('u.id', 1));
```

I know we could write
```
$this
     ->createQueryBuilder()
      ->select('u')
      ->from('User', 'u')
      ->where($this->getEntityManager()->getExpressionBuilder()->eq('u.id', 1));
```
but that's a little more complicated and people are used to the `expr` syntax (they might not even not it's called an ExpressionBuilder).