### PR TITLE
Reject IDENTITY() on inverse-side associations

### DIFF
--- a/src/Query/AST/Functions/IdentityFunction.php
+++ b/src/Query/AST/Functions/IdentityFunction.php
@@ -36,7 +36,10 @@ class IdentityFunction extends FunctionNode
         $assoc         = $sqlWalker->getMetadataForDqlAlias($dqlAlias)->associationMappings[$assocField];
         $targetEntity  = $entityManager->getClassMetadata($assoc->targetEntity);
 
-        assert($assoc->isToOneOwningSide());
+        if (! $assoc->isToOneOwningSide()) {
+            throw QueryException::associationPathInverseSideNotSupported($this->pathExpression);
+        }
+
         $joinColumn = reset($assoc->joinColumns);
 
         if ($this->fieldMapping !== null) {

--- a/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1361,6 +1361,19 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
+    public function testIdentityFunctionOnInverseSideThrowsQueryException(): void
+    {
+        $this->expectExceptionMessage(
+            'A single-valued association path expression to an inverse side is not supported in DQL queries. ' .
+            'Instead of "u.address" use an explicit join.',
+        );
+
+        $this->assertInvalidSqlGeneration(
+            'SELECT IDENTITY(u.address) FROM Doctrine\Tests\Models\CMS\CmsUser u',
+            QueryException::class,
+        );
+    }
+
     public function testIdentityFunctionInJoinedSubclass(): void
     {
         //relation is in the subclass (CompanyManager) we are querying


### PR DESCRIPTION
Fixes #7332

### Summary

- reject `IDENTITY()` calls on inverse-side associations with the existing descriptive `QueryException`
- add a regression test that verifies both the exception type and its explicit-join guidance

### Root cause

`IdentityFunction::getSql()` relied on an assertion to ensure that the association was the owning side. Depending on assertion settings, an inverse-side association therefore produced an `AssertionError` or continued without join-column metadata and failed later with a lower-level error.

### Testing

- `php vendor/bin/phpunit tests/Tests/ORM/Query/SelectSqlGenerationTest.php --filter testIdentityFunctionOnInverseSideThrowsQueryException`
- `php vendor/bin/phpunit tests/Tests/ORM/Query/SelectSqlGenerationTest.php`
- `php vendor/bin/phpcs --standard=phpcs.xml.dist src/Query/AST/Functions/IdentityFunction.php tests/Tests/ORM/Query/SelectSqlGenerationTest.php`
- `php vendor/bin/phpstan analyse src/Query/AST/Functions/IdentityFunction.php --no-progress`