### PR TITLE
Validate ManyToOne associations used as sole identifiers

### DIFF
--- a/src/Tools/SchemaValidator.php
+++ b/src/Tools/SchemaValidator.php
@@ -135,6 +135,11 @@ class SchemaValidator
                 return $ce;
             }
 
+            if ($assoc->isManyToOne() && count($class->identifier) === 1 && $class->identifier[0] === $fieldName) {
+                $ce[] = "The association '" . $class->name . '#' . $fieldName . "' is a many-to-one association and is the sole identifier of the entity. " .
+                        'This effectively makes the association one-to-one; use a one-to-one association instead or add another identifier field.';
+            }
+
             if (isset($assoc->id) && $targetMetadata->containsForeignIdentifier) {
                 $ce[] = "Cannot map association '" . $class->name . '#' . $fieldName . ' as identifier, because ' .
                         "the target entity '" . $targetMetadata->name . "' also maps an association as identifier.";

--- a/tests/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -111,6 +111,25 @@ class SchemaValidatorTest extends OrmTestCase
         self::assertEquals([], $ce);
     }
 
+    public function testInvalidManyToOneAsSoleIdentifier(): void
+    {
+        $class = $this->em->getClassMetadata(DDC1649Two::class);
+        $ce    = $this->validator->validateClass($class);
+
+        self::assertEquals(
+            ["The association 'Doctrine\Tests\ORM\Tools\DDC1649Two#one' is a many-to-one association and is the sole identifier of the entity. This effectively makes the association one-to-one; use a one-to-one association instead or add another identifier field."],
+            $ce,
+        );
+    }
+
+    public function testValidManyToOneAsPartOfCompositeIdentifier(): void
+    {
+        $class = $this->em->getClassMetadata(ValidCompositeIdentifier::class);
+        $ce    = $this->validator->validateClass($class);
+
+        self::assertEquals([], $ce);
+    }
+
     #[Group('DDC-1649')]
     public function testInvalidTripleAssociationAsKeyMapping(): void
     {
@@ -119,6 +138,7 @@ class SchemaValidatorTest extends OrmTestCase
 
         self::assertEquals(
             [
+                "The association 'Doctrine\Tests\ORM\Tools\DDC1649Three#two' is a many-to-one association and is the sole identifier of the entity. This effectively makes the association one-to-one; use a one-to-one association instead or add another identifier field.",
                 "Cannot map association 'Doctrine\Tests\ORM\Tools\DDC1649Three#two as identifier, because the target entity 'Doctrine\Tests\ORM\Tools\DDC1649Two' also maps an association as identifier.",
                 "The referenced column name 'id' has to be a primary key column on the target entity class 'Doctrine\Tests\ORM\Tools\DDC1649Two'.",
             ],
@@ -364,6 +384,18 @@ class DDC1649Two
     #[Id]
     #[ManyToOne(targetEntity: 'DDC1649One')]
     public $one;
+}
+
+#[Entity]
+class ValidCompositeIdentifier
+{
+    #[Id]
+    #[Column]
+    public int $id;
+
+    #[Id]
+    #[ManyToOne(targetEntity: 'DDC1649One')]
+    public DDC1649One $one;
 }
 
 #[Entity]


### PR DESCRIPTION
## Summary

- report a schema validation error when a `ManyToOne` association is the entity's sole identifier
- explain that this mapping is effectively one-to-one and suggest using `OneToOne` or adding another identifier field
- keep `ManyToOne` associations in composite identifiers and sole `OneToOne` identifiers valid

## Why

A `ManyToOne` association used as the only identifier is unique by definition, so the mapping cannot represent the "many" side of the relationship. This can also hide an accidentally omitted identifier field. The schema validator should make that configuration error explicit.

Fixes #12427

## Validation

- `php vendor/bin/phpunit tests/Tests/ORM/Tools/SchemaValidatorTest.php --filter "testInvalidManyToOneAsSoleIdentifier|testValidManyToOneAsPartOfCompositeIdentifier|testInvalidTripleAssociationAsKeyMapping|testValidOneToOneAsIdentifierSchema"`
- `php vendor/bin/phpunit tests/Tests/ORM/Tools/SchemaValidatorTest.php`
- `php vendor/bin/phpcs --standard=phpcs.xml.dist src/Tools/SchemaValidator.php`
- `php vendor/bin/phpcs --standard=phpcs.xml.dist tests/Tests/ORM/Tools/SchemaValidatorTest.php`

The tests were run with PHP 8.4.23.
