### PR TITLE
Avoid adding then dropping FK constraints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3011,50 +3011,8 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getForeignColumns\(\) of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint\:
-				Use \{@see getReferencedColumnNames\(\)\} instead\.
-
-				Returns the names of the referenced table columns
-				the foreign key constraint is associated with\.$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '''
-				#^Call to deprecated method getForeignTableName\(\) of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint\:
-				Use \{@see getReferencedTableName\(\)\} instead\.
-
-				Returns the name of the referenced table
-				the foreign key constraint is associated with\.$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '''
-				#^Call to deprecated method getLocalColumns\(\) of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint\:
-				Use \{@see getReferencingColumnNames\(\)\} instead\.$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '''
 				#^Call to deprecated method getPrimaryKey\(\) of class Doctrine\\DBAL\\Schema\\Table\:
 				Use \{@see getPrimaryKeyConstraint\(\)\} instead\.$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
-			message: '''
-				#^Call to deprecated method removeForeignKey\(\) of class Doctrine\\DBAL\\Schema\\Table\:
-				Use \{@link dropForeignKey\(\)\} instead\.$#
 			'''
 			identifier: method.deprecated
 			count: 1
@@ -3221,6 +3179,18 @@ parameters:
 
 		-
 			message: '#^Parameter \#3 \$foreignColumnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addForeignKeyConstraint\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \$foreignColumnNames of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \$localColumnNames of class Doctrine\\DBAL\\Schema\\ForeignKeyConstraint constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Tools/SchemaTool.php

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -180,6 +180,14 @@ parameters:
 
         # DBAL 4/5 Schema Editor API compatibility
         -
+            message: '~^Parameter \$tableEditor of anonymous function has invalid type .*TableEditor\.$~'
+            path: src/Tools/SchemaTool.php
+
+        -
+            message: '~^Call to method addForeignKeyConstraint\(\) on an unknown class.*TableEditor\.$~'
+            path: src/Tools/SchemaTool.php
+
+        -
             message: '~^Class Doctrine\\DBAL\\Schema\\Table constructor invoked with 7 parameters, 1-6 required\.$~'
             path: src/Tools/SchemaTool.php
 

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Schema\DefaultExpression;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTime;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
-use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Name\Identifier;
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableEditor;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
@@ -499,6 +500,41 @@ class SchemaTool
             }
         }
 
+        // After all classes have been processed and all FK metadata collected,
+        // apply the non-conflicting FK constraints to their respective tables
+        foreach ($addedFks as $compositeName => $fkData) {
+            // Skip if this composite key was blacklisted due to conflicts
+            if (isset($blacklistedFks[$compositeName])) {
+                continue;
+            }
+
+            // @phpstan-ignore function.impossibleType (Using unreleased Schema::edit() API)
+            if (method_exists(Schema::class, 'edit')) {
+                // the table might have been dropped by a listener, so we ignore this error
+                if ($schema->hasTable($fkData['table']->getObjectName()->toString())) {
+                    $schema = $schema->edit()->modifyTable(
+                        $fkData['table']->getObjectName(),
+                        static function (TableEditor $tableEditor) use ($fkData): void {
+                            $tableEditor->addForeignKeyConstraint(new ForeignKeyConstraint(
+                                localColumnNames: $fkData['localColumns'],
+                                foreignTableName: $fkData['foreignTableName'],
+                                foreignColumnNames: $fkData['foreignColumns'],
+                                options: $fkData['fkOptions'],
+                            ));
+                        },
+                    )->create();
+                }
+            } else {
+                // Add the FK constraint to the table
+                $fkData['table']->addForeignKeyConstraint(
+                    $fkData['foreignTableName'],
+                    $fkData['localColumns'],
+                    $fkData['foreignColumns'],
+                    $fkData['fkOptions'],
+                );
+            }
+        }
+
         $schemaEventArgs = new GenerateSchemaEventArgs($this->em, $schema);
         $eventManager->dispatchEvent(
             ToolEvents::postGenerateSchema,
@@ -698,7 +734,9 @@ class SchemaTool
      * @phpstan-param array<string, array{
      *                  foreignTableName: string,
      *                  foreignColumns: list<string>,
-     *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool}
+     *                  localColumns: list<string>,
+     *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  table: Table
      *              }>                               $addedFks
      * @phpstan-param array<string, bool>              $blacklistedFks
      * @phpstan-param list<Table>                      $joinTablesToAdd
@@ -837,11 +875,21 @@ class SchemaTool
      * @phpstan-param array<string, array{
      *                  foreignTableName: string,
      *                  foreignColumns: list<string>,
-     *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool}
+     *                  localColumns: list<string>,
+     *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  table: Table
      *              }>                               $addedFks
      * @phpstan-param array<string,bool>               $blacklistedFks
      *
      * @throws MissingColumnException
+     *
+     * @phpstan-param-out array<string, array{
+     *                  foreignTableName: string,
+     *                  foreignColumns: list<string>,
+     *                  localColumns: list<string>,
+     *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  table: Table
+     *              }>                               $addedFks
      */
     private function gatherRelationJoinColumns(
         array $joinColumns,
@@ -960,53 +1008,28 @@ class SchemaTool
             $areOptionsIdentical = $onDeleteMatches && $deferrableMatches && $deferredMatches;
 
             if ($isForeignTableIdentical && $areForeignColumnsIdentical && $areOptionsIdentical) {
-                // Identical FK already registered - skip adding duplicate.
-                // This prevents attempting to overwrite an existing FK constraint with an identical one.
-                // This scenario occurs in Single Table Inheritance (STI) when multiple child entities
-                // define their own associations using the same join column to the same target entity.
-                // Since all STI entities share the same physical table, having identical FK constraints
-                // is semantically correct and necessary for database normalization.
+                // Identical FK already registered - will be skipped during application phase
                 return;
             }
 
-            // FK exists but is different (conflicting FK) - drop the existing one and blacklist
-            foreach ($theJoinTable->getForeignKeys() as $fkName => $key) {
-                if (
-                    class_exists(ForeignKeyConstraintEditor::class)
-                    && count(array_diff(array_map(static fn (UnqualifiedName $name) => $name->toString(), $key->getReferencingColumnNames()), $localColumns)) === 0
-                    && (($key->getReferencedTableName()->toString() !== $foreignTableName)
-                    || 0 < count(array_diff(array_map(static fn (UnqualifiedName $name) => $name->toString(), $key->getReferencedColumnNames()), $foreignColumns)))
-                ) {
-                    $theJoinTable->dropForeignKey($fkName);
-                    break;
-                }
-
-                if (
-                    ! class_exists(ForeignKeyConstraintEditor::class)
-                    && count(array_diff($key->getLocalColumns(), $localColumns)) === 0
-                    && (($key->getForeignTableName() !== $foreignTableName)
-                    || 0 < count(array_diff($key->getForeignColumns(), $foreignColumns)))
-                ) {
-                    $theJoinTable->removeForeignKey($fkName);
-                    break;
-                }
-            }
-
+            // FK exists but is different (conflicting FK) - blacklist this composite key
+            // No FK will be added for this composite key, but we need to ensure an index exists
+            // since FKs normally create indexes automatically
             $blacklistedFks[$compositeName] = true;
+
+            // Add an index for the local columns since we won't be adding a FK
+            // (FKs normally create implicit indexes)
+            // @phpstan-ignore argument.type ($localColumns is not empty)
+            $theJoinTable->addIndex($localColumns);
         } elseif (! isset($blacklistedFks[$compositeName])) {
-            // No existing FK and not blacklisted - add the new FK constraint
-            // Store FK details including options that affect constraint identity
+            // No existing FK and not blacklisted - store FK metadata for application phase
             $addedFks[$compositeName] = [
                 'foreignTableName' => $foreignTableName,
                 'foreignColumns' => $foreignColumns,
+                'localColumns' => $localColumns,
                 'fkOptions' => $fkOptions,
+                'table' => $theJoinTable,
             ];
-            $theJoinTable->addForeignKeyConstraint(
-                $foreignTableName,
-                $localColumns,
-                $foreignColumns,
-                $fkOptions,
-            );
         }
     }
 

--- a/tests/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -102,13 +102,48 @@ class MySqlSchemaToolTest extends OrmFunctionalTestCase
             // DBAL 4.3 (see https://github.com/doctrine/dbal/pull/6864)
             self::equalTo('CREATE TABLE cms_phonenumbers (phonenumber VARCHAR(50) NOT NULL, user_id INT DEFAULT NULL, INDEX IDX_F21F790FA76ED395 (user_id), PRIMARY KEY (phonenumber)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'),
         ));
-        self::assertEquals('ALTER TABLE cms_users ADD CONSTRAINT FK_3AF03EC5A832C1C9 FOREIGN KEY (email_id) REFERENCES cms_emails (id)', $sql[8]);
-        self::assertEquals('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)', $sql[9]);
-        self::assertEquals('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AFE54D947 FOREIGN KEY (group_id) REFERENCES cms_groups (id)', $sql[10]);
-        self::assertEquals('ALTER TABLE cms_users_tags ADD CONSTRAINT FK_93F5A1ADA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)', $sql[11]);
-        self::assertEquals('ALTER TABLE cms_users_tags ADD CONSTRAINT FK_93F5A1ADBAD26311 FOREIGN KEY (tag_id) REFERENCES cms_tags (id)', $sql[12]);
-        self::assertEquals('ALTER TABLE cms_addresses ADD CONSTRAINT FK_ACAC157BA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)', $sql[13]);
-        self::assertEquals('ALTER TABLE cms_phonenumbers ADD CONSTRAINT FK_F21F790FA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)', $sql[14]);
+        self::assertThat($sql[8], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_users ADD CONSTRAINT FK_3AF03EC5A832C1C9 FOREIGN KEY (email_id) REFERENCES cms_emails (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_users ADD FOREIGN KEY (email_id) REFERENCES cms_emails (id)'),
+        ));
+        self::assertThat($sql[9], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_users_groups ADD FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+        ));
+        self::assertThat($sql[10], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AFE54D947 FOREIGN KEY (group_id) REFERENCES cms_groups (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_users_groups ADD FOREIGN KEY (group_id) REFERENCES cms_groups (id)'),
+        ));
+        self::assertThat($sql[11], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_users_tags ADD CONSTRAINT FK_93F5A1ADA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_users_tags ADD FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+        ));
+        self::assertThat($sql[12], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_users_tags ADD CONSTRAINT FK_93F5A1ADBAD26311 FOREIGN KEY (tag_id) REFERENCES cms_tags (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_users_tags ADD FOREIGN KEY (tag_id) REFERENCES cms_tags (id)'),
+        ));
+        self::assertThat($sql[13], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_addresses ADD CONSTRAINT FK_ACAC157BA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_addresses ADD FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+        ));
+        self::assertThat($sql[14], self::logicalOr(
+            // DBAL < 4.5
+            self::equalTo('ALTER TABLE cms_phonenumbers ADD CONSTRAINT FK_F21F790FA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE cms_phonenumbers ADD FOREIGN KEY (user_id) REFERENCES cms_users (id)'),
+        ));
 
         self::assertCount(15, $sql);
     }

--- a/tests/Tests/ORM/Functional/Ticket/DDC2182Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC2182Test.php
@@ -39,7 +39,12 @@ class DDC2182Test extends OrmFunctionalTestCase
             // DBAL 4.3 (see https://github.com/doctrine/dbal/pull/6864)
             self::equalTo('CREATE TABLE DDC2182OptionChild (id VARCHAR(255) NOT NULL, parent_id INT UNSIGNED DEFAULT NULL, INDEX IDX_B314D4AD727ACA70 (parent_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'),
         ));
-        self::assertEquals('ALTER TABLE DDC2182OptionChild ADD CONSTRAINT FK_B314D4AD727ACA70 FOREIGN KEY (parent_id) REFERENCES DDC2182OptionParent (id)', $sql[2]);
+        self::assertThat($sql[2], self::logicalOr(
+            // DBAL < 4.3
+            self::equalTo('ALTER TABLE DDC2182OptionChild ADD CONSTRAINT FK_B314D4AD727ACA70 FOREIGN KEY (parent_id) REFERENCES DDC2182OptionParent (id)'),
+            // DBAL 4.5
+            self::equalTo('ALTER TABLE DDC2182OptionChild ADD FOREIGN KEY (parent_id) REFERENCES DDC2182OptionParent (id)'),
+        ));
     }
 }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH11501Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11501Test.php
@@ -53,7 +53,7 @@ class GH11501Test extends OrmFunctionalTestCase
 }
 
 #[ORM\Entity]
-#[ORM\Table(name: 'one_to_many_single_table_inheritance_test_entities_parent_join')]
+#[ORM\Table(name: 'one_to_many_sti_test_entities_parent_join')]
 #[ORM\InheritanceType('SINGLE_TABLE')]
 #[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
 #[ORM\DiscriminatorMap([


### PR DESCRIPTION
Previously, when processing entity relationships, SchemaTool would:

1. Add FK constraints as they were encountered
2. If a conflict was detected (same columns, different target), drop the previously added FK
3. Blacklist the composite key to prevent adding any FK for those columns

This add-then-drop pattern is not great, and will make things even worse when migrating to the TableEditor API, because it will require known the exact auto-generated FK name, which in turn would force copying the DBAL algorithm for generating FK names.

Solution:
Implement a two-pass approach:
1. Collection Phase: Gather all FK metadata without adding to tables
   - Detect conflicts between FKs (same local columns, different targets)
   - Mark conflicting composite keys as blacklisted
   - Store FK metadata for non-conflicting cases
2. Application Phase: Add only non-conflicting FKs to their tables
   - Skip any composite keys that were blacklisted due to conflicts