### PR TITLE
Deprecate `TypedExpression` in favor of `ExpressionWithReturnType`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,33 @@ and directly start using native lazy objects.
 
 # Upgrade to 3.7
 
+## Deprecated `Doctrine\ORM\Query\AST\TypedExpression`
+
+Implement `Doctrine\ORM\Query\AST\ExpressionWithReturnType` instead, which exposes
+the DBAL type name directly.
+
+```diff
+-use Doctrine\DBAL\Types\Type;
+ use Doctrine\DBAL\Types\Types;
+-use Doctrine\ORM\Query\AST\TypedExpression;
++use Doctrine\ORM\Query\AST\ExpressionWithReturnType;
+
+-class MyFunction extends FunctionNode implements TypedExpression
++class MyFunction extends FunctionNode implements ExpressionWithReturnType
+ {
+-    public function getReturnType(): Type
++    public function getReturnTypeName(): string
+     {
+-        return Type::getType(Types::INTEGER);
++        return Types::INTEGER;
+     }
+ }
+```
+
+Libraries that need to support older ORM versions can safely implement both
+interfaces at the same time: `SqlWalker` prefers `ExpressionWithReturnType`
+when available and no deprecation is triggered.
+
 ## Deprecated using strings or null as sort directions
 
 PHP 8.6 provides a native `\SortDirection` enum that should be used instead of

--- a/src/Query/AST/ExpressionWithReturnType.php
+++ b/src/Query/AST/ExpressionWithReturnType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+/**
+ * Provides an API for resolving the DBAL type name of a Node.
+ */
+interface ExpressionWithReturnType
+{
+    /**
+     * Returns the DBAL type name (see {@see \Doctrine\DBAL\Types\Types}) of
+     * the value produced by this expression.
+     */
+    public function getReturnTypeName(): string;
+}

--- a/src/Query/AST/Functions/CountFunction.php
+++ b/src/Query/AST/Functions/CountFunction.php
@@ -7,14 +7,17 @@ namespace Doctrine\ORM\Query\AST\Functions;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\AST\AggregateExpression;
+use Doctrine\ORM\Query\AST\ExpressionWithReturnType;
 use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * "COUNT" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @phpstan-ignore class.implementsDeprecatedInterface
  */
-final class CountFunction extends FunctionNode implements TypedExpression
+final class CountFunction extends FunctionNode implements ExpressionWithReturnType, TypedExpression
 {
     private AggregateExpression $aggregateExpression;
 
@@ -28,8 +31,14 @@ final class CountFunction extends FunctionNode implements TypedExpression
         $this->aggregateExpression = $parser->AggregateExpression();
     }
 
+    public function getReturnTypeName(): string
+    {
+        return Types::INTEGER;
+    }
+
+    /** @deprecated Use {@see getReturnTypeName()} instead. */
     public function getReturnType(): Type
     {
-        return Type::getType(Types::INTEGER);
+        return Type::getType($this->getReturnTypeName());
     }
 }

--- a/src/Query/AST/Functions/LengthFunction.php
+++ b/src/Query/AST/Functions/LengthFunction.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Query\AST\ExpressionWithReturnType;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Query\Parser;
@@ -16,8 +17,10 @@ use Doctrine\ORM\Query\TokenType;
  * "LENGTH" "(" StringPrimary ")"
  *
  * @link    www.doctrine-project.org
+ *
+ * @phpstan-ignore class.implementsDeprecatedInterface
  */
-class LengthFunction extends FunctionNode implements TypedExpression
+class LengthFunction extends FunctionNode implements ExpressionWithReturnType, TypedExpression
 {
     public Node $stringPrimary;
 
@@ -38,8 +41,14 @@ class LengthFunction extends FunctionNode implements TypedExpression
         $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
+    public function getReturnTypeName(): string
+    {
+        return Types::INTEGER;
+    }
+
+    /** @deprecated Use {@see getReturnTypeName()} instead. */
     public function getReturnType(): Type
     {
-        return Type::getType(Types::INTEGER);
+        return Type::getType($this->getReturnTypeName());
     }
 }

--- a/src/Query/AST/TypedExpression.php
+++ b/src/Query/AST/TypedExpression.php
@@ -7,7 +7,10 @@ namespace Doctrine\ORM\Query\AST;
 use Doctrine\DBAL\Types\Type;
 
 /**
- * Provides an API for resolving the type of a Node
+ * Provides an API for resolving the type of a Node.
+ *
+ * @deprecated Implement {@see ExpressionWithReturnType} instead, which returns
+ *             the type name as a string and avoids a static Type lookup.
  */
 interface TypedExpression
 {

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -1337,15 +1338,30 @@ class SqlWalker
                     break;
                 }
 
-                if (! $expr instanceof Query\AST\TypedExpression) {
-                    // Conceptually we could resolve field type here by traverse through AST to retrieve field type,
-                    // but this is not a feasible solution; assume 'string'.
-                    $this->rsm->addScalarResult($columnAlias, $resultAlias, 'string');
+                if ($expr instanceof Query\AST\ExpressionWithReturnType) {
+                    $this->rsm->addScalarResult($columnAlias, $resultAlias, $expr->getReturnTypeName());
 
                     break;
                 }
 
-                $this->rsm->addScalarResult($columnAlias, $resultAlias, Type::getTypeRegistry()->lookupName($expr->getReturnType()));
+                if ($expr instanceof Query\AST\TypedExpression) {
+                    Deprecation::trigger(
+                        'doctrine/orm',
+                        'https://github.com/doctrine/orm/pull/12543',
+                        'Implementing %s is deprecated, implement %s instead.',
+                        Query\AST\TypedExpression::class, // @phpstan-ignore classConstant.deprecatedInterface
+                        Query\AST\ExpressionWithReturnType::class,
+                    );
+
+                    // @phpstan-ignore method.deprecatedInterface
+                    $this->rsm->addScalarResult($columnAlias, $resultAlias, Type::getTypeRegistry()->lookupName($expr->getReturnType()));
+
+                    break;
+                }
+
+                // Conceptually we could resolve field type here by traverse through AST to retrieve field type,
+                // but this is not a feasible solution; assume 'string'.
+                $this->rsm->addScalarResult($columnAlias, $resultAlias, Types::STRING);
 
                 break;
 
@@ -1359,7 +1375,7 @@ class SqlWalker
 
                 if (! $hidden) {
                     // We cannot resolve field type here; assume 'string'.
-                    $this->rsm->addScalarResult($columnAlias, $resultAlias, 'string');
+                    $this->rsm->addScalarResult($columnAlias, $resultAlias, Types::STRING);
                 }
 
                 break;

--- a/tests/Tests/ORM/Query/TypedExpressionDeprecationTest.php
+++ b/tests/Tests/ORM/Query/TypedExpressionDeprecationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\AST\ExpressionWithReturnType;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\AST\TypedExpression;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+
+class TypedExpressionDeprecationTest extends OrmTestCase
+{
+    use VerifyDeprecations;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getTestEntityManager();
+    }
+
+    #[IgnoreDeprecations]
+    public function testImplementingLegacyTypedExpressionTriggersDeprecation(): void
+    {
+        $this->entityManager
+            ->getConfiguration()
+            ->addCustomNumericFunction('LEGACY_TYPED', LegacyTypedFunctionStub::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12543');
+
+        $this->entityManager
+            ->createQuery('SELECT LEGACY_TYPED(p.phonenumber) FROM ' . CmsPhonenumber::class . ' p')
+            ->getSQL();
+    }
+
+    public function testImplementingExpressionWithReturnTypeDoesNotTriggerDeprecation(): void
+    {
+        $this->entityManager
+            ->getConfiguration()
+            ->addCustomNumericFunction('MODERN_TYPED', ModernTypedFunctionStub::class);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12543');
+
+        $this->entityManager
+            ->createQuery('SELECT MODERN_TYPED(p.phonenumber) FROM ' . CmsPhonenumber::class . ' p')
+            ->getSQL();
+    }
+}
+
+final class LegacyTypedFunctionStub extends FunctionNode implements TypedExpression
+{
+    private Node $arithmeticExpression;
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return 'ABS(' . $sqlWalker->walkSimpleArithmeticExpression($this->arithmeticExpression) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getReturnType(): Type
+    {
+        return Type::getType(Types::INTEGER);
+    }
+}
+
+final class ModernTypedFunctionStub extends FunctionNode implements ExpressionWithReturnType, TypedExpression
+{
+    private Node $arithmeticExpression;
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return 'ABS(' . $sqlWalker->walkSimpleArithmeticExpression($this->arithmeticExpression) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getReturnTypeName(): string
+    {
+        return Types::INTEGER;
+    }
+
+    public function getReturnType(): Type
+    {
+        return Type::getType($this->getReturnTypeName());
+    }
+}


### PR DESCRIPTION
### Improvement

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

Follow-up to [this comment](https://github.com/doctrine/orm/pull/12421#issuecomment-4903926022).
- #12421

### History

The `TypedExpression` interface was introduced in December 2019 (commit 24e9a7ca, issue #7941) to let DQL functions declare their scalar return type. At the time, DBAL 2.x exposed `Type::getName()` on the instance, so `SqlWalker` cheaply extracted the name via `\$expr->getReturnType()->getName()`. Returning a `Type` object was the natural handle for "a type" and required no static lookup on the walker side.

DBAL 4 removed `Type::getName()` in favour of `TypeRegistry::lookupName($type)`. `SqlWalker` had to reach for `Type::getTypeRegistry()->lookupName(...)`, and implementers had to keep calling the static `Type::getType(Types::INTEGER)` to hand back a `Type` instance the walker only uses to extract a name. The round-trip is vestigial, and it pins two static `Type::*` calls that block the instance-based type registry work in #12421.

### Solution

Introduce a new interface `Doctrine\ORM\Query\AST\ExpressionWithReturnType` that exposes the DBAL type name directly. `TypedExpression` is deprecated; `SqlWalker` prefers the new interface, falls back to the legacy one with a runtime deprecation, and finally to the historical `'string'` default.

## Upgrade

Before:

```php
use Doctrine\DBAL\Types\Type;
use Doctrine\DBAL\Types\Types;
use Doctrine\ORM\Query\AST\TypedExpression;

class MyFunction extends FunctionNode implements TypedExpression
{
    public function getReturnType(): Type
    {
        return Type::getType(Types::INTEGER);
    }
}
```

After:

```php
use Doctrine\DBAL\Types\Types;
use Doctrine\ORM\Query\AST\ExpressionWithReturnType;

class MyFunction extends FunctionNode implements ExpressionWithReturnType
{
    public function getReturnTypeName(): string
    {
        return Types::INTEGER;
    }
}
```