### PR TITLE
Allow passing `NULL` to `SELECT NEW` expressions

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -617,7 +617,13 @@ You can also nest several DTO :
     $query = $em->createQuery('SELECT NEW CustomerDTO(c.name, e.email, NEW AddressDTO(a.street, a.city, a.zip)) FROM Customer c JOIN c.email e JOIN c.address a');
     $users = $query->getResult(); // array of CustomerDTO
 
-Note that you can only pass scalar expressions or other Data Transfer Objects to the constructor.
+Note that you can only pass scalar expressions, the ``NULL`` literal or other Data Transfer Objects to the constructor:
+
+.. code-block:: php
+
+    <?php
+    $query = $em->createQuery('SELECT NEW CustomerDTO(c.name, e.email, NEW AddressDTO(a.street, a.city, a.zip), NULL) FROM Customer c JOIN c.email e JOIN c.address a');
+    $users = $query->getResult(); // array of CustomerDTO
 
 If you use your data transfer objects for multiple queries, and you would rather not have to
 specify arguments that precede the ones you are really interested in, you can use named arguments.
@@ -1718,7 +1724,7 @@ Select Expressions
     PartialObjectExpression       ::= "PARTIAL" IdentificationVariable "." PartialFieldSet
     PartialFieldSet               ::= "{" SimpleStateField {"," SimpleStateField}* "}"
     NewObjectExpression           ::= "NEW" AbstractSchemaName "(" NewObjectArg {"," NewObjectArg}* ")"
-    NewObjectArg                  ::= (ScalarExpression | "(" Subselect ")" | NewObjectExpression | EntityAsDtoArgumentExpression) ["AS" AliasResultVariable]
+    NewObjectArg                  ::= (ScalarExpression | "(" Subselect ")" | NewObjectExpression | EntityAsDtoArgumentExpression | "NULL") ["AS" AliasResultVariable]
     EntityAsDtoArgumentExpression ::= IdentificationVariable
 
 Conditional Expressions

--- a/src/Query/AST/NewObjectNullArg.php
+++ b/src/Query/AST/NewObjectNullArg.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * NewObjectNullArg ::= "NULL"
+ *
+ * Represents a NULL argument passed to the constructor of a NewObjectExpression.
+ *
+ * @link    www.doctrine-project.org
+ */
+class NewObjectNullArg extends Node
+{
+    public function dispatch(SqlWalker $walker): string
+    {
+        return 'NULL';
+    }
+}

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1894,7 +1894,7 @@ final class Parser
     }
 
     /**
-     * NewObjectArg ::= (ScalarExpression | "(" Subselect ")" | NewObjectExpression) ["AS" AliasResultVariable]
+     * NewObjectArg ::= (ScalarExpression | "(" Subselect ")" | NewObjectExpression | "NULL") ["AS" AliasResultVariable]
      */
     public function NewObjectArg(string|null &$fieldAlias = null): mixed
     {
@@ -1914,6 +1914,9 @@ final class Parser
             $this->match(TokenType::T_CLOSE_PARENTHESIS);
         } elseif ($token->type === TokenType::T_NEW) {
             $expression = $this->NewObjectExpression();
+        } elseif ($token->type === TokenType::T_NULL) {
+            $this->match(TokenType::T_NULL);
+            $expression = new AST\NewObjectNullArg();
         } elseif ($token->type === TokenType::T_IDENTIFIER && $peek->type !== TokenType::T_DOT && $peek->type !== TokenType::T_OPEN_PARENTHESIS) {
             $expression = $this->EntityAsDtoArgumentExpression();
             $fieldAlias = $expression->aliasVariable;

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1588,6 +1588,10 @@ class SqlWalker
                     $sqlSelectExpressions[] = trim($e->dispatch($this)) . ' AS ' . $columnAlias;
                     break;
 
+                case $e instanceof AST\NewObjectNullArg:
+                    $sqlSelectExpressions[] = $e->dispatch($this) . ' AS ' . $columnAlias;
+                    break;
+
                 case $e instanceof AST\EntityAsDtoArgumentExpression:
                     $alias                                             = $e->identificationVariable ?: $columnAlias;
                     $this->rsm->nestedNewObjectArguments[$columnAlias] = ['ownerIndex' => $objIndex, 'argIndex' => $argIndex, 'argAlias' => $alias];

--- a/tests/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Tests/ORM/Functional/NewOperatorTest.php
@@ -266,6 +266,47 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals(123, $result[2]->phonenumbers);
     }
 
+    public function testShouldSupportNullLiteralExpression(): void
+    {
+        $dql = "
+            SELECT
+                new Doctrine\Tests\Models\CMS\CmsUserDTO(
+                    u.name,
+                    'fabio.bat.silva@gmail.com',
+                    null,
+                    123
+                )
+            FROM
+                Doctrine\Tests\Models\CMS\CmsUser u
+            ORDER BY
+                u.name";
+
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getResult();
+
+        self::assertCount(3, $result);
+
+        self::assertInstanceOf(CmsUserDTO::class, $result[0]);
+        self::assertInstanceOf(CmsUserDTO::class, $result[1]);
+        self::assertInstanceOf(CmsUserDTO::class, $result[2]);
+
+        self::assertEquals($this->fixtures[0]->name, $result[0]->name);
+        self::assertEquals($this->fixtures[1]->name, $result[1]->name);
+        self::assertEquals($this->fixtures[2]->name, $result[2]->name);
+
+        self::assertEquals('fabio.bat.silva@gmail.com', $result[0]->email);
+        self::assertEquals('fabio.bat.silva@gmail.com', $result[1]->email);
+        self::assertEquals('fabio.bat.silva@gmail.com', $result[2]->email);
+
+        self::assertNull($result[0]->address);
+        self::assertNull($result[1]->address);
+        self::assertNull($result[2]->address);
+
+        self::assertEquals(123, $result[0]->phonenumbers);
+        self::assertEquals(123, $result[1]->phonenumbers);
+        self::assertEquals(123, $result[2]->phonenumbers);
+    }
+
     public function testShouldSupportCaseExpression(): void
     {
         $dql = "

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -670,6 +670,12 @@ class LanguageRecognitionTest extends OrmTestCase
         $this->assertValidDQL('SELECT new ' . __NAMESPACE__ . "\\DummyStruct(u.id, 'foo', (SELECT 1 FROM Doctrine\Tests\Models\CMS\CmsUser su), true) FROM Doctrine\Tests\Models\CMS\CmsUser u");
     }
 
+    #[Group('GH-8918')]
+    public function testNewNullLiteralExpression(): void
+    {
+        $this->assertValidDQL('SELECT new ' . __NAMESPACE__ . "\\DummyStruct(u.id, 'foo', null, true) FROM Doctrine\Tests\Models\CMS\CmsUser u");
+    }
+
     public function testStringPrimaryAcceptsAggregateExpression(): void
     {
         $this->assertValidDQL(

--- a/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1708,6 +1708,11 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT new Doctrine\Tests\Models\CMS\CmsUserDTO(a.id, (SELECT 1 FROM Doctrine\Tests\Models\CMS\CmsUser su), a.country, a.city), new Doctrine\Tests\Models\CMS\CmsAddressDTO(u.name, e.email) FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e JOIN u.address a ORDER BY u.name',
             'SELECT c0_.id AS sclr_0, (SELECT 1 AS sclr_2 FROM cms_users c1_) AS sclr_1, c0_.country AS sclr_3, c0_.city AS sclr_4, c2_.name AS sclr_5, c3_.email AS sclr_6 FROM cms_users c2_ INNER JOIN cms_emails c3_ ON c2_.email_id = c3_.id INNER JOIN cms_addresses c0_ ON c2_.id = c0_.user_id ORDER BY c2_.name ASC',
         );
+
+        $this->assertSqlGeneration(
+            'SELECT new Doctrine\Tests\Models\CMS\CmsUserDTO(u.name, e.email, NULL, 123) FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e',
+            'SELECT c0_.name AS sclr_0, c1_.email AS sclr_1, NULL AS sclr_2, 123 AS sclr_3 FROM cms_users c0_ INNER JOIN cms_emails c1_ ON c0_.email_id = c1_.id',
+        );
     }
 
     #[Group('DDC-2234')]


### PR DESCRIPTION
Closes #8918

Allows using the `NULL` literal as a constructor argument in `SELECT NEW` expressions:

```php
$query = $em->createQuery('SELECT NEW CustomerDTO(c.name, c.email, NULL) FROM Customer c');
```