### PR TITLE
[GH-12403] Fix stale partial-load tracking with native lazy objects

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -312,6 +312,13 @@ class UnitOfWork implements PropertyChangedListener
      * thing from the shape of originalEntityData, which can be legitimately
      * empty for other reasons.
      *
+     * Only trustworthy while the object is still reported as uninitialized by
+     * isUninitializedObject(): PHP can complete a native lazy object's
+     * initialization without going through UnitOfWork::createEntity() (e.g. a
+     * to-one association proxy whose remaining properties all end up set as a
+     * side effect of hydrating the owning side), in which case this entry
+     * becomes stale and computeChangeSet() reconciles it away.
+     *
      * @var array<int, list<string>>
      */
     private array $partialObjectLoadedFields = [];
@@ -686,6 +693,41 @@ class UnitOfWork implements PropertyChangedListener
             $originalData  = $this->originalEntityData[$oid];
             $partialFields = $this->partialObjectLoadedFields[$oid] ?? null;
             $changeSet     = [];
+
+            if ($partialFields !== null && ! $this->isUninitializedObject($entity)) {
+                // PHP itself can complete a native lazy object's initialization without
+                // ever running its registered initializer or going through
+                // UnitOfWork::createEntity() — e.g. a to-one association proxy whose
+                // every property ends up assigned as a side effect of hydrating the
+                // owning side's inverse-association sync. When that happens, the
+                // recorded partial-field list is stale: trusting it here would
+                // permanently hide every field outside that list from change
+                // tracking, even though the entity is (per isUninitializedObject())
+                // no longer partial at all. Drop the stale bookkeeping. We have no
+                // reliable prior value for fields it never learned about, so force
+                // them into this change set (mirroring how brand-new entities are
+                // treated below) to make sure the entity's current value reaches the
+                // database, then adopt it as the baseline for future comparisons.
+                unset($this->partialObjectLoadedFields[$oid]);
+                $partialFields = null;
+
+                foreach ($actualData as $propName => $actualValue) {
+                    if (array_key_exists($propName, $originalData)) {
+                        continue;
+                    }
+
+                    if (
+                        ! isset($class->associationMappings[$propName])
+                        || $class->associationMappings[$propName]->isToOneOwningSide()
+                    ) {
+                        $changeSet[$propName] = [null, $actualValue];
+                    }
+
+                    $originalData[$propName] = $actualValue;
+                }
+
+                $this->originalEntityData[$oid] = $originalData;
+            }
 
             foreach ($actualData as $propName => $actualValue) {
                 if ($partialFields !== null) {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -695,38 +695,8 @@ class UnitOfWork implements PropertyChangedListener
             $changeSet     = [];
 
             if ($partialFields !== null && ! $this->isUninitializedObject($entity)) {
-                // PHP itself can complete a native lazy object's initialization without
-                // ever running its registered initializer or going through
-                // UnitOfWork::createEntity() — e.g. a to-one association proxy whose
-                // every property ends up assigned as a side effect of hydrating the
-                // owning side's inverse-association sync. When that happens, the
-                // recorded partial-field list is stale: trusting it here would
-                // permanently hide every field outside that list from change
-                // tracking, even though the entity is (per isUninitializedObject())
-                // no longer partial at all. Drop the stale bookkeeping. We have no
-                // reliable prior value for fields it never learned about, so force
-                // them into this change set (mirroring how brand-new entities are
-                // treated below) to make sure the entity's current value reaches the
-                // database, then adopt it as the baseline for future comparisons.
-                unset($this->partialObjectLoadedFields[$oid]);
+                $this->reconcileStalePartialLoadTracking($oid, $class, $actualData, $originalData, $changeSet);
                 $partialFields = null;
-
-                foreach ($actualData as $propName => $actualValue) {
-                    if (array_key_exists($propName, $originalData)) {
-                        continue;
-                    }
-
-                    if (
-                        ! isset($class->associationMappings[$propName])
-                        || $class->associationMappings[$propName]->isToOneOwningSide()
-                    ) {
-                        $changeSet[$propName] = [null, $actualValue];
-                    }
-
-                    $originalData[$propName] = $actualValue;
-                }
-
-                $this->originalEntityData[$oid] = $originalData;
             }
 
             foreach ($actualData as $propName => $actualValue) {
@@ -841,6 +811,54 @@ class UnitOfWork implements PropertyChangedListener
                 $this->entityUpdates[$oid]      = $entity;
             }
         }
+    }
+
+    /**
+     * PHP itself can complete a native lazy object's initialization without
+     * ever running its registered initializer or going through
+     * UnitOfWork::createEntity() — e.g. a to-one association proxy whose
+     * every property ends up assigned as a side effect of hydrating the
+     * owning side's inverse-association sync. When that happens, the
+     * recorded partial-field list is stale: trusting it here would
+     * permanently hide every field outside that list from change
+     * tracking, even though the entity is (per isUninitializedObject())
+     * no longer partial at all. Drop the stale bookkeeping. We have no
+     * reliable prior value for fields it never learned about, so force
+     * them into this change set (mirroring how brand-new entities are
+     * treated in computeChangeSet()) to make sure the entity's current
+     * value reaches the database, then adopt it as the baseline for
+     * future comparisons.
+     *
+     * @param ClassMetadata<object> $class
+     * @param array<string, mixed>  $actualData
+     * @param array<string, mixed>  $originalData
+     * @param array<string, mixed>  $changeSet
+     */
+    private function reconcileStalePartialLoadTracking(
+        int $oid,
+        ClassMetadata $class,
+        array $actualData,
+        array &$originalData,
+        array &$changeSet,
+    ): void {
+        unset($this->partialObjectLoadedFields[$oid]);
+
+        foreach ($actualData as $propName => $actualValue) {
+            if (array_key_exists($propName, $originalData)) {
+                continue;
+            }
+
+            if (
+                ! isset($class->associationMappings[$propName])
+                || $class->associationMappings[$propName]->isToOneOwningSide()
+            ) {
+                $changeSet[$propName] = [null, $actualValue];
+            }
+
+            $originalData[$propName] = $actualValue;
+        }
+
+        $this->originalEntityData[$oid] = $originalData;
     }
 
     /**

--- a/tests/Tests/Models/GH12403/GH12403ScalarEntity.php
+++ b/tests/Tests/Models/GH12403/GH12403ScalarEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH12403;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'gh12403_scalar_entity')]
+class GH12403ScalarEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int|null $id = null;
+
+    #[Column(type: 'string', length: 50)]
+    public string $name = '';
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH12403\GH12403ScalarEntity;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/** @see https://github.com/doctrine/orm/issues/12403 */
+class GH12403Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH12403ScalarEntity::class, OwningSide::class, InverseSide::class);
+    }
+
+    /**
+     * A to-one association's target proxy can end up with every one of its
+     * properties assigned (identifier at proxy-creation time, remaining
+     * properties as a side effect of hydrating the owning side, e.g. the
+     * inverse-association sync) without ever running the proxy's registered
+     * initializer. PHP then reports such an object as no longer uninitialized,
+     * even though UnitOfWork::createEntity() never ran for it and never
+     * recorded a snapshot of its data.
+     */
+    public function testAssociationTargetCanSilentlyCompleteNativeLazyInitialization(): void
+    {
+        $owner   = new OwningSide();
+        $inverse = new InverseSide();
+
+        $owner->id       = 'gh12403-owner';
+        $inverse->id     = 'gh12403-inverse';
+        $owner->inverse  = $inverse;
+        $inverse->owning = $owner;
+
+        $this->_em->persist($owner);
+        $this->_em->persist($inverse);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reloadedOwner = $this->_em->find(OwningSide::class, 'gh12403-owner');
+        self::assertNotNull($reloadedOwner);
+
+        $target = $reloadedOwner->inverse;
+
+        self::assertFalse(
+            $this->isUninitializedObject($target),
+            'InverseSide has no scalar fields of its own, so hydrating the owning side leaves it fully assigned and therefore no longer "uninitialized" per PHP, despite never being loaded through UnitOfWork::createEntity().',
+        );
+
+        // A flush must not error out or otherwise mishandle this entity, even
+        // though it is now included in change-tracking despite having never
+        // gone through the ORM's own hydration bookkeeping.
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $checked = $this->_em->find(InverseSide::class, 'gh12403-inverse');
+        self::assertNotNull($checked);
+        self::assertInstanceOf(OwningSide::class, $checked->owning);
+        self::assertSame('gh12403-owner', $checked->owning->id);
+    }
+
+    /**
+     * Direct reproduction of the reported symptom: once an entity's native
+     * lazy object is completed by some means other than
+     * UnitOfWork::createEntity(), its changes used to be silently and
+     * permanently dropped from every future flush(), because the stale
+     * "no fields loaded yet" bookkeeping was trusted forever.
+     */
+    public function testChangeIsPersistedAfterEntityIsInitializedWithoutGoingThroughCreateEntity(): void
+    {
+        $entity       = new GH12403ScalarEntity();
+        $entity->name = 'old name';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $id        = $entity->id;
+        $reference = $this->_em->getReference(GH12403ScalarEntity::class, $id);
+
+        self::assertTrue($this->isUninitializedObject($reference));
+
+        // Simulate the object becoming initialized through a path other than
+        // UnitOfWork::createEntity(), as observed for association proxies
+        // above.
+        $this->_em->getClassMetadata(GH12403ScalarEntity::class)->reflClass->markLazyObjectAsInitialized($reference);
+        self::assertFalse($this->isUninitializedObject($reference));
+
+        $reference->name = 'new name';
+        $this->_em->flush();
+
+        $name = $this->_em->getConnection()->fetchOne(
+            'SELECT name FROM gh12403_scalar_entity WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame('new name', $name);
+    }
+}


### PR DESCRIPTION
Various ways can trigger PHP to mark object as not uninitialized anymore, which Doctrine UoW does not get notified about.

This can be fixed on 3.6.x, another PR for that branch coming in.

Fixes #12403 