### PR TITLE
Fix usage of RequiresPhp

### DIFF
--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -221,7 +221,7 @@ class ConfigurationTest extends TestCase
         self::assertSame($defaultTypedFieldMapper, $this->configuration->getTypedFieldMapper());
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[IgnoreDeprecations]
     public function testDisablingNativeLazyObjectsIsDeprecated(): void
     {

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -221,7 +221,7 @@ class ConfigurationTest extends TestCase
         self::assertSame($defaultTypedFieldMapper, $this->configuration->getTypedFieldMapper());
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[IgnoreDeprecations]
     public function testDisablingNativeLazyObjectsIsDeprecated(): void
     {

--- a/tests/Tests/ORM/EntityManagerTest.php
+++ b/tests/Tests/ORM/EntityManagerTest.php
@@ -181,7 +181,7 @@ class EntityManagerTest extends OrmTestCase
     }
 
     /** Resetting the EntityManager relies on lazy objects until https://github.com/doctrine/orm/issues/5933 is resolved */
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testLazyGhostEntityManager(): void
     {
         $reflector = new ReflectionClass(EntityManager::class);

--- a/tests/Tests/ORM/EntityManagerTest.php
+++ b/tests/Tests/ORM/EntityManagerTest.php
@@ -181,7 +181,7 @@ class EntityManagerTest extends OrmTestCase
     }
 
     /** Resetting the EntityManager relies on lazy objects until https://github.com/doctrine/orm/issues/5933 is resolved */
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testLazyGhostEntityManager(): void
     {
         $reflector = new ReflectionClass(EntityManager::class);

--- a/tests/Tests/ORM/Functional/Ticket/GH11072/GH11072Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11072/GH11072Test.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
-#[RequiresPhp('>=8.2')]
+#[RequiresPhp('>=8.2.0')]
 final class GH11072Test extends OrmFunctionalTestCase
 {
     /** @var SchemaValidator */

--- a/tests/Tests/ORM/Functional/Ticket/GH11072/GH11072Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH11072/GH11072Test.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
-#[RequiresPhp('8.2')]
+#[RequiresPhp('>=8.2')]
 final class GH11072Test extends OrmFunctionalTestCase
 {
     /** @var SchemaValidator */

--- a/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
+++ b/tests/Tests/ORM/Mapping/PropertyAccessors/RawValuePropertyAccessorTest.php
@@ -12,7 +12,7 @@ use ReflectionObject;
 
 use function trim;
 
-#[RequiresPhp(versionRequirement: '>= 8.4.0')]
+#[RequiresPhp('>= 8.4.0')]
 class RawValuePropertyAccessorTest extends OrmTestCase
 {
     public function testSetGetValue(): void

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -239,7 +239,7 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertSame('Bob', $cloned->getName(), 'Expect properties on the CompanyPerson class to be cloned');
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[IgnoreDeprecations]
     public function testProxyFactoryAcceptsNullProxyArgsWhenNativeLazyObjectsAreEnabled(): void
     {
@@ -258,7 +258,7 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertTrue($reflection->isUninitializedLazyObject($proxy));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresMethod(ProxyHelper::class, 'generateLazyGhost')]
     #[IgnoreDeprecations]
     public function testProxyFactoryTriggersDeprecationWhenNativeLazyObjectsAreDisabled(): void
@@ -275,7 +275,7 @@ class ProxyFactoryTest extends OrmTestCase
         );
     }
 
-    #[RequiresPhp('< 8.4')]
+    #[RequiresPhp('< 8.4.0')]
     public function testProxyFactoryDoesNotTriggerDeprecationWhenNativeLazyObjectsAreDisabled(): void
     {
         $this->emMock->getConfiguration()->enableNativeLazyObjects(false);

--- a/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -239,7 +239,8 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertSame('Bob', $cloned->getName(), 'Expect properties on the CompanyPerson class to be cloned');
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
+    #[IgnoreDeprecations]
     public function testProxyFactoryAcceptsNullProxyArgsWhenNativeLazyObjectsAreEnabled(): void
     {
         $this->emMock->getConfiguration()->enableNativeLazyObjects(true);
@@ -257,7 +258,7 @@ class ProxyFactoryTest extends OrmTestCase
         self::assertTrue($reflection->isUninitializedLazyObject($proxy));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresMethod(ProxyHelper::class, 'generateLazyGhost')]
     #[IgnoreDeprecations]
     public function testProxyFactoryTriggersDeprecationWhenNativeLazyObjectsAreDisabled(): void


### PR DESCRIPTION
The original intention was to require at least the version of PHP passed.